### PR TITLE
Support archived repos as archive-only and harden archive seeding

### DIFF
--- a/cmd/kenn-forge/main.go
+++ b/cmd/kenn-forge/main.go
@@ -763,6 +763,14 @@ func resolveStartupRepos(
 				expanded = fallbackExactFromDB(ctx, database, raw)
 				if len(expanded) == 0 {
 					expanded = ghclient.FallbackConfiguredRepoRefs(nil, raw)
+				} else {
+					// The catalog recovered a stable identity on a renamed
+					// route; without the alias, repo-scoped credentials for
+					// the configured route would fall through to owner or
+					// host credentials.
+					ghclient.RegisterConfiguredRepoCredentialAliases(
+						githubRouters, raw, expanded,
+					)
 				}
 			}
 		} else {

--- a/cmd/kenn-forge/main.go
+++ b/cmd/kenn-forge/main.go
@@ -760,7 +760,10 @@ func resolveStartupRepos(
 					ctx, database, raw,
 				)
 			} else {
-				expanded = ghclient.FallbackConfiguredRepoRefs(nil, raw)
+				expanded = fallbackExactFromDB(ctx, database, raw)
+				if len(expanded) == 0 {
+					expanded = ghclient.FallbackConfiguredRepoRefs(nil, raw)
+				}
 			}
 		} else {
 			ghclient.RegisterConfiguredRepoCredentialAliases(
@@ -784,6 +787,71 @@ func splitProviderHostKey(key string) (string, string) {
 		return key, ""
 	}
 	return platformName, host
+}
+
+// fallbackExactFromDB recovers the stored identity for an exact config
+// entry whose provider resolution failed at startup. Catalog route history
+// follows a provider-side rename, so the fallback keeps the stable provider
+// id — deduplicating against overlapping resolved entries — instead of
+// synthesizing an identity-less ref under the stale configured route.
+func fallbackExactFromDB(
+	ctx context.Context,
+	database *db.DB,
+	raw config.Repo,
+) []ghclient.RepoRef {
+	if database == nil {
+		return nil
+	}
+	repoPath := strings.TrimSpace(raw.RepoPath)
+	if repoPath == "" {
+		repoPath = raw.Owner + "/" + raw.Name
+	}
+	entries, err := database.ListRepositoryCatalog(ctx, db.RepositoryCatalogFilter{
+		Platform:     raw.PlatformOrDefault(),
+		PlatformHost: raw.PlatformHostOrDefault(),
+		RepoPath:     repoPath,
+		Lifecycle:    db.RepositoryLifecycleActive,
+	})
+	if err != nil {
+		slog.Warn("fallback exact from db", "err", err)
+		return nil
+	}
+	entry := catalogEntryForConfiguredRoute(entries, repoPath)
+	if entry == nil {
+		return nil
+	}
+	return []ghclient.RepoRef{{
+		Platform:           platform.Kind(raw.PlatformOrDefault()),
+		Owner:              entry.Repository.Owner,
+		Name:               entry.Repository.Name,
+		PlatformHost:       entry.Repository.PlatformHost,
+		RepoPath:           entry.Repository.RepoPath,
+		PlatformExternalID: entry.Repository.PlatformRepoID,
+		WebURL:             entry.Repository.WebURL,
+		CloneURL:           entry.Repository.CloneURL,
+		DefaultBranch:      entry.Repository.DefaultBranch,
+		ConfiguredRepoPath: repoPath,
+	}}
+}
+
+// catalogEntryForConfiguredRoute prefers the repository currently occupying
+// the configured route; a reused route may also historically match the
+// renamed repository that held it before. Multiple historical matches with
+// no current occupant cannot be attributed safely.
+func catalogEntryForConfiguredRoute(
+	entries []db.RepositoryCatalogEntry, repoPath string,
+) *db.RepositoryCatalogEntry {
+	for i := range entries {
+		for _, route := range entries[i].Routes {
+			if route.Current && strings.EqualFold(route.RepoPath, repoPath) {
+				return &entries[i]
+			}
+		}
+	}
+	if len(entries) == 1 {
+		return &entries[0]
+	}
+	return nil
 }
 
 // fallbackGlobFromDB returns repos from the database that match

--- a/cmd/kenn-forge/main.go
+++ b/cmd/kenn-forge/main.go
@@ -748,8 +748,7 @@ func resolveStartupRepos(
 	database *db.DB,
 	githubRouters map[string]*ghclient.HostRouter,
 ) []ghclient.RepoRef {
-	seen := make(map[string]struct{})
-	repos := make([]ghclient.RepoRef, 0, len(cfg.Repos))
+	set := ghclient.NewExpandedRepoSet()
 	for _, raw := range cfg.Repos {
 		_, expanded, err := ghclient.ResolveConfiguredRepoWithRegistry(
 			ctx, registry, raw,
@@ -769,18 +768,10 @@ func resolveStartupRepos(
 			)
 		}
 		for _, repo := range expanded {
-			key := string(repoPlatform(repo)) + "\x00" +
-				strings.ToLower(repoHost(repo)) + "\x00" +
-				strings.ToLower(repo.Owner) + "\x00" +
-				strings.ToLower(repo.Name)
-			if _, ok := seen[key]; ok {
-				continue
-			}
-			seen[key] = struct{}{}
-			repos = append(repos, repo)
+			set.Add(repo, err == nil)
 		}
 	}
-	return repos
+	return set.Refs()
 }
 
 func providerHostKey(platformName, host string) string {
@@ -793,23 +784,6 @@ func splitProviderHostKey(key string) (string, string) {
 		return key, ""
 	}
 	return platformName, host
-}
-
-func repoPlatform(repo ghclient.RepoRef) platform.Kind {
-	if repo.Platform != "" {
-		return repo.Platform
-	}
-	return platform.KindGitHub
-}
-
-func repoHost(repo ghclient.RepoRef) string {
-	if repo.PlatformHost != "" {
-		return strings.ToLower(repo.PlatformHost)
-	}
-	if host, ok := platform.DefaultHost(repoPlatform(repo)); ok {
-		return host
-	}
-	return platform.DefaultGitHubHost
 }
 
 // fallbackGlobFromDB returns repos from the database that match

--- a/cmd/kenn-forge/main_test.go
+++ b/cmd/kenn-forge/main_test.go
@@ -375,6 +375,47 @@ func TestResolveStartupReposRecoversRenamedExactEntryFromCatalog(t *testing.T) {
 	assert.Equal("acme/tools", repos[0].ConfiguredRepoPath)
 }
 
+func TestResolveStartupReposRegistersCredentialAliasForCatalogFallback(t *testing.T) {
+	require := require.New(t)
+	database := dbtest.Open(t)
+	now := time.Now().UTC()
+	before := db.GitHubRepoIdentity("github.com", "acme", "tools")
+	before.PlatformRepoID = "repo-acme-tools"
+	_, _, err := database.ReconcileRepositoryObservation(
+		t.Context(), before, now.Add(-time.Hour),
+	)
+	require.NoError(err)
+	after := db.GitHubRepoIdentity("github.com", "acme", "tools-new")
+	after.PlatformRepoID = "repo-acme-tools"
+	_, _, err = database.ReconcileRepositoryObservation(t.Context(), after, now)
+	require.NoError(err)
+
+	client := getRepoFailingClient{&testutil.FixtureClient{}}
+	router, err := ghclient.NewHostRouter("github.com", &ghclient.Route{
+		Key:    ghclient.RouteKey{Host: "github.com", Owner: "acme", Name: "tools"},
+		Client: client,
+	})
+	require.NoError(err)
+	cfg := &config.Config{Repos: []config.Repo{{Owner: "acme", Name: "tools"}}}
+
+	repos := resolveStartupRepos(
+		t.Context(),
+		cfg,
+		mustProviderRegistry(t, map[string]ghclient.Client{"github.com": client}),
+		database,
+		map[string]*ghclient.HostRouter{"github.com": router},
+	)
+
+	require.Len(repos, 1)
+	require.Equal("tools-new", repos[0].Name)
+	// The recovered renamed route must keep resolving to the exact entry's
+	// repo-scoped credential instead of falling through to owner or host
+	// routes.
+	route, err := router.RouteForRepo("acme", "tools-new")
+	require.NoError(err)
+	require.Equal("tools", route.Key.Name)
+}
+
 func TestResolveStartupReposFallsBackToDBForOfflineGlobs(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/cmd/kenn-forge/main_test.go
+++ b/cmd/kenn-forge/main_test.go
@@ -249,6 +249,57 @@ func TestResolveStartupReposExpandsConfiguredGlobs(t *testing.T) {
 	}, repos)
 }
 
+type getRepoFailingClient struct {
+	*testutil.FixtureClient
+}
+
+func (getRepoFailingClient) GetRepository(
+	context.Context, string, string,
+) (*gh.Repository, error) {
+	return nil, errors.New("transient resolve failure")
+}
+
+func TestResolveStartupReposPrefersResolvedOverFallbackDuplicates(t *testing.T) {
+	assert := assert.New(t)
+	// The exact entry fails resolution and falls back to a synthetic ref;
+	// the overlapping glob resolves the same repo as archived. The resolved
+	// metadata must win or the archived repo would be polled as live.
+	cfg := &config.Config{
+		Repos: []config.Repo{
+			{Owner: "acme", Name: "archived"},
+			{Owner: "acme", Name: "*"},
+		},
+	}
+	client := getRepoFailingClient{&testutil.FixtureClient{
+		ReposByOwner: map[string][]*gh.Repository{
+			"acme": {{
+				NodeID:   new("repo-acme-archived"),
+				Name:     new("archived"),
+				Owner:    &gh.User{Login: new("acme")},
+				Archived: new(true),
+			}},
+		},
+	}}
+
+	repos := resolveStartupRepos(
+		t.Context(),
+		cfg,
+		mustProviderRegistry(t, map[string]ghclient.Client{"github.com": client}),
+		nil,
+		nil,
+	)
+
+	assert.Equal([]ghclient.RepoRef{{
+		Platform:           "github",
+		Owner:              "acme",
+		Name:               "archived",
+		PlatformHost:       "github.com",
+		RepoPath:           "acme/archived",
+		PlatformExternalID: "repo-acme-archived",
+		Archived:           true,
+	}}, repos)
+}
+
 func TestResolveStartupReposKeepsExactReposWhenResolutionFails(t *testing.T) {
 	assert := assert.New(t)
 	cfg := &config.Config{

--- a/cmd/kenn-forge/main_test.go
+++ b/cmd/kenn-forge/main_test.go
@@ -232,21 +232,19 @@ func TestResolveStartupReposExpandsConfiguredGlobs(t *testing.T) {
 
 	assert.Equal([]ghclient.RepoRef{
 		{
-			Platform:           "github",
-			Owner:              "roborev-dev",
-			Name:               "kenn-forge",
-			PlatformHost:       "github.com",
-			RepoPath:           "roborev-dev/kenn-forge",
-			ConfiguredRepoPath: "roborev-dev/*",
+			Platform:     "github",
+			Owner:        "roborev-dev",
+			Name:         "kenn-forge",
+			PlatformHost: "github.com",
+			RepoPath:     "roborev-dev/kenn-forge",
 		},
 		{
-			Platform:           "github",
-			Owner:              "roborev-dev",
-			Name:               "archived",
-			PlatformHost:       "github.com",
-			RepoPath:           "roborev-dev/archived",
-			Archived:           true,
-			ConfiguredRepoPath: "roborev-dev/*",
+			Platform:     "github",
+			Owner:        "roborev-dev",
+			Name:         "archived",
+			PlatformHost: "github.com",
+			RepoPath:     "roborev-dev/archived",
+			Archived:     true,
 		},
 	}, repos)
 }
@@ -299,7 +297,7 @@ func TestResolveStartupReposPrefersResolvedOverFallbackDuplicates(t *testing.T) 
 		RepoPath:           "acme/archived",
 		PlatformExternalID: "repo-acme-archived",
 		Archived:           true,
-		ConfiguredRepoPath: "acme/*",
+		ConfiguredRepoPath: "acme/archived",
 	}}, repos)
 }
 

--- a/cmd/kenn-forge/main_test.go
+++ b/cmd/kenn-forge/main_test.go
@@ -232,19 +232,21 @@ func TestResolveStartupReposExpandsConfiguredGlobs(t *testing.T) {
 
 	assert.Equal([]ghclient.RepoRef{
 		{
-			Platform:     "github",
-			Owner:        "roborev-dev",
-			Name:         "kenn-forge",
-			PlatformHost: "github.com",
-			RepoPath:     "roborev-dev/kenn-forge",
+			Platform:           "github",
+			Owner:              "roborev-dev",
+			Name:               "kenn-forge",
+			PlatformHost:       "github.com",
+			RepoPath:           "roborev-dev/kenn-forge",
+			ConfiguredRepoPath: "roborev-dev/*",
 		},
 		{
-			Platform:     "github",
-			Owner:        "roborev-dev",
-			Name:         "archived",
-			PlatformHost: "github.com",
-			RepoPath:     "roborev-dev/archived",
-			Archived:     true,
+			Platform:           "github",
+			Owner:              "roborev-dev",
+			Name:               "archived",
+			PlatformHost:       "github.com",
+			RepoPath:           "roborev-dev/archived",
+			Archived:           true,
+			ConfiguredRepoPath: "roborev-dev/*",
 		},
 	}, repos)
 }
@@ -297,6 +299,7 @@ func TestResolveStartupReposPrefersResolvedOverFallbackDuplicates(t *testing.T) 
 		RepoPath:           "acme/archived",
 		PlatformExternalID: "repo-acme-archived",
 		Archived:           true,
+		ConfiguredRepoPath: "acme/*",
 	}}, repos)
 }
 
@@ -315,11 +318,12 @@ func TestResolveStartupReposKeepsExactReposWhenResolutionFails(t *testing.T) {
 	)
 
 	assert.Equal([]ghclient.RepoRef{{
-		Platform:     "github",
-		Owner:        "roborev-dev",
-		Name:         "kenn-forge",
-		PlatformHost: "github.com",
-		RepoPath:     "roborev-dev/kenn-forge",
+		Platform:           "github",
+		Owner:              "roborev-dev",
+		Name:               "kenn-forge",
+		PlatformHost:       "github.com",
+		RepoPath:           "roborev-dev/kenn-forge",
+		ConfiguredRepoPath: "roborev-dev/kenn-forge",
 	}}, repos)
 }
 
@@ -381,11 +385,12 @@ func TestResolveStartupReposUsesProviderRegistryForGitLab(t *testing.T) {
 	repos := resolveStartupRepos(t.Context(), cfg, registry, nil, nil)
 
 	assert.Equal([]ghclient.RepoRef{{
-		Platform:     platform.KindGitLab,
-		PlatformHost: "gitlab.com",
-		Owner:        "group/subgroup",
-		Name:         "project",
-		RepoPath:     "group/subgroup/project",
+		Platform:           platform.KindGitLab,
+		PlatformHost:       "gitlab.com",
+		Owner:              "group/subgroup",
+		Name:               "project",
+		RepoPath:           "group/subgroup/project",
+		ConfiguredRepoPath: "group/subgroup/project",
 	}}, repos)
 }
 

--- a/cmd/kenn-forge/main_test.go
+++ b/cmd/kenn-forge/main_test.go
@@ -230,13 +230,23 @@ func TestResolveStartupReposExpandsConfiguredGlobs(t *testing.T) {
 		nil,
 	)
 
-	assert.Equal([]ghclient.RepoRef{{
-		Platform:     "github",
-		Owner:        "roborev-dev",
-		Name:         "kenn-forge",
-		PlatformHost: "github.com",
-		RepoPath:     "roborev-dev/kenn-forge",
-	}}, repos)
+	assert.Equal([]ghclient.RepoRef{
+		{
+			Platform:     "github",
+			Owner:        "roborev-dev",
+			Name:         "kenn-forge",
+			PlatformHost: "github.com",
+			RepoPath:     "roborev-dev/kenn-forge",
+		},
+		{
+			Platform:     "github",
+			Owner:        "roborev-dev",
+			Name:         "archived",
+			PlatformHost: "github.com",
+			RepoPath:     "roborev-dev/archived",
+			Archived:     true,
+		},
+	}, repos)
 }
 
 func TestResolveStartupReposKeepsExactReposWhenResolutionFails(t *testing.T) {

--- a/cmd/kenn-forge/main_test.go
+++ b/cmd/kenn-forge/main_test.go
@@ -325,6 +325,56 @@ func TestResolveStartupReposKeepsExactReposWhenResolutionFails(t *testing.T) {
 	}}, repos)
 }
 
+func TestResolveStartupReposRecoversRenamedExactEntryFromCatalog(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	now := time.Now().UTC()
+	before := db.GitHubRepoIdentity("github.com", "acme", "tools")
+	before.PlatformRepoID = "repo-acme-tools"
+	_, _, err := database.ReconcileRepositoryObservation(
+		t.Context(), before, now.Add(-time.Hour),
+	)
+	require.NoError(err)
+	after := db.GitHubRepoIdentity("github.com", "acme", "tools-new")
+	after.PlatformRepoID = "repo-acme-tools"
+	_, _, err = database.ReconcileRepositoryObservation(t.Context(), after, now)
+	require.NoError(err)
+
+	// The renamed repository resolves through the glob; the exact entry
+	// still lists the old path and fails transiently. Catalog route
+	// history recovers the stable identity so the fallback deduplicates
+	// instead of tracking an identity-less duplicate on the stale route.
+	cfg := &config.Config{Repos: []config.Repo{
+		{Owner: "acme", Name: "tools"},
+		{Owner: "acme", Name: "*"},
+	}}
+	client := getRepoFailingClient{&testutil.FixtureClient{
+		ReposByOwner: map[string][]*gh.Repository{
+			"acme": {{
+				NodeID:   new("repo-acme-tools"),
+				Name:     new("tools-new"),
+				Owner:    &gh.User{Login: new("acme")},
+				Archived: new(true),
+			}},
+		},
+	}}
+
+	repos := resolveStartupRepos(
+		t.Context(),
+		cfg,
+		mustProviderRegistry(t, map[string]ghclient.Client{"github.com": client}),
+		database,
+		nil,
+	)
+
+	require.Len(repos, 1)
+	assert.Equal("tools-new", repos[0].Name)
+	assert.Equal("repo-acme-tools", repos[0].PlatformExternalID)
+	assert.True(repos[0].Archived)
+	assert.Equal("acme/tools", repos[0].ConfiguredRepoPath)
+}
+
 func TestResolveStartupReposFallsBackToDBForOfflineGlobs(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -255,6 +255,33 @@ fallback repository listing.
 ## Historical Archive Rules
 
 - The legacy closed-item backfill is retired; configured repositories seed durable archive discovery before sync cutover, with no cursor translation. (`internal/github/sync.go::SetReposWithContext`)
+- Provider-archived repositories are configurable and archive-only: resolution
+  accepts them (exact and glob) with `RepoRef.Archived` set, live sync skips
+  them, and archive discovery/hydration treat them like any configured repo.
+  Archived state refreshes wherever resolution already happens (startup,
+  config reload, settings add/refresh) and must survive catalog
+  republication, which cannot read it from the store. GitLab namespace
+  listings filter archived projects server-side, so GitLab globs cannot see
+  them; exact GitLab refs work. (`internal/github/repo_config_resolver.go::resolveConfiguredRepo`,
+  `internal/github/sync.go::excludeArchivedRepos`,
+  `internal/github/sync.go::repoRefFromCatalog`)
+- Archive seeding degrades per repository: a ref that fails validation,
+  provider resolution, or catalog reconciliation is logged with its identity
+  and skipped, never fatal — one bad configured entry must not crash-loop the
+  daemon at startup. Only batch reconciliation errors (a broken store)
+  propagate. Refs skipped by seeding are excluded from authentication retry
+  so they cannot fail a config reload.
+  (`internal/archive/service.go::EnsureConfigured`,
+  `internal/github/sync.go::SetReposWithContext`)
+- Removal pausing (`configuration_removed`) requires a complete picture: when
+  any configured ref fails seeding without a known repository row, the pass
+  ensures discovery archives but defers the pausing side entirely — an
+  incomplete protection list could pause the wrong repository's archive
+  (renamed owners resolve to rows under other identities). A ref that failed
+  after its row was identified stays protected without deferring the pass.
+  While an unresolvable ref persists in config, genuinely removed repos keep
+  collecting; the recurring deferral warning is the operator signal.
+  (`internal/archive/service.go::EnsureConfigured`)
 - Initial issue and pull-request inventory includes all states in stable created-time ascending order; issue enumeration excludes PR-shaped rows. (`internal/github/pages.go::ListIssuesPage`, `internal/github/pages.go::ListMergeRequestsPage`)
 - Every issue-only GitHub lookup rejects a PR-shaped Issues API response before normalization; `SyncItemByNumber` is the kind-dispatching exception. (`internal/github/pages.go::gitHubClientProvider.issuePullRequestOutcomeError`, `internal/github/sync.go::SyncItemByNumber`)
 - Updated issue scans query one second before the durable watermark while keeping cursor identity bound to the original boundary. Updated pull-request scans run newest-first across the same overlap. (`internal/github/pages.go::ListIssuesPage`, `internal/github/pages.go::ListMergeRequestsPage`)

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -283,15 +283,23 @@ fallback repository listing.
   provider-side rename moves the tracked route away from the configured path,
   and without the provenance match the fallback would synthesize an
   identity-less live ref — dropping the archived flag and duplicating the
-  repository next to a resolved overlapping entry.
+  repository next to a resolved overlapping entry. Settings merges preserve
+  tracked provenance the same way (settings-resolved refs never author it),
+  and startup — which has no tracked set — recovers a failed exact entry's
+  stable identity through catalog route history before synthesizing.
   (`internal/github/repo_config_resolver.go::FallbackConfiguredRepoRefs`,
   `internal/github/repo_config_resolver.go::ExpandedRepoSet`,
   `internal/github/sync.go::repoRefFromCatalog`,
-  `internal/github/sync.go::publishResolvedRepository`)
+  `internal/github/sync.go::publishResolvedRepository`,
+  `internal/server/settings_handlers.go::trackedRepoProvenance`,
+  `cmd/kenn-forge/main.go::fallbackExactFromDB`)
 - Catalog republication without fresh provider metadata preserves the
   currently tracked archived flag: a sync that began before a newer archived
-  flip must not clear it when its own snapshot predates the flip.
-  (`internal/github/sync.go::publishResolvedRepository`)
+  flip must not clear it when its own snapshot predates the flip. When the
+  tracked flag differs from the operation's snapshot, a concurrent resolution
+  flipped it mid-flight — ordering against the in-flight provider response is
+  unknowable, so the newer tracked value stands even over fresh provider
+  metadata. (`internal/github/sync.go::publishResolvedRepository`)
   Archived state refreshes wherever resolution already happens (startup,
   config reload, settings add/refresh) and must survive catalog
   republication, which cannot read it from the store. GitLab namespace

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -303,7 +303,10 @@ fallback repository listing.
   the repository the snapshot named. The route fallback may displace the
   snapshot's own entry — configured-route reuse replaces the occupant and
   the archive lifecycle pauses the old repository — but never an entry
-  whose id conflicts with the snapshot.
+  whose id conflicts with the snapshot. On a cross-identity landing the
+  snapshot's archived flag belongs to a different repository: authoritative
+  resolved metadata applies, and only a non-authoritative publication
+  preserves the successor's tracked state.
   (`internal/github/repo_config_resolver.go::FallbackConfiguredRepoRefs`,
   `internal/github/repo_config_resolver.go::ExpandedRepoSet`,
   `internal/github/sync.go::repoRefFromCatalog`,

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -289,7 +289,16 @@ fallback repository listing.
   a route reused by a different repository must not inherit the displaced
   repository's provenance, or two refs would claim the same config entry.
   Startup — which has no tracked set — recovers a failed exact entry's
-  stable identity through catalog route history before synthesizing.
+  stable identity through catalog route history before synthesizing, and
+  registers the repo credential alias for the recovered route so repo-scoped
+  credentials do not fall through to owner or host routes. Config-entry
+  matching (glob refresh, entry removal) honors provenance the same way — a
+  renamed repo still belongs to its exact entry — and removal clears
+  provenance whose entry no longer exists, so a stale claim cannot bind a
+  future entry with the same path to the wrong repository.
+  Publications locate their tracked slot by stable identity first and refuse
+  the route fallback across conflicting ids, so a stale sync of a
+  renamed-away repository cannot overwrite the route successor's state.
   (`internal/github/repo_config_resolver.go::FallbackConfiguredRepoRefs`,
   `internal/github/repo_config_resolver.go::ExpandedRepoSet`,
   `internal/github/sync.go::repoRefFromCatalog`,

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -303,10 +303,11 @@ fallback repository listing.
   the repository the snapshot named. The route fallback may displace the
   snapshot's own entry — configured-route reuse replaces the occupant and
   the archive lifecycle pauses the old repository — but never an entry
-  whose id conflicts with the snapshot. On a cross-identity landing the
-  snapshot's archived flag belongs to a different repository: authoritative
-  resolved metadata applies, and only a non-authoritative publication
-  preserves the successor's tracked state.
+  whose id conflicts with the snapshot. When the snapshot and resolved ids
+  differ, the data belongs to the route successor — whether it lands on the
+  successor's own entry or displaces the snapshot's — so the snapshot's
+  archived flag is meaningless: authoritative resolved metadata applies,
+  and only a non-authoritative publication preserves tracked state.
   (`internal/github/repo_config_resolver.go::FallbackConfiguredRepoRefs`,
   `internal/github/repo_config_resolver.go::ExpandedRepoSet`,
   `internal/github/sync.go::repoRefFromCatalog`,

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -323,11 +323,24 @@ fallback repository listing.
   metadata. (`internal/github/sync.go::publishResolvedRepository`)
   Archived state refreshes wherever resolution already happens (startup,
   config reload, settings add/refresh) and must survive catalog
-  republication, which cannot read it from the store. GitLab namespace
-  listings filter archived projects server-side, so GitLab globs cannot see
-  them; exact GitLab refs work. (`internal/github/repo_config_resolver.go::resolveConfiguredRepo`,
-  `internal/github/sync.go::excludeArchivedRepos`,
+  republication, which cannot read it from the store. GitLab configuration
+  enumeration lists namespaces with archived projects included — the
+  server-side `archived=false` filter and the client-side drop apply only to
+  import previews — so GitLab globs match archived projects like GitHub
+  globs do. (`internal/github/repo_config_resolver.go::resolveConfiguredRepo`,
+  `internal/platform/gitlab/client.go::ListRepositories`,
   `internal/github/sync.go::repoRefFromCatalog`)
+- Archived state transitions are observed during normal sync passes, not
+  only at resolution sites: each pass reconciles archived tracked refs with
+  metadata-only identity resolution, so an upstream unarchive returns the
+  repository to live syncing without a restart or reload, while refs still
+  archived (or whose refresh fails) stay excluded. In the other direction, a
+  live repository whose in-pass identity resolution reports archived stops
+  before any clone, overview, label, or item syncing — the publication has
+  already flipped the tracked flag, and the pass must not sync an archived
+  repository's content on the way out.
+  (`internal/github/sync.go::reconcileArchivedRepos`,
+  `internal/github/sync.go::syncRepo`)
 - Archive seeding degrades per repository: a ref that fails validation,
   provider resolution, or catalog reconciliation is logged with its identity
   and skipped, never fatal — one bad configured entry must not crash-loop the

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -293,12 +293,17 @@ fallback repository listing.
   registers the repo credential alias for the recovered route so repo-scoped
   credentials do not fall through to owner or host routes. Config-entry
   matching (glob refresh, entry removal) honors provenance the same way — a
-  renamed repo still belongs to its exact entry — and removal clears
-  provenance whose entry no longer exists, so a stale claim cannot bind a
-  future entry with the same path to the wrong repository.
-  Publications locate their tracked slot by stable identity first and refuse
-  the route fallback across conflicting ids, so a stale sync of a
-  renamed-away repository cannot overwrite the route successor's state.
+  renamed repo still belongs to its exact entry, scoped to the entry's
+  provider and host since the same path can be configured on several — and
+  removal clears provenance whose entry no longer exists, so a stale claim
+  cannot bind a future entry with the same path to the wrong repository.
+  Publications locate their tracked slot by stable identity first, keyed on
+  the resolved id: the provider response says whose data this is, so a
+  lookup through a reused route lands on the tracked successor, never on
+  the repository the snapshot named. The route fallback may displace the
+  snapshot's own entry — configured-route reuse replaces the occupant and
+  the archive lifecycle pauses the old repository — but never an entry
+  whose id conflicts with the snapshot.
   (`internal/github/repo_config_resolver.go::FallbackConfiguredRepoRefs`,
   `internal/github/repo_config_resolver.go::ExpandedRepoSet`,
   `internal/github/sync.go::repoRefFromCatalog`,

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -303,11 +303,12 @@ fallback repository listing.
   the repository the snapshot named. The route fallback may displace the
   snapshot's own entry — configured-route reuse replaces the occupant and
   the archive lifecycle pauses the old repository — but never an entry
-  whose id conflicts with the snapshot. When the snapshot and resolved ids
-  differ, the data belongs to the route successor — whether it lands on the
-  successor's own entry or displaces the snapshot's — so the snapshot's
-  archived flag is meaningless: authoritative resolved metadata applies,
-  and only a non-authoritative publication preserves tracked state.
+  whose id conflicts with the snapshot. When the resolved id differs from
+  the snapshot's — or from the landed slot's, which matters when the
+  snapshot carries no id — the data belongs to a different repository than
+  the flags describe, so the snapshot's archived flag is meaningless:
+  authoritative resolved metadata applies, and only a non-authoritative
+  publication preserves tracked state.
   (`internal/github/repo_config_resolver.go::FallbackConfiguredRepoRefs`,
   `internal/github/repo_config_resolver.go::ExpandedRepoSet`,
   `internal/github/sync.go::repoRefFromCatalog`,
@@ -323,11 +324,14 @@ fallback repository listing.
   metadata. (`internal/github/sync.go::publishResolvedRepository`)
   Archived state refreshes wherever resolution already happens (startup,
   config reload, settings add/refresh) and must survive catalog
-  republication, which cannot read it from the store. GitLab configuration
-  enumeration lists namespaces with archived projects included — the
-  server-side `archived=false` filter and the client-side drop apply only to
-  import previews — so GitLab globs match archived projects like GitHub
-  globs do. (`internal/github/repo_config_resolver.go::resolveConfiguredRepo`,
+  republication, which cannot read it from the store. Archived inclusion in
+  repository listings is an explicit request
+  (`RepositoryListOptions.IncludeArchived`): configuration expansion sets it
+  so GitLab globs match archived projects like GitHub globs do, while
+  default listings — import previews and the repo-import handler — keep
+  GitLab's server-side `archived=false` filter, which runs before any
+  listing limit so archived projects cannot crowd live ones out of a
+  bounded preview. (`internal/github/repo_config_resolver.go::resolveConfiguredRepo`,
   `internal/platform/gitlab/client.go::ListRepositories`,
   `internal/github/sync.go::repoRefFromCatalog`)
 - Archived state transitions are observed during normal sync passes, not
@@ -342,14 +346,20 @@ fallback repository listing.
   refresh also advances the bucket's next-sync cadence gate — including for
   buckets holding only archived repositories, which drop out of the pass
   before dispatch eligibility is computed — so the refresh honors the
-  bucket's throttle factor instead of rerunning every base interval. In the
-  other direction, a
-  live repository whose in-pass identity resolution reports archived stops
-  before any clone, overview, label, or item syncing — the publication has
-  already flipped the tracked flag, and the pass must not sync an archived
-  repository's content on the way out.
+  bucket's throttle factor instead of rerunning every base interval. The
+  refresh registers provider work like a live repo sync, so an admitted
+  archive request on the same credential is preempted rather than
+  overlapping it. In the other direction, a live repository whose in-pass
+  identity resolution reports archived stops before any clone, overview,
+  label, or item syncing — the publication has already flipped the tracked
+  flag, and the pass must not sync an archived repository's content on the
+  way out. Identity resolution returns the ref the publication actually
+  stored, not its own snapshot: when the publication kept a newer tracked
+  archived flip over the operation's metadata, the caller deciding whether
+  to keep syncing must see the published value.
   (`internal/github/sync.go::reconcileArchivedRepos`,
-  `internal/github/sync.go::syncRepo`)
+  `internal/github/sync.go::syncRepo`,
+  `internal/github/sync.go::reconcileRepoIdentity`)
 - Archive seeding degrades per repository: a ref that fails validation,
   provider resolution, or catalog reconciliation is logged with its identity
   and skipped, never fatal — one bad configured entry must not crash-loop the

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -272,6 +272,15 @@ fallback repository listing.
   Provider-resolved refs replace fallback-derived duplicates; fallback refs
   never overwrite resolved ones. (`internal/github/repo_config_resolver.go::ExpandedRepoSet`,
   `internal/server/settings_handlers.go::trackedRepoIndex`)
+- Every config-resolved ref records the config-entry path it came from
+  (`RepoRef.ConfiguredRepoPath`), and catalog republication preserves it. When
+  an exact entry cannot resolve, the fallback matches previously tracked refs
+  by that provenance before the route path: a provider-side rename moves the
+  tracked route away from the configured path, and without the provenance
+  match the fallback would synthesize an identity-less live ref — dropping the
+  archived flag and duplicating the repository next to a resolved overlapping
+  entry. (`internal/github/repo_config_resolver.go::FallbackConfiguredRepoRefs`,
+  `internal/github/sync.go::repoRefFromCatalog`)
 - Catalog republication without fresh provider metadata preserves the
   currently tracked archived flag: a sync that began before a newer archived
   flip must not clear it when its own snapshot predates the flip.
@@ -300,6 +309,13 @@ fallback repository listing.
   While an unresolvable ref persists in config, genuinely removed repos keep
   collecting; the recurring deferral warning is the operator signal.
   (`internal/archive/service.go::EnsureConfigured`)
+- The archive worker poll resolves configured repositories tolerantly: a ref
+  that seeding skipped stays in the syncer's tracked set, so an all-or-nothing
+  resolve would fail every one-second pass and starve archive work for all
+  healthy repositories. Repository-scoped resolution failures are dropped
+  (debug-logged; seeding already warned), and only context cancellation
+  aborts the pass. (`internal/archive/scheduler.go::RunEligible`,
+  `internal/archive/service.go::resolveRepositoriesTolerant`)
 - Initial issue and pull-request inventory includes all states in stable created-time ascending order; issue enumeration excludes PR-shaped rows. (`internal/github/pages.go::ListIssuesPage`, `internal/github/pages.go::ListMergeRequestsPage`)
 - Every issue-only GitHub lookup rejects a PR-shaped Issues API response before normalization; `SyncItemByNumber` is the kind-dispatching exception. (`internal/github/pages.go::gitHubClientProvider.issuePullRequestOutcomeError`, `internal/github/sync.go::SyncItemByNumber`)
 - Updated issue scans query one second before the durable watermark while keeping cursor identity bound to the original boundary. Updated pull-request scans run newest-first across the same overlap. (`internal/github/pages.go::ListIssuesPage`, `internal/github/pages.go::ListMergeRequestsPage`)

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -356,10 +356,18 @@ fallback repository listing.
   way out. Identity resolution returns the ref the publication actually
   stored, not its own snapshot: when the publication kept a newer tracked
   archived flip over the operation's metadata, the caller deciding whether
-  to keep syncing must see the published value.
+  to keep syncing must see the published value. Follow-on detail work
+  honors the flip too: the detail drain skips queue items whose tracked or
+  freshly resolved ref is archived — the queue was built before the pass
+  observed the transition — and per-item MR/issue syncing stops on an
+  archived resolve except under the archive sync budget, which is exactly
+  the hydration path archived repositories rely on.
   (`internal/github/sync.go::reconcileArchivedRepos`,
   `internal/github/sync.go::syncRepo`,
-  `internal/github/sync.go::reconcileRepoIdentity`)
+  `internal/github/sync.go::reconcileRepoIdentity`,
+  `internal/github/sync.go::drainDetailQueue`,
+  `internal/github/sync.go::syncMRForRepo`,
+  `internal/github/sync.go::syncIssueForRepo`)
 - Archive seeding degrades per repository: a ref that fails validation,
   provider resolution, or catalog reconciliation is logged with its identity
   and skipped, never fatal — one bad configured entry must not crash-loop the

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -285,7 +285,10 @@ fallback repository listing.
   identity-less live ref — dropping the archived flag and duplicating the
   repository next to a resolved overlapping entry. Settings merges preserve
   tracked provenance the same way (settings-resolved refs never author it),
-  and startup — which has no tracked set — recovers a failed exact entry's
+  but route-keyed recovery refuses to cross conflicting stable provider ids:
+  a route reused by a different repository must not inherit the displaced
+  repository's provenance, or two refs would claim the same config entry.
+  Startup — which has no tracked set — recovers a failed exact entry's
   stable identity through catalog route history before synthesizing.
   (`internal/github/repo_config_resolver.go::FallbackConfiguredRepoRefs`,
   `internal/github/repo_config_resolver.go::ExpandedRepoSet`,

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -257,7 +257,15 @@ fallback repository listing.
 - The legacy closed-item backfill is retired; configured repositories seed durable archive discovery before sync cutover, with no cursor translation. (`internal/github/sync.go::SetReposWithContext`)
 - Provider-archived repositories are configurable and archive-only: resolution
   accepts them (exact and glob) with `RepoRef.Archived` set, live sync skips
-  them, and archive discovery/hydration treat them like any configured repo.
+  them — the bulk sync pass, notification polling, and watched-MR fast sync
+  alike — and archive discovery/hydration treat them like any configured repo.
+  Settings add/refresh merges apply freshly resolved metadata to
+  already-tracked refs, so an archived flip (either direction) takes effect
+  without a daemon restart even when exact and glob entries overlap.
+  (`internal/github/notifications_sync.go::SyncNotifications`,
+  `internal/github/sync.go::watchedMRsForFastSync`,
+  `internal/server/settings_handlers.go::mergeTrackedRepos`,
+  `internal/server/settings_handlers.go::replaceGlobRepos`)
   Archived state refreshes wherever resolution already happens (startup,
   config reload, settings add/refresh) and must survive catalog
   republication, which cannot read it from the store. GitLab namespace

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -338,7 +338,12 @@ fallback repository listing.
   same credential-bucket eligibility that gates dispatch — a throttled,
   reserve-exhausted, or next-sync-deferred bucket defers its archived
   refreshes without a provider call, so they cannot spend essential sync
-  budget a live repository's dispatch would be denied. In the other direction, a
+  budget a live repository's dispatch would be denied. An attempted archived
+  refresh also advances the bucket's next-sync cadence gate — including for
+  buckets holding only archived repositories, which drop out of the pass
+  before dispatch eligibility is computed — so the refresh honors the
+  bucket's throttle factor instead of rerunning every base interval. In the
+  other direction, a
   live repository whose in-pass identity resolution reports archived stops
   before any clone, overview, label, or item syncing — the publication has
   already flipped the tracked flag, and the pass must not sync an archived

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -266,6 +266,16 @@ fallback repository listing.
   `internal/github/sync.go::watchedMRsForFastSync`,
   `internal/server/settings_handlers.go::mergeTrackedRepos`,
   `internal/server/settings_handlers.go::replaceGlobRepos`)
+- Tracked-set deduplication reconciles by stable provider id when one is
+  present, falling back to the route key: a renamed route must collapse onto
+  the same tracked entry, never sync or archive-seed the repository twice.
+  Provider-resolved refs replace fallback-derived duplicates; fallback refs
+  never overwrite resolved ones. (`internal/github/repo_config_resolver.go::ExpandedRepoSet`,
+  `internal/server/settings_handlers.go::trackedRepoIndex`)
+- Catalog republication without fresh provider metadata preserves the
+  currently tracked archived flag: a sync that began before a newer archived
+  flip must not clear it when its own snapshot predates the flip.
+  (`internal/github/sync.go::publishResolvedRepository`)
   Archived state refreshes wherever resolution already happens (startup,
   config reload, settings add/refresh) and must survive catalog
   republication, which cannot read it from the store. GitLab namespace

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -272,15 +272,22 @@ fallback repository listing.
   Provider-resolved refs replace fallback-derived duplicates; fallback refs
   never overwrite resolved ones. (`internal/github/repo_config_resolver.go::ExpandedRepoSet`,
   `internal/server/settings_handlers.go::trackedRepoIndex`)
-- Every config-resolved ref records the config-entry path it came from
-  (`RepoRef.ConfiguredRepoPath`), and catalog republication preserves it. When
-  an exact entry cannot resolve, the fallback matches previously tracked refs
-  by that provenance before the route path: a provider-side rename moves the
-  tracked route away from the configured path, and without the provenance
-  match the fallback would synthesize an identity-less live ref — dropping the
-  archived flag and duplicating the repository next to a resolved overlapping
-  entry. (`internal/github/repo_config_resolver.go::FallbackConfiguredRepoRefs`,
-  `internal/github/sync.go::repoRefFromCatalog`)
+- Exact-resolved refs record the config-entry path they came from
+  (`RepoRef.ConfiguredRepoPath`); glob refs carry none — a pattern identifies
+  no single entry, and stamping it would displace exact provenance on
+  deduplicated overlaps. Tracked-set deduplication merges provenance across
+  duplicates in both directions, catalog republication preserves it, and
+  publication never overwrites the currently tracked value: config resolution
+  is the only author. When an exact entry cannot resolve, the fallback matches
+  previously tracked refs by that provenance before the route path: a
+  provider-side rename moves the tracked route away from the configured path,
+  and without the provenance match the fallback would synthesize an
+  identity-less live ref — dropping the archived flag and duplicating the
+  repository next to a resolved overlapping entry.
+  (`internal/github/repo_config_resolver.go::FallbackConfiguredRepoRefs`,
+  `internal/github/repo_config_resolver.go::ExpandedRepoSet`,
+  `internal/github/sync.go::repoRefFromCatalog`,
+  `internal/github/sync.go::publishResolvedRepository`)
 - Catalog republication without fresh provider metadata preserves the
   currently tracked archived flag: a sync that began before a newer archived
   flip must not clear it when its own snapshot predates the flip.
@@ -312,9 +319,11 @@ fallback repository listing.
 - The archive worker poll resolves configured repositories tolerantly: a ref
   that seeding skipped stays in the syncer's tracked set, so an all-or-nothing
   resolve would fail every one-second pass and starve archive work for all
-  healthy repositories. Repository-scoped resolution failures are dropped
-  (debug-logged; seeding already warned), and only context cancellation
-  aborts the pass. (`internal/archive/scheduler.go::RunEligible`,
+  healthy repositories. Only provider-classified failures (invalid ref,
+  provider not configured, missing capability) are dropped as
+  repository-scoped (debug-logged; seeding already warned); a broken store or
+  any other infrastructure error still surfaces — an empty pass reported as
+  success would hide a dead worker. (`internal/archive/scheduler.go::RunEligible`,
   `internal/archive/service.go::resolveRepositoriesTolerant`)
 - Initial issue and pull-request inventory includes all states in stable created-time ascending order; issue enumeration excludes PR-shaped rows. (`internal/github/pages.go::ListIssuesPage`, `internal/github/pages.go::ListMergeRequestsPage`)
 - Every issue-only GitHub lookup rejects a PR-shaped Issues API response before normalization; `SyncItemByNumber` is the kind-dispatching exception. (`internal/github/pages.go::gitHubClientProvider.issuePullRequestOutcomeError`, `internal/github/sync.go::SyncItemByNumber`)

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -334,7 +334,11 @@ fallback repository listing.
   only at resolution sites: each pass reconciles archived tracked refs with
   metadata-only identity resolution, so an upstream unarchive returns the
   repository to live syncing without a restart or reload, while refs still
-  archived (or whose refresh fails) stay excluded. In the other direction, a
+  archived (or whose refresh fails) stay excluded. The refresh honors the
+  same credential-bucket eligibility that gates dispatch — a throttled,
+  reserve-exhausted, or next-sync-deferred bucket defers its archived
+  refreshes without a provider call, so they cannot spend essential sync
+  budget a live repository's dispatch would be denied. In the other direction, a
   live repository whose in-pass identity resolution reports archived stops
   before any clone, overview, label, or item syncing — the publication has
   already flipped the tracked flag, and the pass must not sync an archived

--- a/frontend/tests/e2e-full/settings-globs.spec.ts
+++ b/frontend/tests/e2e-full/settings-globs.spec.ts
@@ -46,34 +46,6 @@ test("settings shows glob match counts and refresh updates tracked repos", async
 
   const row = page.locator(".repo-row", { hasText: "roborev-dev/*" });
   await expect(row).toContainText("roborev-dev/*");
-  await expect(row).toContainText("(2)");
-  await expect
-    .poll(async () => {
-      if (!api) {
-        throw new Error("settings-globs API context not initialized");
-      }
-      const response = await api.get("/api/v1/repos");
-      const repos = (await response.json()) as RepoSummary[];
-      return repos
-        .filter((repo) => repo.Owner === "roborev-dev")
-        .map((repo) => repo.Name)
-        .sort()
-        .join(",");
-    })
-    .toBe("kenn-forge,worker");
-
-  await page.goto(`${isolatedServer!.info.base_url}/pulls`);
-  const selector = page.getByRole("button", { name: /^Select repository:/ });
-  await expect(selector).toBeVisible();
-  await selector.click();
-  await expect(page.getByRole("option", { name: /roborev-dev\/kenn-forge/ })).toBeVisible();
-  await expect(page.getByRole("option", { name: /roborev-dev\/worker/ })).toBeVisible();
-  await page.keyboard.press("Escape");
-
-  await page.goto(`${isolatedServer!.info.base_url}/settings`);
-  await page.locator(".settings-page").waitFor({ state: "visible", timeout: 10_000 });
-  await row.getByRole("button", { name: "Refresh" }).click();
-
   await expect(row).toContainText("(3)");
   await expect
     .poll(async () => {
@@ -88,7 +60,35 @@ test("settings shows glob match counts and refresh updates tracked repos", async
         .sort()
         .join(",");
     })
-    .toBe("kenn-forge,review-bot,worker");
+    .toBe("archived,kenn-forge,worker");
+
+  await page.goto(`${isolatedServer!.info.base_url}/pulls`);
+  const selector = page.getByRole("button", { name: /^Select repository:/ });
+  await expect(selector).toBeVisible();
+  await selector.click();
+  await expect(page.getByRole("option", { name: /roborev-dev\/kenn-forge/ })).toBeVisible();
+  await expect(page.getByRole("option", { name: /roborev-dev\/worker/ })).toBeVisible();
+  await page.keyboard.press("Escape");
+
+  await page.goto(`${isolatedServer!.info.base_url}/settings`);
+  await page.locator(".settings-page").waitFor({ state: "visible", timeout: 10_000 });
+  await row.getByRole("button", { name: "Refresh" }).click();
+
+  await expect(row).toContainText("(4)");
+  await expect
+    .poll(async () => {
+      if (!api) {
+        throw new Error("settings-globs API context not initialized");
+      }
+      const response = await api.get("/api/v1/repos");
+      const repos = (await response.json()) as RepoSummary[];
+      return repos
+        .filter((repo) => repo.Owner === "roborev-dev")
+        .map((repo) => repo.Name)
+        .sort()
+        .join(",");
+    })
+    .toBe("archived,kenn-forge,review-bot,worker");
 
   await page.screenshot({
     path: "test-results/settings-globs-pr.png",

--- a/internal/archive/maintenance_test.go
+++ b/internal/archive/maintenance_test.go
@@ -201,7 +201,7 @@ func archiveMaintenanceService(
 	registry, err := platform.NewRegistry(provider)
 	require.NoError(t, err)
 	service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, nil, now)
-	require.NoError(t, service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
 	require.NoError(t, err)
 	return service

--- a/internal/archive/report_service_test.go
+++ b/internal/archive/report_service_test.go
@@ -24,7 +24,7 @@ func TestArchiveServiceReportBuildsOfflineCountsCoverageAndDetails(t *testing.T)
 	registry, err := platform.NewRegistry(provider)
 	require.NoError(err)
 	service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, nil, now)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
 	require.NoError(err)
 	completeArchiveInitial(t, service)
@@ -79,7 +79,7 @@ func TestArchiveServiceReportFiltersFullRepositoryIdentityAndRejectsEmptyScope(t
 	registry, err := platform.NewRegistry(firstProvider, secondProvider)
 	require.NoError(err)
 	service := newArchiveTestService(t, database, registry, []platform.RepoRef{first, second}, nil, now)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{first, second}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{first, second})
 
 	all, err := service.Report(t.Context(), ReportOptions{
 		Start: now.Add(-time.Hour), End: now.Add(time.Hour),
@@ -114,7 +114,7 @@ func TestArchiveServiceReportUsesRangeEndAsDeterministicStatusTime(t *testing.T)
 	registry, err := platform.NewRegistry(provider)
 	require.NoError(err)
 	before := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, nil, end.Add(-time.Minute))
-	require.NoError(before.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, before, []platform.RepoRef{ref})
 	retryAt := end.Add(30 * time.Minute)
 	require.NoError(database.RecordArchiveRepositoryFailure(
 		t.Context(), repoID, db.ArchiveErrorCodeBudgetExhausted, "waiting", &retryAt, end,
@@ -141,7 +141,7 @@ func TestArchiveServiceReportRejectsPartiallyMissingExplicitScope(t *testing.T) 
 	registry, err := platform.NewRegistry(provider)
 	require.NoError(err)
 	service := newArchiveTestService(t, database, registry, []platform.RepoRef{first, second}, nil, now)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{first}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{first})
 
 	_, err = service.Report(t.Context(), ReportOptions{
 		Start: now.Add(-time.Hour), End: now, Repositories: []platform.RepoRef{first, second},
@@ -162,7 +162,7 @@ func TestArchiveServiceReportUsesOneSQLiteSnapshot(t *testing.T) {
 	registry, err := platform.NewRegistry(provider)
 	require.NoError(err)
 	service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, nil, now)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 
 	coverageRead := make(chan struct{})
 	writerDone := make(chan struct{})
@@ -216,7 +216,7 @@ func TestArchiveServiceDetailedReportLimitDoesNotLimitSummary(t *testing.T) {
 	registry, err := platform.NewRegistry(provider)
 	require.NoError(err)
 	service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, nil, now)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 	_, err = database.WriteDB().ExecContext(t.Context(), `
 		WITH RECURSIVE sequence(n) AS (
 			VALUES(1) UNION ALL SELECT n + 1 FROM sequence WHERE n < 10001

--- a/internal/archive/scheduler.go
+++ b/internal/archive/scheduler.go
@@ -76,7 +76,9 @@ func (s *Service) RunEligible(ctx context.Context) error {
 	}
 	// Configuration reconciliation runs at startup and on configuration reload.
 	// The one-second worker poll must remain read-only when no work is eligible.
-	resolved, err := s.resolveRepositories(ctx, refs, true)
+	// Resolution failures are repository-scoped: a configured entry that seeding
+	// skipped must not block archive work for every healthy repository.
+	resolved, err := s.resolveRepositoriesTolerant(ctx, refs, true)
 	if err != nil {
 		return err
 	}

--- a/internal/archive/scheduler_test.go
+++ b/internal/archive/scheduler_test.go
@@ -88,6 +88,35 @@ func TestArchiveWorkPrioritiesPreserveForegroundOrdering(t *testing.T) {
 	assert.Less(PriorityFullArchive, PriorityDiscoveryInventory)
 }
 
+func TestRunEligibleSkipsUnresolvableConfiguredRef(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	now := archiveTestTime()
+	healthy := archiveServiceRef(platform.KindGitHub, "github.test", "healthy")
+	ghost := platform.RepoRef{
+		Platform: platform.KindGitHub, Host: "github.test",
+		Owner: "owner", Name: "ghost", RepoPath: "owner/ghost",
+	}
+	healthyID := archiveServiceSeedRepo(t, database, healthy)
+	provider := newArchiveServiceProvider(healthy.Platform, healthy.Host)
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	service := newArchiveTestService(
+		t, database, registry, []platform.RepoRef{healthy, ghost}, &archiveTestAdmission{}, now,
+	)
+	requireEnsureConfigured(t, service, []platform.RepoRef{healthy})
+	_, err = service.Start(t.Context(), []platform.RepoRef{healthy})
+	require.NoError(err)
+
+	require.NoError(service.RunEligible(t.Context()))
+
+	states, err := database.ListArchiveRepoStates(t.Context(), []int64{healthyID})
+	require.NoError(err)
+	require.Len(states, 1)
+	assert.True(states[0].IssueInventory.Complete())
+}
+
 func TestArchiveBootstrapFeatureDeferralSkipsToNextRepository(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/archive/scheduler_test.go
+++ b/internal/archive/scheduler_test.go
@@ -109,7 +109,7 @@ func TestArchiveBootstrapFeatureDeferralSkipsToNextRepository(t *testing.T) {
 	service := newArchiveTestService(
 		t, database, registry, []platform.RepoRef{cooled, ready}, admission, now,
 	)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{cooled, ready}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{cooled, ready})
 	_, err = service.Start(t.Context(), []platform.RepoRef{cooled, ready})
 	require.NoError(err)
 
@@ -146,7 +146,7 @@ func TestArchiveMaintenanceFeatureDeferralSkipsToNextRepository(t *testing.T) {
 	service := newArchiveTestService(
 		t, database, registry, []platform.RepoRef{cooled, ready}, admission, now,
 	)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{cooled, ready}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{cooled, ready})
 	_, err = service.Start(t.Context(), []platform.RepoRef{cooled, ready})
 	require.NoError(err)
 

--- a/internal/archive/scheduler_test.go
+++ b/internal/archive/scheduler_test.go
@@ -117,6 +117,27 @@ func TestRunEligibleSkipsUnresolvableConfiguredRef(t *testing.T) {
 	assert.True(states[0].IssueInventory.Complete())
 }
 
+func TestRunEligiblePropagatesStoreFailure(t *testing.T) {
+	require := require.New(t)
+	database := dbtest.Open(t)
+	now := archiveTestTime()
+	healthy := archiveServiceRef(platform.KindGitHub, "github.test", "healthy")
+	archiveServiceSeedRepo(t, database, healthy)
+	provider := newArchiveServiceProvider(healthy.Platform, healthy.Host)
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	service := newArchiveTestService(
+		t, database, registry, []platform.RepoRef{healthy}, &archiveTestAdmission{}, now,
+	)
+	requireEnsureConfigured(t, service, []platform.RepoRef{healthy})
+
+	// A broken store is an infrastructure failure, not a repository-scoped
+	// one: the worker pass must surface it instead of reporting an idle,
+	// successful iteration.
+	require.NoError(database.Close())
+	require.Error(service.RunEligible(t.Context()))
+}
+
 func TestArchiveBootstrapFeatureDeferralSkipsToNextRepository(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/archive/service.go
+++ b/internal/archive/service.go
@@ -449,6 +449,14 @@ func (s *Service) resolveRepositoriesTolerant(ctx context.Context, refs []platfo
 			if ctx.Err() != nil {
 				return nil, ctx.Err()
 			}
+			// Only provider-classified failures (invalid ref, provider not
+			// configured, missing capability) are repository-scoped. Anything
+			// else — a broken store above all — is infrastructure and must
+			// surface instead of emptying the pass into a silent success.
+			var platformErr *platform.Error
+			if !errors.As(err, &platformErr) {
+				return nil, err
+			}
 			slog.Debug("skip unresolvable archive repository",
 				"platform", ref.Platform, "host", ref.Host,
 				"owner", ref.Owner, "name", ref.Name, "error", err)

--- a/internal/archive/service.go
+++ b/internal/archive/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strings"
 	"time"
@@ -116,70 +117,128 @@ func (s *Service) SetMaintenanceInterval(interval time.Duration) {
 
 func (s *Service) SetWake(wake func()) { s.wake = wake }
 
-func (s *Service) EnsureConfigured(ctx context.Context, refs []platform.RepoRef) error {
+// EnsureConfigured seeds archive state for the configured repositories and
+// returns the refs that seeded successfully. Failures scoped to a single
+// repository are logged and skipped so one bad configured entry cannot block
+// the rest (or crash-loop the daemon at startup); only batch reconciliation
+// errors (a broken store) are returned.
+func (s *Service) EnsureConfigured(ctx context.Context, refs []platform.RepoRef) ([]platform.RepoRef, error) {
+	seededRefs := make([]platform.RepoRef, 0, len(refs))
+	resolved := make([]resolvedRepository, 0, len(refs))
+	protectedIDs := make([]int64, 0, len(refs))
+	seen := make(map[string]struct{}, len(refs))
+	unresolvable := make([]string, 0)
 	for _, ref := range refs {
-		if err := validateArchiveRepoRef(ref); err != nil {
-			return err
+		key := archiveRepoIdentityKey(ref)
+		if _, ok := seen[key]; ok {
+			continue
 		}
-		if _, err := s.registry.Provider(ref.Platform, ref.Host); err != nil {
-			return err
-		}
-	}
-	for _, ref := range refs {
-		identity := platform.DBRepoIdentity(ref)
-		// Captured before any provider lookup so a slow resolve cannot
-		// stamp its route data newer than intervening sync observations.
-		observedAt := time.Now().UTC()
-		// Config-asserted and provider-verified identities may move
-		// routes; a catalog-cached identity resolves read-only.
-		authoritative := identity.PlatformRepoID != ""
-		if identity.PlatformRepoID == "" {
-			stored, err := s.db.ResolveActiveRepositoryRoute(ctx, identity)
-			if err != nil {
-				return fmt.Errorf("resolve stored archive repository %s: %w", archiveRepoIdentityKey(ref), err)
-			}
-			if stored != nil && stored.Repository.PlatformRepoID != "" {
-				identity.PlatformRepoID = stored.Repository.PlatformRepoID
-			} else {
-				reader, err := s.registry.RepositoryReader(ref.Platform, ref.Host)
-				if err != nil {
-					return fmt.Errorf("resolve archive repository %s: %w", archiveRepoIdentityKey(ref), err)
-				}
-				resolved, err := reader.GetRepository(ctx, ref)
-				if err != nil {
-					return fmt.Errorf("resolve archive repository %s: %w", archiveRepoIdentityKey(ref), err)
-				}
-				identity = platform.DBRepositoryIdentity(resolved)
-				if identity.PlatformRepoID == "" {
-					return fmt.Errorf("resolve archive repository %s: provider returned no repository id", archiveRepoIdentityKey(ref))
-				}
-				authoritative = true
+		seen[key] = struct{}{}
+		repoID, err := s.seedArchiveRepository(ctx, ref)
+		if err == nil {
+			var repo *resolvedRepository
+			repo, err = s.resolveRepository(ctx, ref, false)
+			if err == nil {
+				seededRefs = append(seededRefs, ref)
+				resolved = append(resolved, *repo)
+				protectedIDs = append(protectedIDs, repo.ID)
+				continue
 			}
 		}
-		if authoritative {
-			if _, _, err := s.db.ReconcileRepositoryObservation(ctx, identity, observedAt); err != nil {
-				return fmt.Errorf("seed archive repository %s: %w", archiveRepoIdentityKey(ref), err)
-			}
-		} else if _, err := s.db.UpsertRepoByProviderID(ctx, identity); err != nil {
-			return fmt.Errorf("seed archive repository %s: %w", archiveRepoIdentityKey(ref), err)
+		slog.Warn("skip archive seeding",
+			"platform", ref.Platform, "host", ref.Host,
+			"owner", ref.Owner, "name", ref.Name, "err", err)
+		if repoID != 0 {
+			// The row is known, so it stays protected from removal pausing
+			// even though this pass could not finish seeding it.
+			protectedIDs = append(protectedIDs, repoID)
+		} else {
+			unresolvable = append(unresolvable, ref.Owner+"/"+ref.Name)
 		}
 	}
-	resolved, err := s.resolveRepositories(ctx, refs, false)
-	if err != nil {
-		return err
-	}
+	sort.Slice(resolved, func(i, j int) bool {
+		return archiveRepoIdentityKey(resolved[i].Ref) < archiveRepoIdentityKey(resolved[j].Ref)
+	})
 	ids := resolvedRepoIDs(resolved)
-	if err := s.db.ReconcileDiscoveryArchives(ctx, ids, s.now()); err != nil {
-		return err
+	if len(unresolvable) > 0 {
+		// An unresolvable ref could correspond to any existing row, so
+		// pausing with an incomplete protection list could pause the wrong
+		// repository's archive. Defer removal pausing until a clean pass.
+		slog.Warn("archive removal reconciliation deferred",
+			"unresolvable_repos", unresolvable)
+		if err := s.db.EnsureDiscoveryArchives(ctx, ids, s.now()); err != nil {
+			return seededRefs, err
+		}
+	} else if err := s.db.ReconcileDiscoveryArchives(ctx, protectedIDs, s.now()); err != nil {
+		return seededRefs, err
 	}
 	for _, repo := range resolved {
 		if err := s.db.ReconcileArchiveCoverage(
 			ctx, repo.ID, archiveCoverage(repo.Capabilities), s.now(),
 		); err != nil {
-			return err
+			return seededRefs, err
 		}
 	}
-	return s.db.RequeueArchiveLifecycleDetails(ctx, ids, s.now())
+	return seededRefs, s.db.RequeueArchiveLifecycleDetails(ctx, ids, s.now())
+}
+
+// seedArchiveRepository reconciles one configured ref into the repository
+// catalog. It returns the repository row id when one is known — including on
+// failure, so callers can keep a known row protected from removal pausing.
+func (s *Service) seedArchiveRepository(ctx context.Context, ref platform.RepoRef) (int64, error) {
+	if err := validateArchiveRepoRef(ref); err != nil {
+		return 0, err
+	}
+	if _, err := s.registry.Provider(ref.Platform, ref.Host); err != nil {
+		return 0, err
+	}
+	identity := platform.DBRepoIdentity(ref)
+	// Captured before any provider lookup so a slow resolve cannot
+	// stamp its route data newer than intervening sync observations.
+	observedAt := time.Now().UTC()
+	// Config-asserted and provider-verified identities may move
+	// routes; a catalog-cached identity resolves read-only.
+	authoritative := identity.PlatformRepoID != ""
+	storedID := int64(0)
+	if identity.PlatformRepoID == "" {
+		stored, err := s.db.ResolveActiveRepositoryRoute(ctx, identity)
+		if err != nil {
+			return 0, fmt.Errorf("resolve stored archive repository %s: %w", archiveRepoIdentityKey(ref), err)
+		}
+		if stored != nil && stored.Repository.PlatformRepoID != "" {
+			identity.PlatformRepoID = stored.Repository.PlatformRepoID
+			storedID = stored.Repository.ID
+		} else {
+			reader, err := s.registry.RepositoryReader(ref.Platform, ref.Host)
+			if err != nil {
+				return 0, fmt.Errorf("resolve archive repository %s: %w", archiveRepoIdentityKey(ref), err)
+			}
+			resolved, err := reader.GetRepository(ctx, ref)
+			if err != nil {
+				return 0, fmt.Errorf("resolve archive repository %s: %w", archiveRepoIdentityKey(ref), err)
+			}
+			identity = platform.DBRepositoryIdentity(resolved)
+			if identity.PlatformRepoID == "" {
+				return 0, fmt.Errorf("resolve archive repository %s: provider returned no repository id", archiveRepoIdentityKey(ref))
+			}
+			authoritative = true
+		}
+	}
+	if authoritative {
+		entry, _, err := s.db.ReconcileRepositoryObservation(ctx, identity, observedAt)
+		if err != nil {
+			return storedID, fmt.Errorf("seed archive repository %s: %w", archiveRepoIdentityKey(ref), err)
+		}
+		if entry != nil {
+			return entry.Repository.ID, nil
+		}
+		return storedID, nil
+	}
+	id, err := s.db.UpsertRepoByProviderID(ctx, identity)
+	if err != nil {
+		return storedID, fmt.Errorf("seed archive repository %s: %w", archiveRepoIdentityKey(ref), err)
+	}
+	return id, nil
 }
 
 // RetryAuthentication makes credential-blocked repositories eligible after a
@@ -354,46 +413,54 @@ func (s *Service) resolveRepositories(ctx context.Context, refs []platform.RepoR
 	resolved := make([]resolvedRepository, 0, len(refs))
 	seen := make(map[string]struct{}, len(refs))
 	for _, ref := range refs {
-		if err := validateArchiveRepoRef(ref); err != nil {
-			return nil, err
-		}
 		key := archiveRepoIdentityKey(ref)
 		if _, ok := seen[key]; ok {
 			continue
 		}
 		seen[key] = struct{}{}
-		provider, err := s.registry.Provider(ref.Platform, ref.Host)
+		repo, err := s.resolveRepository(ctx, ref, requireArchive)
 		if err != nil {
 			return nil, err
 		}
-		issues, err := s.registry.IssuePageReader(ref.Platform, ref.Host)
-		if err != nil && requireArchive {
-			return nil, err
-		}
-		mergeRequests, err := s.registry.MergeRequestPageReader(ref.Platform, ref.Host)
-		if err != nil && requireArchive {
-			return nil, err
-		}
-		repo, err := s.db.GetRepoByIdentity(ctx, platform.DBRepoIdentity(ref))
-		if err != nil {
-			return nil, fmt.Errorf("resolve archive repository %s: %w", key, err)
-		}
-		if repo == nil {
-			return nil, &platform.Error{
-				Code: platform.ErrCodeInvalidRepoRef, Provider: ref.Platform,
-				PlatformHost: ref.Host, Field: "repository",
-				Err: errors.New("repository is not configured"),
-			}
-		}
-		resolved = append(resolved, resolvedRepository{
-			ID: repo.ID, Ref: ref, Issues: issues, MergeRequests: mergeRequests,
-			Capabilities: provider.Capabilities().Archive,
-		})
+		resolved = append(resolved, *repo)
 	}
 	sort.Slice(resolved, func(i, j int) bool {
 		return archiveRepoIdentityKey(resolved[i].Ref) < archiveRepoIdentityKey(resolved[j].Ref)
 	})
 	return resolved, nil
+}
+
+func (s *Service) resolveRepository(ctx context.Context, ref platform.RepoRef, requireArchive bool) (*resolvedRepository, error) {
+	if err := validateArchiveRepoRef(ref); err != nil {
+		return nil, err
+	}
+	provider, err := s.registry.Provider(ref.Platform, ref.Host)
+	if err != nil {
+		return nil, err
+	}
+	issues, err := s.registry.IssuePageReader(ref.Platform, ref.Host)
+	if err != nil && requireArchive {
+		return nil, err
+	}
+	mergeRequests, err := s.registry.MergeRequestPageReader(ref.Platform, ref.Host)
+	if err != nil && requireArchive {
+		return nil, err
+	}
+	repo, err := s.db.GetRepoByIdentity(ctx, platform.DBRepoIdentity(ref))
+	if err != nil {
+		return nil, fmt.Errorf("resolve archive repository %s: %w", archiveRepoIdentityKey(ref), err)
+	}
+	if repo == nil {
+		return nil, &platform.Error{
+			Code: platform.ErrCodeInvalidRepoRef, Provider: ref.Platform,
+			PlatformHost: ref.Host, Field: "repository",
+			Err: fmt.Errorf("repository %s/%s is not configured", ref.Owner, ref.Name),
+		}
+	}
+	return &resolvedRepository{
+		ID: repo.ID, Ref: ref, Issues: issues, MergeRequests: mergeRequests,
+		Capabilities: provider.Capabilities().Archive,
+	}, nil
 }
 
 func validateArchiveRepoRef(ref platform.RepoRef) error {

--- a/internal/archive/service.go
+++ b/internal/archive/service.go
@@ -430,6 +430,38 @@ func (s *Service) resolveRepositories(ctx context.Context, refs []platform.RepoR
 	return resolved, nil
 }
 
+// resolveRepositoriesTolerant resolves each reference independently and drops
+// the ones that fail, so a configured entry whose seeding was skipped cannot
+// starve archive work for every healthy repository. Failures are logged at
+// debug level: the worker polls every second and EnsureConfigured already
+// warns once per reconciliation for the same repositories.
+func (s *Service) resolveRepositoriesTolerant(ctx context.Context, refs []platform.RepoRef, requireArchive bool) ([]resolvedRepository, error) {
+	resolved := make([]resolvedRepository, 0, len(refs))
+	seen := make(map[string]struct{}, len(refs))
+	for _, ref := range refs {
+		key := archiveRepoIdentityKey(ref)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		repo, err := s.resolveRepository(ctx, ref, requireArchive)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			slog.Debug("skip unresolvable archive repository",
+				"platform", ref.Platform, "host", ref.Host,
+				"owner", ref.Owner, "name", ref.Name, "error", err)
+			continue
+		}
+		resolved = append(resolved, *repo)
+	}
+	sort.Slice(resolved, func(i, j int) bool {
+		return archiveRepoIdentityKey(resolved[i].Ref) < archiveRepoIdentityKey(resolved[j].Ref)
+	})
+	return resolved, nil
+}
+
 func (s *Service) resolveRepository(ctx context.Context, ref platform.RepoRef, requireArchive bool) (*resolvedRepository, error) {
 	if err := validateArchiveRepoRef(ref); err != nil {
 		return nil, err

--- a/internal/archive/service_test.go
+++ b/internal/archive/service_test.go
@@ -88,13 +88,89 @@ func TestArchiveServiceStartValidatesAllRepositoriesBeforePromotion(t *testing.T
 	registry, err := platform.NewRegistry(provider)
 	require.NoError(err)
 	service := newArchiveTestService(t, database, registry, []platform.RepoRef{valid, missing}, nil, now)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{valid}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{valid})
 
 	_, err = service.Start(t.Context(), []platform.RepoRef{valid, missing})
 	require.Error(err)
 	states, err := database.ListArchiveRepoStates(t.Context(), []int64{validID})
 	require.NoError(err)
 	assert.Equal(db.ArchiveCollectionModeDiscovery, states[0].CollectionMode)
+}
+
+func TestArchiveServiceEnsureConfiguredSkipsUnresolvableRef(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	good := archiveServiceRef(platform.KindGitHub, "github.test", "good")
+	// No provider id, no stored route, and the provider fake has no
+	// repository reader: the seed path cannot identify this ref.
+	ghost := platform.RepoRef{
+		Platform: platform.KindGitHub, Host: "github.test",
+		Owner: "owner", Name: "ghost", RepoPath: "owner/ghost",
+	}
+	provider := newArchiveServiceProvider(good.Platform, good.Host)
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	service := newArchiveTestService(t, database, registry, []platform.RepoRef{good, ghost}, nil, now)
+
+	seeded, err := service.EnsureConfigured(t.Context(), []platform.RepoRef{good, ghost})
+	require.NoError(err, "an unresolvable ref must degrade, not fail the pass")
+	assert.Equal([]platform.RepoRef{good}, seeded)
+
+	repo, err := database.GetRepoByIdentity(t.Context(), platform.DBRepoIdentity(good))
+	require.NoError(err)
+	require.NotNil(repo)
+	states, err := database.ListArchiveRepoStates(t.Context(), []int64{repo.ID})
+	require.NoError(err)
+	require.Len(states, 1)
+	assert.Equal(db.ArchiveOperatorStateActive, states[0].OperatorState)
+
+	ghostRepo, err := database.GetRepoByIdentity(t.Context(), platform.DBRepoIdentity(ghost))
+	require.NoError(err)
+	assert.Nil(ghostRepo)
+}
+
+func TestArchiveServiceEnsureConfiguredDefersRemovalPausingWhenRefUnresolvable(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	removed := archiveServiceRef(platform.KindGitHub, "github.test", "removed")
+	good := archiveServiceRef(platform.KindGitHub, "github.test", "good")
+	ghost := platform.RepoRef{
+		Platform: platform.KindGitHub, Host: "github.test",
+		Owner: "owner", Name: "ghost", RepoPath: "owner/ghost",
+	}
+	provider := newArchiveServiceProvider(good.Platform, good.Host)
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	service := newArchiveTestService(t, database, registry, []platform.RepoRef{good}, nil, now)
+
+	requireEnsureConfigured(t, service, []platform.RepoRef{removed})
+	removedRepo, err := database.GetRepoByIdentity(t.Context(), platform.DBRepoIdentity(removed))
+	require.NoError(err)
+	require.NotNil(removedRepo)
+
+	// An unresolvable ref could correspond to any existing row, so removal
+	// pausing must be deferred rather than pause the wrong archive.
+	seeded, err := service.EnsureConfigured(t.Context(), []platform.RepoRef{good, ghost})
+	require.NoError(err)
+	assert.Equal([]platform.RepoRef{good}, seeded)
+	states, err := database.ListArchiveRepoStates(t.Context(), []int64{removedRepo.ID})
+	require.NoError(err)
+	require.Len(states, 1)
+	assert.Equal(db.ArchiveOperatorStateActive, states[0].OperatorState,
+		"removal pausing must be deferred while a ref is unresolvable")
+
+	// A clean pass applies the deferred removal.
+	requireEnsureConfigured(t, service, []platform.RepoRef{good})
+	states, err = database.ListArchiveRepoStates(t.Context(), []int64{removedRepo.ID})
+	require.NoError(err)
+	require.Len(states, 1)
+	assert.Equal(db.ArchiveOperatorStatePaused, states[0].OperatorState)
+	require.NotNil(states[0].LastErrorCode)
+	assert.Equal(string(db.ArchiveErrorCodeConfigurationRemoved), *states[0].LastErrorCode)
 }
 
 func TestArchiveServiceEnsureConfiguredSeedsFreshRepository(t *testing.T) {
@@ -108,7 +184,7 @@ func TestArchiveServiceEnsureConfiguredSeedsFreshRepository(t *testing.T) {
 	require.NoError(err)
 	service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, nil, now)
 
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 	repo, err := database.GetRepoByIdentity(t.Context(), platform.DBRepoIdentity(ref))
 	require.NoError(err)
 	require.NotNil(repo)
@@ -140,7 +216,7 @@ func TestArchiveServiceEnsureConfiguredPreservesRenamedRepositoryAtExistingDesti
 	require.NoError(err)
 	service := newArchiveTestService(t, database, registry, []platform.RepoRef{current}, nil, now)
 
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{current}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{current})
 	repos, err := database.ListRepositoryCatalog(
 		t.Context(), db.RepositoryCatalogFilter{},
 	)
@@ -189,7 +265,7 @@ func TestArchiveServiceAllScopeAndWakeLifecycle(t *testing.T) {
 	)
 	wakeCount := 0
 	service.SetWake(func() { wakeCount++ })
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{first, second}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{first, second})
 
 	started, err := service.StartAll(t.Context())
 	require.NoError(err)
@@ -224,7 +300,7 @@ func TestArchiveServicePauseRejectsInFlightInventoryCommit(t *testing.T) {
 	registry, err := platform.NewRegistry(provider)
 	require.NoError(err)
 	service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, nil, now)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
 	require.NoError(err)
 
@@ -261,7 +337,7 @@ func TestArchiveServiceRetryAuthenticationPreservesProgress(t *testing.T) {
 	registry, err := platform.NewRegistry(provider)
 	require.NoError(err)
 	service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, nil, now)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 	cursor := "issue-page-2"
 	watermark := now.Add(-time.Hour)
 	_, err = database.WriteDB().ExecContext(t.Context(), `
@@ -297,7 +373,7 @@ func TestArchiveAuthenticationFailureDefersPendingHydration(t *testing.T) {
 	registry, err := platform.NewRegistry(provider)
 	require.NoError(err)
 	service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, nil, now)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
 	require.NoError(err)
 	require.NoError(service.RunEligible(t.Context()))
@@ -329,7 +405,7 @@ func TestArchiveIdlePollDoesNotReconcileConfiguredRepositories(t *testing.T) {
 	registry, err := platform.NewRegistry(provider)
 	require.NoError(err)
 	service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, nil, now)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 	_, err = service.Pause(t.Context(), []platform.RepoRef{ref})
 	require.NoError(err)
 	_, err = database.WriteDB().ExecContext(t.Context(), `
@@ -357,7 +433,7 @@ func TestArchiveServiceRemovedRepositoryStopsWorkAndReaddResumesState(t *testing
 	source := &archiveMutableSource{refs: []platform.RepoRef{ref}}
 	service, err := NewService(database, registry, nil, source, nil, fixedClock{value: now})
 	require.NoError(err)
-	require.NoError(service.EnsureConfigured(t.Context(), source.refs))
+	requireEnsureConfigured(t, service, source.refs)
 	_, err = service.Start(t.Context(), source.refs)
 	require.NoError(err)
 	cursor := "durable-cursor"
@@ -368,7 +444,7 @@ func TestArchiveServiceRemovedRepositoryStopsWorkAndReaddResumesState(t *testing
 	require.NoError(err)
 
 	source.refs = nil
-	require.NoError(service.EnsureConfigured(t.Context(), source.refs))
+	requireEnsureConfigured(t, service, source.refs)
 	require.NoError(service.RunEligible(t.Context()))
 	assert.Empty(provider.calls)
 	states, err := database.ListArchiveRepoStates(t.Context(), []int64{repoID})
@@ -380,7 +456,7 @@ func TestArchiveServiceRemovedRepositoryStopsWorkAndReaddResumesState(t *testing
 	assert.Equal(&cursor, states[0].IssueInventory.NextCursor)
 
 	source.refs = []platform.RepoRef{ref}
-	require.NoError(service.EnsureConfigured(t.Context(), source.refs))
+	requireEnsureConfigured(t, service, source.refs)
 	states, err = database.ListArchiveRepoStates(t.Context(), []int64{repoID})
 	require.NoError(err)
 	assert.Equal(db.ArchiveCollectionModeFull, states[0].CollectionMode)
@@ -390,9 +466,9 @@ func TestArchiveServiceRemovedRepositoryStopsWorkAndReaddResumesState(t *testing
 
 	require.NoError(database.PauseArchives(t.Context(), []int64{repoID}, now.Add(time.Minute)))
 	source.refs = nil
-	require.NoError(service.EnsureConfigured(t.Context(), source.refs))
+	requireEnsureConfigured(t, service, source.refs)
 	source.refs = []platform.RepoRef{ref}
-	require.NoError(service.EnsureConfigured(t.Context(), source.refs))
+	requireEnsureConfigured(t, service, source.refs)
 	states, err = database.ListArchiveRepoStates(t.Context(), []int64{repoID})
 	require.NoError(err)
 	assert.Equal(db.ArchiveOperatorStatePaused, states[0].OperatorState)
@@ -414,7 +490,7 @@ func TestArchiveInventoryInvalidCursorBlocksScanWithoutRestart(t *testing.T) {
 	registry, err := platform.NewRegistry(provider)
 	require.NoError(err)
 	service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, nil, now)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
 	require.NoError(err)
 
@@ -453,7 +529,7 @@ func TestArchiveResumesDiscoveryAppliesMaintenanceAndReportsDeterministically(t 
 	registry, err := platform.NewRegistry(provider)
 	require.NoError(err)
 	service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, nil, now)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
 	require.NoError(err)
 	require.NoError(service.RunEligible(t.Context()))
@@ -530,7 +606,7 @@ func TestArchiveInventoryFailureIsDurableAndClearedBySuccessfulProgress(t *testi
 	require.NoError(err)
 	service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, nil, now)
 	service.retries = archiveTestRetryClassifier{}
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
 	require.NoError(err)
 
@@ -563,7 +639,7 @@ func TestArchiveStartAllowsPartialHistoricalInventory(t *testing.T) {
 	registry, err := platform.NewRegistry(provider)
 	require.NoError(err)
 	service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, nil, now)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 
 	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
 	require.NoError(err)
@@ -584,7 +660,7 @@ func TestArchiveDiscoverySkipsUnsupportedInventoryStream(t *testing.T) {
 	registry, err := platform.NewRegistry(provider)
 	require.NoError(err)
 	service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, nil, now)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 	require.NoError(service.RunEligible(t.Context()))
 	require.NoError(service.RunEligible(t.Context()))
 
@@ -617,7 +693,7 @@ func TestArchiveInventoryReopensRepositoryFeatureAfterReenable(t *testing.T) {
 	service := newArchiveTestService(
 		t, database, registry, []platform.RepoRef{ref}, admission, now,
 	)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 
 	require.NoError(service.RunEligible(t.Context()))
 	require.NoError(service.RunEligible(t.Context()))
@@ -633,7 +709,7 @@ func TestArchiveInventoryReopensRepositoryFeatureAfterReenable(t *testing.T) {
 	unsupportedGeneration := states[0].IssueInventory.Generation
 
 	provider.issueInventoryErr = nil
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 	states, err = database.ListArchiveRepoStates(t.Context(), []int64{repoID})
 	require.NoError(err)
 	require.Len(states, 1)
@@ -684,7 +760,7 @@ func TestArchiveBudgetDeferralDoesNotIncrementAttempts(t *testing.T) {
 	retryAt := now.Add(time.Hour)
 	admission := &archiveTestAdmission{deny: true, retryAt: retryAt}
 	service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, admission, now)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
 	require.NoError(err)
 
@@ -708,7 +784,7 @@ func TestArchiveInventoryAdmissionReservesProviderConfirmationAttempts(t *testin
 	require.NoError(err)
 	admission := &archiveTestAdmission{}
 	service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, admission, now)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
 	require.NoError(err)
 
@@ -728,7 +804,7 @@ func TestArchivePausePreventsFutureProviderReads(t *testing.T) {
 	registry, err := platform.NewRegistry(provider)
 	require.NoError(err)
 	service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, nil, now)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
 	require.NoError(err)
 	_, err = service.Pause(t.Context(), []platform.RepoRef{ref})
@@ -753,7 +829,7 @@ func TestArchiveHydrationRetryClassifierReceivesStoredAttemptCount(t *testing.T)
 		classifier, fixedClock{value: now},
 	)
 	require.NoError(err)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
 	require.NoError(err)
 
@@ -983,4 +1059,10 @@ func archiveTestIssue(ref platform.RepoRef) platform.Issue {
 func archiveTestMergeRequest(ref platform.RepoRef) platform.MergeRequest {
 	created := archiveTestTime().Add(time.Minute)
 	return platform.MergeRequest{Repo: ref, PlatformID: 2, PlatformExternalID: "mr-2", Number: 2, State: "closed", CreatedAt: created, UpdatedAt: created, LastActivityAt: created}
+}
+
+func requireEnsureConfigured(t *testing.T, s *Service, refs []platform.RepoRef) {
+	t.Helper()
+	_, err := s.EnsureConfigured(t.Context(), refs)
+	require.NoError(t, err)
 }

--- a/internal/github/archive_lifecycle_test.go
+++ b/internal/github/archive_lifecycle_test.go
@@ -979,6 +979,60 @@ func TestSyncReusedRouteResolvingSuccessorKeepsBothReposTracked(t *testing.T) {
 	assert.NotEqual(oldEntry.Repository.ID, newEntry.Repository.ID)
 }
 
+func TestSyncRouteReplacementIgnoresDisplacedArchivedFlipE2E(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	database := dbtest.Open(t)
+	// The tracked occupant of the configured route was archived after this
+	// sync pass snapshotted it, and the route meanwhile resolves to an
+	// untracked replacement repository. The displaced repo's archived flip
+	// must not stamp the replacement, which would silently exclude it from
+	// live sync.
+	displaced := RepoRef{
+		Platform: platform.KindGitLab, PlatformHost: "gitlab.test",
+		Owner: "group", Name: "project", RepoPath: "group/project",
+		PlatformExternalID: "gid://gitlab/Project/old", Archived: true,
+	}
+	provider := &syncTestRepositoryReadProvider{
+		syncTestReadProvider: &syncTestReadProvider{
+			syncTestProvider: syncTestProvider{
+				kind: platform.KindGitLab, host: "gitlab.test",
+			},
+		},
+		repository: platform.Repository{
+			Ref: platform.RepoRef{
+				Platform: platform.KindGitLab, Host: "gitlab.test",
+				Owner: "group", Name: "project", RepoPath: "group/project",
+			},
+			PlatformExternalID: "gid://gitlab/Project/new",
+			Archived:           false,
+		},
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	syncer := NewSyncerWithRegistry(
+		registry, database, nil, []RepoRef{displaced}, time.Hour, nil, nil,
+	)
+	service, err := archive.NewService(database, registry, nil, syncer, nil, nil)
+	require.NoError(err)
+	syncer.SetArchiveService(service)
+	_, err = service.EnsureConfigured(
+		ctx, []platform.RepoRef{platformRepoRef(displaced)},
+	)
+	require.NoError(err)
+
+	snapshot := displaced
+	snapshot.Archived = false
+	require.NoError(syncer.syncRepo(ctx, snapshot))
+
+	tracked := syncer.TrackedRepos()
+	require.Len(tracked, 1)
+	assert.Equal("gid://gitlab/Project/new", tracked[0].PlatformExternalID)
+	assert.False(tracked[0].Archived,
+		"the replacement keeps its authoritative unarchived state")
+}
+
 func TestArchiveAdmissionSharesSyncBudgetAndProviderReserve(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/github/archive_lifecycle_test.go
+++ b/internal/github/archive_lifecycle_test.go
@@ -906,6 +906,79 @@ func TestSyncRepoReplacementReconcilesArchiveLifecycle(t *testing.T) {
 	)
 }
 
+func TestSyncReusedRouteResolvingSuccessorKeepsBothReposTracked(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	database := dbtest.Open(t)
+	// The renamed repository moved to a new route; a different repository
+	// reused its old route. Both are tracked. A sync of the old route
+	// whose snapshot still carries the renamed repository's id resolves
+	// the successor — neither repository may be lost or duplicated.
+	renamed := RepoRef{
+		Platform: platform.KindGitLab, PlatformHost: "gitlab.test",
+		Owner: "group", Name: "project-moved", RepoPath: "group/project-moved",
+		PlatformExternalID: "gid://gitlab/Project/old",
+	}
+	successor := RepoRef{
+		Platform: platform.KindGitLab, PlatformHost: "gitlab.test",
+		Owner: "group", Name: "project", RepoPath: "group/project",
+		PlatformExternalID: "gid://gitlab/Project/new",
+	}
+	provider := &syncTestRepositoryReadProvider{
+		syncTestReadProvider: &syncTestReadProvider{
+			syncTestProvider: syncTestProvider{
+				kind: platform.KindGitLab, host: "gitlab.test",
+			},
+		},
+		repository: platform.Repository{
+			Ref: platform.RepoRef{
+				Platform: platform.KindGitLab, Host: "gitlab.test",
+				Owner: "group", Name: "project", RepoPath: "group/project",
+			},
+			PlatformExternalID: "gid://gitlab/Project/new",
+		},
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	syncer := NewSyncerWithRegistry(
+		registry, database, nil, []RepoRef{renamed, successor}, time.Hour, nil, nil,
+	)
+	service, err := archive.NewService(database, registry, nil, syncer, nil, nil)
+	require.NoError(err)
+	syncer.SetArchiveService(service)
+	_, err = service.EnsureConfigured(ctx, []platform.RepoRef{
+		platformRepoRef(renamed), platformRepoRef(successor),
+	})
+	require.NoError(err)
+
+	stale := successor
+	stale.PlatformExternalID = renamed.PlatformExternalID
+	require.NoError(syncer.syncRepo(ctx, stale))
+
+	tracked := syncer.TrackedRepos()
+	require.Len(tracked, 2, "neither repository may be lost or duplicated")
+	byID := map[string]RepoRef{}
+	for _, repo := range tracked {
+		byID[repo.PlatformExternalID] = repo
+	}
+	assert.Equal("project-moved", byID["gid://gitlab/Project/old"].Name,
+		"the renamed repository keeps its tracked entry")
+	assert.Equal("project", byID["gid://gitlab/Project/new"].Name)
+
+	oldEntry, err := database.GetRepositoryByProviderID(
+		ctx, "gitlab", "gitlab.test", "gid://gitlab/Project/old",
+	)
+	require.NoError(err)
+	require.NotNil(oldEntry)
+	newEntry, err := database.GetRepositoryByProviderID(
+		ctx, "gitlab", "gitlab.test", "gid://gitlab/Project/new",
+	)
+	require.NoError(err)
+	require.NotNil(newEntry)
+	assert.NotEqual(oldEntry.Repository.ID, newEntry.Repository.ID)
+}
+
 func TestArchiveAdmissionSharesSyncBudgetAndProviderReserve(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/github/archive_lifecycle_test.go
+++ b/internal/github/archive_lifecycle_test.go
@@ -32,6 +32,9 @@ type blockingArchiveRunner struct {
 type archiveLifecycleRecorder struct {
 	ensured []platform.RepoRef
 	retried []platform.RepoRef
+	// ensureResult, when set, is returned from EnsureConfigured in place of
+	// the full ref list to simulate refs skipped by seeding.
+	ensureResult []platform.RepoRef
 }
 
 type archiveWorkerProvider struct{ ref platform.RepoRef }
@@ -292,7 +295,7 @@ func TestArchiveHydrationPRShapedIssueBecomesTerminalInSQLite(t *testing.T) {
 		archiveLifecycleClock{now: func() time.Time { return now }},
 	)
 	require.NoError(err)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
 	require.NoError(err)
 
@@ -361,7 +364,7 @@ func TestArchivePreemptedItemRecordsNoFailureAndCompletesOnNextPass(t *testing.T
 	// already-canceled admission.
 	service, err := archive.NewService(database, registry, syncer, syncer, nil, nil)
 	require.NoError(err)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
 	require.NoError(err)
 
@@ -467,7 +470,7 @@ func TestArchiveDisabledIssueInventoryCompletesUnsupportedWithoutBlockingMergeRe
 		database, syncer.clients, syncer, syncer, nil, clock,
 	)
 	require.NoError(err)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
 	require.NoError(err)
 
@@ -576,7 +579,7 @@ func newDisabledArchiveHydrationFixture(t *testing.T) *disabledArchiveHydrationF
 		fixture.syncer, fixture.syncer, nil, clock,
 	)
 	require.NoError(err)
-	require.NoError(fixture.service.EnsureConfigured(t.Context(), []platform.RepoRef{fixture.ref}))
+	requireEnsureConfigured(t, fixture.service, []platform.RepoRef{fixture.ref})
 	_, err = fixture.service.Start(t.Context(), []platform.RepoRef{fixture.ref})
 	require.NoError(err)
 	for range 3 {
@@ -653,9 +656,12 @@ func TestArchiveDisabledIssueHydrationRecoversAfterManualProbe(t *testing.T) {
 
 func (*archiveLifecycleRecorder) RunEligible(context.Context) error { return nil }
 
-func (r *archiveLifecycleRecorder) EnsureConfigured(_ context.Context, refs []platform.RepoRef) error {
+func (r *archiveLifecycleRecorder) EnsureConfigured(_ context.Context, refs []platform.RepoRef) ([]platform.RepoRef, error) {
 	r.ensured = append(r.ensured, refs...)
-	return nil
+	if r.ensureResult != nil {
+		return r.ensureResult, nil
+	}
+	return refs, nil
 }
 
 func (r *archiveLifecycleRecorder) RetryAuthentication(_ context.Context, refs []platform.RepoRef) error {
@@ -722,7 +728,7 @@ func TestArchiveWorkerAdvancesRealServiceAfterStart(t *testing.T) {
 	service.SetWake(syncer.WakeArchive)
 	syncer.SetArchiveService(service)
 	syncer.SetArchivePollIntervalForTesting(time.Millisecond)
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
 	require.NoError(err)
 	syncer.Start(t.Context())
@@ -772,6 +778,62 @@ func TestSetReposSeedsArchiveDiscoveryAndRetriesCredentialsBeforeCutover(t *test
 	assert.Equal(repos, syncer.TrackedRepos())
 }
 
+func TestSetReposSeedsActiveArchiveForArchivedRepo(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	registry, err := platform.NewRegistry(syncTestProvider{
+		kind: platform.KindGitHub, host: "github.test",
+	})
+	require.NoError(err)
+	syncer := NewSyncerWithRegistry(registry, database, nil, nil, time.Hour, nil, nil)
+	service, err := archive.NewService(database, registry, nil, syncer, nil, nil)
+	require.NoError(err)
+	syncer.SetArchiveService(service)
+	ref := RepoRef{
+		Platform: platform.KindGitHub, PlatformHost: "github.test",
+		Owner: "acme", Name: "frozen", RepoPath: "acme/frozen",
+		PlatformExternalID: "repo-frozen", Archived: true,
+	}
+
+	require.NoError(syncer.SetReposWithContext(t.Context(), []RepoRef{ref}, false))
+
+	repo, err := database.GetRepoByIdentity(
+		t.Context(), platform.DBRepoIdentity(platformRepoRef(ref)),
+	)
+	require.NoError(err)
+	require.NotNil(repo)
+	states, err := database.ListArchiveRepoStates(t.Context(), []int64{repo.ID})
+	require.NoError(err)
+	require.Len(states, 1)
+	assert.Equal(db.ArchiveOperatorStateActive, states[0].OperatorState,
+		"an archived configured repo keeps an active archive")
+}
+
+func TestSetReposPassesOnlySeededRefsToRetryAuthentication(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	syncer := NewSyncerWithRegistry(nil, database, nil, nil, time.Hour, nil, nil)
+	seeded := platform.RepoRef{
+		Platform: platform.KindGitHub, Host: "github.com",
+		Owner: "acme", Name: "good", RepoPath: "acme/good",
+	}
+	recorder := &archiveLifecycleRecorder{
+		ensureResult: []platform.RepoRef{seeded},
+	}
+	syncer.SetArchiveService(recorder)
+	repos := []RepoRef{
+		{Owner: "acme", Name: "good", PlatformHost: "github.com"},
+		{Owner: "acme", Name: "ghost", PlatformHost: "github.com"},
+	}
+
+	require.NoError(syncer.SetReposWithContext(t.Context(), repos, true))
+	require.Len(recorder.ensured, 2)
+	assert.Equal([]platform.RepoRef{seeded}, recorder.retried,
+		"refs skipped by seeding must not reach authentication retry")
+}
+
 func TestSyncRepoReplacementReconcilesArchiveLifecycle(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -804,9 +866,10 @@ func TestSyncRepoReplacementReconcilesArchiveLifecycle(t *testing.T) {
 	service, err := archive.NewService(database, registry, nil, syncer, nil, nil)
 	require.NoError(err)
 	syncer.SetArchiveService(service)
-	require.NoError(service.EnsureConfigured(
+	_, err = service.EnsureConfigured(
 		ctx, []platform.RepoRef{platformRepoRef(configured)},
-	))
+	)
+	require.NoError(err)
 	oldEntry, err := database.GetRepositoryByProviderID(
 		ctx, "gitlab", "gitlab.test", "gid://gitlab/Project/old",
 	)
@@ -1842,4 +1905,10 @@ func TestGitHubArchiveAdmissionRetriesWhenDeficientPoolResets(t *testing.T) {
 	assert.Contains(denied.Detail, "provider rate reserve")
 	require.NotNil(denied.RetryAt)
 	assert.Equal(restReset, *denied.RetryAt)
+}
+
+func requireEnsureConfigured(t *testing.T, s *archive.Service, refs []platform.RepoRef) {
+	t.Helper()
+	_, err := s.EnsureConfigured(t.Context(), refs)
+	require.NoError(t, err)
 }

--- a/internal/github/auth_router_test.go
+++ b/internal/github/auth_router_test.go
@@ -1342,7 +1342,7 @@ func TestPublishResolvedRepositoryClearsDisplacedCredentialAlias(t *testing.T) {
 		Platform: platform.KindGitHub, PlatformHost: "github.com",
 		Owner: "acme", Name: "widget", PlatformExternalID: "R_new",
 	}
-	syncer.publishResolvedRepository(replacement, replacement)
+	syncer.publishResolvedRepository(replacement, replacement, true)
 
 	_, err = router.ReadIdentityForRepo("acme", "widget")
 	require.Error(err,

--- a/internal/github/notifications_sync.go
+++ b/internal/github/notifications_sync.go
@@ -130,7 +130,7 @@ func (s *Syncer) NotificationSyncStatus() NotificationSyncStatus {
 
 func (s *Syncer) SyncNotifications(ctx context.Context) error {
 	ctx = WithSyncBudget(ctx)
-	repos := s.TrackedRepos()
+	repos := excludeArchivedRepos(s.TrackedRepos())
 	tracked := make(map[string]RepoRef, len(repos))
 	for _, repo := range repos {
 		platformName := string(repoPlatform(repo))
@@ -776,7 +776,7 @@ func (s *Syncer) ackRepoBuckets(
 		byNotification[notification.ID] = bucket
 		add(bucket, notification.RepoOwner, notification.RepoName)
 	}
-	for _, repo := range s.TrackedRepos() {
+	for _, repo := range excludeArchivedRepos(s.TrackedRepos()) {
 		if repoPlatform(repo) != kind || repoHost(repo) != host {
 			continue
 		}

--- a/internal/github/notifications_sync.go
+++ b/internal/github/notifications_sync.go
@@ -776,7 +776,10 @@ func (s *Syncer) ackRepoBuckets(
 		byNotification[notification.ID] = bucket
 		add(bucket, notification.RepoOwner, notification.RepoName)
 	}
-	for _, repo := range excludeArchivedRepos(s.TrackedRepos()) {
+	// Archived repos stay in the grouping: their queued acknowledgements
+	// (from before archiving) must still be covered by credential-wide
+	// rate-limit deferral. Only polling skips archived repos.
+	for _, repo := range s.TrackedRepos() {
 		if repoPlatform(repo) != kind || repoHost(repo) != host {
 			continue
 		}

--- a/internal/github/repo_config_resolver.go
+++ b/internal/github/repo_config_resolver.go
@@ -343,39 +343,83 @@ func appendExpandedRepo(
 }
 
 // ExpandedRepoSet accumulates configured-repo expansions across config
-// entries, deduplicating by platform/host/owner/name. A provider-resolved
-// ref replaces a fallback-derived duplicate from an earlier entry, so a
-// transient resolve failure on one entry cannot freeze stale metadata (an
-// archived flip, a rename) when an overlapping entry resolved successfully.
-// Fallback refs never overwrite resolved ones; same-class duplicates keep
-// the first entry.
+// entries, deduplicating by platform/host/owner/name and — when a stable
+// provider id is present — by platform/host/provider-id, so a renamed route
+// cannot track the same repository twice. A provider-resolved ref replaces a
+// fallback-derived duplicate from an earlier entry, so a transient resolve
+// failure on one entry cannot freeze stale metadata (an archived flip, a
+// rename) when an overlapping entry resolved successfully. Fallback refs
+// never overwrite resolved ones; same-class duplicates keep the first entry.
 type ExpandedRepoSet struct {
-	refs     []RepoRef
-	index    map[string]int
-	resolved map[string]bool
+	refs       []RepoRef
+	resolved   []bool
+	byRoute    map[string]int
+	byIdentity map[string]int
 }
 
 func NewExpandedRepoSet() *ExpandedRepoSet {
 	return &ExpandedRepoSet{
-		index:    make(map[string]int),
-		resolved: make(map[string]bool),
+		byRoute:    make(map[string]int),
+		byIdentity: make(map[string]int),
 	}
 }
 
-func (s *ExpandedRepoSet) Add(repo RepoRef, providerResolved bool) {
+func expandedRepoRouteKey(repo RepoRef) string {
 	canonical := canonicalRepoRef(repo)
-	key := string(repoPlatform(canonical)) + "\x00" + canonical.PlatformHost +
+	return string(repoPlatform(canonical)) + "\x00" + canonical.PlatformHost +
 		"\x00" + canonical.Owner + "\x00" + canonical.Name
-	if i, ok := s.index[key]; ok {
-		if providerResolved && !s.resolved[key] {
-			s.refs[i] = repo
-			s.resolved[key] = true
+}
+
+func expandedRepoIdentityKey(repo RepoRef) string {
+	if strings.TrimSpace(repo.PlatformExternalID) == "" {
+		return ""
+	}
+	canonical := canonicalRepoRef(repo)
+	return string(repoPlatform(canonical)) + "\x00" + canonical.PlatformHost +
+		"\x00" + canonical.PlatformExternalID
+}
+
+func (s *ExpandedRepoSet) Add(repo RepoRef, providerResolved bool) {
+	routeKey := expandedRepoRouteKey(repo)
+	identityKey := expandedRepoIdentityKey(repo)
+	slot, ok := -1, false
+	if identityKey != "" {
+		slot, ok = lookupSlot(s.byIdentity, identityKey)
+	}
+	if !ok {
+		slot, ok = lookupSlot(s.byRoute, routeKey)
+	}
+	if ok {
+		if providerResolved && !s.resolved[slot] {
+			old := s.refs[slot]
+			delete(s.byRoute, expandedRepoRouteKey(old))
+			if oldIdentity := expandedRepoIdentityKey(old); oldIdentity != "" {
+				delete(s.byIdentity, oldIdentity)
+			}
+			s.refs[slot] = repo
+			s.resolved[slot] = true
+			s.byRoute[routeKey] = slot
+			if identityKey != "" {
+				s.byIdentity[identityKey] = slot
+			}
 		}
 		return
 	}
-	s.index[key] = len(s.refs)
-	s.resolved[key] = providerResolved
+	slot = len(s.refs)
 	s.refs = append(s.refs, repo)
+	s.resolved = append(s.resolved, providerResolved)
+	s.byRoute[routeKey] = slot
+	if identityKey != "" {
+		s.byIdentity[identityKey] = slot
+	}
+}
+
+func lookupSlot(index map[string]int, key string) (int, bool) {
+	i, ok := index[key]
+	if !ok {
+		return -1, false
+	}
+	return i, true
 }
 
 func (s *ExpandedRepoSet) Refs() []RepoRef {

--- a/internal/github/repo_config_resolver.go
+++ b/internal/github/repo_config_resolver.go
@@ -39,6 +39,7 @@ func canonicalRepoRef(repo RepoRef) RepoRef {
 		CloneURL:           strings.TrimSpace(repo.CloneURL),
 		DefaultBranch:      strings.TrimSpace(repo.DefaultBranch),
 		Archived:           repo.Archived,
+		ConfiguredRepoPath: strings.TrimSpace(repo.ConfiguredRepoPath),
 	}
 	if kind == platform.KindGitHub {
 		out.Owner = canonicalRepoOwner(out.Owner)
@@ -82,6 +83,18 @@ func FallbackConfiguredRepoRefs(
 	host := raw.PlatformHostOrDefault()
 	repoPath := configuredRepoPath(raw)
 	if !raw.HasNameGlob() {
+		// Provenance first: a provider-side rename moves the tracked route
+		// away from the configured path, but the tracked ref still records
+		// which config entry it was resolved from. Falling back to it keeps
+		// the provider identity and archived state instead of synthesizing
+		// an identity-less live duplicate under the stale route.
+		for _, repo := range previous {
+			if repoPlatform(repo) == kind &&
+				sameConfiguredRepoHost(repoHost(repo), host) &&
+				strings.EqualFold(repo.ConfiguredRepoPath, repoPath) {
+				return []RepoRef{repo}
+			}
+		}
 		for _, repo := range previous {
 			if repoPlatform(repo) == kind &&
 				sameConfiguredRepoHost(repoHost(repo), host) &&
@@ -113,11 +126,12 @@ func FallbackConfiguredRepoRefs(
 
 func fallbackRepoRef(raw config.Repo, kind platform.Kind, host string) RepoRef {
 	repo := RepoRef{
-		Platform:     kind,
-		Owner:        strings.TrimSpace(raw.Owner),
-		Name:         strings.TrimSpace(raw.Name),
-		PlatformHost: strings.ToLower(strings.TrimSpace(host)),
-		RepoPath:     strings.TrimSpace(configuredRepoPath(raw)),
+		Platform:           kind,
+		Owner:              strings.TrimSpace(raw.Owner),
+		Name:               strings.TrimSpace(raw.Name),
+		PlatformHost:       strings.ToLower(strings.TrimSpace(host)),
+		RepoPath:           strings.TrimSpace(configuredRepoPath(raw)),
+		ConfiguredRepoPath: configuredRepoPath(raw),
 	}
 	if kind == "" {
 		kind = platform.KindGitHub
@@ -301,6 +315,7 @@ func repoRefFromRepository(
 		CloneURL:           repo.CloneURL,
 		DefaultBranch:      repo.DefaultBranch,
 		Archived:           repo.Archived,
+		ConfiguredRepoPath: configuredRepoPath(raw),
 	}
 	if ref.PlatformRepoID == 0 {
 		ref.PlatformRepoID = repo.Ref.PlatformID

--- a/internal/github/repo_config_resolver.go
+++ b/internal/github/repo_config_resolver.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"path"
 	"strings"
@@ -10,8 +9,6 @@ import (
 	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/platform"
 )
-
-var ErrConfiguredRepoArchived = errors.New("configured repo archived")
 
 func canonicalRepoName(name string) string {
 	return strings.ToLower(name)
@@ -41,6 +38,7 @@ func canonicalRepoRef(repo RepoRef) RepoRef {
 		WebURL:             strings.TrimSpace(repo.WebURL),
 		CloneURL:           strings.TrimSpace(repo.CloneURL),
 		DefaultBranch:      strings.TrimSpace(repo.DefaultBranch),
+		Archived:           repo.Archived,
 	}
 	if kind == platform.KindGitHub {
 		out.Owner = canonicalRepoOwner(out.Owner)
@@ -226,12 +224,6 @@ func resolveConfiguredRepo(
 				raw.Owner, raw.Name, err,
 			)
 		}
-		if repo.Archived {
-			return status, nil, fmt.Errorf(
-				"%w: %s/%s",
-				ErrConfiguredRepoArchived, raw.Owner, raw.Name,
-			)
-		}
 		status.MatchedRepoCount = 1
 		return status, []RepoRef{repoRefFromRepository(raw, kind, host, repo)}, nil
 	}
@@ -246,9 +238,6 @@ func resolveConfiguredRepo(
 
 	matches := make([]RepoRef, 0, len(repos))
 	for _, repo := range repos {
-		if repo.Archived {
-			continue
-		}
 		repoName := repo.Ref.Name
 		if repoName == "" {
 			repoName = repo.Ref.DisplayName()
@@ -311,6 +300,7 @@ func repoRefFromRepository(
 		WebURL:             repo.WebURL,
 		CloneURL:           repo.CloneURL,
 		DefaultBranch:      repo.DefaultBranch,
+		Archived:           repo.Archived,
 	}
 	if ref.PlatformRepoID == 0 {
 		ref.PlatformRepoID = repo.Ref.PlatformID

--- a/internal/github/repo_config_resolver.go
+++ b/internal/github/repo_config_resolver.go
@@ -242,7 +242,9 @@ func resolveConfiguredRepo(
 		return status, []RepoRef{repoRefFromRepository(raw, kind, host, repo)}, nil
 	}
 
-	repos, err := reader.ListRepositories(ctx, raw.Owner, platform.RepositoryListOptions{})
+	repos, err := reader.ListRepositories(ctx, raw.Owner, platform.RepositoryListOptions{
+		IncludeArchived: true,
+	})
 	if err != nil {
 		return status, nil, fmt.Errorf(
 			"resolve configured repo glob %s/%s: %w",

--- a/internal/github/repo_config_resolver.go
+++ b/internal/github/repo_config_resolver.go
@@ -342,6 +342,46 @@ func appendExpandedRepo(
 	*dst = append(*dst, repo)
 }
 
+// ExpandedRepoSet accumulates configured-repo expansions across config
+// entries, deduplicating by platform/host/owner/name. A provider-resolved
+// ref replaces a fallback-derived duplicate from an earlier entry, so a
+// transient resolve failure on one entry cannot freeze stale metadata (an
+// archived flip, a rename) when an overlapping entry resolved successfully.
+// Fallback refs never overwrite resolved ones; same-class duplicates keep
+// the first entry.
+type ExpandedRepoSet struct {
+	refs     []RepoRef
+	index    map[string]int
+	resolved map[string]bool
+}
+
+func NewExpandedRepoSet() *ExpandedRepoSet {
+	return &ExpandedRepoSet{
+		index:    make(map[string]int),
+		resolved: make(map[string]bool),
+	}
+}
+
+func (s *ExpandedRepoSet) Add(repo RepoRef, providerResolved bool) {
+	canonical := canonicalRepoRef(repo)
+	key := string(repoPlatform(canonical)) + "\x00" + canonical.PlatformHost +
+		"\x00" + canonical.Owner + "\x00" + canonical.Name
+	if i, ok := s.index[key]; ok {
+		if providerResolved && !s.resolved[key] {
+			s.refs[i] = repo
+			s.resolved[key] = true
+		}
+		return
+	}
+	s.index[key] = len(s.refs)
+	s.resolved[key] = providerResolved
+	s.refs = append(s.refs, repo)
+}
+
+func (s *ExpandedRepoSet) Refs() []RepoRef {
+	return s.refs
+}
+
 func sameConfiguredRepoHost(left, right string) bool {
 	if left == "" {
 		left = "github.com"

--- a/internal/github/repo_config_resolver.go
+++ b/internal/github/repo_config_resolver.go
@@ -282,6 +282,17 @@ func configuredRepoPath(raw config.Repo) string {
 	return raw.Owner + "/" + raw.Name
 }
 
+// exactConfiguredRepoPath is the provenance stamped on resolved refs: only
+// exact entries author it — a glob pattern identifies no single entry to
+// correlate with, and stamping it would displace exact provenance on
+// deduplicated overlaps.
+func exactConfiguredRepoPath(raw config.Repo) string {
+	if raw.HasNameGlob() {
+		return ""
+	}
+	return configuredRepoPath(raw)
+}
+
 func repoPathOrFullName(repo RepoRef) string {
 	if strings.TrimSpace(repo.RepoPath) != "" {
 		return strings.TrimSpace(repo.RepoPath)
@@ -315,7 +326,7 @@ func repoRefFromRepository(
 		CloneURL:           repo.CloneURL,
 		DefaultBranch:      repo.DefaultBranch,
 		Archived:           repo.Archived,
-		ConfiguredRepoPath: configuredRepoPath(raw),
+		ConfiguredRepoPath: exactConfiguredRepoPath(raw),
 	}
 	if ref.PlatformRepoID == 0 {
 		ref.PlatformRepoID = repo.Ref.PlatformID
@@ -405,8 +416,15 @@ func (s *ExpandedRepoSet) Add(repo RepoRef, providerResolved bool) {
 		slot, ok = lookupSlot(s.byRoute, routeKey)
 	}
 	if ok {
+		// Config-entry provenance is authored only by exact entries; glob
+		// refs carry none. Merge it across duplicates in both directions so
+		// whichever ref wins the slot, the exact entry stays correlatable
+		// on the next reload.
 		if providerResolved && !s.resolved[slot] {
 			old := s.refs[slot]
+			if repo.ConfiguredRepoPath == "" {
+				repo.ConfiguredRepoPath = old.ConfiguredRepoPath
+			}
 			delete(s.byRoute, expandedRepoRouteKey(old))
 			if oldIdentity := expandedRepoIdentityKey(old); oldIdentity != "" {
 				delete(s.byIdentity, oldIdentity)
@@ -417,6 +435,8 @@ func (s *ExpandedRepoSet) Add(repo RepoRef, providerResolved bool) {
 			if identityKey != "" {
 				s.byIdentity[identityKey] = slot
 			}
+		} else if s.refs[slot].ConfiguredRepoPath == "" {
+			s.refs[slot].ConfiguredRepoPath = repo.ConfiguredRepoPath
 		}
 		return
 	}

--- a/internal/github/repo_config_resolver_test.go
+++ b/internal/github/repo_config_resolver_test.go
@@ -12,7 +12,7 @@ import (
 	"go.kenn.io/forge/internal/platform"
 )
 
-func TestResolveConfiguredRepos_ExpandsGlobAndSkipsArchived(t *testing.T) {
+func TestResolveConfiguredRepos_ExpandsGlobIncludingArchived(t *testing.T) {
 	assert := assert.New(t)
 	client := &mockClient{
 		listReposByOwnerFn: func(_ context.Context, owner string) ([]*gh.Repository, error) {
@@ -43,13 +43,56 @@ func TestResolveConfiguredRepos_ExpandsGlobAndSkipsArchived(t *testing.T) {
 	)
 
 	require.Len(t, result.Configured, 1)
+	assert.Equal(2, result.Configured[0].MatchedRepoCount)
+	assert.Equal([]RepoRef{
+		{
+			Platform:     platform.KindGitHub,
+			Owner:        "acme",
+			Name:         "widgets-api",
+			PlatformHost: "github.com",
+			RepoPath:     "acme/widgets-api",
+		},
+		{
+			Platform:     platform.KindGitHub,
+			Owner:        "acme",
+			Name:         "widgets-legacy",
+			PlatformHost: "github.com",
+			RepoPath:     "acme/widgets-legacy",
+			Archived:     true,
+		},
+	}, result.Expanded)
+}
+
+func TestResolveConfiguredRepos_AcceptsArchivedRepoAsArchiveOnly(t *testing.T) {
+	assert := assert.New(t)
+	client := &mockClient{
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			return &gh.Repository{
+				Name:     new(repo),
+				Owner:    &gh.User{Login: new(owner)},
+				Archived: new(true),
+			}, nil
+		},
+	}
+
+	result := ResolveConfiguredRepos(
+		t.Context(),
+		map[string]Client{"github.com": client},
+		[]config.Repo{{Owner: "acme", Name: "widgets-legacy"}},
+	)
+
+	assert.Empty(result.Warnings)
+	require.Len(t, result.Configured, 1)
 	assert.Equal(1, result.Configured[0].MatchedRepoCount)
 	assert.Equal([]RepoRef{{
 		Platform:     platform.KindGitHub,
 		Owner:        "acme",
-		Name:         "widgets-api",
+		Name:         "widgets-legacy",
 		PlatformHost: "github.com",
-		RepoPath:     "acme/widgets-api",
+		RepoPath:     "acme/widgets-legacy",
+		Archived:     true,
 	}}, result.Expanded)
 }
 

--- a/internal/github/repo_config_resolver_test.go
+++ b/internal/github/repo_config_resolver_test.go
@@ -46,19 +46,21 @@ func TestResolveConfiguredRepos_ExpandsGlobIncludingArchived(t *testing.T) {
 	assert.Equal(2, result.Configured[0].MatchedRepoCount)
 	assert.Equal([]RepoRef{
 		{
-			Platform:     platform.KindGitHub,
-			Owner:        "acme",
-			Name:         "widgets-api",
-			PlatformHost: "github.com",
-			RepoPath:     "acme/widgets-api",
+			Platform:           platform.KindGitHub,
+			Owner:              "acme",
+			Name:               "widgets-api",
+			PlatformHost:       "github.com",
+			RepoPath:           "acme/widgets-api",
+			ConfiguredRepoPath: "acme/widgets-*",
 		},
 		{
-			Platform:     platform.KindGitHub,
-			Owner:        "acme",
-			Name:         "widgets-legacy",
-			PlatformHost: "github.com",
-			RepoPath:     "acme/widgets-legacy",
-			Archived:     true,
+			Platform:           platform.KindGitHub,
+			Owner:              "acme",
+			Name:               "widgets-legacy",
+			PlatformHost:       "github.com",
+			RepoPath:           "acme/widgets-legacy",
+			Archived:           true,
+			ConfiguredRepoPath: "acme/widgets-*",
 		},
 	}, result.Expanded)
 }
@@ -87,12 +89,13 @@ func TestResolveConfiguredRepos_AcceptsArchivedRepoAsArchiveOnly(t *testing.T) {
 	require.Len(t, result.Configured, 1)
 	assert.Equal(1, result.Configured[0].MatchedRepoCount)
 	assert.Equal([]RepoRef{{
-		Platform:     platform.KindGitHub,
-		Owner:        "acme",
-		Name:         "widgets-legacy",
-		PlatformHost: "github.com",
-		RepoPath:     "acme/widgets-legacy",
-		Archived:     true,
+		Platform:           platform.KindGitHub,
+		Owner:              "acme",
+		Name:               "widgets-legacy",
+		PlatformHost:       "github.com",
+		RepoPath:           "acme/widgets-legacy",
+		Archived:           true,
+		ConfiguredRepoPath: "acme/widgets-legacy",
 	}}, result.Expanded)
 }
 
@@ -197,8 +200,8 @@ func TestResolveConfiguredRepos_DeduplicatesExactAndGlobMatches(t *testing.T) {
 
 	assert.Len(result.Expanded, 2)
 	assert.ElementsMatch([]RepoRef{
-		{Platform: platform.KindGitHub, Owner: "acme", Name: "widgets", PlatformHost: "github.com", RepoPath: "acme/widgets"},
-		{Platform: platform.KindGitHub, Owner: "acme", Name: "widgets-api", PlatformHost: "github.com", RepoPath: "acme/widgets-api"},
+		{Platform: platform.KindGitHub, Owner: "acme", Name: "widgets", PlatformHost: "github.com", RepoPath: "acme/widgets", ConfiguredRepoPath: "acme/widgets"},
+		{Platform: platform.KindGitHub, Owner: "acme", Name: "widgets-api", PlatformHost: "github.com", RepoPath: "acme/widgets-api", ConfiguredRepoPath: "acme/widgets*"},
 	}, result.Expanded)
 }
 
@@ -235,11 +238,12 @@ func TestResolveConfiguredRepos_DeduplicatesOwnerCase(t *testing.T) {
 	)
 
 	assert.Equal([]RepoRef{{
-		Platform:     platform.KindGitHub,
-		Owner:        "acme",
-		Name:         "widgets",
-		PlatformHost: "github.com",
-		RepoPath:     "acme/widgets",
+		Platform:           platform.KindGitHub,
+		Owner:              "acme",
+		Name:               "widgets",
+		PlatformHost:       "github.com",
+		RepoPath:           "acme/widgets",
+		ConfiguredRepoPath: "Acme/widgets",
 	}}, result.Expanded)
 }
 
@@ -264,11 +268,12 @@ func TestResolveConfiguredReposCasefoldsResolvedRepoRefs(t *testing.T) {
 	)
 
 	assert.Equal([]RepoRef{{
-		Platform:     platform.KindGitHub,
-		Owner:        "org",
-		Name:         "foo",
-		PlatformHost: "github.com",
-		RepoPath:     "org/foo",
+		Platform:           platform.KindGitHub,
+		Owner:              "org",
+		Name:               "foo",
+		PlatformHost:       "github.com",
+		RepoPath:           "org/foo",
+		ConfiguredRepoPath: "org/foo",
 	}}, result.Expanded)
 }
 
@@ -318,11 +323,12 @@ func TestResolveConfiguredRepos_MatchesRepoNamesCaseInsensitively(t *testing.T) 
 	require.Len(t, result.Configured, 1)
 	assert.Equal(1, result.Configured[0].MatchedRepoCount)
 	assert.Equal([]RepoRef{{
-		Platform:     platform.KindGitHub,
-		Owner:        "acme",
-		Name:         "widget-api",
-		PlatformHost: "github.com",
-		RepoPath:     "acme/widget-api",
+		Platform:           platform.KindGitHub,
+		Owner:              "acme",
+		Name:               "widget-api",
+		PlatformHost:       "github.com",
+		RepoPath:           "acme/widget-api",
+		ConfiguredRepoPath: "acme/widget-*",
 	}}, result.Expanded)
 }
 
@@ -408,18 +414,20 @@ func TestResolveConfiguredReposKeepsDuplicateOwnerNameOnDifferentPlatforms(t *te
 	require.Empty(t, result.Warnings)
 	assert.ElementsMatch(t, []RepoRef{
 		{
-			Platform:     platform.KindGitHub,
-			PlatformHost: "code.example.com",
-			Owner:        "acme",
-			Name:         "widget",
-			RepoPath:     "acme/widget",
+			Platform:           platform.KindGitHub,
+			PlatformHost:       "code.example.com",
+			Owner:              "acme",
+			Name:               "widget",
+			RepoPath:           "acme/widget",
+			ConfiguredRepoPath: "acme/widget",
 		},
 		{
-			Platform:     platform.KindGitLab,
-			PlatformHost: "code.example.com",
-			Owner:        "acme",
-			Name:         "widget",
-			RepoPath:     "acme/widget",
+			Platform:           platform.KindGitLab,
+			PlatformHost:       "code.example.com",
+			Owner:              "acme",
+			Name:               "widget",
+			RepoPath:           "acme/widget",
+			ConfiguredRepoPath: "acme/widget",
 		},
 	}, result.Expanded)
 }
@@ -435,11 +443,12 @@ func TestFallbackConfiguredRepoRefsSynthesizesGitHubProvider(t *testing.T) {
 	})
 
 	assert.Equal([]RepoRef{{
-		Platform:     platform.KindGitHub,
-		PlatformHost: "code.example.com",
-		Owner:        "acme",
-		Name:         "widget",
-		RepoPath:     "Acme/Widget",
+		Platform:           platform.KindGitHub,
+		PlatformHost:       "code.example.com",
+		Owner:              "acme",
+		Name:               "widget",
+		RepoPath:           "Acme/Widget",
+		ConfiguredRepoPath: "Acme/Widget",
 	}}, got)
 }
 
@@ -475,6 +484,45 @@ func TestFallbackConfiguredRepoRefsPreservesProviderIdentity(t *testing.T) {
 	}}, got)
 }
 
+func TestRepoRefFromRepositoryStampsConfiguredRepoPath(t *testing.T) {
+	assert := assert.New(t)
+
+	ref := repoRefFromRepository(
+		config.Repo{Owner: "acme", Name: "tools"},
+		platform.KindGitHub, "github.com",
+		platform.Repository{
+			Ref: platform.RepoRef{
+				Owner: "acme", Name: "tools-new",
+				RepoPath: "acme/tools-new",
+			},
+			PlatformExternalID: "repo-acme-tools",
+		},
+	)
+
+	assert.Equal("acme/tools", ref.ConfiguredRepoPath)
+}
+
+func TestFallbackConfiguredRepoRefsMatchesRenamedRouteByConfiguredPath(t *testing.T) {
+	assert := assert.New(t)
+	renamed := RepoRef{
+		Platform:           platform.KindGitHub,
+		PlatformHost:       "github.com",
+		Owner:              "acme",
+		Name:               "tools-new",
+		RepoPath:           "acme/tools-new",
+		PlatformExternalID: "repo-acme-tools",
+		ConfiguredRepoPath: "acme/tools",
+		Archived:           true,
+	}
+
+	got := FallbackConfiguredRepoRefs([]RepoRef{renamed}, config.Repo{
+		Owner: "acme",
+		Name:  "tools",
+	})
+
+	assert.Equal([]RepoRef{renamed}, got)
+}
+
 func TestFallbackConfiguredRepoRefsSynthesizesNonGitHubProvider(t *testing.T) {
 	assert := assert.New(t)
 
@@ -485,11 +533,12 @@ func TestFallbackConfiguredRepoRefsSynthesizesNonGitHubProvider(t *testing.T) {
 	})
 
 	assert.Equal([]RepoRef{{
-		Platform:     platform.KindGitLab,
-		PlatformHost: "gitlab.com",
-		Owner:        "Acme/SubGroup",
-		Name:         "Widget",
-		RepoPath:     "Acme/SubGroup/Widget",
+		Platform:           platform.KindGitLab,
+		PlatformHost:       "gitlab.com",
+		Owner:              "Acme/SubGroup",
+		Name:               "Widget",
+		RepoPath:           "Acme/SubGroup/Widget",
+		ConfiguredRepoPath: "Acme/SubGroup/Widget",
 	}}, got)
 }
 
@@ -544,11 +593,12 @@ func TestResolveConfiguredReposWithRegistryUsesNonGitHubProvider(t *testing.T) {
 
 	require.Empty(t, result.Warnings)
 	assert.Equal(t, []RepoRef{{
-		Platform:     platform.KindGitLab,
-		PlatformHost: "gitlab.com",
-		Owner:        "acme/subgroup",
-		Name:         "widget",
-		RepoPath:     "acme/subgroup/widget",
+		Platform:           platform.KindGitLab,
+		PlatformHost:       "gitlab.com",
+		Owner:              "acme/subgroup",
+		Name:               "widget",
+		RepoPath:           "acme/subgroup/widget",
+		ConfiguredRepoPath: "acme/subgroup/widget",
 	}}, result.Expanded)
 }
 

--- a/internal/github/repo_config_resolver_test.go
+++ b/internal/github/repo_config_resolver_test.go
@@ -96,6 +96,40 @@ func TestResolveConfiguredRepos_AcceptsArchivedRepoAsArchiveOnly(t *testing.T) {
 	}}, result.Expanded)
 }
 
+func TestExpandedRepoSetPrefersResolvedOverFallbackDuplicates(t *testing.T) {
+	assert := assert.New(t)
+	fallback := RepoRef{
+		Platform: platform.KindGitHub, Owner: "acme", Name: "frozen",
+		PlatformHost: "github.com", RepoPath: "acme/frozen",
+	}
+	resolved := RepoRef{
+		Platform: platform.KindGitHub, Owner: "acme", Name: "frozen",
+		PlatformHost: "github.com", RepoPath: "acme/frozen",
+		PlatformExternalID: "repo-acme-frozen", Archived: true,
+	}
+
+	set := NewExpandedRepoSet()
+	set.Add(fallback, false)
+	set.Add(resolved, true)
+	assert.Equal([]RepoRef{resolved}, set.Refs(),
+		"a provider-resolved duplicate must replace fallback metadata")
+
+	// The reverse order keeps the resolved ref: fallback metadata never
+	// overwrites a successful resolution.
+	set = NewExpandedRepoSet()
+	set.Add(resolved, true)
+	set.Add(fallback, false)
+	assert.Equal([]RepoRef{resolved}, set.Refs())
+
+	// Same-class duplicates keep the first entry.
+	set = NewExpandedRepoSet()
+	set.Add(resolved, true)
+	other := resolved
+	other.Archived = false
+	set.Add(other, true)
+	assert.Equal([]RepoRef{resolved}, set.Refs())
+}
+
 func TestResolveConfiguredRepos_DeduplicatesExactAndGlobMatches(t *testing.T) {
 	assert := assert.New(t)
 	client := &mockClient{

--- a/internal/github/repo_config_resolver_test.go
+++ b/internal/github/repo_config_resolver_test.go
@@ -130,6 +130,34 @@ func TestExpandedRepoSetPrefersResolvedOverFallbackDuplicates(t *testing.T) {
 	assert.Equal([]RepoRef{resolved}, set.Refs())
 }
 
+func TestExpandedRepoSetReconcilesRenamedRouteByProviderIdentity(t *testing.T) {
+	assert := assert.New(t)
+	// A fallback ref keeps the old route of a renamed repo; the resolved
+	// duplicate arrives under the new route with the same stable provider
+	// id. Route-keyed dedup alone would track both and sync them twice.
+	fallback := RepoRef{
+		Platform: platform.KindGitHub, Owner: "acme", Name: "old-name",
+		PlatformHost: "github.com", RepoPath: "acme/old-name",
+		PlatformExternalID: "repo-x",
+	}
+	resolved := RepoRef{
+		Platform: platform.KindGitHub, Owner: "acme", Name: "new-name",
+		PlatformHost: "github.com", RepoPath: "acme/new-name",
+		PlatformExternalID: "repo-x", Archived: true,
+	}
+
+	set := NewExpandedRepoSet()
+	set.Add(fallback, false)
+	set.Add(resolved, true)
+	assert.Equal([]RepoRef{resolved}, set.Refs())
+
+	// The resolved route survives a later fallback under the old route.
+	set = NewExpandedRepoSet()
+	set.Add(resolved, true)
+	set.Add(fallback, false)
+	assert.Equal([]RepoRef{resolved}, set.Refs())
+}
+
 func TestResolveConfiguredRepos_DeduplicatesExactAndGlobMatches(t *testing.T) {
 	assert := assert.New(t)
 	client := &mockClient{

--- a/internal/github/repo_config_resolver_test.go
+++ b/internal/github/repo_config_resolver_test.go
@@ -46,21 +46,19 @@ func TestResolveConfiguredRepos_ExpandsGlobIncludingArchived(t *testing.T) {
 	assert.Equal(2, result.Configured[0].MatchedRepoCount)
 	assert.Equal([]RepoRef{
 		{
-			Platform:           platform.KindGitHub,
-			Owner:              "acme",
-			Name:               "widgets-api",
-			PlatformHost:       "github.com",
-			RepoPath:           "acme/widgets-api",
-			ConfiguredRepoPath: "acme/widgets-*",
+			Platform:     platform.KindGitHub,
+			Owner:        "acme",
+			Name:         "widgets-api",
+			PlatformHost: "github.com",
+			RepoPath:     "acme/widgets-api",
 		},
 		{
-			Platform:           platform.KindGitHub,
-			Owner:              "acme",
-			Name:               "widgets-legacy",
-			PlatformHost:       "github.com",
-			RepoPath:           "acme/widgets-legacy",
-			Archived:           true,
-			ConfiguredRepoPath: "acme/widgets-*",
+			Platform:     platform.KindGitHub,
+			Owner:        "acme",
+			Name:         "widgets-legacy",
+			PlatformHost: "github.com",
+			RepoPath:     "acme/widgets-legacy",
+			Archived:     true,
 		},
 	}, result.Expanded)
 }
@@ -161,6 +159,45 @@ func TestExpandedRepoSetReconcilesRenamedRouteByProviderIdentity(t *testing.T) {
 	assert.Equal([]RepoRef{resolved}, set.Refs())
 }
 
+func TestExpandedRepoSetMergesExactProvenanceAcrossDuplicates(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	// The exact entry's fallback preserved a renamed tracked ref with its
+	// config-entry provenance; the overlapping glob resolves the same
+	// provider id without any (glob refs carry none). Whichever ref wins
+	// the slot, losing the exact provenance would leave the next failed
+	// reload unable to correlate the entry and synthesize a duplicate.
+	exactFallback := RepoRef{
+		Platform: platform.KindGitHub, Owner: "acme", Name: "tools-new",
+		PlatformHost: "github.com", RepoPath: "acme/tools-new",
+		PlatformExternalID: "repo-acme-tools",
+		ConfiguredRepoPath: "acme/tools", Archived: true,
+	}
+	resolvedGlob := RepoRef{
+		Platform: platform.KindGitHub, Owner: "acme", Name: "tools-new",
+		PlatformHost: "github.com", RepoPath: "acme/tools-new",
+		PlatformExternalID: "repo-acme-tools",
+		WebURL:             "https://github.com/acme/tools-new",
+		Archived:           true,
+	}
+
+	set := NewExpandedRepoSet()
+	set.Add(exactFallback, false)
+	set.Add(resolvedGlob, true)
+	refs := set.Refs()
+	require.Len(refs, 1)
+	assert.Equal("https://github.com/acme/tools-new", refs[0].WebURL)
+	assert.Equal("acme/tools", refs[0].ConfiguredRepoPath)
+
+	set = NewExpandedRepoSet()
+	set.Add(resolvedGlob, true)
+	set.Add(exactFallback, false)
+	refs = set.Refs()
+	require.Len(refs, 1)
+	assert.Equal("https://github.com/acme/tools-new", refs[0].WebURL)
+	assert.Equal("acme/tools", refs[0].ConfiguredRepoPath)
+}
+
 func TestResolveConfiguredRepos_DeduplicatesExactAndGlobMatches(t *testing.T) {
 	assert := assert.New(t)
 	client := &mockClient{
@@ -201,7 +238,7 @@ func TestResolveConfiguredRepos_DeduplicatesExactAndGlobMatches(t *testing.T) {
 	assert.Len(result.Expanded, 2)
 	assert.ElementsMatch([]RepoRef{
 		{Platform: platform.KindGitHub, Owner: "acme", Name: "widgets", PlatformHost: "github.com", RepoPath: "acme/widgets", ConfiguredRepoPath: "acme/widgets"},
-		{Platform: platform.KindGitHub, Owner: "acme", Name: "widgets-api", PlatformHost: "github.com", RepoPath: "acme/widgets-api", ConfiguredRepoPath: "acme/widgets*"},
+		{Platform: platform.KindGitHub, Owner: "acme", Name: "widgets-api", PlatformHost: "github.com", RepoPath: "acme/widgets-api"},
 	}, result.Expanded)
 }
 
@@ -323,12 +360,11 @@ func TestResolveConfiguredRepos_MatchesRepoNamesCaseInsensitively(t *testing.T) 
 	require.Len(t, result.Configured, 1)
 	assert.Equal(1, result.Configured[0].MatchedRepoCount)
 	assert.Equal([]RepoRef{{
-		Platform:           platform.KindGitHub,
-		Owner:              "acme",
-		Name:               "widget-api",
-		PlatformHost:       "github.com",
-		RepoPath:           "acme/widget-api",
-		ConfiguredRepoPath: "acme/widget-*",
+		Platform:     platform.KindGitHub,
+		Owner:        "acme",
+		Name:         "widget-api",
+		PlatformHost: "github.com",
+		RepoPath:     "acme/widget-api",
 	}}, result.Expanded)
 }
 

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5476,7 +5476,7 @@ func (s *Syncer) reconcileRepoIdentity(
 		}
 	}
 	authoritative := repoRefFromCatalog(repo, entry.Repository, resolved)
-	s.publishResolvedRepository(repo, authoritative)
+	s.publishResolvedRepository(repo, authoritative, resolved != nil)
 	if err := s.reconcileArchiveRepositoryIfNeeded(
 		ctx, previousID, entry.Repository.ID,
 	); err != nil {
@@ -5572,13 +5572,22 @@ func repoRefFromCatalog(previous RepoRef, stored db.Repo, resolved *platform.Rep
 	return repo
 }
 
-func (s *Syncer) publishResolvedRepository(previous, resolved RepoRef) {
+func (s *Syncer) publishResolvedRepository(
+	previous, resolved RepoRef, archivedAuthoritative bool,
+) {
 	s.clearDisplacedCredentialAlias(resolved)
 	s.aliasRenamedCredentialRoute(previous, resolved)
 	s.reposMu.Lock()
 	defer s.reposMu.Unlock()
 	for i := range s.repos {
 		if repoPriorityKey(s.repos[i]) == repoPriorityKey(previous) {
+			if !archivedAuthoritative {
+				// Without fresh provider metadata the archived flag was
+				// reconstructed from the operation's snapshot, which may
+				// predate a newer flip on the tracked ref. The current
+				// tracked state stays authoritative.
+				resolved.Archived = s.repos[i].Archived
+			}
 			s.repos[i] = resolved
 			return
 		}

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5595,6 +5595,10 @@ func (s *Syncer) publishResolvedRepository(
 				// tracked state stays authoritative.
 				resolved.Archived = s.repos[i].Archived
 			}
+			// Config-entry provenance is authored only by configuration
+			// resolution; a publication built from an older snapshot must
+			// not overwrite a value a concurrent reload just updated.
+			resolved.ConfiguredRepoPath = s.repos[i].ConfiguredRepoPath
 			s.repos[i] = resolved
 			return
 		}

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5586,29 +5586,57 @@ func (s *Syncer) publishResolvedRepository(
 	s.aliasRenamedCredentialRoute(previous, resolved)
 	s.reposMu.Lock()
 	defer s.reposMu.Unlock()
-	for i := range s.repos {
-		if repoPriorityKey(s.repos[i]) == repoPriorityKey(previous) {
-			if s.repos[i].Archived != previous.Archived {
-				// A concurrent resolution flipped archived state after this
-				// operation snapshotted the ref. The in-flight provider
-				// response cannot be ordered against that flip, so the newer
-				// tracked value stands even over fresh provider metadata.
-				resolved.Archived = s.repos[i].Archived
-			} else if !archivedAuthoritative {
-				// Without fresh provider metadata the archived flag was
-				// reconstructed from the operation's snapshot, which may
-				// predate a newer flip on the tracked ref. The current
-				// tracked state stays authoritative.
-				resolved.Archived = s.repos[i].Archived
+	i, ok := s.trackedRepoSlotLocked(previous)
+	if !ok {
+		return
+	}
+	if s.repos[i].Archived != previous.Archived {
+		// A concurrent resolution flipped archived state after this
+		// operation snapshotted the ref. The in-flight provider
+		// response cannot be ordered against that flip, so the newer
+		// tracked value stands even over fresh provider metadata.
+		resolved.Archived = s.repos[i].Archived
+	} else if !archivedAuthoritative {
+		// Without fresh provider metadata the archived flag was
+		// reconstructed from the operation's snapshot, which may
+		// predate a newer flip on the tracked ref. The current
+		// tracked state stays authoritative.
+		resolved.Archived = s.repos[i].Archived
+	}
+	// Config-entry provenance is authored only by configuration
+	// resolution; a publication built from an older snapshot must
+	// not overwrite a value a concurrent reload just updated.
+	resolved.ConfiguredRepoPath = s.repos[i].ConfiguredRepoPath
+	s.repos[i] = resolved
+}
+
+// trackedRepoSlotLocked locates the tracked entry a publication should land
+// on: stable provider identity first — a renamed route must still find its
+// repository — then the route key, rejected when both sides carry different
+// ids because that means the route was reused by another repository whose
+// tracked state a stale publication must not overwrite. Callers hold reposMu.
+func (s *Syncer) trackedRepoSlotLocked(previous RepoRef) (int, bool) {
+	previousID := strings.TrimSpace(previous.PlatformExternalID)
+	if previousID != "" {
+		for i := range s.repos {
+			if repoPlatform(s.repos[i]) == repoPlatform(previous) &&
+				strings.EqualFold(repoHost(s.repos[i]), repoHost(previous)) &&
+				strings.TrimSpace(s.repos[i].PlatformExternalID) == previousID {
+				return i, true
 			}
-			// Config-entry provenance is authored only by configuration
-			// resolution; a publication built from an older snapshot must
-			// not overwrite a value a concurrent reload just updated.
-			resolved.ConfiguredRepoPath = s.repos[i].ConfiguredRepoPath
-			s.repos[i] = resolved
-			return
 		}
 	}
+	for i := range s.repos {
+		if repoPriorityKey(s.repos[i]) != repoPriorityKey(previous) {
+			continue
+		}
+		trackedID := strings.TrimSpace(s.repos[i].PlatformExternalID)
+		if trackedID != "" && previousID != "" && trackedID != previousID {
+			continue
+		}
+		return i, true
+	}
+	return 0, false
 }
 
 // aliasRenamedCredentialRoute keeps GitHub credential selection on the

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5408,7 +5408,12 @@ func (s *Syncer) reconcileArchivedRepos(
 			skipped = append(skipped, repo.Owner+"/"+repo.Name)
 			continue
 		}
+		// Register provider work so an admitted archive request on the
+		// same credential is preempted instead of overlapping the
+		// refresh, matching the coordination live repo syncs get.
+		release := s.beginProviderWork(bucket, archive.PriorityNormalIndex)
 		resolved, _, _, err := s.reconcileRepoIdentity(ctx, repo)
+		release()
 		if err != nil {
 			slog.Debug("archived repo metadata refresh failed",
 				"repo", repo.Owner+"/"+repo.Name, "err", err,
@@ -5544,7 +5549,14 @@ func (s *Syncer) reconcileRepoIdentity(
 		}
 	}
 	authoritative := repoRefFromCatalog(repo, entry.Repository, resolved)
-	s.publishResolvedRepository(repo, authoritative, resolved != nil)
+	if published, ok := s.publishResolvedRepository(
+		repo, authoritative, resolved != nil,
+	); ok {
+		// The publication may have kept a newer tracked archived flip
+		// over this snapshot's metadata; callers deciding whether to
+		// keep syncing must see the value that was actually published.
+		authoritative = published
+	}
 	if err := s.reconcileArchiveRepositoryIfNeeded(
 		ctx, previousID, entry.Repository.ID,
 	); err != nil {
@@ -5644,25 +5656,29 @@ func repoRefFromCatalog(previous RepoRef, stored db.Repo, resolved *platform.Rep
 
 func (s *Syncer) publishResolvedRepository(
 	previous, resolved RepoRef, archivedAuthoritative bool,
-) {
+) (RepoRef, bool) {
 	s.clearDisplacedCredentialAlias(resolved)
 	s.aliasRenamedCredentialRoute(previous, resolved)
 	s.reposMu.Lock()
 	defer s.reposMu.Unlock()
 	i, ok := s.trackedRepoSlotLocked(previous, resolved)
 	if !ok {
-		return
+		return resolved, false
 	}
 	// The snapshot comparison below only means anything when the
 	// publication concerns the repository the snapshot named: differing
 	// snapshot and resolved ids mean the data belongs to a route
 	// successor — whether it landed on the successor's own entry or is
 	// displacing the snapshot's — and the snapshot's archived flag says
-	// nothing about it.
+	// nothing about it. A conflicting slot id is cross-identity even
+	// when the snapshot carries no id: the slot's occupant is not the
+	// repository the provider response describes.
 	slotID := strings.TrimSpace(s.repos[i].PlatformExternalID)
 	previousID := strings.TrimSpace(previous.PlatformExternalID)
 	resolvedID := strings.TrimSpace(resolved.PlatformExternalID)
-	crossIdentity := resolvedID != "" && previousID != "" && resolvedID != previousID
+	crossIdentity := resolvedID != "" &&
+		((previousID != "" && resolvedID != previousID) ||
+			(slotID != "" && resolvedID != slotID))
 	sameIdentity := !crossIdentity &&
 		(slotID == "" || previousID == "" || slotID == previousID)
 	if sameIdentity && s.repos[i].Archived != previous.Archived {
@@ -5683,6 +5699,7 @@ func (s *Syncer) publishResolvedRepository(
 	// not overwrite a value a concurrent reload just updated.
 	resolved.ConfiguredRepoPath = s.repos[i].ConfiguredRepoPath
 	s.repos[i] = resolved
+	return resolved, true
 }
 
 // trackedRepoSlotLocked locates the tracked entry a publication should land

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5586,7 +5586,7 @@ func (s *Syncer) publishResolvedRepository(
 	s.aliasRenamedCredentialRoute(previous, resolved)
 	s.reposMu.Lock()
 	defer s.reposMu.Unlock()
-	i, ok := s.trackedRepoSlotLocked(previous)
+	i, ok := s.trackedRepoSlotLocked(previous, resolved)
 	if !ok {
 		return
 	}
@@ -5612,20 +5612,34 @@ func (s *Syncer) publishResolvedRepository(
 
 // trackedRepoSlotLocked locates the tracked entry a publication should land
 // on: stable provider identity first — a renamed route must still find its
-// repository — then the route key, rejected when both sides carry different
-// ids because that means the route was reused by another repository whose
-// tracked state a stale publication must not overwrite. Callers hold reposMu.
-func (s *Syncer) trackedRepoSlotLocked(previous RepoRef) (int, bool) {
+// repository — then the route key, rejected when the ids conflict because
+// that means the route was reused by another repository whose tracked state
+// a stale publication must not overwrite. The resolved id outranks the
+// snapshot id: the provider response says whose data this is, so a lookup
+// keyed by a reused route lands on the successor, never on the repository
+// the snapshot named. Callers hold reposMu.
+func (s *Syncer) trackedRepoSlotLocked(previous, resolved RepoRef) (int, bool) {
 	previousID := strings.TrimSpace(previous.PlatformExternalID)
-	if previousID != "" {
+	resolvedID := strings.TrimSpace(resolved.PlatformExternalID)
+	lookupID := resolvedID
+	if lookupID == "" {
+		lookupID = previousID
+	}
+	if lookupID != "" {
 		for i := range s.repos {
 			if repoPlatform(s.repos[i]) == repoPlatform(previous) &&
 				strings.EqualFold(repoHost(s.repos[i]), repoHost(previous)) &&
-				strings.TrimSpace(s.repos[i].PlatformExternalID) == previousID {
+				strings.TrimSpace(s.repos[i].PlatformExternalID) == lookupID {
 				return i, true
 			}
 		}
 	}
+	// Route fallback: landing on the entry this operation snapshotted is
+	// legitimate even under a new resolved identity — a configured route
+	// reused by a replacement repository displaces its tracked occupant,
+	// and the archive lifecycle pauses the old repository. Landing on an
+	// entry whose id conflicts with the snapshot is not: that entry is a
+	// different repository this publication knows nothing about.
 	for i := range s.repos {
 		if repoPriorityKey(s.repos[i]) != repoPriorityKey(previous) {
 			continue

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5590,12 +5590,18 @@ func (s *Syncer) publishResolvedRepository(
 	if !ok {
 		return
 	}
-	// The snapshot comparison below only means anything when the slot is
-	// the repository the snapshot named; on a cross-identity landing the
-	// snapshot's archived flag belongs to a different repository.
+	// The snapshot comparison below only means anything when the
+	// publication concerns the repository the snapshot named: differing
+	// snapshot and resolved ids mean the data belongs to a route
+	// successor — whether it landed on the successor's own entry or is
+	// displacing the snapshot's — and the snapshot's archived flag says
+	// nothing about it.
 	slotID := strings.TrimSpace(s.repos[i].PlatformExternalID)
 	previousID := strings.TrimSpace(previous.PlatformExternalID)
-	sameIdentity := slotID == "" || previousID == "" || slotID == previousID
+	resolvedID := strings.TrimSpace(resolved.PlatformExternalID)
+	crossIdentity := resolvedID != "" && previousID != "" && resolvedID != previousID
+	sameIdentity := !crossIdentity &&
+		(slotID == "" || previousID == "" || slotID == previousID)
 	if sameIdentity && s.repos[i].Archived != previous.Archived {
 		// A concurrent resolution flipped archived state after this
 		// operation snapshotted the ref. The in-flight provider

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5590,7 +5590,13 @@ func (s *Syncer) publishResolvedRepository(
 	if !ok {
 		return
 	}
-	if s.repos[i].Archived != previous.Archived {
+	// The snapshot comparison below only means anything when the slot is
+	// the repository the snapshot named; on a cross-identity landing the
+	// snapshot's archived flag belongs to a different repository.
+	slotID := strings.TrimSpace(s.repos[i].PlatformExternalID)
+	previousID := strings.TrimSpace(previous.PlatformExternalID)
+	sameIdentity := slotID == "" || previousID == "" || slotID == previousID
+	if sameIdentity && s.repos[i].Archived != previous.Archived {
 		// A concurrent resolution flipped archived state after this
 		// operation snapshotted the ref. The in-flight provider
 		// response cannot be ordered against that flip, so the newer

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -4345,7 +4345,38 @@ func (s *Syncer) watchedMRsForFastSync(ctx context.Context, now time.Time) []Wat
 	for _, mr := range s.hotAndWarmOpenMRs(ctx, now, activeWindow, watchInt) {
 		watched.add(mr)
 	}
-	return watched.slice()
+	items := watched.slice()
+	archived := s.archivedRepoKeys()
+	if len(archived) == 0 {
+		return items
+	}
+	live := make([]WatchedMR, 0, len(items))
+	for _, mr := range items {
+		key := detailRepoKey(
+			watchedMRPlatform(mr), watchedMRHost(mr), mr.Owner, mr.Name,
+		)
+		if _, ok := archived[key]; ok {
+			continue
+		}
+		live = append(live, mr)
+	}
+	return live
+}
+
+// archivedRepoKeys returns detailRepoKey identities for tracked archived
+// repositories so live lanes (fast sync, notifications) can skip them.
+func (s *Syncer) archivedRepoKeys() map[string]struct{} {
+	s.reposMu.Lock()
+	defer s.reposMu.Unlock()
+	keys := make(map[string]struct{})
+	for _, repo := range s.repos {
+		if repo.Archived {
+			keys[detailRepoKey(
+				repoPlatform(repo), repo.PlatformHost, repo.Owner, repo.Name,
+			)] = struct{}{}
+		}
+	}
+	return keys
 }
 
 func (s *Syncer) watchSettingsLocked() (time.Duration, time.Duration) {

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -244,6 +244,11 @@ type RepoRef struct {
 	// Archived marks a provider-archived repository: configured for archive
 	// collection only, skipped by live sync.
 	Archived bool
+	// ConfiguredRepoPath is the config-entry path this ref was resolved
+	// from. It correlates a tracked repository with its config entry after
+	// a provider-side rename, so a transient resolve failure falls back to
+	// the tracked ref instead of synthesizing an identity-less duplicate.
+	ConfiguredRepoPath string
 }
 
 // PartialSyncError reports a repo sync cycle whose index scan completed but
@@ -5530,9 +5535,11 @@ func repoRefFromCatalog(previous RepoRef, stored db.Repo, resolved *platform.Rep
 		WebURL:             stored.WebURL,
 		CloneURL:           stored.CloneURL,
 		DefaultBranch:      stored.DefaultBranch,
-		// The repo catalog does not record archived state; without a fresh
-		// provider resolve, the previously tracked flag stands.
-		Archived: previous.Archived,
+		// The repo catalog does not record archived state or config-entry
+		// provenance; without a fresh provider resolve, the previously
+		// tracked values stand.
+		Archived:           previous.Archived,
+		ConfiguredRepoPath: previous.ConfiguredRepoPath,
 	}
 	if repo.PlatformRepoID == 0 {
 		repo.PlatformRepoID = previous.PlatformRepoID

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -241,6 +241,9 @@ type RepoRef struct {
 	WebURL             string
 	CloneURL           string
 	DefaultBranch      string
+	// Archived marks a provider-archived repository: configured for archive
+	// collection only, skipped by live sync.
+	Archived bool
 }
 
 // PartialSyncError reports a repo sync cycle whose index scan completed but
@@ -602,7 +605,7 @@ type archiveRunner interface {
 }
 
 type archiveRepositoryLifecycle interface {
-	EnsureConfigured(context.Context, []platform.RepoRef) error
+	EnsureConfigured(context.Context, []platform.RepoRef) ([]platform.RepoRef, error)
 	RetryAuthentication(context.Context, []platform.RepoRef) error
 }
 
@@ -3790,11 +3793,14 @@ func (s *Syncer) SetReposWithContext(ctx context.Context, repos []RepoRef, retry
 		refs = append(refs, platformRepoRef(repo))
 	}
 	if s.archiveLifecycle != nil {
-		if err := s.archiveLifecycle.EnsureConfigured(ctx, refs); err != nil {
+		seeded, err := s.archiveLifecycle.EnsureConfigured(ctx, refs)
+		if err != nil {
 			return fmt.Errorf("seed archive discovery: %w", err)
 		}
 		if retryAuthentication {
-			if err := s.archiveLifecycle.RetryAuthentication(ctx, refs); err != nil {
+			// Only refs that seeded can resolve; a ref skipped by seeding
+			// must not fail the retry pass (and with it the config reload).
+			if err := s.archiveLifecycle.RetryAuthentication(ctx, seeded); err != nil {
 				return fmt.Errorf("retry archive authentication: %w", err)
 			}
 		}
@@ -5116,6 +5122,7 @@ func (s *Syncer) runOnce(
 	s.reposMu.Lock()
 	repos := slices.Clone(s.repos)
 	s.reposMu.Unlock()
+	repos = excludeArchivedRepos(repos)
 	if onlyRepos != nil {
 		repos = selectRepos(repos, onlyRepos)
 	}
@@ -5322,6 +5329,25 @@ func prioritizeRepos(repos, priorityRepos []RepoRef) []RepoRef {
 	return out
 }
 
+// excludeArchivedRepos drops provider-archived repositories from a live sync
+// pass. Archived repos stay tracked in s.repos for archive collection and
+// API surfaces; only live polling skips them.
+func excludeArchivedRepos(repos []RepoRef) []RepoRef {
+	live := make([]RepoRef, 0, len(repos))
+	skipped := make([]string, 0)
+	for _, repo := range repos {
+		if repo.Archived {
+			skipped = append(skipped, repo.Owner+"/"+repo.Name)
+			continue
+		}
+		live = append(live, repo)
+	}
+	if len(skipped) > 0 {
+		slog.Debug("skipping archived repos in live sync", "repos", skipped)
+	}
+	return live
+}
+
 func selectRepos(repos, selectedRepos []RepoRef) []RepoRef {
 	selectedKeys := make(map[string]struct{}, len(selectedRepos))
 	for _, repo := range selectedRepos {
@@ -5454,7 +5480,7 @@ func (s *Syncer) reconcileArchiveRepositoryIfNeeded(
 	for _, trackedRepo := range tracked {
 		refs = append(refs, platformRepoRef(trackedRepo))
 	}
-	if err := s.archiveLifecycle.EnsureConfigured(ctx, refs); err != nil {
+	if _, err := s.archiveLifecycle.EnsureConfigured(ctx, refs); err != nil {
 		return fmt.Errorf("reconcile archive repository replacement: %w", err)
 	}
 	s.WakeArchive()
@@ -5473,6 +5499,9 @@ func repoRefFromCatalog(previous RepoRef, stored db.Repo, resolved *platform.Rep
 		WebURL:             stored.WebURL,
 		CloneURL:           stored.CloneURL,
 		DefaultBranch:      stored.DefaultBranch,
+		// The repo catalog does not record archived state; without a fresh
+		// provider resolve, the previously tracked flag stands.
+		Archived: previous.Archived,
 	}
 	if repo.PlatformRepoID == 0 {
 		repo.PlatformRepoID = previous.PlatformRepoID
@@ -5489,6 +5518,7 @@ func repoRefFromCatalog(previous RepoRef, stored db.Repo, resolved *platform.Rep
 	if resolved == nil {
 		return repo
 	}
+	repo.Archived = resolved.Archived
 	repo.PlatformRepoID = resolved.PlatformID
 	if repo.PlatformRepoID == 0 {
 		repo.PlatformRepoID = resolved.Ref.PlatformID

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5165,9 +5165,11 @@ func (s *Syncer) runOnce(
 	if bypassNextSyncAfter {
 		nextAfter = nil
 	}
-	repos = s.reconcileArchivedRepos(
-		ctx, repos, s.repoEligibility(repos, nextAfter),
-	)
+	// Computed over the selected set before still-archived refs drop
+	// out, so buckets holding only archived repositories keep an entry
+	// for the cadence advance below.
+	archivedEligibility := s.repoEligibility(repos, nextAfter)
+	repos = s.reconcileArchivedRepos(ctx, repos, archivedEligibility)
 	repos = prioritizeRepos(repos, priorityRepos)
 
 	total := len(repos)
@@ -5309,9 +5311,15 @@ dispatch:
 		s.RefreshRateLimitSnapshots(rateLimitSnapshotCtx)
 	}
 	if onlyRepos == nil {
-		s.advanceNextSync(
-			eligibleBuckets, s.nextSyncAfter, s.interval,
-		)
+		// Archived-only buckets are absent from eligibleBuckets — their
+		// refs dropped out before it was computed — but an attempted
+		// archived refresh must advance the bucket's cadence gate too,
+		// or the refresh would rerun every base interval regardless of
+		// throttle factor. The post-reconciliation value wins for
+		// buckets present in both maps.
+		advance := maps.Clone(archivedEligibility)
+		maps.Copy(advance, eligibleBuckets)
+		s.advanceNextSync(advance, s.nextSyncAfter, s.interval)
 	}
 
 	slog.Info("sync complete", "repos", total)

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5588,7 +5588,13 @@ func (s *Syncer) publishResolvedRepository(
 	defer s.reposMu.Unlock()
 	for i := range s.repos {
 		if repoPriorityKey(s.repos[i]) == repoPriorityKey(previous) {
-			if !archivedAuthoritative {
+			if s.repos[i].Archived != previous.Archived {
+				// A concurrent resolution flipped archived state after this
+				// operation snapshotted the ref. The in-flight provider
+				// response cannot be ordered against that flip, so the newer
+				// tracked value stands even over fresh provider metadata.
+				resolved.Archived = s.repos[i].Archived
+			} else if !archivedAuthoritative {
 				// Without fresh provider metadata the archived flag was
 				// reconstructed from the operation's snapshot, which may
 				// predate a newer flip on the tracked ref. The current

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5161,7 +5161,13 @@ func (s *Syncer) runOnce(
 	if onlyRepos != nil {
 		repos = selectRepos(repos, onlyRepos)
 	}
-	repos = s.reconcileArchivedRepos(ctx, repos)
+	nextAfter := s.nextSyncAfter
+	if bypassNextSyncAfter {
+		nextAfter = nil
+	}
+	repos = s.reconcileArchivedRepos(
+		ctx, repos, s.repoEligibility(repos, nextAfter),
+	)
 	repos = prioritizeRepos(repos, priorityRepos)
 
 	total := len(repos)
@@ -5189,10 +5195,6 @@ func (s *Syncer) runOnce(
 		}
 	}
 
-	nextAfter := s.nextSyncAfter
-	if bypassNextSyncAfter {
-		nextAfter = nil
-	}
 	if rateLimitSnapshotCtx.Err() == nil {
 		refreshed := s.refreshRateLimitSnapshots(rateLimitSnapshotCtx)
 		s.clearRecoveredRateLimitGates(refreshed, nextAfter, s.interval)
@@ -5372,9 +5374,15 @@ func prioritizeRepos(repos, priorityRepos []RepoRef) []RepoRef {
 // tracked refs so an upstream unarchive is observed during normal
 // sync passes. Refs the provider still reports archived (or whose
 // metadata refresh fails) stay excluded from the pass; refs that
-// resolved unarchived rejoin it with fresh metadata.
+// resolved unarchived rejoin it with fresh metadata. Refs in
+// credential buckets the pass would not dispatch — throttled,
+// reserve-exhausted, or deferred by next-sync-after — are deferred
+// without a provider call: the refresh must not spend sync budget a
+// live repository's dispatch would be denied. Eligibility is read
+// before the pass refreshes rate-limit snapshots, so a gate that has
+// recovered upstream defers the refresh by at most one pass.
 func (s *Syncer) reconcileArchivedRepos(
-	ctx context.Context, repos []RepoRef,
+	ctx context.Context, repos []RepoRef, eligibility map[string]bool,
 ) []RepoRef {
 	live := make([]RepoRef, 0, len(repos))
 	skipped := make([]string, 0)
@@ -5384,6 +5392,11 @@ func (s *Syncer) reconcileArchivedRepos(
 			continue
 		}
 		if ctx.Err() != nil {
+			skipped = append(skipped, repo.Owner+"/"+repo.Name)
+			continue
+		}
+		bucket, err := s.bucketKeyForRepo(repo, false)
+		if err != nil || !eligibility[bucket] {
 			skipped = append(skipped, repo.Owner+"/"+repo.Name)
 			continue
 		}

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5158,10 +5158,10 @@ func (s *Syncer) runOnce(
 	s.reposMu.Lock()
 	repos := slices.Clone(s.repos)
 	s.reposMu.Unlock()
-	repos = excludeArchivedRepos(repos)
 	if onlyRepos != nil {
 		repos = selectRepos(repos, onlyRepos)
 	}
+	repos = s.reconcileArchivedRepos(ctx, repos)
 	repos = prioritizeRepos(repos, priorityRepos)
 
 	total := len(repos)
@@ -5368,6 +5368,48 @@ func prioritizeRepos(repos, priorityRepos []RepoRef) []RepoRef {
 // excludeArchivedRepos drops provider-archived repositories from a live sync
 // pass. Archived repos stay tracked in s.repos for archive collection and
 // API surfaces; only live polling skips them.
+// reconcileArchivedRepos refreshes provider metadata for archived
+// tracked refs so an upstream unarchive is observed during normal
+// sync passes. Refs the provider still reports archived (or whose
+// metadata refresh fails) stay excluded from the pass; refs that
+// resolved unarchived rejoin it with fresh metadata.
+func (s *Syncer) reconcileArchivedRepos(
+	ctx context.Context, repos []RepoRef,
+) []RepoRef {
+	live := make([]RepoRef, 0, len(repos))
+	skipped := make([]string, 0)
+	for _, repo := range repos {
+		if !repo.Archived {
+			live = append(live, repo)
+			continue
+		}
+		if ctx.Err() != nil {
+			skipped = append(skipped, repo.Owner+"/"+repo.Name)
+			continue
+		}
+		resolved, _, _, err := s.reconcileRepoIdentity(ctx, repo)
+		if err != nil {
+			slog.Debug("archived repo metadata refresh failed",
+				"repo", repo.Owner+"/"+repo.Name, "err", err,
+			)
+			skipped = append(skipped, repo.Owner+"/"+repo.Name)
+			continue
+		}
+		if resolved.Archived {
+			skipped = append(skipped, repo.Owner+"/"+repo.Name)
+			continue
+		}
+		slog.Info("repo unarchived upstream; resuming live sync",
+			"repo", resolved.Owner+"/"+resolved.Name,
+		)
+		live = append(live, resolved)
+	}
+	if len(skipped) > 0 {
+		slog.Debug("skipping archived repos in live sync", "repos", skipped)
+	}
+	return live
+}
+
 func excludeArchivedRepos(repos []RepoRef) []RepoRef {
 	live := make([]RepoRef, 0, len(repos))
 	skipped := make([]string, 0)
@@ -5738,6 +5780,15 @@ func (s *Syncer) syncRepo(ctx context.Context, repo RepoRef) error {
 		return fmt.Errorf("resolve repo identity %s/%s: %w", repo.Owner, repo.Name, err)
 	}
 	repo = resolvedRef
+	if repo.Archived {
+		// Identity resolution already published the archived flag, so
+		// the repo drops out of future passes; stop before any live
+		// clone, overview, or item syncing touches the archived repo.
+		slog.Info("repo archived upstream; skipping live sync",
+			"repo", repo.Owner+"/"+repo.Name,
+		)
+		return nil
+	}
 
 	s.refreshRepoSettings(ctx, repo, repoID, resolvedRepo)
 

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -10571,6 +10571,13 @@ func (s *Syncer) drainDetailQueue(
 			repo.Name = qi.RepoName
 			repo.PlatformHost = host
 		}
+		// The queue was built before the pass ran, so it can hold items
+		// for a repository the pass just published as archived. Detail
+		// work is live syncing; archived repos hydrate through the
+		// archive budget path instead.
+		if repo.Archived {
+			continue
+		}
 		// Resolve the credential bucket from the tracked repository. Routing
 		// keys off the owner and host that survive tracking, not the raw
 		// queue row, so this must follow the lookup above.
@@ -10639,6 +10646,13 @@ func (s *Syncer) drainDetailQueue(
 			repoID = resolvedRepoID
 			verifiedRepos[repoKey] = repo
 			verifiedRepoIDs[repoKey] = repoID
+		}
+		if repo.Archived {
+			// Identity verification just discovered the archived flip;
+			// the publication already dropped the repo from live sync.
+			probe.abandon()
+			rejectedRepos[repoKey] = true
+			continue
 		}
 		if repoID == 0 {
 			probe.abandon()
@@ -10994,6 +11008,14 @@ func (s *Syncer) syncMRForRepo(
 		return fmt.Errorf("resolve repo identity %s/%s: %w", owner, name, err)
 	}
 	repo = resolvedRef
+	if repo.Archived && !IsArchiveSyncBudgetContext(ctx) {
+		// Live detail syncing stops on an archived repo; only archive
+		// hydration, which runs under the archive budget, proceeds.
+		slog.Debug("skipping MR detail sync for archived repo",
+			"repo", owner+"/"+name, "number", number,
+		)
+		return nil
+	}
 
 	// Preserve derived fields that provider detail doesn't populate. CI is
 	// refreshed later in this sync path; keeping the previous values here
@@ -11562,6 +11584,14 @@ func (s *Syncer) syncIssueForRepo(
 		)
 	}
 	repo = resolvedRef
+	if repo.Archived && !IsArchiveSyncBudgetContext(ctx) {
+		// Live detail syncing stops on an archived repo; only archive
+		// hydration, which runs under the archive budget, proceeds.
+		slog.Debug("skipping issue detail sync for archived repo",
+			"repo", repo.Owner+"/"+repo.Name, "number", number,
+		)
+		return nil
+	}
 
 	providerCalls, err := s.fetchIssueDetail(ctx, repo, repoID, number)
 	if providerAttempted != nil && providerCalls > 0 {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -10306,6 +10306,26 @@ func TestRepoRefFromCatalogKeepsArchived(t *testing.T) {
 	}).Archived)
 }
 
+func TestRepoRefFromCatalogKeepsConfiguredRepoPath(t *testing.T) {
+	assert := assert.New(t)
+	previous := RepoRef{
+		Owner: "acme", Name: "tools-new",
+		PlatformHost:       "github.com",
+		ConfiguredRepoPath: "acme/tools",
+	}
+	stored := db.Repo{
+		ID: 7, Platform: "github", PlatformHost: "github.com",
+		Owner: "acme", Name: "tools-new",
+	}
+
+	// Catalog republication must not erase the config-entry provenance
+	// that correlates a renamed route with its config entry on reload.
+	assert.Equal("acme/tools",
+		repoRefFromCatalog(previous, stored, nil).ConfiguredRepoPath)
+	assert.Equal("acme/tools",
+		repoRefFromCatalog(previous, stored, &platform.Repository{}).ConfiguredRepoPath)
+}
+
 func TestPublishResolvedRepositoryPreservesNewerArchivedState(t *testing.T) {
 	assert := assert.New(t)
 	d := openTestDB(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -10375,6 +10375,59 @@ func TestPublishResolvedRepositoryPreservesMidflightArchivedFlip(t *testing.T) {
 		"a mid-flight archived flip must not be clobbered by an older publication")
 }
 
+func TestPublishResolvedRepositoryMatchesByStableIdentityFirst(t *testing.T) {
+	assert := assert.New(t)
+	d := openTestDB(t)
+	tracked := RepoRef{
+		Owner: "acme", Name: "tools-new", PlatformHost: "github.com",
+		RepoPath: "acme/tools-new", PlatformExternalID: "repo-x",
+	}
+	syncer := NewSyncer(
+		map[string]Client{}, d, nil, []RepoRef{tracked}, time.Hour, nil, nil,
+	)
+
+	// A slower operation publishes with a snapshot bearing the old route
+	// after the tracked ref already moved to the renamed one. The stable
+	// provider id still locates the tracked entry.
+	previous := RepoRef{
+		Owner: "acme", Name: "tools", PlatformHost: "github.com",
+		RepoPath: "acme/tools", PlatformExternalID: "repo-x",
+	}
+	resolved := tracked
+	resolved.DefaultBranch = "main"
+	syncer.publishResolvedRepository(previous, resolved, true)
+	assert.Equal("main", syncer.TrackedRepos()[0].DefaultBranch,
+		"identity match must publish onto the renamed tracked entry")
+}
+
+func TestPublishResolvedRepositoryDoesNotOverwriteRouteSuccessor(t *testing.T) {
+	assert := assert.New(t)
+	d := openTestDB(t)
+	successor := RepoRef{
+		Owner: "acme", Name: "tools", PlatformHost: "github.com",
+		RepoPath: "acme/tools", PlatformExternalID: "repo-y",
+	}
+	syncer := NewSyncer(
+		map[string]Client{}, d, nil, []RepoRef{successor}, time.Hour, nil, nil,
+	)
+
+	// A stale sync of the renamed-away repository publishes with the old
+	// route while a different repository now occupies it. Conflicting
+	// stable ids mean the route match is reuse, not a rename: the
+	// successor's tracked state must survive.
+	previous := RepoRef{
+		Owner: "acme", Name: "tools", PlatformHost: "github.com",
+		RepoPath: "acme/tools", PlatformExternalID: "repo-x",
+	}
+	resolved := previous
+	resolved.Archived = true
+	syncer.publishResolvedRepository(previous, resolved, true)
+	got := syncer.TrackedRepos()[0]
+	assert.Equal("repo-y", got.PlatformExternalID,
+		"a stale publication must not overwrite the route successor")
+	assert.False(got.Archived)
+}
+
 func TestPublishResolvedRepositoryPreservesNewerConfiguredRepoPath(t *testing.T) {
 	assert := assert.New(t)
 	d := openTestDB(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -10353,6 +10353,28 @@ func TestPublishResolvedRepositoryPreservesNewerArchivedState(t *testing.T) {
 	assert.False(syncer.TrackedRepos()[0].Archived)
 }
 
+func TestPublishResolvedRepositoryPreservesMidflightArchivedFlip(t *testing.T) {
+	assert := assert.New(t)
+	d := openTestDB(t)
+	tracked := RepoRef{
+		Owner: "acme", Name: "frozen", PlatformHost: "github.com",
+		RepoPath: "acme/frozen", Archived: true,
+	}
+	syncer := NewSyncer(
+		map[string]Client{}, d, nil, []RepoRef{tracked}, time.Hour, nil, nil,
+	)
+
+	// The operation snapshotted the ref before a concurrent resolution
+	// flipped the tracked archived flag. Its own provider response cannot
+	// be ordered against that flip, so the newer tracked value survives
+	// even a publication carrying fresh provider metadata.
+	stale := tracked
+	stale.Archived = false
+	syncer.publishResolvedRepository(stale, stale, true)
+	assert.True(syncer.TrackedRepos()[0].Archived,
+		"a mid-flight archived flip must not be clobbered by an older publication")
+}
+
 func TestPublishResolvedRepositoryPreservesNewerConfiguredRepoPath(t *testing.T) {
 	assert := assert.New(t)
 	d := openTestDB(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -10388,6 +10388,58 @@ func TestRunOnceDefersArchivedRefreshForThrottledBucket(t *testing.T) {
 		"deferred archived ref must keep its archived flag")
 }
 
+func TestRunOnceAdvancesCadenceForArchivedOnlyBucket(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+
+	var getRepositoryCalls atomic.Int32
+	gheMock := &mockClient{
+		openPRs:  []*gh.PullRequest{},
+		comments: []*gh.IssueComment{},
+		reviews:  []*gh.PullRequestReview{},
+		commits:  []*gh.RepositoryCommit{},
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			getRepositoryCalls.Add(1)
+			id := int64(1)
+			nodeID := "repo-" + owner + "-" + repo
+			archived := true
+			return &gh.Repository{
+				ID:       &id,
+				NodeID:   &nodeID,
+				Name:     &repo,
+				Owner:    &gh.User{Login: &owner},
+				Archived: &archived,
+			}, nil
+		},
+	}
+
+	gheTracker := NewRateTracker(d, "ghe.corp.com", "host", "rest")
+	gheTracker.UpdateFromRate(Rate{
+		Limit:     5000,
+		Remaining: 4000,
+		Reset:     time.Now().Add(30 * time.Minute),
+	})
+
+	repos := []RepoRef{
+		{Owner: "corp", Name: "frozen", PlatformHost: "ghe.corp.com", Archived: true},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"ghe.corp.com": gheMock}, d, nil, repos,
+		time.Minute, map[string]*RateTracker{"ghe.corp.com": gheTracker}, nil,
+	)
+
+	syncer.RunOnce(t.Context())
+	require.Equal(int32(1), getRepositoryCalls.Load(),
+		"first pass refreshes the archived ref")
+
+	syncer.RunOnce(t.Context())
+	assert.Equal(int32(1), getRepositoryCalls.Load(),
+		"second pass inside the cadence gate must defer the archived refresh")
+}
+
 func TestRunOnceStopsLiveSyncWhenRepoArchivesMidPass(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -10549,6 +10549,168 @@ func TestPublishResolvedRepositoryEmptySnapshotIDKeepsSuccessorArchivedState(t *
 			"when the snapshot id is empty")
 }
 
+func TestDetailDrainSkipsRepoArchivedMidPass(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	// A stale open item queued before the repository archived.
+	repoID, err := d.UpsertRepo(ctx, verifiedGitHubRepoIdentity(
+		"github.com", "owner", "repo",
+	))
+	require.NoError(err)
+	seededAt := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	_, err = d.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      1000,
+		Number:          1,
+		URL:             "https://github.com/owner/repo/pull/1",
+		Title:           "stale PR",
+		Author:          "alice",
+		State:           "open",
+		HeadBranch:      "feature",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "abc123",
+		CreatedAt:       seededAt,
+		UpdatedAt:       seededAt,
+		LastActivityAt:  seededAt,
+	})
+	require.NoError(err)
+
+	mc := &detailTrackingClient{}
+	mc.openPRs = []*gh.PullRequest{}
+	mc.comments = []*gh.IssueComment{}
+	mc.reviews = []*gh.PullRequestReview{}
+	mc.commits = []*gh.RepositoryCommit{}
+	archived := true
+	mc.getRepositoryFn = func(
+		_ context.Context, owner, repo string,
+	) (*gh.Repository, error) {
+		id := int64(1)
+		nodeID := "repo-" + owner + "-" + repo
+		return &gh.Repository{
+			ID:       &id,
+			NodeID:   &nodeID,
+			Name:     &repo,
+			Owner:    &gh.User{Login: &owner},
+			Archived: &archived,
+		}, nil
+	}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		time.Minute, nil, testBudget(500),
+	)
+
+	syncer.RunOnce(ctx)
+
+	assert.Zero(int(mc.getPRCalls.Load()),
+		"detail drain must not fetch details for a repo that archived mid-pass")
+	tracked := syncer.TrackedRepos()
+	require.Len(tracked, 1)
+	assert.True(tracked[0].Archived)
+}
+
+func TestSyncWatchedMRsSkipsRepoArchivedMidPass(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	archived := true
+	mc := &mockClient{
+		openPRs:  []*gh.PullRequest{},
+		singlePR: buildOpenPR(7, now),
+		comments: []*gh.IssueComment{},
+		reviews:  []*gh.PullRequestReview{},
+		commits:  []*gh.RepositoryCommit{},
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			id := int64(1)
+			nodeID := "repo-" + owner + "-" + repo
+			return &gh.Repository{
+				ID:       &id,
+				NodeID:   &nodeID,
+				Name:     &repo,
+				Owner:    &gh.User{Login: &owner},
+				Archived: &archived,
+			}, nil
+		},
+	}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{{Owner: "acme", Name: "app", PlatformHost: "github.com"}},
+		time.Hour, nil, nil,
+	)
+	hookCalls := 0
+	syncer.SetOnMRSynced(func(_ string, _ string, _ *db.MergeRequest) {
+		hookCalls++
+	})
+	syncer.SetWatchedMRs([]WatchedMR{{Owner: "acme", Name: "app", Number: 7}})
+
+	syncer.syncWatchedMRs(ctx)
+
+	assert.Zero(hookCalls,
+		"watched-MR sync must stop when resolution reports the repo archived")
+	mr, err := d.GetMergeRequest(ctx, "github", "github.com", "acme", "app", 7)
+	require.NoError(err)
+	assert.Nil(mr, "no MR detail should be persisted for the archived repo")
+	tracked := syncer.TrackedRepos()
+	require.Len(tracked, 1)
+	assert.True(tracked[0].Archived)
+}
+
+func TestSyncMRForRepoHydratesArchivedRepoUnderArchiveBudget(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	archived := true
+	mc := &mockClient{
+		openPRs:  []*gh.PullRequest{},
+		singlePR: buildOpenPR(7, now),
+		comments: []*gh.IssueComment{},
+		reviews:  []*gh.PullRequestReview{},
+		commits:  []*gh.RepositoryCommit{},
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			id := int64(1)
+			nodeID := "repo-" + owner + "-" + repo
+			return &gh.Repository{
+				ID:       &id,
+				NodeID:   &nodeID,
+				Name:     &repo,
+				Owner:    &gh.User{Login: &owner},
+				Archived: &archived,
+			}, nil
+		},
+	}
+	repo := RepoRef{
+		Owner: "acme", Name: "frozen", PlatformHost: "github.com", Archived: true,
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil, []RepoRef{repo},
+		time.Hour, nil, nil,
+	)
+
+	err := syncer.syncMRForRepo(WithArchiveSyncBudget(ctx), repo, 7, false, nil)
+	require.NoError(err)
+
+	mr, err := d.GetMergeRequest(ctx, "github", "github.com", "acme", "frozen", 7)
+	require.NoError(err)
+	require.NotNil(mr,
+		"archive hydration must still sync an archived repo's items")
+	assert.Equal(7, mr.Number)
+}
+
 func TestRunOnceStopsLiveSyncWhenRepoArchivesMidPass(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -10428,6 +10428,44 @@ func TestPublishResolvedRepositoryDoesNotOverwriteRouteSuccessor(t *testing.T) {
 	assert.False(got.Archived)
 }
 
+func TestPublishResolvedRepositoryLandsCrossIdentityLookupOnSuccessor(t *testing.T) {
+	assert := assert.New(t)
+	d := openTestDB(t)
+	renamed := RepoRef{
+		Owner: "acme", Name: "tools-new", PlatformHost: "github.com",
+		RepoPath: "acme/tools-new", PlatformExternalID: "repo-x",
+	}
+	successor := RepoRef{
+		Owner: "acme", Name: "tools", PlatformHost: "github.com",
+		RepoPath: "acme/tools", PlatformExternalID: "repo-y",
+	}
+	syncer := NewSyncer(
+		map[string]Client{}, d, nil,
+		[]RepoRef{renamed, successor}, time.Hour, nil, nil,
+	)
+
+	// An in-flight lookup keyed by the old route resolved the successor:
+	// the snapshot carries the renamed repo's id, the response the
+	// successor's. The publication belongs to the successor — it must not
+	// overwrite the renamed repository's entry.
+	previous := RepoRef{
+		Owner: "acme", Name: "tools", PlatformHost: "github.com",
+		RepoPath: "acme/tools", PlatformExternalID: "repo-x",
+	}
+	resolved := successor
+	resolved.DefaultBranch = "main"
+	syncer.publishResolvedRepository(previous, resolved, true)
+
+	byID := make(map[string]RepoRef)
+	for _, repo := range syncer.TrackedRepos() {
+		byID[repo.PlatformExternalID] = repo
+	}
+	assert.Len(byID, 2, "the renamed repository must not be overwritten")
+	assert.Equal("tools-new", byID["repo-x"].Name)
+	assert.Equal("main", byID["repo-y"].DefaultBranch,
+		"the publication lands on the repository the provider identified")
+}
+
 func TestPublishResolvedRepositoryPreservesNewerConfiguredRepoPath(t *testing.T) {
 	assert := assert.New(t)
 	d := openTestDB(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -2180,6 +2180,44 @@ func TestSyncNotificationsContinuesAfterRepoErrorOnSameHost(t *testing.T) {
 	assert.False(widgetWatermark.LastSuccessfulSyncAt.IsZero())
 }
 
+func TestSyncNotificationsSkipsArchivedRepos(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	database := openTestDB(t)
+	for _, name := range []string{"frozen", "widget"} {
+		_, err := database.UpsertRepo(
+			t.Context(), verifiedGitHubRepoIdentity("github.com", "acme", name),
+		)
+		require.NoError(err)
+	}
+	var listedRepos sync.Map
+	client := &mockClient{
+		listNotificationsFn: func(
+			_ context.Context, opts NotificationListOptions,
+		) ([]NotificationThread, bool, error) {
+			if opts.RepoName != "" {
+				listedRepos.Store(opts.RepoName, true)
+			}
+			return nil, false, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, nil,
+		[]RepoRef{
+			{Owner: "acme", Name: "frozen", PlatformHost: "github.com", Archived: true},
+			{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+		},
+		time.Minute, nil, nil,
+	)
+
+	require.NoError(syncer.SyncNotifications(t.Context()))
+	_, listedWidget := listedRepos.Load("widget")
+	assert.True(listedWidget, "live repo notifications should sync")
+	_, listedFrozen := listedRepos.Load("frozen")
+	assert.False(listedFrozen,
+		"archived repo must not receive notification polling")
+}
+
 func TestSyncNotificationsSkipsUnroutedRepoAndAdvancesRoutedSibling(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -9554,6 +9592,53 @@ func TestSetWatchedMRsReplacesList(t *testing.T) {
 	mu.Unlock()
 	assert.LessOrEqual(countPR1After, countPR1Before+1,
 		"PR #1 should stop being synced after watch list replacement")
+}
+
+func TestWatchedMRsForFastSyncSkipsArchivedRepos(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+
+	liveID, err := d.UpsertRepo(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repo-acme-live", Owner: "acme", Name: "live",
+	})
+	require.NoError(err)
+	frozenID, err := d.UpsertRepo(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repo-acme-frozen", Owner: "acme", Name: "frozen",
+	})
+	require.NoError(err)
+	seedMR := func(repoID int64, number int) {
+		_, upsertErr := d.UpsertMergeRequest(ctx, &db.MergeRequest{
+			RepoID: repoID, PlatformID: int64(number), Number: number,
+			Title: "PR", Author: "octo", State: db.MergeRequestStateOpen,
+			HeadBranch: "feature", BaseBranch: "main",
+			CreatedAt: now.Add(-24 * time.Hour),
+			UpdatedAt: now.Add(-30 * time.Minute), LastActivityAt: now.Add(-30 * time.Minute),
+		})
+		require.NoError(upsertErr)
+	}
+	seedMR(liveID, 1)
+	seedMR(frozenID, 2)
+
+	syncer := NewSyncer(
+		map[string]Client{}, d, nil,
+		[]RepoRef{
+			{Platform: platform.KindGitHub, PlatformHost: "github.com", Owner: "acme", Name: "live"},
+			{Platform: platform.KindGitHub, PlatformHost: "github.com", Owner: "acme", Name: "frozen", Archived: true},
+		},
+		time.Hour, nil, nil,
+	)
+	syncer.SetActiveMRWindow(4 * time.Hour)
+
+	got := syncer.watchedMRsForFastSync(ctx, now)
+	assert.ElementsMatch([]WatchedMR{{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "live", Number: 1,
+	}}, got, "open MRs on archived repos must not enter fast sync")
 }
 
 func TestWatchedMRsIncludeRecentlyActiveOpenPRs(t *testing.T) {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -10353,6 +10353,28 @@ func TestPublishResolvedRepositoryPreservesNewerArchivedState(t *testing.T) {
 	assert.False(syncer.TrackedRepos()[0].Archived)
 }
 
+func TestPublishResolvedRepositoryPreservesNewerConfiguredRepoPath(t *testing.T) {
+	assert := assert.New(t)
+	d := openTestDB(t)
+	tracked := RepoRef{
+		Owner: "acme", Name: "frozen", PlatformHost: "github.com",
+		RepoPath: "acme/frozen", ConfiguredRepoPath: "acme/frozen",
+	}
+	syncer := NewSyncer(
+		map[string]Client{}, d, nil, []RepoRef{tracked}, time.Hour, nil, nil,
+	)
+
+	// A sync snapshot taken before a config reload rewired the entry
+	// carries stale provenance. Provider resolution never authors
+	// config-entry provenance, so the currently tracked value survives
+	// even a publication with fresh provider metadata.
+	stale := tracked
+	stale.ConfiguredRepoPath = ""
+	syncer.publishResolvedRepository(stale, stale, true)
+	assert.Equal("acme/frozen", syncer.TrackedRepos()[0].ConfiguredRepoPath,
+		"a stale republication must not erase config-entry provenance")
+}
+
 func TestRunOnceScopesGitHubProviderReserveToRepoCredential(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -2218,6 +2218,37 @@ func TestSyncNotificationsSkipsArchivedRepos(t *testing.T) {
 		"archived repo must not receive notification polling")
 }
 
+func TestAckRepoBucketsIncludesArchivedTrackedRepos(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := openTestDB(t)
+	syncer := NewSyncer(
+		map[string]Client{"github.com": &mockClient{}}, database, nil,
+		[]RepoRef{
+			{Owner: "acme", Name: "frozen", PlatformHost: "github.com", Archived: true},
+			{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+		},
+		time.Minute, nil, nil,
+	)
+	queued := []db.Notification{{
+		ID: 1, RepoOwner: "acme", RepoName: "widget",
+	}}
+
+	byBucket, byNotification := syncer.ackRepoBuckets(
+		platform.KindGitHub, "github.com", queued,
+	)
+
+	bucket, ok := byNotification[1]
+	require.True(ok)
+	names := make([]string, 0, len(byBucket[bucket]))
+	for _, repo := range byBucket[bucket] {
+		names = append(names, repo.Name)
+	}
+	assert.Contains(names, "frozen",
+		"archived repos must stay in ack deferral buckets: their queued "+
+			"acknowledgements share the credential's rate limit")
+}
+
 func TestSyncNotificationsSkipsUnroutedRepoAndAdvancesRoutedSibling(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/shurcooL/githubv4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/archive"
 	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/gitclone"
 	"go.kenn.io/forge/internal/platform"
@@ -10438,6 +10439,114 @@ func TestRunOnceAdvancesCadenceForArchivedOnlyBucket(t *testing.T) {
 	syncer.RunOnce(t.Context())
 	assert.Equal(int32(1), getRepositoryCalls.Load(),
 		"second pass inside the cadence gate must defer the archived refresh")
+}
+
+func TestRunOnceRegistersProviderWorkForArchivedRefresh(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+
+	var syncer *Syncer
+	var workActive atomic.Bool
+	ghMock := &mockClient{
+		openPRs:  []*gh.PullRequest{},
+		comments: []*gh.IssueComment{},
+		reviews:  []*gh.PullRequestReview{},
+		commits:  []*gh.RepositoryCommit{},
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			workActive.Store(syncer.higherPriorityProviderWorkActive(
+				"github.com", archive.PriorityFullArchive,
+			))
+			id := int64(1)
+			nodeID := "repo-" + owner + "-" + repo
+			archived := true
+			return &gh.Repository{
+				ID:       &id,
+				NodeID:   &nodeID,
+				Name:     &repo,
+				Owner:    &gh.User{Login: &owner},
+				Archived: &archived,
+			}, nil
+		},
+	}
+	repos := []RepoRef{
+		{Owner: "acme", Name: "frozen", PlatformHost: "github.com", Archived: true},
+	}
+	syncer = NewSyncer(
+		map[string]Client{"github.com": ghMock}, d, nil, repos,
+		time.Minute, nil, nil,
+	)
+
+	syncer.RunOnce(t.Context())
+
+	require.True(workActive.Load(),
+		"archived metadata refresh must register provider work so an "+
+			"admitted archive lease on the credential is preempted")
+}
+
+func TestReconcileRepoIdentityReturnsMidflightArchivedFlip(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+
+	// The default mockClient GetRepository reports the repo unarchived.
+	ghMock := &mockClient{
+		openPRs:  []*gh.PullRequest{},
+		comments: []*gh.IssueComment{},
+		reviews:  []*gh.PullRequestReview{},
+		commits:  []*gh.RepositoryCommit{},
+	}
+	// The tracked ref was flipped archived by a concurrent resolution
+	// after this operation snapshotted it as live.
+	repos := []RepoRef{
+		{Owner: "acme", Name: "widget", PlatformHost: "github.com", Archived: true},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": ghMock}, d, nil, repos,
+		time.Minute, nil, nil,
+	)
+
+	snapshot := RepoRef{Owner: "acme", Name: "widget", PlatformHost: "github.com"}
+	authoritative, _, _, err := syncer.reconcileRepoIdentity(t.Context(), snapshot)
+	require.NoError(err)
+
+	assert.True(authoritative.Archived,
+		"returned ref must carry the newer tracked archived flip the publication preserved")
+	tracked := syncer.TrackedRepos()
+	require.Len(tracked, 1)
+	assert.True(tracked[0].Archived)
+}
+
+func TestPublishResolvedRepositoryEmptySnapshotIDKeepsSuccessorArchivedState(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+
+	syncer := NewSyncer(nil, d, nil, []RepoRef{
+		{
+			Owner: "acme", Name: "widget", PlatformHost: "github.com",
+			PlatformExternalID: "repo-x", Archived: true,
+		},
+	}, time.Minute, nil, nil)
+
+	// The operation's snapshot predates identity resolution and carries no
+	// provider id; fresh metadata resolves the route to a different
+	// repository. The displaced occupant's archived flag must not stamp
+	// the successor.
+	previous := RepoRef{Owner: "acme", Name: "widget", PlatformHost: "github.com"}
+	resolved := RepoRef{
+		Owner: "acme", Name: "widget", PlatformHost: "github.com",
+		PlatformExternalID: "repo-y",
+	}
+	syncer.publishResolvedRepository(previous, resolved, true)
+
+	tracked := syncer.TrackedRepos()
+	require.Len(tracked, 1)
+	assert.Equal("repo-y", tracked[0].PlatformExternalID)
+	assert.False(tracked[0].Archived,
+		"authoritative resolved metadata must apply across identities even "+
+			"when the snapshot id is empty")
 }
 
 func TestRunOnceStopsLiveSyncWhenRepoArchivesMidPass(t *testing.T) {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -10258,6 +10258,20 @@ func TestRunOnceSkipsArchivedRepos(t *testing.T) {
 		comments: []*gh.IssueComment{},
 		reviews:  []*gh.PullRequestReview{},
 		commits:  []*gh.RepositoryCommit{},
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			id := int64(1)
+			nodeID := "repo-" + owner + "-" + repo
+			archived := repo == "frozen"
+			return &gh.Repository{
+				ID:       &id,
+				NodeID:   &nodeID,
+				Name:     &repo,
+				Owner:    &gh.User{Login: &owner},
+				Archived: &archived,
+			}, nil
+		},
 	}
 	repos := []RepoRef{
 		{Owner: "acme", Name: "live", PlatformHost: "github.com"},
@@ -10280,6 +10294,88 @@ func TestRunOnceSkipsArchivedRepos(t *testing.T) {
 		"archived repo should not produce a live sync result")
 	assert.Equal("live", gotResults[0].Name)
 	assert.True(ghMock.listOpenPRsCalled.Load())
+}
+
+func TestRunOnceRestoresLiveSyncForUnarchivedRepo(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+
+	// The default mockClient GetRepository reports the repo unarchived,
+	// so the tracked archived flag is stale.
+	ghMock := &mockClient{
+		openPRs:  []*gh.PullRequest{},
+		comments: []*gh.IssueComment{},
+		reviews:  []*gh.PullRequestReview{},
+		commits:  []*gh.RepositoryCommit{},
+	}
+	repos := []RepoRef{
+		{Owner: "acme", Name: "thawed", PlatformHost: "github.com", Archived: true},
+	}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": ghMock}, d, nil, repos,
+		time.Minute, nil, nil,
+	)
+
+	var gotResults []RepoSyncResult
+	syncer.SetOnSyncCompleted(func(results []RepoSyncResult) {
+		gotResults = results
+	})
+
+	syncer.RunOnce(t.Context())
+
+	require.Len(gotResults, 1,
+		"provider-unarchived repo should rejoin the live pass")
+	assert.Equal("thawed", gotResults[0].Name)
+	assert.True(ghMock.listOpenPRsCalled.Load())
+	tracked := syncer.TrackedRepos()
+	require.Len(tracked, 1)
+	assert.False(tracked[0].Archived,
+		"tracked ref should be live again after the provider unarchives")
+}
+
+func TestRunOnceStopsLiveSyncWhenRepoArchivesMidPass(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+
+	archived := true
+	ghMock := &mockClient{
+		openPRs:  []*gh.PullRequest{},
+		comments: []*gh.IssueComment{},
+		reviews:  []*gh.PullRequestReview{},
+		commits:  []*gh.RepositoryCommit{},
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			id := int64(1)
+			nodeID := "repo-" + owner + "-" + repo
+			return &gh.Repository{
+				ID:       &id,
+				NodeID:   &nodeID,
+				Name:     &repo,
+				Owner:    &gh.User{Login: &owner},
+				Archived: &archived,
+			}, nil
+		},
+	}
+	repos := []RepoRef{
+		{Owner: "acme", Name: "closing", PlatformHost: "github.com"},
+	}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": ghMock}, d, nil, repos,
+		time.Minute, nil, nil,
+	)
+
+	syncer.RunOnce(t.Context())
+
+	assert.False(ghMock.listOpenPRsCalled.Load(),
+		"live item sync must stop once resolution reports the repo archived")
+	tracked := syncer.TrackedRepos()
+	require.Len(tracked, 1)
+	assert.True(tracked[0].Archived)
 }
 
 func TestRepoRefFromCatalogKeepsArchived(t *testing.T) {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -10511,6 +10511,35 @@ func TestPublishResolvedRepositoryCrossIdentityUsesAuthoritativeArchived(t *test
 	}
 }
 
+func TestPublishResolvedRepositoryReplacementIgnoresDisplacedArchivedFlip(t *testing.T) {
+	assert := assert.New(t)
+	d := openTestDB(t)
+	// The configured route's occupant was archived after this operation
+	// snapshotted it; meanwhile the route now resolves to an untracked
+	// replacement repository. The displaced repo's archived flip says
+	// nothing about the replacement — authoritative metadata applies.
+	displaced := RepoRef{
+		Owner: "acme", Name: "tools", PlatformHost: "github.com",
+		RepoPath: "acme/tools", PlatformExternalID: "repo-x", Archived: true,
+	}
+	syncer := NewSyncer(
+		map[string]Client{}, d, nil, []RepoRef{displaced}, time.Hour, nil, nil,
+	)
+
+	previous := displaced
+	previous.Archived = false
+	replacement := RepoRef{
+		Owner: "acme", Name: "tools", PlatformHost: "github.com",
+		RepoPath: "acme/tools", PlatformExternalID: "repo-y", Archived: false,
+	}
+	syncer.publishResolvedRepository(previous, replacement, true)
+
+	got := syncer.TrackedRepos()[0]
+	assert.Equal("repo-y", got.PlatformExternalID)
+	assert.False(got.Archived,
+		"the displaced repo's archived flip must not stamp the replacement")
+}
+
 func TestPublishResolvedRepositoryPreservesNewerConfiguredRepoPath(t *testing.T) {
 	assert := assert.New(t)
 	d := openTestDB(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -10335,6 +10335,59 @@ func TestRunOnceRestoresLiveSyncForUnarchivedRepo(t *testing.T) {
 		"tracked ref should be live again after the provider unarchives")
 }
 
+func TestRunOnceDefersArchivedRefreshForThrottledBucket(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+
+	var getRepositoryCalled atomic.Bool
+	gheMock := &mockClient{
+		openPRs:  []*gh.PullRequest{},
+		comments: []*gh.IssueComment{},
+		reviews:  []*gh.PullRequestReview{},
+		commits:  []*gh.RepositoryCommit{},
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			getRepositoryCalled.Store(true)
+			id := int64(1)
+			nodeID := "repo-" + owner + "-" + repo
+			archived := false
+			return &gh.Repository{
+				ID:       &id,
+				NodeID:   &nodeID,
+				Name:     &repo,
+				Owner:    &gh.User{Login: &owner},
+				Archived: &archived,
+			}, nil
+		},
+	}
+
+	gheTracker := NewRateTracker(d, "ghe.corp.com", "host", "rest")
+	gheTracker.UpdateFromRate(Rate{
+		Limit:     5000,
+		Remaining: 100, // below RateReserveBuffer (200)
+		Reset:     time.Now().Add(30 * time.Minute),
+	})
+
+	repos := []RepoRef{
+		{Owner: "corp", Name: "frozen", PlatformHost: "ghe.corp.com", Archived: true},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"ghe.corp.com": gheMock}, d, nil, repos,
+		time.Minute, map[string]*RateTracker{"ghe.corp.com": gheTracker}, nil,
+	)
+
+	syncer.RunOnce(t.Context())
+
+	assert.False(getRepositoryCalled.Load(),
+		"archived metadata refresh must not spend budget on a throttled bucket")
+	tracked := syncer.TrackedRepos()
+	require.Len(tracked, 1)
+	assert.True(tracked[0].Archived,
+		"deferred archived ref must keep its archived flag")
+}
+
 func TestRunOnceStopsLiveSyncWhenRepoArchivesMidPass(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -4975,7 +4975,7 @@ func TestSyncerOwnsConstructorRepositorySlice(t *testing.T) {
 	syncer.publishResolvedRepository(repos[0], RepoRef{
 		Platform: platform.KindGitHub, PlatformHost: "github.com",
 		Owner: "org-a", Name: "new-name", RepoPath: "org-a/new-name",
-	})
+	}, true)
 
 	assert.Equal("old-name", repos[0].Name)
 	assert.Equal("org-a/old-name", repos[0].RepoPath)
@@ -5054,8 +5054,8 @@ func TestIsTrackedRepoConcurrentPublishResolvedRepository(t *testing.T) {
 	wg.Go(func() {
 		<-start
 		for range iterations {
-			syncer.publishResolvedRepository(orig, renamed)
-			syncer.publishResolvedRepository(renamed, orig)
+			syncer.publishResolvedRepository(orig, renamed, true)
+			syncer.publishResolvedRepository(renamed, orig, true)
 		}
 	})
 	for range 4 {
@@ -10304,6 +10304,33 @@ func TestRepoRefFromCatalogKeepsArchived(t *testing.T) {
 	assert.False(repoRefFromCatalog(previous, stored, &platform.Repository{
 		Archived: false,
 	}).Archived)
+}
+
+func TestPublishResolvedRepositoryPreservesNewerArchivedState(t *testing.T) {
+	assert := assert.New(t)
+	d := openTestDB(t)
+	tracked := RepoRef{
+		Owner: "acme", Name: "frozen", PlatformHost: "github.com",
+		RepoPath: "acme/frozen", Archived: true,
+	}
+	syncer := NewSyncer(
+		map[string]Client{}, d, nil, []RepoRef{tracked}, time.Hour, nil, nil,
+	)
+
+	// A sync that began before the repo was marked archived publishes a
+	// catalog identity built from its stale snapshot. Without fresh
+	// provider metadata the currently tracked archived flag must survive.
+	stale := tracked
+	stale.Archived = false
+	syncer.publishResolvedRepository(stale, stale, false)
+	assert.True(syncer.TrackedRepos()[0].Archived,
+		"a stale catalog republication must not clear archived state")
+
+	// Fresh provider metadata is authoritative in both directions.
+	unarchived := tracked
+	unarchived.Archived = false
+	syncer.publishResolvedRepository(tracked, unarchived, true)
+	assert.False(syncer.TrackedRepos()[0].Archived)
 }
 
 func TestRunOnceScopesGitHubProviderReserveToRepoCredential(t *testing.T) {
@@ -18037,7 +18064,7 @@ func TestPublishResolvedRepositoryAliasesCredentialRoute(t *testing.T) {
 	renamed := configured
 	renamed.Name = "gadget"
 	renamed.RepoPath = "acme/gadget"
-	syncer.publishResolvedRepository(configured, renamed)
+	syncer.publishResolvedRepository(configured, renamed, true)
 
 	identity, ok := syncer.ReadIdentityForRepo(renamed)
 	require.True(ok)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -10466,6 +10466,51 @@ func TestPublishResolvedRepositoryLandsCrossIdentityLookupOnSuccessor(t *testing
 		"the publication lands on the repository the provider identified")
 }
 
+func TestPublishResolvedRepositoryCrossIdentityUsesAuthoritativeArchived(t *testing.T) {
+	assert := assert.New(t)
+	d := openTestDB(t)
+	renamed := RepoRef{
+		Owner: "acme", Name: "tools-new", PlatformHost: "github.com",
+		RepoPath: "acme/tools-new", PlatformExternalID: "repo-x",
+	}
+	successor := RepoRef{
+		Owner: "acme", Name: "tools", PlatformHost: "github.com",
+		RepoPath: "acme/tools", PlatformExternalID: "repo-y", Archived: true,
+	}
+	syncer := NewSyncer(
+		map[string]Client{}, d, nil,
+		[]RepoRef{renamed, successor}, time.Hour, nil, nil,
+	)
+
+	// The publication lands on the successor, but the snapshot belongs to
+	// the renamed repository — its archived flag says nothing about the
+	// successor, so authoritative resolved metadata applies.
+	previous := RepoRef{
+		Owner: "acme", Name: "tools", PlatformHost: "github.com",
+		RepoPath: "acme/tools", PlatformExternalID: "repo-x",
+	}
+	resolved := successor
+	resolved.Archived = false
+	syncer.publishResolvedRepository(previous, resolved, true)
+	for _, repo := range syncer.TrackedRepos() {
+		if repo.PlatformExternalID == "repo-y" {
+			assert.False(repo.Archived,
+				"authoritative metadata must apply on a cross-identity landing")
+		}
+	}
+
+	// Without fresh provider metadata the successor's tracked flag stands.
+	stale := resolved
+	stale.Archived = true
+	syncer.publishResolvedRepository(previous, stale, false)
+	for _, repo := range syncer.TrackedRepos() {
+		if repo.PlatformExternalID == "repo-y" {
+			assert.False(repo.Archived,
+				"non-authoritative publication must preserve the successor's state")
+		}
+	}
+}
+
 func TestPublishResolvedRepositoryPreservesNewerConfiguredRepoPath(t *testing.T) {
 	assert := assert.New(t)
 	d := openTestDB(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -10132,6 +10132,64 @@ func TestRunOnceSkipsThrottledHosts(t *testing.T) {
 		"ghe.corp.com client should NOT have been called")
 }
 
+func TestRunOnceSkipsArchivedRepos(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+
+	ghMock := &mockClient{
+		openPRs:  []*gh.PullRequest{},
+		comments: []*gh.IssueComment{},
+		reviews:  []*gh.PullRequestReview{},
+		commits:  []*gh.RepositoryCommit{},
+	}
+	repos := []RepoRef{
+		{Owner: "acme", Name: "live", PlatformHost: "github.com"},
+		{Owner: "acme", Name: "frozen", PlatformHost: "github.com", Archived: true},
+	}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": ghMock}, d, nil, repos,
+		time.Minute, nil, nil,
+	)
+
+	var gotResults []RepoSyncResult
+	syncer.SetOnSyncCompleted(func(results []RepoSyncResult) {
+		gotResults = results
+	})
+
+	syncer.RunOnce(t.Context())
+
+	require.Len(gotResults, 1,
+		"archived repo should not produce a live sync result")
+	assert.Equal("live", gotResults[0].Name)
+	assert.True(ghMock.listOpenPRsCalled.Load())
+}
+
+func TestRepoRefFromCatalogKeepsArchived(t *testing.T) {
+	assert := assert.New(t)
+	previous := RepoRef{
+		Owner: "acme", Name: "frozen",
+		PlatformHost: "github.com", Archived: true,
+	}
+	stored := db.Repo{
+		ID: 7, Platform: "github", PlatformHost: "github.com",
+		Owner: "acme", Name: "frozen",
+	}
+
+	// Catalog republication without a fresh provider resolve keeps the
+	// previously known archived flag.
+	assert.True(repoRefFromCatalog(previous, stored, nil).Archived)
+
+	// A fresh provider resolve is authoritative in both directions.
+	assert.True(repoRefFromCatalog(previous, stored, &platform.Repository{
+		Archived: true,
+	}).Archived)
+	assert.False(repoRefFromCatalog(previous, stored, &platform.Repository{
+		Archived: false,
+	}).Archived)
+}
+
 func TestRunOnceScopesGitHubProviderReserveToRepoCredential(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/platform/gitlab/client.go
+++ b/internal/platform/gitlab/client.go
@@ -53,6 +53,11 @@ type Client struct {
 
 type PreviewOptions struct {
 	Limit int
+	// IncludeArchived keeps archived projects in the listing.
+	// Import previews leave it unset so archived projects stay
+	// hidden; configuration enumeration sets it so archived
+	// repositories can match configured globs.
+	IncludeArchived bool
 }
 
 type PreviewResult struct {
@@ -339,7 +344,10 @@ func (c *Client) ListRepositories(
 	owner string,
 	opts platform.RepositoryListOptions,
 ) ([]platform.Repository, error) {
-	preview, err := c.PreviewNamespace(ctx, owner, PreviewOptions{Limit: opts.Limit})
+	preview, err := c.PreviewNamespace(ctx, owner, PreviewOptions{
+		Limit:           opts.Limit,
+		IncludeArchived: true,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -360,7 +368,7 @@ func (c *Client) PreviewNamespace(
 	ctx, cancel := c.withForegroundTimeout(ctx)
 	defer cancel()
 
-	result, err := c.previewGroup(ctx, namespace, result)
+	result, err := c.previewGroup(ctx, namespace, result, opts.IncludeArchived)
 	if err == nil {
 		return result.finish(), nil
 	}
@@ -371,7 +379,7 @@ func (c *Client) PreviewNamespace(
 		return PreviewResult{}, err
 	}
 	result = PreviewResult{Limit: limit, Truncated: capped}
-	result, err = c.previewUser(ctx, namespace, result)
+	result, err = c.previewUser(ctx, namespace, result, opts.IncludeArchived)
 	if err != nil {
 		return PreviewResult{}, mapGitLabError("preview_user", err)
 	}
@@ -764,16 +772,19 @@ func (c *Client) previewGroup(
 	ctx context.Context,
 	namespace string,
 	result PreviewResult,
+	includeArchived bool,
 ) (PreviewResult, error) {
-	archived := false
 	includeSubGroups := true
 	opt := &gitlab.ListGroupProjectsOptions{
-		Archived:         &archived,
 		IncludeSubGroups: &includeSubGroups,
 		ListOptions: gitlab.ListOptions{
 			Page:    1,
 			PerPage: pageSizeForRemaining(result.Limit),
 		},
+	}
+	if !includeArchived {
+		archived := false
+		opt.Archived = &archived
 	}
 	for {
 		projects, resp, err := c.api.Groups.ListGroupProjects(namespace, opt, gitlab.WithContext(ctx))
@@ -785,7 +796,7 @@ func (c *Client) previewGroup(
 			}
 			return result, err
 		}
-		result = appendPreviewProjects(result, c.host, namespace, projects)
+		result = appendPreviewProjects(result, c.host, namespace, projects, includeArchived)
 		if result.ReturnedCount >= result.Limit {
 			result.Truncated = true
 			return result, nil
@@ -802,14 +813,17 @@ func (c *Client) previewUser(
 	ctx context.Context,
 	namespace string,
 	result PreviewResult,
+	includeArchived bool,
 ) (PreviewResult, error) {
-	archived := false
 	opt := &gitlab.ListProjectsOptions{
-		Archived: &archived,
 		ListOptions: gitlab.ListOptions{
 			Page:    1,
 			PerPage: pageSizeForRemaining(result.Limit),
 		},
+	}
+	if !includeArchived {
+		archived := false
+		opt.Archived = &archived
 	}
 	for {
 		projects, resp, err := c.api.Projects.ListUserProjects(namespace, opt, gitlab.WithContext(ctx))
@@ -821,7 +835,7 @@ func (c *Client) previewUser(
 			}
 			return result, err
 		}
-		result = appendPreviewProjects(result, c.host, namespace, projects)
+		result = appendPreviewProjects(result, c.host, namespace, projects, includeArchived)
 		if result.ReturnedCount >= result.Limit {
 			result.Truncated = true
 			return result, nil
@@ -839,13 +853,14 @@ func appendPreviewProjects(
 	host string,
 	namespace string,
 	projects []*gitlab.Project,
+	includeArchived bool,
 ) PreviewResult {
 	for _, project := range projects {
 		if project == nil {
 			continue
 		}
 		result.ScannedCount++
-		if project.Archived {
+		if project.Archived && !includeArchived {
 			continue
 		}
 		if !namespaceMatches(namespace, project.PathWithNamespace) {

--- a/internal/platform/gitlab/client.go
+++ b/internal/platform/gitlab/client.go
@@ -346,7 +346,7 @@ func (c *Client) ListRepositories(
 ) ([]platform.Repository, error) {
 	preview, err := c.PreviewNamespace(ctx, owner, PreviewOptions{
 		Limit:           opts.Limit,
-		IncludeArchived: true,
+		IncludeArchived: opts.IncludeArchived,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/platform/gitlab/client_test.go
+++ b/internal/platform/gitlab/client_test.go
@@ -629,13 +629,35 @@ func TestListRepositoriesIncludesArchivedProjects(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 	repos, err := client.ListRepositories(
-		context.Background(), "kenn-forge", platform.RepositoryListOptions{},
+		context.Background(), "kenn-forge",
+		platform.RepositoryListOptions{IncludeArchived: true},
 	)
 	require.NoError(t, err)
 
 	require.Len(t, repos, 2)
 	assert.False(repos[0].Archived)
 	assert.True(repos[1].Archived)
+}
+
+func TestListRepositoriesFiltersArchivedByDefault(t *testing.T) {
+	assert := assert.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("false", r.URL.Query().Get("archived"),
+			"default listings must filter archived server-side, before any limit applies")
+		writeJSON(w, `[
+			{"id": 1, "path": "one", "path_with_namespace": "kenn-forge/one", "archived": false}
+		]`)
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	repos, err := client.ListRepositories(
+		context.Background(), "kenn-forge", platform.RepositoryListOptions{},
+	)
+	require.NoError(t, err)
+
+	require.Len(t, repos, 1)
+	assert.False(repos[0].Archived)
 }
 
 func TestPreviewNamespaceFallsBackToUserProjectsAfterGroupNotFound(t *testing.T) {

--- a/internal/platform/gitlab/client_test.go
+++ b/internal/platform/gitlab/client_test.go
@@ -615,6 +615,29 @@ func TestPreviewNamespaceUsesGroupFirstFallbackPaginatesAndFiltersArchived(t *te
 	}, paths)
 }
 
+func TestListRepositoriesIncludesArchivedProjects(t *testing.T) {
+	assert := assert.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(r.URL.Query().Get("archived"),
+			"configuration enumeration must not filter archived projects server-side")
+		writeJSON(w, `[
+			{"id": 1, "path": "one", "path_with_namespace": "kenn-forge/one", "archived": false},
+			{"id": 2, "path": "old", "path_with_namespace": "kenn-forge/old", "archived": true}
+		]`)
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	repos, err := client.ListRepositories(
+		context.Background(), "kenn-forge", platform.RepositoryListOptions{},
+	)
+	require.NoError(t, err)
+
+	require.Len(t, repos, 2)
+	assert.False(repos[0].Archived)
+	assert.True(repos[1].Archived)
+}
+
 func TestPreviewNamespaceFallsBackToUserProjectsAfterGroupNotFound(t *testing.T) {
 	assert := assert.New(t)
 	var paths []string

--- a/internal/platform/gitlab/config_resolution_test.go
+++ b/internal/platform/gitlab/config_resolution_test.go
@@ -1,0 +1,52 @@
+package gitlab
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/config"
+	ghsync "go.kenn.io/forge/internal/github"
+	"go.kenn.io/forge/internal/platform"
+)
+
+func TestConfiguredGlobResolutionIncludesArchivedProjects(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, `[
+			{"id": 1, "path": "one", "path_with_namespace": "kenn-forge/one", "archived": false},
+			{"id": 2, "path": "old", "path_with_namespace": "kenn-forge/old", "archived": true}
+		]`)
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	registry, err := platform.NewRegistry(client)
+	require.NoError(err)
+
+	status, refs, err := ghsync.ResolveConfiguredRepoWithRegistry(
+		context.Background(), registry, config.Repo{
+			Platform:     "gitlab",
+			PlatformHost: "gitlab.example.com",
+			Owner:        "kenn-forge",
+			Name:         "*",
+		},
+	)
+	require.NoError(err)
+	assert.Equal(2, status.MatchedRepoCount)
+	require.Len(refs, 2)
+
+	byName := make(map[string]ghsync.RepoRef, len(refs))
+	for _, ref := range refs {
+		byName[ref.Name] = ref
+	}
+	require.Contains(byName, "old")
+	assert.True(byName["old"].Archived,
+		"archived GitLab project must expand from the glob as archive-only")
+	require.Contains(byName, "one")
+	assert.False(byName["one"].Archived)
+}

--- a/internal/platform/types.go
+++ b/internal/platform/types.go
@@ -555,4 +555,11 @@ type Capabilities struct {
 type RepositoryListOptions struct {
 	Limit  int
 	Offset int
+	// IncludeArchived asks providers that filter archived repositories
+	// out of listings (GitLab) to keep them. Configuration expansion
+	// sets it so archived repositories can match configured globs;
+	// import previews leave it unset so archived repositories never
+	// crowd live ones out of a limited listing. Providers that never
+	// filter archived repositories (GitHub, gitea-like) ignore it.
+	IncludeArchived bool
 }

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -4431,6 +4431,7 @@ func TestAPIGitLabConfiguredRepoSyncThroughProviderRegistry(t *testing.T) {
 		WebURL:             "https://gitlab.example.com/group/subgroup/project",
 		CloneURL:           "https://gitlab.example.com/group/subgroup/project.git",
 		DefaultBranch:      "main",
+		ConfiguredRepoPath: "group/subgroup/project",
 	}}, repos)
 
 	syncer := ghclient.NewSyncerWithRegistry(

--- a/internal/server/apitest/archive_test.go
+++ b/internal/server/apitest/archive_test.go
@@ -393,7 +393,7 @@ func setupArchiveTestServer(
 		)
 		require.NoError(t, serviceErr)
 		service.SetWake(func() { wakeCount.Add(1) })
-		require.NoError(t, service.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+		requireEnsureConfigured(t, service, []platform.RepoRef{ref})
 		controller = service
 	}
 	syncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
@@ -579,4 +579,10 @@ func TestAPIArchivePacingUsesPerPoolReserves(t *testing.T) {
 	assert.Equal(3000, row.Remaining)
 	assert.Equal(3000, row.Reserve)
 	assert.Zero(row.Available)
+}
+
+func requireEnsureConfigured(t *testing.T, s *archive.Service, refs []platform.RepoRef) {
+	t.Helper()
+	_, err := s.EnsureConfigured(t.Context(), refs)
+	require.NoError(t, err)
 }

--- a/internal/server/config_reload.go
+++ b/internal/server/config_reload.go
@@ -655,8 +655,7 @@ func (s *Server) resolveReposForReload(
 	if s.syncer == nil {
 		return nil, nil
 	}
-	resolved := make([]ghclient.RepoRef, 0, len(repos))
-	seen := make(map[string]struct{}, len(repos))
+	set := ghclient.NewExpandedRepoSet()
 	skipped := make([]string, 0)
 
 	for _, raw := range repos {
@@ -687,35 +686,10 @@ func (s *Server) resolveReposForReload(
 			expanded = ghclient.FallbackConfiguredRepoRefs(previous, raw)
 		}
 		for _, repo := range expanded {
-			key := strings.ToLower(string(repoPlatformOrDefault(repo))) + "\x00" +
-				strings.ToLower(canonicalReloadHost(repo)) + "\x00" +
-				strings.ToLower(repo.Owner) + "\x00" +
-				strings.ToLower(repo.Name)
-			if _, ok := seen[key]; ok {
-				continue
-			}
-			seen[key] = struct{}{}
-			resolved = append(resolved, repo)
+			set.Add(repo, err == nil)
 		}
 	}
-	return resolved, skipped
-}
-
-func repoPlatformOrDefault(repo ghclient.RepoRef) platform.Kind {
-	if repo.Platform != "" {
-		return repo.Platform
-	}
-	return platform.KindGitHub
-}
-
-func canonicalReloadHost(repo ghclient.RepoRef) string {
-	if repo.PlatformHost != "" {
-		return repo.PlatformHost
-	}
-	if host, ok := platform.DefaultHost(repoPlatformOrDefault(repo)); ok {
-		return host
-	}
-	return platform.DefaultGitHubHost
+	return set.Refs(), skipped
 }
 
 // sanitizeConfigError trims internal path prefixes from the error so the

--- a/internal/server/config_reload.go
+++ b/internal/server/config_reload.go
@@ -310,11 +310,13 @@ func (s *Server) startConfigWatcher() {
 // event. The daemon stays running on the previous in-memory config when
 // the reload fails so an editor mid-save cannot crash the process.
 func (s *Server) handleConfigFileChanged() {
+	s.configReloadMu.Lock()
+	defer s.configReloadMu.Unlock()
+	// Checked under the reload lock: cfgPath is settled at construction,
+	// but tests swap it to exercise persistence failures.
 	if s.cfgPath == "" {
 		return
 	}
-	s.configReloadMu.Lock()
-	defer s.configReloadMu.Unlock()
 
 	event := s.applyConfigChange(s.bgCtx)
 	s.hub.Broadcast(Event{

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -1829,6 +1829,49 @@ func TestConfigReload_ResolvedArchivedStateReplacesFallbackDuplicate(t *testing.
 		"repo resolved as archived must be excluded from notification polling")
 }
 
+func TestConfigReload_FallbackKeepsRenamedArchivedTrackedRepo(t *testing.T) {
+	require := require.New(t)
+
+	srv, _, cfgPath := setupTestServerWithConfigContent(
+		t, validReloadConfig, &mockGH{
+			// The exact entry cannot resolve during the reload; the
+			// previously tracked repo was renamed provider-side, so its
+			// route no longer matches the configured path.
+			getRepositoryFn: func(
+				context.Context, string, string,
+			) (*gh.Repository, error) {
+				return nil, errors.New("temporary repo lookup failure")
+			},
+		},
+	)
+	waitForConfigWatcher(t, srv, 2*time.Second)
+	stream := streamConfigEvents(t, srv)
+	defer stream.Close()
+
+	srv.syncer.SetRepos([]ghclient.RepoRef{{
+		Owner:              "acme",
+		Name:               "widget-next",
+		PlatformHost:       "github.com",
+		RepoPath:           "acme/widget-next",
+		PlatformExternalID: "repo-acme-widget",
+		ConfiguredRepoPath: "acme/widget",
+		Archived:           true,
+	}})
+
+	writeConfigToml(t, cfgPath, validReloadConfigChangedActivity)
+
+	ev := waitForConfigEvent(t, stream, 2*time.Second)
+	require.True(ev.Valid)
+
+	require.True(trackedRepoArchived(srv, "acme", "widget-next"),
+		"fallback must keep the renamed archived tracked repo, not"+
+			" synthesize a live duplicate under the stale configured route")
+	for _, repo := range srv.syncer.TrackedRepos() {
+		require.NotEqual("widget", repo.Name,
+			"stale configured route must not be tracked as a duplicate")
+	}
+}
+
 func TestConfigReload_GlobFailureKeepsPreviouslyTrackedMatches(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -268,6 +268,21 @@ owner = "acme"
 name = "widget-*"
 `
 
+const validReloadConfigExactPlusGlob = `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+
+[[repos]]
+owner = "acme"
+name = "*"
+`
+
 const validReloadConfigChangedActivity = `
 sync_interval = "5m"
 github_token_env = "KENN_FORGE_GITHUB_TOKEN"
@@ -1747,6 +1762,71 @@ func TestConfigReload_NewRepoEntersSyncerTrackedSet(t *testing.T) {
 	assert.Equal(archiveLifecycle.ensured, archiveLifecycle.retried)
 	assert.Equal("acme/widget", archiveLifecycle.ensured[0].RepoPath)
 	assert.Equal("globex/engine", archiveLifecycle.ensured[1].RepoPath)
+}
+
+func TestConfigReload_ResolvedArchivedStateReplacesFallbackDuplicate(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	var listedRepos sync.Map
+	srv, database, cfgPath := setupTestServerWithConfigContent(
+		t, validReloadConfig, &mockGH{
+			// The exact entry cannot resolve, so it falls back to the
+			// previously tracked (stale, live) ref.
+			getRepositoryFn: func(
+				context.Context, string, string,
+			) (*gh.Repository, error) {
+				return nil, errors.New("temporary repo lookup failure")
+			},
+			// The overlapping glob resolves the same repo as archived.
+			listReposByOwnerFn: func(
+				_ context.Context, owner string,
+			) ([]*gh.Repository, error) {
+				return []*gh.Repository{{
+					NodeID:   new("repo-acme-widget"),
+					Name:     new("widget"),
+					Owner:    &gh.User{Login: new(owner)},
+					Archived: new(true),
+				}}, nil
+			},
+			listNotificationsFn: func(
+				_ context.Context, opts ghclient.NotificationListOptions,
+			) ([]ghclient.NotificationThread, bool, error) {
+				if opts.RepoName != "" {
+					listedRepos.Store(opts.RepoName, true)
+				}
+				return nil, false, nil
+			},
+		},
+	)
+	_, err := database.UpsertRepo(t.Context(), db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repo-acme-widget", Owner: "acme", Name: "widget",
+	})
+	require.NoError(err)
+	waitForConfigWatcher(t, srv, 2*time.Second)
+	stream := streamConfigEvents(t, srv)
+	defer stream.Close()
+
+	srv.syncer.SetRepos([]ghclient.RepoRef{{
+		Owner:        "acme",
+		Name:         "widget",
+		PlatformHost: "github.com",
+		RepoPath:     "acme/widget",
+	}})
+
+	writeConfigToml(t, cfgPath, validReloadConfigExactPlusGlob)
+
+	ev := waitForConfigEvent(t, stream, 2*time.Second)
+	require.True(ev.Valid)
+
+	require.True(trackedRepoArchived(srv, "acme", "widget"),
+		"resolved archived metadata must replace the fallback duplicate")
+
+	require.NoError(srv.syncer.SyncNotifications(t.Context()))
+	_, listedWidget := listedRepos.Load("widget")
+	assert.False(listedWidget,
+		"repo resolved as archived must be excluded from notification polling")
 }
 
 func TestConfigReload_GlobFailureKeepsPreviouslyTrackedMatches(t *testing.T) {

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -281,6 +282,25 @@ name = "widget"
 [[repos]]
 owner = "acme"
 name = "*"
+`
+
+const validReloadConfigExactPlusGlobChangedActivity = `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+
+[[repos]]
+owner = "acme"
+name = "*"
+
+[activity]
+view_mode = "flat"
+time_range = "30d"
 `
 
 const validReloadConfigChangedActivity = `
@@ -1870,6 +1890,90 @@ func TestConfigReload_FallbackKeepsRenamedArchivedTrackedRepo(t *testing.T) {
 		require.NotEqual("widget", repo.Name,
 			"stale configured route must not be tracked as a duplicate")
 	}
+}
+
+func TestConfigReload_RouteReuseRefreshThenFailedReloadTracksRenamedRepoOnce(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// Phase 0: acme/widget resolves normally. Phase 1: the provider renamed
+	// widget to widget-next and a different repository reused the old route;
+	// exact lookups fail transiently while the glob still lists both.
+	renamed := atomic.Bool{}
+	mock := &mockGH{
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			if renamed.Load() {
+				return nil, errors.New("temporary repo lookup failure")
+			}
+			return &gh.Repository{
+				NodeID:   new("repo-x"),
+				Name:     new(repo),
+				Owner:    &gh.User{Login: new(owner)},
+				Archived: new(false),
+			}, nil
+		},
+		listReposByOwnerFn: func(
+			_ context.Context, owner string,
+		) ([]*gh.Repository, error) {
+			if !renamed.Load() {
+				return []*gh.Repository{{
+					NodeID:   new("repo-x"),
+					Name:     new("widget"),
+					Owner:    &gh.User{Login: new(owner)},
+					Archived: new(false),
+				}}, nil
+			}
+			return []*gh.Repository{
+				{
+					NodeID:   new("repo-x"),
+					Name:     new("widget-next"),
+					Owner:    &gh.User{Login: new(owner)},
+					Archived: new(false),
+				},
+				{
+					NodeID:   new("repo-y"),
+					Name:     new("widget"),
+					Owner:    &gh.User{Login: new(owner)},
+					Archived: new(false),
+				},
+			}, nil
+		},
+	}
+	srv, _, cfgPath := setupTestServerWithConfigContent(
+		t, validReloadConfigExactPlusGlob, mock,
+	)
+	require.True(srv.syncer.IsTrackedRepo("acme", "widget"))
+	waitForConfigWatcher(t, srv, 2*time.Second)
+	stream := streamConfigEvents(t, srv)
+	defer stream.Close()
+
+	renamed.Store(true)
+	rr := doJSON(
+		t, srv, http.MethodPost,
+		"/api/v1/repo/gh/acme/*/refresh", nil,
+	)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	writeConfigToml(t, cfgPath, validReloadConfigExactPlusGlobChangedActivity)
+	ev := waitForConfigEvent(t, stream, 2*time.Second)
+	require.True(ev.Valid)
+
+	tracked := srv.syncer.TrackedRepos()
+	require.Len(tracked, 2,
+		"renamed repo and route successor, no synthetic duplicate")
+	byName := make(map[string]ghclient.RepoRef, len(tracked))
+	for _, repo := range tracked {
+		byName[repo.Name] = repo
+	}
+	assert.Equal("repo-x", byName["widget-next"].PlatformExternalID)
+	assert.Equal("acme/widget", byName["widget-next"].ConfiguredRepoPath,
+		"the renamed repo keeps the exact entry's provenance through the"+
+			" API refresh and the failed reload")
+	assert.Equal("repo-y", byName["widget"].PlatformExternalID)
+	assert.Empty(byName["widget"].ConfiguredRepoPath,
+		"the route successor must not claim the exact entry")
 }
 
 func TestConfigReload_GlobFailureKeepsPreviouslyTrackedMatches(t *testing.T) {

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -36,9 +36,9 @@ type reloadArchiveLifecycleRecorder struct {
 
 func (*reloadArchiveLifecycleRecorder) RunEligible(context.Context) error { return nil }
 
-func (r *reloadArchiveLifecycleRecorder) EnsureConfigured(_ context.Context, refs []platform.RepoRef) error {
+func (r *reloadArchiveLifecycleRecorder) EnsureConfigured(_ context.Context, refs []platform.RepoRef) ([]platform.RepoRef, error) {
 	r.ensured = append([]platform.RepoRef(nil), refs...)
-	return nil
+	return refs, nil
 }
 
 func (r *reloadArchiveLifecycleRecorder) RetryAuthentication(_ context.Context, refs []platform.RepoRef) error {

--- a/internal/server/e2etest/archive_poison_items_test.go
+++ b/internal/server/e2etest/archive_poison_items_test.go
@@ -100,7 +100,7 @@ func TestArchiveAPIPersistsTerminalAndBackoffOutcomesE2E(t *testing.T) {
 		database, registry, nil, syncer, nil, clock,
 	)
 	require.NoError(err)
-	require.NoError(archiveService.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, archiveService, []platform.RepoRef{ref})
 
 	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{
 		Archive:                       archiveService,

--- a/internal/server/e2etest/archive_quota_test.go
+++ b/internal/server/e2etest/archive_quota_test.go
@@ -139,7 +139,7 @@ func TestArchiveAPIStopsProviderBurstAtObservedQuotaHeadroomE2E(t *testing.T) {
 		database, registry, syncer, source, nil, nil,
 	)
 	require.NoError(err)
-	require.NoError(archiveService.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, archiveService, []platform.RepoRef{ref})
 	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{
 		Archive:                       archiveService,
 		HostCheckAllowLoopbackAnyPort: true,
@@ -277,7 +277,7 @@ func TestArchiveAPIDefersHydrationAtLargerPoolReserveE2E(t *testing.T) {
 		database, registry, syncer, source, nil, nil,
 	)
 	require.NoError(err)
-	require.NoError(archiveService.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	requireEnsureConfigured(t, archiveService, []platform.RepoRef{ref})
 	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{
 		Archive:                       archiveService,
 		HostCheckAllowLoopbackAnyPort: true,
@@ -335,4 +335,10 @@ func TestArchiveAPIDefersHydrationAtLargerPoolReserveE2E(t *testing.T) {
 	)
 	require.NoError(err)
 	assert.Equal(db.ArchiveDatasetProgressPending, progress.Status)
+}
+
+func requireEnsureConfigured(t *testing.T, s *archive.Service, refs []platform.RepoRef) {
+	t.Helper()
+	_, err := s.EnsureConfigured(t.Context(), refs)
+	require.NoError(t, err)
 }

--- a/internal/server/e2etest/archive_skip_unresolvable_test.go
+++ b/internal/server/e2etest/archive_skip_unresolvable_test.go
@@ -1,0 +1,148 @@
+package e2etest
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/forge/internal/apiclient"
+	"go.kenn.io/forge/internal/apiclient/generated"
+	"go.kenn.io/forge/internal/archive"
+	"go.kenn.io/forge/internal/db"
+	ghclient "go.kenn.io/forge/internal/github"
+	"go.kenn.io/forge/internal/platform"
+	"go.kenn.io/forge/internal/server"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+	"go.kenn.io/forge/internal/testutil/servertest"
+)
+
+// A configured repository that archive seeding skipped stays in the syncer's
+// tracked set. The archive worker must keep collecting for every healthy
+// repository regardless: the tracked ghost is repository-scoped noise, not a
+// reason to fail the pass.
+func TestArchiveWorkerSkipsUnresolvableTrackedRepoE2E(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	providerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/graphql":
+			var request struct {
+				Query string `json:"query"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				http.Error(w, `{"message":"invalid GraphQL request"}`, http.StatusBadRequest)
+				return
+			}
+			if !strings.Contains(request.Query, "issues(first: 100") {
+				http.Error(w, `{"message":"unexpected GraphQL query"}`, http.StatusBadRequest)
+				return
+			}
+			_, _ = w.Write([]byte(`{"data":{"repository":{"issues":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}`))
+		case "/api/v3/repos/acme/widget/pulls":
+			_, _ = w.Write([]byte(`[]`))
+		case "/api/v3/repos/acme/widget":
+			_, _ = w.Write([]byte(`{"id":1,"node_id":"R_widget","name":"widget","full_name":"acme/widget","owner":{"login":"acme"}}`))
+		default:
+			// The ghost repository resolves nowhere, matching a renamed or
+			// deleted route whose config entry went stale.
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(providerServer.Close)
+
+	providerClient, err := ghclient.NewClient(
+		staticTokenSource("archive-token"), "github.com", nil, nil,
+		ghclient.WithBaseURLForTesting(providerServer.URL),
+	)
+	require.NoError(err)
+	registry, err := ghclient.NewProviderRegistry(map[string]ghclient.Client{
+		"github.com": providerClient,
+	})
+	require.NoError(err)
+	database := dbtest.Open(t)
+	healthy := platform.RepoRef{
+		Platform: platform.KindGitHub, Host: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		PlatformExternalID: "R_widget",
+	}
+	ghost := platform.RepoRef{
+		Platform: platform.KindGitHub, Host: "github.com",
+		Owner: "acme", Name: "ghost", RepoPath: "acme/ghost",
+	}
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry, database, nil,
+		[]ghclient.RepoRef{
+			{
+				Platform: healthy.Platform, PlatformHost: healthy.Host,
+				Owner: healthy.Owner, Name: healthy.Name,
+				RepoPath:           healthy.RepoPath,
+				PlatformExternalID: healthy.PlatformExternalID,
+			},
+			{
+				Platform: ghost.Platform, PlatformHost: ghost.Host,
+				Owner: ghost.Owner, Name: ghost.Name, RepoPath: ghost.RepoPath,
+			},
+		},
+		time.Hour, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	archiveService, err := archive.NewService(
+		database, registry, nil, syncer, nil, nil,
+	)
+	require.NoError(err)
+
+	// Seeding degrades per repository: the ghost is skipped, the healthy
+	// repository seeds, and the call as a whole succeeds.
+	requireEnsureConfigured(t, archiveService, []platform.RepoRef{healthy, ghost})
+
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{
+		Archive:                       archiveService,
+		HostCheckAllowLoopbackAnyPort: true,
+	})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	forgeServer := httptest.NewServer(srv)
+	t.Cleanup(forgeServer.Close)
+	api, err := apiclient.NewWithHTTPClient(forgeServer.URL, forgeServer.Client())
+	require.NoError(err)
+	repositories := []generated.ArchiveRepositoryRef{{
+		Provider: "github", PlatformHost: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	}}
+	started, err := api.HTTP.StartArchivesWithResponse(
+		t.Context(), generated.ArchiveMutationBody{Repositories: &repositories},
+	)
+	require.NoError(err)
+	require.NotNil(started.JSON200)
+	require.Len(*started.JSON200, 1)
+
+	// The worker pass sees both tracked refs from the syncer and must not
+	// fail on the ghost: issue then merge-request inventory for the healthy
+	// repository complete across two passes.
+	require.NoError(archiveService.RunEligible(t.Context()))
+	require.NoError(archiveService.RunEligible(t.Context()))
+
+	repo, err := database.GetRepoByIdentity(t.Context(), platform.DBRepoIdentity(healthy))
+	require.NoError(err)
+	require.NotNil(repo)
+	states, err := database.ListArchiveRepoStates(t.Context(), []int64{repo.ID})
+	require.NoError(err)
+	require.Len(states, 1)
+	assert.True(states[0].IssueInventory.Complete(),
+		"healthy issue inventory must complete despite the tracked ghost")
+	assert.True(states[0].MergeRequestInventory.Complete(),
+		"healthy merge-request inventory must complete despite the tracked ghost")
+	assert.Equal(db.ArchiveOperatorStateActive, states[0].OperatorState)
+
+	status, err := api.HTTP.ListArchiveStatusWithResponse(t.Context(), nil)
+	require.NoError(err)
+	require.NotNil(status.JSON200)
+	require.Len(*status.JSON200, 1,
+		"only the healthy repository has archive state; the ghost never seeded")
+}

--- a/internal/server/e2etest/archived_cadence_test.go
+++ b/internal/server/e2etest/archived_cadence_test.go
@@ -1,0 +1,90 @@
+package e2etest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ghclient "go.kenn.io/forge/internal/github"
+	"go.kenn.io/forge/internal/server"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+	"go.kenn.io/forge/internal/testutil/servertest"
+)
+
+// A bucket holding only archived repositories drops out of the pass before
+// dispatch eligibility is computed, so its cadence gate must be advanced by
+// the attempted metadata refresh itself: consecutive scheduled passes inside
+// the gate fetch archived metadata exactly once. Passes are driven through
+// RunOnce — the scheduled entry point — because the explicit API sync
+// trigger deliberately bypasses cadence gates.
+func TestScheduledSyncFetchesArchivedMetadataOncePerCadenceE2E(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	var repoFetches atomic.Int32
+	providerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v3/repos/corp/frozen":
+			repoFetches.Add(1)
+			_, _ = w.Write([]byte(`{"id":1,"node_id":"R_frozen","name":"frozen","full_name":"corp/frozen","owner":{"login":"corp"},"archived":true}`))
+		case "/api/v3/rate_limit":
+			_, _ = w.Write([]byte(`{"resources":{"core":{"limit":5000,"remaining":4000,"reset":4102444800}}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(providerServer.Close)
+
+	providerClient, err := ghclient.NewClient(
+		staticTokenSource("archive-token"), "github.com", nil, nil,
+		ghclient.WithBaseURLForTesting(providerServer.URL),
+	)
+	require.NoError(err)
+	registry, err := ghclient.NewProviderRegistry(map[string]ghclient.Client{
+		"github.com": providerClient,
+	})
+	require.NoError(err)
+	database := dbtest.Open(t)
+
+	tracker := ghclient.NewRateTracker(database, "github.com", "host", "rest")
+	tracker.UpdateFromRate(ghclient.Rate{
+		Limit:     5000,
+		Remaining: 4000,
+		Reset:     time.Now().UTC().Add(time.Hour),
+	})
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry, database, nil,
+		[]ghclient.RepoRef{{
+			Platform: "github", PlatformHost: "github.com",
+			Owner: "corp", Name: "frozen", RepoPath: "corp/frozen",
+			Archived: true,
+		}},
+		time.Hour,
+		map[string]*ghclient.RateTracker{"github.com": tracker},
+		nil,
+	)
+	t.Cleanup(syncer.Stop)
+
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{
+		HostCheckAllowLoopbackAnyPort: true,
+	})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+
+	syncer.RunOnce(t.Context())
+	require.Equal(int32(1), repoFetches.Load(),
+		"first scheduled pass refreshes the archived repo's metadata")
+
+	syncer.RunOnce(t.Context())
+	assert.Equal(int32(1), repoFetches.Load(),
+		"second pass inside the cadence gate must not refetch archived metadata")
+
+	tracked := syncer.TrackedRepos()
+	require.Len(tracked, 1)
+	assert.True(tracked[0].Archived)
+}

--- a/internal/server/gitealike_container_e2e_test.go
+++ b/internal/server/gitealike_container_e2e_test.go
@@ -252,7 +252,8 @@ func assertGiteaLikeContainerSync(
 		Platform: kind, Host: manifest.Host, Owner: manifest.Owner,
 		Name: manifest.Name, RepoPath: manifest.RepoPath,
 	}
-	require.NoError(archiveService.EnsureConfigured(ctx, []platform.RepoRef{archiveRef}))
+	_, err = archiveService.EnsureConfigured(ctx, []platform.RepoRef{archiveRef})
+	require.NoError(err)
 	_, err = archiveService.Start(ctx, []platform.RepoRef{archiveRef})
 	require.NoError(err)
 	var archiveStatus []archive.Status

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -342,7 +342,7 @@ func repoMatchesConfig(
 	// A provider-side rename moves the tracked route (possibly across
 	// owners) away from the configured path; provenance still ties the
 	// repo to its exact entry.
-	if repoMatchesConfigProvenance(repo, raw) {
+	if repoConfiguredPathMatches(repo, raw) {
 		return true
 	}
 	if !strings.EqualFold(repo.Owner, raw.Owner) {
@@ -359,7 +359,18 @@ func repoMatchesConfig(
 		strings.EqualFold(repo.Name, raw.Name)
 }
 
+// repoMatchesConfigProvenance reports whether raw is the exact entry the
+// tracked repo's provenance names — provider- and host-scoped, since the
+// same path can be configured on multiple providers or hosts.
 func repoMatchesConfigProvenance(
+	repo ghclient.RepoRef, raw config.Repo,
+) bool {
+	return strings.EqualFold(repoProvider(repo), raw.PlatformOrDefault()) &&
+		samePlatformHost(repo.PlatformHost, raw.PlatformHostOrDefault()) &&
+		repoConfiguredPathMatches(repo, raw)
+}
+
+func repoConfiguredPathMatches(
 	repo ghclient.RepoRef, raw config.Repo,
 ) bool {
 	return !raw.HasNameGlob() && repo.ConfiguredRepoPath != "" &&

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -416,14 +416,10 @@ func (s *Server) defaultPlatformHost() string {
 }
 
 // classifyResolveProblem maps a configured-repo resolve error to its wire
-// problem. Archived repos are caller-side validation; everything else goes
-// through the shared provider mapping so a missing token during token-file
-// rotation surfaces as 400 badRequest like the sync and runtime paths,
-// not a 502 upstream error.
+// problem through the shared provider mapping so a missing token during
+// token-file rotation surfaces as 400 badRequest like the sync and runtime
+// paths, not a 502 upstream error.
 func classifyResolveProblem(err error) huma.StatusError {
-	if errors.Is(err, ghclient.ErrConfiguredRepoArchived) {
-		return httpapi.BadRequest(httpapi.CodeBadRequest, err.Error(), nil)
-	}
 	return httpapi.ProviderCallProblem(err, "github", "")
 }
 

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -222,19 +222,31 @@ func (s *Server) replaceGlobRepos(
 }
 
 // removeConfigRepos keeps only tracked repos that match at
-// least one of the remaining config entries.
+// least one of the remaining config entries. A kept repo whose exact-entry
+// provenance no longer names a remaining entry loses it: a stale claim
+// would bind a future entry with the same path to the wrong repository.
 func (s *Server) removeConfigRepos(
 	remaining []config.Repo,
 ) {
 	current := s.syncer.TrackedRepos()
 	kept := make([]ghclient.RepoRef, 0, len(current))
 	for _, repo := range current {
+		matched, provenanceRemains := false, false
 		for _, raw := range remaining {
 			if repoMatchesConfig(repo, raw) {
-				kept = append(kept, repo)
-				break
+				matched = true
+			}
+			if repoMatchesConfigProvenance(repo, raw) {
+				provenanceRemains = true
 			}
 		}
+		if !matched {
+			continue
+		}
+		if !provenanceRemains {
+			repo.ConfiguredRepoPath = ""
+		}
+		kept = append(kept, repo)
 	}
 	s.syncer.SetRepos(kept)
 }
@@ -324,8 +336,16 @@ func repoMatchesConfig(
 ) bool {
 	host := raw.PlatformHostOrDefault()
 	if !strings.EqualFold(repoProvider(repo), raw.PlatformOrDefault()) ||
-		!samePlatformHost(repo.PlatformHost, host) ||
-		!strings.EqualFold(repo.Owner, raw.Owner) {
+		!samePlatformHost(repo.PlatformHost, host) {
+		return false
+	}
+	// A provider-side rename moves the tracked route (possibly across
+	// owners) away from the configured path; provenance still ties the
+	// repo to its exact entry.
+	if repoMatchesConfigProvenance(repo, raw) {
+		return true
+	}
+	if !strings.EqualFold(repo.Owner, raw.Owner) {
 		return false
 	}
 	if raw.HasNameGlob() {
@@ -337,6 +357,13 @@ func repoMatchesConfig(
 	}
 	return strings.EqualFold(trackedRepoPath(repo), configRepoPath(raw)) ||
 		strings.EqualFold(repo.Name, raw.Name)
+}
+
+func repoMatchesConfigProvenance(
+	repo ghclient.RepoRef, raw config.Repo,
+) bool {
+	return !raw.HasNameGlob() && repo.ConfiguredRepoPath != "" &&
+		strings.EqualFold(repo.ConfiguredRepoPath, configRepoPath(raw))
 }
 
 func configRepoPath(raw config.Repo) string {

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -430,10 +430,11 @@ func withTrackedProvenance(
 	}
 	// A route match with two different stable provider ids is route reuse
 	// by another repository, not a rename of the same one: provenance stays
-	// with the identity it was resolved for.
+	// with the identity it was resolved for. Provider ids are opaque and
+	// case-sensitive — compared exactly, like identity keys.
 	incomingID := strings.TrimSpace(repo.PlatformExternalID)
 	if entry.providerID != "" && incomingID != "" &&
-		!strings.EqualFold(entry.providerID, incomingID) {
+		entry.providerID != incomingID {
 		return repo
 	}
 	repo.ConfiguredRepoPath = entry.path

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -155,20 +155,23 @@ func matchedRepoCount(
 	return count
 }
 
-// mergeTrackedRepos adds repos to the syncer's tracked set,
-// deduplicating by host/owner/name.
+// mergeTrackedRepos adds repos to the syncer's tracked set, deduplicating by
+// host/owner/name. An already-tracked repo takes the freshly resolved
+// metadata so provider state transitions (renames, archived flips) apply
+// without a daemon restart.
 func (s *Server) mergeTrackedRepos(add []ghclient.RepoRef) {
 	current := s.syncer.TrackedRepos()
-	seen := make(map[string]struct{}, len(current))
-	for _, r := range current {
-		seen[trackedRepoKey(r)] = struct{}{}
+	index := make(map[string]int, len(current))
+	for i, r := range current {
+		index[trackedRepoKey(r)] = i
 	}
 	for _, r := range add {
 		key := trackedRepoKey(r)
-		if _, ok := seen[key]; ok {
+		if i, ok := index[key]; ok {
+			current[i] = r
 			continue
 		}
-		seen[key] = struct{}{}
+		index[key] = len(current)
 		current = append(current, r)
 	}
 	s.syncer.SetRepos(current)
@@ -184,16 +187,29 @@ func (s *Server) replaceGlobRepos(
 ) {
 	current := s.syncer.TrackedRepos()
 	kept := make([]ghclient.RepoRef, 0, len(current))
-	seen := make(map[string]struct{}, len(current)+len(expanded))
+	index := make(map[string]int, len(current)+len(expanded))
 	for _, repo := range current {
 		if repoMatchesConfig(repo, raw) &&
 			!repoMatchesOtherConfig(repo, raw, configured) {
 			continue
 		}
-		appendTrackedRepo(&kept, seen, repo)
+		key := trackedRepoKey(repo)
+		if _, ok := index[key]; ok {
+			continue
+		}
+		index[key] = len(kept)
+		kept = append(kept, repo)
 	}
+	// Freshly resolved matches overwrite refs kept for overlapping config
+	// entries so provider state transitions (renames, archived flips) apply.
 	for _, repo := range expanded {
-		appendTrackedRepo(&kept, seen, repo)
+		key := trackedRepoKey(repo)
+		if i, ok := index[key]; ok {
+			kept[i] = repo
+			continue
+		}
+		index[key] = len(kept)
+		kept = append(kept, repo)
 	}
 	s.syncer.SetRepos(kept)
 }
@@ -328,19 +344,6 @@ func trackedRepoPath(repo ghclient.RepoRef) string {
 		return strings.TrimSpace(repo.RepoPath)
 	}
 	return repo.Owner + "/" + repo.Name
-}
-
-func appendTrackedRepo(
-	dst *[]ghclient.RepoRef,
-	seen map[string]struct{},
-	repo ghclient.RepoRef,
-) {
-	key := trackedRepoKey(repo)
-	if _, ok := seen[key]; ok {
-		return
-	}
-	seen[key] = struct{}{}
-	*dst = append(*dst, repo)
 }
 
 func repoProvider(repo ghclient.RepoRef) string {

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -161,12 +161,14 @@ func matchedRepoCount(
 // transitions (renames, archived flips) apply without a daemon restart.
 func (s *Server) mergeTrackedRepos(add []ghclient.RepoRef) {
 	current := s.syncer.TrackedRepos()
+	provenance := trackedRepoProvenance(current)
 	byRoute := make(map[string]int, len(current))
 	byIdentity := make(map[string]int, len(current))
 	for i, r := range current {
 		indexTrackedRepo(byRoute, byIdentity, r, i)
 	}
 	for _, r := range add {
+		r = withTrackedProvenance(provenance, r)
 		if i, ok := trackedRepoIndex(byRoute, byIdentity, r); ok {
 			unindexTrackedRepo(byRoute, byIdentity, current[i])
 			current[i] = r
@@ -188,6 +190,7 @@ func (s *Server) replaceGlobRepos(
 	configured []config.Repo,
 ) {
 	current := s.syncer.TrackedRepos()
+	provenance := trackedRepoProvenance(current)
 	kept := make([]ghclient.RepoRef, 0, len(current))
 	byRoute := make(map[string]int, len(current)+len(expanded))
 	byIdentity := make(map[string]int, len(current)+len(expanded))
@@ -205,6 +208,7 @@ func (s *Server) replaceGlobRepos(
 	// Freshly resolved matches overwrite refs kept for overlapping config
 	// entries so provider state transitions (renames, archived flips) apply.
 	for _, repo := range expanded {
+		repo = withTrackedProvenance(provenance, repo)
 		if i, ok := trackedRepoIndex(byRoute, byIdentity, repo); ok {
 			unindexTrackedRepo(byRoute, byIdentity, kept[i])
 			kept[i] = repo
@@ -377,6 +381,43 @@ func trackedRepoKey(repo ghclient.RepoRef) string {
 // trackedRepoIdentityKey keys a tracked repo by its stable provider id, so a
 // renamed route reconciles onto the same entry instead of tracking the
 // repository twice. Empty when the ref carries no provider id.
+// trackedRepoProvenance captures config-entry provenance from the tracked
+// set before a settings merge rebuilds it. Settings-resolved refs never
+// author provenance — only config resolution does — so a merge or glob
+// refresh must not erase the correlation an exact entry needs to reclaim
+// its repository on the next failed reload.
+func trackedRepoProvenance(refs []ghclient.RepoRef) map[string]string {
+	provenance := make(map[string]string)
+	for _, repo := range refs {
+		if repo.ConfiguredRepoPath == "" {
+			continue
+		}
+		if key := trackedRepoIdentityKey(repo); key != "" {
+			provenance["id\x00"+key] = repo.ConfiguredRepoPath
+		}
+		provenance["route\x00"+trackedRepoKey(repo)] = repo.ConfiguredRepoPath
+	}
+	return provenance
+}
+
+func withTrackedProvenance(
+	provenance map[string]string, repo ghclient.RepoRef,
+) ghclient.RepoRef {
+	if repo.ConfiguredRepoPath != "" {
+		return repo
+	}
+	if key := trackedRepoIdentityKey(repo); key != "" {
+		if path, ok := provenance["id\x00"+key]; ok {
+			repo.ConfiguredRepoPath = path
+			return repo
+		}
+	}
+	if path, ok := provenance["route\x00"+trackedRepoKey(repo)]; ok {
+		repo.ConfiguredRepoPath = path
+	}
+	return repo
+}
+
 func trackedRepoIdentityKey(repo ghclient.RepoRef) string {
 	if strings.TrimSpace(repo.PlatformExternalID) == "" {
 		return ""

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -156,22 +156,24 @@ func matchedRepoCount(
 }
 
 // mergeTrackedRepos adds repos to the syncer's tracked set, deduplicating by
-// host/owner/name. An already-tracked repo takes the freshly resolved
-// metadata so provider state transitions (renames, archived flips) apply
-// without a daemon restart.
+// stable provider id when present and host/owner/name otherwise. An
+// already-tracked repo takes the freshly resolved metadata so provider state
+// transitions (renames, archived flips) apply without a daemon restart.
 func (s *Server) mergeTrackedRepos(add []ghclient.RepoRef) {
 	current := s.syncer.TrackedRepos()
-	index := make(map[string]int, len(current))
+	byRoute := make(map[string]int, len(current))
+	byIdentity := make(map[string]int, len(current))
 	for i, r := range current {
-		index[trackedRepoKey(r)] = i
+		indexTrackedRepo(byRoute, byIdentity, r, i)
 	}
 	for _, r := range add {
-		key := trackedRepoKey(r)
-		if i, ok := index[key]; ok {
+		if i, ok := trackedRepoIndex(byRoute, byIdentity, r); ok {
+			unindexTrackedRepo(byRoute, byIdentity, current[i])
 			current[i] = r
+			indexTrackedRepo(byRoute, byIdentity, r, i)
 			continue
 		}
-		index[key] = len(current)
+		indexTrackedRepo(byRoute, byIdentity, r, len(current))
 		current = append(current, r)
 	}
 	s.syncer.SetRepos(current)
@@ -187,28 +189,29 @@ func (s *Server) replaceGlobRepos(
 ) {
 	current := s.syncer.TrackedRepos()
 	kept := make([]ghclient.RepoRef, 0, len(current))
-	index := make(map[string]int, len(current)+len(expanded))
+	byRoute := make(map[string]int, len(current)+len(expanded))
+	byIdentity := make(map[string]int, len(current)+len(expanded))
 	for _, repo := range current {
 		if repoMatchesConfig(repo, raw) &&
 			!repoMatchesOtherConfig(repo, raw, configured) {
 			continue
 		}
-		key := trackedRepoKey(repo)
-		if _, ok := index[key]; ok {
+		if _, ok := trackedRepoIndex(byRoute, byIdentity, repo); ok {
 			continue
 		}
-		index[key] = len(kept)
+		indexTrackedRepo(byRoute, byIdentity, repo, len(kept))
 		kept = append(kept, repo)
 	}
 	// Freshly resolved matches overwrite refs kept for overlapping config
 	// entries so provider state transitions (renames, archived flips) apply.
 	for _, repo := range expanded {
-		key := trackedRepoKey(repo)
-		if i, ok := index[key]; ok {
+		if i, ok := trackedRepoIndex(byRoute, byIdentity, repo); ok {
+			unindexTrackedRepo(byRoute, byIdentity, kept[i])
 			kept[i] = repo
+			indexTrackedRepo(byRoute, byIdentity, repo, i)
 			continue
 		}
-		index[key] = len(kept)
+		indexTrackedRepo(byRoute, byIdentity, repo, len(kept))
 		kept = append(kept, repo)
 	}
 	s.syncer.SetRepos(kept)
@@ -369,6 +372,49 @@ func trackedRepoKey(repo ghclient.RepoRef) string {
 	return repoProvider(repo) + "\x00" +
 		trackedRepoHost(repo) + "\x00" +
 		strings.ToLower(strings.Trim(trackedRepoPath(repo), "/ "))
+}
+
+// trackedRepoIdentityKey keys a tracked repo by its stable provider id, so a
+// renamed route reconciles onto the same entry instead of tracking the
+// repository twice. Empty when the ref carries no provider id.
+func trackedRepoIdentityKey(repo ghclient.RepoRef) string {
+	if strings.TrimSpace(repo.PlatformExternalID) == "" {
+		return ""
+	}
+	return repoProvider(repo) + "\x00" +
+		trackedRepoHost(repo) + "\x00" + repo.PlatformExternalID
+}
+
+// trackedRepoIndex locates repo in current, matching by stable provider id
+// first and falling back to the route key.
+func trackedRepoIndex(
+	byRoute, byIdentity map[string]int, repo ghclient.RepoRef,
+) (int, bool) {
+	if key := trackedRepoIdentityKey(repo); key != "" {
+		if i, ok := byIdentity[key]; ok {
+			return i, true
+		}
+	}
+	i, ok := byRoute[trackedRepoKey(repo)]
+	return i, ok
+}
+
+func indexTrackedRepo(
+	byRoute, byIdentity map[string]int, repo ghclient.RepoRef, slot int,
+) {
+	byRoute[trackedRepoKey(repo)] = slot
+	if key := trackedRepoIdentityKey(repo); key != "" {
+		byIdentity[key] = slot
+	}
+}
+
+func unindexTrackedRepo(
+	byRoute, byIdentity map[string]int, repo ghclient.RepoRef,
+) {
+	delete(byRoute, trackedRepoKey(repo))
+	if key := trackedRepoIdentityKey(repo); key != "" {
+		delete(byIdentity, key)
+	}
 }
 
 func (s *Server) persistResolvedRepos(

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -381,40 +381,62 @@ func trackedRepoKey(repo ghclient.RepoRef) string {
 // trackedRepoIdentityKey keys a tracked repo by its stable provider id, so a
 // renamed route reconciles onto the same entry instead of tracking the
 // repository twice. Empty when the ref carries no provider id.
+// trackedProvenanceEntry records where a tracked ref's config-entry
+// provenance came from, so route-keyed recovery can refuse to hand it to a
+// different repository that merely reuses the route.
+type trackedProvenanceEntry struct {
+	path       string
+	providerID string
+}
+
 // trackedRepoProvenance captures config-entry provenance from the tracked
 // set before a settings merge rebuilds it. Settings-resolved refs never
 // author provenance — only config resolution does — so a merge or glob
 // refresh must not erase the correlation an exact entry needs to reclaim
 // its repository on the next failed reload.
-func trackedRepoProvenance(refs []ghclient.RepoRef) map[string]string {
-	provenance := make(map[string]string)
+func trackedRepoProvenance(refs []ghclient.RepoRef) map[string]trackedProvenanceEntry {
+	provenance := make(map[string]trackedProvenanceEntry)
 	for _, repo := range refs {
 		if repo.ConfiguredRepoPath == "" {
 			continue
 		}
-		if key := trackedRepoIdentityKey(repo); key != "" {
-			provenance["id\x00"+key] = repo.ConfiguredRepoPath
+		entry := trackedProvenanceEntry{
+			path:       repo.ConfiguredRepoPath,
+			providerID: strings.TrimSpace(repo.PlatformExternalID),
 		}
-		provenance["route\x00"+trackedRepoKey(repo)] = repo.ConfiguredRepoPath
+		if key := trackedRepoIdentityKey(repo); key != "" {
+			provenance["id\x00"+key] = entry
+		}
+		provenance["route\x00"+trackedRepoKey(repo)] = entry
 	}
 	return provenance
 }
 
 func withTrackedProvenance(
-	provenance map[string]string, repo ghclient.RepoRef,
+	provenance map[string]trackedProvenanceEntry, repo ghclient.RepoRef,
 ) ghclient.RepoRef {
 	if repo.ConfiguredRepoPath != "" {
 		return repo
 	}
 	if key := trackedRepoIdentityKey(repo); key != "" {
-		if path, ok := provenance["id\x00"+key]; ok {
-			repo.ConfiguredRepoPath = path
+		if entry, ok := provenance["id\x00"+key]; ok {
+			repo.ConfiguredRepoPath = entry.path
 			return repo
 		}
 	}
-	if path, ok := provenance["route\x00"+trackedRepoKey(repo)]; ok {
-		repo.ConfiguredRepoPath = path
+	entry, ok := provenance["route\x00"+trackedRepoKey(repo)]
+	if !ok {
+		return repo
 	}
+	// A route match with two different stable provider ids is route reuse
+	// by another repository, not a rename of the same one: provenance stays
+	// with the identity it was resolved for.
+	incomingID := strings.TrimSpace(repo.PlatformExternalID)
+	if entry.providerID != "" && incomingID != "" &&
+		!strings.EqualFold(entry.providerID, incomingID) {
+		return repo
+	}
+	repo.ConfiguredRepoPath = entry.path
 	return repo
 }
 

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -834,6 +834,121 @@ name = "widget"
 		"archived repo is tracked archive-only after add")
 }
 
+func TestHandleAddRepoRefreshesArchivedStateForTrackedRepo(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	archivedNow := atomic.Bool{}
+	mock := &mockGH{
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			return &gh.Repository{
+				Name:     new(repo),
+				Owner:    &gh.User{Login: new(owner)},
+				Archived: new(archivedNow.Load()),
+			}, nil
+		},
+		listReposByOwnerFn: func(
+			_ context.Context, owner string,
+		) ([]*gh.Repository, error) {
+			return []*gh.Repository{{
+				Name:     new("widget"),
+				Owner:    &gh.User{Login: new(owner)},
+				Archived: new(archivedNow.Load()),
+			}}, nil
+		},
+	}
+	srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "*"
+`, mock)
+	require.True(srv.syncer.IsTrackedRepo("acme", "widget"))
+
+	// The repo gets archived on the provider; adding an overlapping exact
+	// entry must refresh the tracked ref, not keep the stale live one.
+	archivedNow.Store(true)
+	rr := doJSON(t, srv, http.MethodPost, "/api/v1/repos", map[string]string{
+		"provider": "github",
+		"host":     "github.com",
+		"owner":    "acme",
+		"name":     "widget",
+	})
+	require.Equal(http.StatusCreated, rr.Code, rr.Body.String())
+
+	assert.True(trackedRepoArchived(srv, "acme", "widget"),
+		"overlapping add must apply fresh archived state")
+}
+
+func TestHandleRefreshRepoUpdatesArchivedStateForOverlappingEntries(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	archivedNow := atomic.Bool{}
+	mock := &mockGH{
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			return &gh.Repository{
+				Name:     new(repo),
+				Owner:    &gh.User{Login: new(owner)},
+				Archived: new(archivedNow.Load()),
+			}, nil
+		},
+		listReposByOwnerFn: func(
+			_ context.Context, owner string,
+		) ([]*gh.Repository, error) {
+			return []*gh.Repository{{
+				Name:     new("widget"),
+				Owner:    &gh.User{Login: new(owner)},
+				Archived: new(archivedNow.Load()),
+			}}, nil
+		},
+	}
+	srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+
+[[repos]]
+owner = "acme"
+name = "*"
+`, mock)
+	require.True(srv.syncer.IsTrackedRepo("acme", "widget"))
+	require.False(trackedRepoArchived(srv, "acme", "widget"))
+
+	// widget matches both the exact entry and the glob; a refresh after the
+	// provider archives it must update the tracked ref even though the
+	// exact entry keeps it in the tracked set.
+	archivedNow.Store(true)
+	rr := doJSON(
+		t, srv, http.MethodPost,
+		"/api/v1/repo/gh/acme/*/refresh", nil,
+	)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	assert.True(trackedRepoArchived(srv, "acme", "widget"),
+		"glob refresh must apply fresh archived state to overlapping repos")
+}
+
+func trackedRepoArchived(srv *Server, owner, name string) bool {
+	for _, repo := range srv.syncer.TrackedRepos() {
+		if strings.EqualFold(repo.Owner, owner) && strings.EqualFold(repo.Name, name) {
+			return repo.Archived
+		}
+	}
+	return false
+}
+
 func TestHandleAddRepoTriggersImmediateSyncDuringCooldown(t *testing.T) {
 	require := require.New(t)
 

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -941,16 +941,31 @@ name = "*"
 		"glob refresh must apply fresh archived state to overlapping repos")
 }
 
-func TestHandleRefreshRepoStopsNotificationPollingForArchivedRepo(t *testing.T) {
+func TestHandleRefreshRepoStopsLiveLanesForArchivedRepo(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	archivedNow := atomic.Bool{}
 	var listedRepos sync.Map
+	var detailRepos sync.Map
+	detailErr := errors.New("detail fetch short-circuited")
 	mock := &mockGH{
+		getPullRequestIfChangedFn: func(
+			_ context.Context, _, repo string, _ int, _ string,
+		) (*gh.PullRequest, string, bool, error) {
+			detailRepos.Store(repo, true)
+			return nil, "", false, detailErr
+		},
+		getPullRequestFn: func(
+			_ context.Context, _, repo string, _ int,
+		) (*gh.PullRequest, error) {
+			detailRepos.Store(repo, true)
+			return nil, detailErr
+		},
 		getRepositoryFn: func(
 			_ context.Context, owner, repo string,
 		) (*gh.Repository, error) {
 			return &gh.Repository{
+				NodeID:   new("repo-acme-" + repo),
 				Name:     new(repo),
 				Owner:    &gh.User{Login: new(owner)},
 				Archived: new(repo == "widget" && archivedNow.Load()),
@@ -961,11 +976,13 @@ func TestHandleRefreshRepoStopsNotificationPollingForArchivedRepo(t *testing.T) 
 		) ([]*gh.Repository, error) {
 			return []*gh.Repository{
 				{
+					NodeID:   new("repo-acme-widget"),
 					Name:     new("widget"),
 					Owner:    &gh.User{Login: new(owner)},
 					Archived: new(archivedNow.Load()),
 				},
 				{
+					NodeID:   new("repo-acme-tools"),
 					Name:     new("tools"),
 					Owner:    &gh.User{Login: new(owner)},
 					Archived: new(false),
@@ -995,18 +1012,28 @@ name = "widget"
 owner = "acme"
 name = "*"
 `, mock)
-	for _, name := range []string{"widget", "tools"} {
-		_, err := database.UpsertRepo(t.Context(), db.RepoIdentity{
+	recentActivity := time.Now().UTC().Add(-10 * time.Minute)
+	for i, name := range []string{"widget", "tools"} {
+		repoID, err := database.UpsertRepo(t.Context(), db.RepoIdentity{
 			Platform: "github", PlatformHost: "github.com",
 			PlatformRepoID: "repo-acme-" + name, Owner: "acme", Name: name,
 		})
 		require.NoError(err)
+		_, err = database.UpsertMergeRequest(t.Context(), &db.MergeRequest{
+			RepoID: repoID, PlatformID: int64(i + 1), Number: i + 1,
+			Title: "PR", Author: "octo", State: db.MergeRequestStateOpen,
+			HeadBranch: "feature", BaseBranch: "main",
+			CreatedAt: recentActivity.Add(-24 * time.Hour),
+			UpdatedAt: recentActivity, LastActivityAt: recentActivity,
+		})
+		require.NoError(err)
 	}
+	srv.syncer.SetActiveMRWindow(4 * time.Hour)
 	require.True(srv.syncer.IsTrackedRepo("acme", "widget"))
 
 	// The provider archives widget; the refresh applies the transition and
-	// the notification lane must stop polling it while the live sibling
-	// keeps syncing.
+	// the live lanes must stop touching it while the live sibling keeps
+	// syncing.
 	archivedNow.Store(true)
 	rr := doJSON(
 		t, srv, http.MethodPost,
@@ -1021,6 +1048,13 @@ name = "*"
 	_, listedWidget := listedRepos.Load("widget")
 	assert.False(listedWidget,
 		"archived repo must not receive notification polling after refresh")
+
+	srv.syncer.SyncWatchedMRs(t.Context())
+	_, detailTools := detailRepos.Load("tools")
+	assert.True(detailTools, "live repo open MR should fast-sync")
+	_, detailWidget := detailRepos.Load("widget")
+	assert.False(detailWidget,
+		"archived repo open MRs must not enter fast sync after refresh")
 }
 
 func trackedRepoArchived(srv *Server, owner, name string) bool {

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -1909,6 +1909,65 @@ platform_host = "ghe.example.com"
 		"an entry with the same path on another host must not retain provenance")
 }
 
+func TestHandleDeleteExactEntryIgnoresSamePathOnOtherProvider(t *testing.T) {
+	mock := &mockGH{
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			return &gh.Repository{
+				Name:  new(repo),
+				Owner: &gh.User{Login: new(owner)},
+			}, nil
+		},
+		listReposByOwnerFn: func(
+			_ context.Context, owner string,
+		) ([]*gh.Repository, error) {
+			return []*gh.Repository{{
+				Name:  new("tools-new"),
+				Owner: &gh.User{Login: new(owner)},
+			}}, nil
+		},
+	}
+	srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "tools"
+
+[[repos]]
+owner = "acme"
+name = "*"
+
+[[repos]]
+platform = "gitlab"
+platform_host = "github.com"
+owner = "acme"
+name = "tools"
+`, mock)
+
+	srv.syncer.SetRepos([]ghclient.RepoRef{{
+		Platform: platform.KindGitHub, Owner: "acme", Name: "tools-new",
+		PlatformHost: "github.com", RepoPath: "acme/tools-new",
+		PlatformExternalID: "repo-x", ConfiguredRepoPath: "acme/tools",
+	}})
+
+	// The remaining acme/tools entry shares the host but belongs to a
+	// different provider; it cannot keep the deleted GitHub entry's
+	// provenance alive.
+	rr := doJSON(
+		t, srv, http.MethodDelete,
+		"/api/v1/repo/gh/acme/tools", nil,
+	)
+	require.Equal(t, http.StatusNoContent, rr.Code, rr.Body.String())
+	require.True(t, srv.syncer.IsTrackedRepo("acme", "tools-new"))
+	assert.Empty(t, trackedRepoProvenancePath(srv, "acme", "tools-new"),
+		"an entry with the same path on another provider must not retain provenance")
+}
+
 func TestHandleDeleteRepoUsesProviderHostQuery(t *testing.T) {
 	require := require.New(t)
 	srv, _, _ := setupTestServerWithConfigContent(t, `

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -1090,6 +1090,54 @@ func TestMergeTrackedReposReconcilesRenamedRouteByProviderIdentity(t *testing.T)
 	assert.True(tracked[0].Archived)
 }
 
+func TestMergeTrackedReposPreservesExactEntryProvenance(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv, _, _ := setupTestServerWithConfig(t)
+	srv.syncer.SetRepos([]ghclient.RepoRef{{
+		Platform: platform.KindGitHub, Owner: "acme", Name: "tools-new",
+		PlatformHost: "github.com", RepoPath: "acme/tools-new",
+		PlatformExternalID: "repo-x", ConfiguredRepoPath: "acme/tools",
+	}})
+
+	// A settings-resolved duplicate (glob refresh, API add) carries no
+	// config-entry provenance; replacing the tracked ref must not erase
+	// the correlation the exact entry needs on the next failed reload.
+	srv.mergeTrackedRepos([]ghclient.RepoRef{{
+		Platform: platform.KindGitHub, Owner: "acme", Name: "tools-new",
+		PlatformHost: "github.com", RepoPath: "acme/tools-new",
+		PlatformExternalID: "repo-x", Archived: true,
+	}})
+
+	tracked := srv.syncer.TrackedRepos()
+	require.Len(tracked, 1)
+	assert.True(tracked[0].Archived)
+	assert.Equal("acme/tools", tracked[0].ConfiguredRepoPath)
+}
+
+func TestReplaceGlobReposPreservesExactEntryProvenance(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv, _, _ := setupTestServerWithConfig(t)
+	srv.syncer.SetRepos([]ghclient.RepoRef{{
+		Platform: platform.KindGitHub, Owner: "acme", Name: "tools-new",
+		PlatformHost: "github.com", RepoPath: "acme/tools-new",
+		PlatformExternalID: "repo-x", ConfiguredRepoPath: "acme/tools",
+	}})
+
+	glob := config.Repo{Owner: "acme", Name: "*"}
+	srv.replaceGlobRepos(glob, []ghclient.RepoRef{{
+		Platform: platform.KindGitHub, Owner: "acme", Name: "tools-new",
+		PlatformHost: "github.com", RepoPath: "acme/tools-new",
+		PlatformExternalID: "repo-x", Archived: true,
+	}}, []config.Repo{{Owner: "acme", Name: "tools"}, glob})
+
+	tracked := srv.syncer.TrackedRepos()
+	require.Len(tracked, 1)
+	assert.True(tracked[0].Archived)
+	assert.Equal("acme/tools", tracked[0].ConfiguredRepoPath)
+}
+
 func trackedRepoArchived(srv *Server, owner, name string) bool {
 	for _, repo := range srv.syncer.TrackedRepos() {
 		if strings.EqualFold(repo.Owner, owner) && strings.EqualFold(repo.Name, name) {

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -451,7 +451,11 @@ func TestHandleUpdateSettingsPublishesPullConfigOnlyAfterPersistence(t *testing.
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	require.True(srv.pullAPI.ConfigSnapshot().AllowMidStackMerges)
 
+	// Swapped under the reload lock: the config watcher goroutine reads
+	// cfgPath under configReloadMu.
+	srv.configReloadMu.Lock()
 	srv.cfgPath = t.TempDir()
+	srv.configReloadMu.Unlock()
 	disabled := config.PullRequests{AllowMidStackMerges: false}
 	rr = doJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
 		PullRequests: &disabled,
@@ -1846,6 +1850,63 @@ name = "*"
 	require.True(t, srv.syncer.IsTrackedRepo("acme", "tools-new"))
 	assert.Empty(t, trackedRepoProvenancePath(srv, "acme", "tools-new"),
 		"provenance must clear when its exact entry is removed")
+}
+
+func TestHandleDeleteExactEntryIgnoresSamePathOnOtherHost(t *testing.T) {
+	mock := &mockGH{
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			return &gh.Repository{
+				Name:  new(repo),
+				Owner: &gh.User{Login: new(owner)},
+			}, nil
+		},
+		listReposByOwnerFn: func(
+			_ context.Context, owner string,
+		) ([]*gh.Repository, error) {
+			return []*gh.Repository{{
+				Name:  new("tools-new"),
+				Owner: &gh.User{Login: new(owner)},
+			}}, nil
+		},
+	}
+	srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "tools"
+
+[[repos]]
+owner = "acme"
+name = "*"
+
+[[repos]]
+owner = "acme"
+name = "tools"
+platform_host = "ghe.example.com"
+`, mock)
+
+	srv.syncer.SetRepos([]ghclient.RepoRef{{
+		Platform: platform.KindGitHub, Owner: "acme", Name: "tools-new",
+		PlatformHost: "github.com", RepoPath: "acme/tools-new",
+		PlatformExternalID: "repo-x", ConfiguredRepoPath: "acme/tools",
+	}})
+
+	// The remaining acme/tools entry lives on a different host; it cannot
+	// keep the deleted github.com entry's provenance alive.
+	rr := doJSON(
+		t, srv, http.MethodDelete,
+		"/api/v1/repo/gh/acme/tools", nil,
+	)
+	require.Equal(t, http.StatusNoContent, rr.Code, rr.Body.String())
+	require.True(t, srv.syncer.IsTrackedRepo("acme", "tools-new"))
+	assert.Empty(t, trackedRepoProvenancePath(srv, "acme", "tools-new"),
+		"an entry with the same path on another host must not retain provenance")
 }
 
 func TestHandleDeleteRepoUsesProviderHostQuery(t *testing.T) {

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -1166,6 +1166,30 @@ func TestMergeTrackedReposDoesNotTransferProvenanceAcrossProviderIdentities(t *t
 		"a different repository reusing the route must not inherit provenance")
 }
 
+func TestMergeTrackedReposTreatsCaseDifferingProviderIdsAsDistinct(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv, _, _ := setupTestServerWithConfig(t)
+	srv.syncer.SetRepos([]ghclient.RepoRef{{
+		Platform: platform.KindGitHub, Owner: "acme", Name: "tools",
+		PlatformHost: "github.com", RepoPath: "acme/tools",
+		PlatformExternalID: "repo-X", ConfiguredRepoPath: "acme/tools",
+	}})
+
+	// Provider ids are opaque, case-sensitive identities (identity keys
+	// compare them exactly); a case-only difference is a different
+	// repository and must not inherit route provenance.
+	srv.mergeTrackedRepos([]ghclient.RepoRef{{
+		Platform: platform.KindGitHub, Owner: "acme", Name: "tools",
+		PlatformHost: "github.com", RepoPath: "acme/tools",
+		PlatformExternalID: "repo-x",
+	}})
+
+	tracked := srv.syncer.TrackedRepos()
+	require.Len(tracked, 1)
+	assert.Empty(tracked[0].ConfiguredRepoPath)
+}
+
 func TestReplaceGlobReposPreservesExactEntryProvenance(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -939,6 +939,17 @@ name = "*"
 
 	assert.True(trackedRepoArchived(srv, "acme", "widget"),
 		"glob refresh must apply fresh archived state to overlapping repos")
+	assert.Equal("acme/widget", trackedRepoProvenancePath(srv, "acme", "widget"),
+		"glob refresh through the API must keep the exact entry's provenance")
+}
+
+func trackedRepoProvenancePath(srv *Server, owner, name string) string {
+	for _, repo := range srv.syncer.TrackedRepos() {
+		if strings.EqualFold(repo.Owner, owner) && strings.EqualFold(repo.Name, name) {
+			return repo.ConfiguredRepoPath
+		}
+	}
+	return ""
 }
 
 func TestHandleRefreshRepoStopsLiveLanesForArchivedRepo(t *testing.T) {
@@ -1113,6 +1124,46 @@ func TestMergeTrackedReposPreservesExactEntryProvenance(t *testing.T) {
 	require.Len(tracked, 1)
 	assert.True(tracked[0].Archived)
 	assert.Equal("acme/tools", tracked[0].ConfiguredRepoPath)
+}
+
+func TestMergeTrackedReposDoesNotTransferProvenanceAcrossProviderIdentities(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv, _, _ := setupTestServerWithConfig(t)
+	srv.syncer.SetRepos([]ghclient.RepoRef{{
+		Platform: platform.KindGitHub, Owner: "acme", Name: "tools",
+		PlatformHost: "github.com", RepoPath: "acme/tools",
+		PlatformExternalID: "repo-x", ConfiguredRepoPath: "acme/tools",
+	}})
+
+	// The tracked repo was renamed away and its old route reused by a
+	// different repository. The renamed repo keeps its provenance through
+	// stable identity; the route successor must not inherit it — two refs
+	// claiming the same config entry would make a later fallback pick
+	// whichever it sees first.
+	srv.mergeTrackedRepos([]ghclient.RepoRef{
+		{
+			Platform: platform.KindGitHub, Owner: "acme", Name: "tools-new",
+			PlatformHost: "github.com", RepoPath: "acme/tools-new",
+			PlatformExternalID: "repo-x",
+		},
+		{
+			Platform: platform.KindGitHub, Owner: "acme", Name: "tools",
+			PlatformHost: "github.com", RepoPath: "acme/tools",
+			PlatformExternalID: "repo-y",
+		},
+	})
+
+	tracked := srv.syncer.TrackedRepos()
+	require.Len(tracked, 2)
+	byName := make(map[string]ghclient.RepoRef, len(tracked))
+	for _, repo := range tracked {
+		byName[repo.Name] = repo
+	}
+	assert.Equal("acme/tools", byName["tools-new"].ConfiguredRepoPath,
+		"stable identity carries provenance through the rename")
+	assert.Empty(byName["tools"].ConfiguredRepoPath,
+		"a different repository reusing the route must not inherit provenance")
 }
 
 func TestReplaceGlobReposPreservesExactEntryProvenance(t *testing.T) {

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -1735,6 +1735,119 @@ name = "tools"
 	assert.False(t, srv.syncer.IsTrackedRepo("roborev-dev", "kenn-forge"))
 }
 
+func TestHandleDeleteGlobKeepsRenamedExactEntryRepo(t *testing.T) {
+	mock := &mockGH{
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			return &gh.Repository{
+				Name:  new(repo),
+				Owner: &gh.User{Login: new(owner)},
+			}, nil
+		},
+		listReposByOwnerFn: func(
+			_ context.Context, owner string,
+		) ([]*gh.Repository, error) {
+			return []*gh.Repository{{
+				Name:  new("tools"),
+				Owner: &gh.User{Login: new(owner)},
+			}}, nil
+		},
+	}
+	srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "tools"
+
+[[repos]]
+owner = "acme"
+name = "*"
+`, mock)
+
+	// The exact entry's repo was renamed provider-side; only provenance
+	// still ties the tracked ref to the entry. A second repo matches only
+	// the glob.
+	srv.syncer.SetRepos([]ghclient.RepoRef{
+		{
+			Platform: platform.KindGitHub, Owner: "acme", Name: "tools-new",
+			PlatformHost: "github.com", RepoPath: "acme/tools-new",
+			PlatformExternalID: "repo-x", ConfiguredRepoPath: "acme/tools",
+		},
+		{
+			Platform: platform.KindGitHub, Owner: "acme", Name: "widgets",
+			PlatformHost: "github.com", RepoPath: "acme/widgets",
+			PlatformExternalID: "repo-w",
+		},
+	})
+
+	rr := doJSON(
+		t, srv, http.MethodDelete,
+		"/api/v1/repo/gh/acme/*", nil,
+	)
+	require.Equal(t, http.StatusNoContent, rr.Code, rr.Body.String())
+	assert.True(t, srv.syncer.IsTrackedRepo("acme", "tools-new"),
+		"deleting the glob must keep the renamed repo its exact entry still claims")
+	assert.False(t, srv.syncer.IsTrackedRepo("acme", "widgets"))
+}
+
+func TestHandleDeleteExactEntryClearsProvenanceOnGlobKeptRepo(t *testing.T) {
+	mock := &mockGH{
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			return &gh.Repository{
+				Name:  new(repo),
+				Owner: &gh.User{Login: new(owner)},
+			}, nil
+		},
+		listReposByOwnerFn: func(
+			_ context.Context, owner string,
+		) ([]*gh.Repository, error) {
+			return []*gh.Repository{{
+				Name:  new("tools-new"),
+				Owner: &gh.User{Login: new(owner)},
+			}}, nil
+		},
+	}
+	srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "tools"
+
+[[repos]]
+owner = "acme"
+name = "*"
+`, mock)
+
+	srv.syncer.SetRepos([]ghclient.RepoRef{{
+		Platform: platform.KindGitHub, Owner: "acme", Name: "tools-new",
+		PlatformHost: "github.com", RepoPath: "acme/tools-new",
+		PlatformExternalID: "repo-x", ConfiguredRepoPath: "acme/tools",
+	}})
+
+	// Removing the exact entry keeps the repo through the glob, but its
+	// provenance now points at a config entry that no longer exists and
+	// must not survive to claim a future entry with the same path.
+	rr := doJSON(
+		t, srv, http.MethodDelete,
+		"/api/v1/repo/gh/acme/tools", nil,
+	)
+	require.Equal(t, http.StatusNoContent, rr.Code, rr.Body.String())
+	require.True(t, srv.syncer.IsTrackedRepo("acme", "tools-new"))
+	assert.Empty(t, trackedRepoProvenancePath(srv, "acme", "tools-new"),
+		"provenance must clear when its exact entry is removed")
+}
+
 func TestHandleDeleteRepoUsesProviderHostQuery(t *testing.T) {
 	require := require.New(t)
 	srv, _, _ := setupTestServerWithConfigContent(t, `

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -1066,6 +1066,30 @@ name = "*"
 		"archived repo open MRs must not enter fast sync after refresh")
 }
 
+func TestMergeTrackedReposReconcilesRenamedRouteByProviderIdentity(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv, _, _ := setupTestServerWithConfig(t)
+	srv.syncer.SetRepos([]ghclient.RepoRef{{
+		Platform: platform.KindGitHub, Owner: "acme", Name: "old-name",
+		PlatformHost: "github.com", RepoPath: "acme/old-name",
+		PlatformExternalID: "repo-x",
+	}})
+
+	// The same stable provider id resolves under a renamed route: the
+	// tracked set must reconcile to one entry, not sync both routes.
+	srv.mergeTrackedRepos([]ghclient.RepoRef{{
+		Platform: platform.KindGitHub, Owner: "acme", Name: "new-name",
+		PlatformHost: "github.com", RepoPath: "acme/new-name",
+		PlatformExternalID: "repo-x", Archived: true,
+	}})
+
+	tracked := srv.syncer.TrackedRepos()
+	require.Len(tracked, 1)
+	assert.Equal("new-name", tracked[0].Name)
+	assert.True(tracked[0].Archived)
+}
+
 func trackedRepoArchived(srv *Server, owner, name string) bool {
 	for _, repo := range srv.syncer.TrackedRepos() {
 		if strings.EqualFold(repo.Owner, owner) && strings.EqualFold(repo.Name, name) {

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -938,6 +939,88 @@ name = "*"
 
 	assert.True(trackedRepoArchived(srv, "acme", "widget"),
 		"glob refresh must apply fresh archived state to overlapping repos")
+}
+
+func TestHandleRefreshRepoStopsNotificationPollingForArchivedRepo(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	archivedNow := atomic.Bool{}
+	var listedRepos sync.Map
+	mock := &mockGH{
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			return &gh.Repository{
+				Name:     new(repo),
+				Owner:    &gh.User{Login: new(owner)},
+				Archived: new(repo == "widget" && archivedNow.Load()),
+			}, nil
+		},
+		listReposByOwnerFn: func(
+			_ context.Context, owner string,
+		) ([]*gh.Repository, error) {
+			return []*gh.Repository{
+				{
+					Name:     new("widget"),
+					Owner:    &gh.User{Login: new(owner)},
+					Archived: new(archivedNow.Load()),
+				},
+				{
+					Name:     new("tools"),
+					Owner:    &gh.User{Login: new(owner)},
+					Archived: new(false),
+				},
+			}, nil
+		},
+		listNotificationsFn: func(
+			_ context.Context, opts ghclient.NotificationListOptions,
+		) ([]ghclient.NotificationThread, bool, error) {
+			if opts.RepoName != "" {
+				listedRepos.Store(opts.RepoName, true)
+			}
+			return nil, false, nil
+		},
+	}
+	srv, database, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+
+[[repos]]
+owner = "acme"
+name = "*"
+`, mock)
+	for _, name := range []string{"widget", "tools"} {
+		_, err := database.UpsertRepo(t.Context(), db.RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformRepoID: "repo-acme-" + name, Owner: "acme", Name: name,
+		})
+		require.NoError(err)
+	}
+	require.True(srv.syncer.IsTrackedRepo("acme", "widget"))
+
+	// The provider archives widget; the refresh applies the transition and
+	// the notification lane must stop polling it while the live sibling
+	// keeps syncing.
+	archivedNow.Store(true)
+	rr := doJSON(
+		t, srv, http.MethodPost,
+		"/api/v1/repo/gh/acme/*/refresh", nil,
+	)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	require.True(trackedRepoArchived(srv, "acme", "widget"))
+
+	require.NoError(srv.syncer.SyncNotifications(t.Context()))
+	_, listedTools := listedRepos.Load("tools")
+	assert.True(listedTools, "live repo notifications should sync")
+	_, listedWidget := listedRepos.Load("widget")
+	assert.False(listedWidget,
+		"archived repo must not receive notification polling after refresh")
 }
 
 func trackedRepoArchived(srv *Server, owner, name string) bool {

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -1030,6 +1030,9 @@ name = "*"
 	}
 	srv.syncer.SetActiveMRWindow(4 * time.Hour)
 	require.True(srv.syncer.IsTrackedRepo("acme", "widget"))
+	// Stop background sync loops so the refresh-triggered async full sync
+	// cannot populate the lane recorders; each lane runs synchronously below.
+	srv.syncer.Stop()
 
 	// The provider archives widget; the refresh applies the transition and
 	// the live lanes must stop touching it while the live sibling keeps
@@ -1049,6 +1052,12 @@ name = "*"
 	assert.False(listedWidget,
 		"archived repo must not receive notification polling after refresh")
 
+	// Clear anything recorded by earlier phases so the assertions below
+	// reflect the watched-MR lane exclusively.
+	detailRepos.Range(func(key, _ any) bool {
+		detailRepos.Delete(key)
+		return true
+	})
 	srv.syncer.SyncWatchedMRs(t.Context())
 	_, detailTools := detailRepos.Load("tools")
 	assert.True(detailTools, "live repo open MR should fast-sync")

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -794,6 +794,46 @@ func TestHandleAddRepo(t *testing.T) {
 	require.Len(t, cfg2.Repos, 2)
 }
 
+func TestHandleAddRepoAcceptsArchivedRepo(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	mock := &mockGH{
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			return &gh.Repository{
+				Name:     new(repo),
+				Owner:    &gh.User{Login: new(owner)},
+				Archived: new(true),
+			}, nil
+		},
+	}
+	srv, _, cfgPath := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+`, mock)
+
+	rr := doJSON(t, srv, http.MethodPost, "/api/v1/repos", map[string]string{
+		"provider": "github",
+		"host":     "github.com",
+		"owner":    "other-org",
+		"name":     "frozen",
+	})
+	require.Equal(http.StatusCreated, rr.Code, rr.Body.String())
+
+	cfg2, err := config.Load(cfgPath)
+	require.NoError(err)
+	require.Len(cfg2.Repos, 2)
+	assert.True(srv.syncer.IsTrackedRepo("other-org", "frozen"),
+		"archived repo is tracked archive-only after add")
+}
+
 func TestHandleAddRepoTriggersImmediateSyncDuringCooldown(t *testing.T) {
 	require := require.New(t)
 
@@ -1085,7 +1125,8 @@ name = "*"
 	assert.Equal("roborev-dev", resp.Repos[0].Owner)
 	assert.Equal("*", resp.Repos[0].Name)
 	assert.True(resp.Repos[0].IsGlob)
-	assert.Equal(2, resp.Repos[0].MatchedRepoCount)
+	assert.Equal(3, resp.Repos[0].MatchedRepoCount,
+		"archived repos count as archive-only glob matches")
 }
 
 func TestHandleRefreshRepoRebuildsExpandedSyncSet(t *testing.T) {
@@ -1133,10 +1174,11 @@ name = "*"
 
 	var resp settingsResponse
 	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
-	require.Equal(2, resp.Repos[0].MatchedRepoCount)
+	require.Equal(3, resp.Repos[0].MatchedRepoCount)
 	assert.True(srv.syncer.IsTrackedRepo("roborev-dev", "kenn-forge"))
 	assert.True(srv.syncer.IsTrackedRepo("roborev-dev", "globber"))
-	assert.False(srv.syncer.IsTrackedRepo("roborev-dev", "archived"))
+	assert.True(srv.syncer.IsTrackedRepo("roborev-dev", "archived"),
+		"archived repos stay tracked as archive-only")
 }
 
 func TestHandleRefreshRepoPersistsExpandedReposBeforeAsyncSync(t *testing.T) {
@@ -1202,7 +1244,7 @@ name = "*"
 			names = append(names, repo.Name)
 		}
 	}
-	assert.ElementsMatch([]string{"kenn-forge", "review-bot"}, names)
+	assert.ElementsMatch([]string{"kenn-forge", "archived", "review-bot"}, names)
 }
 
 func TestHandleRefreshRepoKeepsReposMatchedByOtherConfigEntries(t *testing.T) {


### PR DESCRIPTION
## Problem

A provider-archived repository cannot be configured: resolution rejects it, so its historical data can never be collected. Worse, an archived repo in config crash-loops the daemon at startup, and the error names no repository.

## Changes

- Accept archived repositories (exact and glob, GitHub and GitLab) and track them archive-only: live sync, notifications, and fast sync skip them; archive collection works normally.
- Detect archived flips without a restart: settings add/refresh applies fresh metadata, each sync pass re-checks archived refs (an unarchived repo resumes live syncing; a repo found archived mid-pass stops before syncing content), and throttled credential buckets defer the refresh.
- Degrade seeding per repository: a bad config entry is logged with its identity and skipped instead of aborting startup, and the archive worker skips unresolvable refs instead of starving healthy repositories.
- Track renamed repositories once: dedupe the tracked set by stable provider id, record each exact entry's config path on its resolved ref, and use that provenance in reload fallback, startup catalog recovery (including credential aliases), settings merges, entry removal, and sync publications — a rename never duplicates a repo, loses its archived flag, or leaks state to a route successor.
- Defer removal pausing while any configured ref cannot be matched to a repository row, so an incomplete protection list cannot pause the wrong repository's archive.
- Fix a pre-existing data race between the config watcher and a settings test on `cfgPath`.

## Notes

- While an unresolvable config entry persists, removal pausing stays deferred; the recurring warning names the refs to fix.
- Startup rename recovery binds a configured path to its current catalog occupant, else a sole historical match; a stale binding self-corrects on the first successful resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
