### PR TITLE
fix: make workspace launch options usable in dialogs

### DIFF
--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -346,7 +346,7 @@ Intent:
 - overflow-constrained parents must not clip menus or hide available choices
 - repeated positioning, collision, z-index, and outside-click behavior belongs in the shared primitive, not local screen CSS
 
-Before placing an overlay inside a split view, compact sidebar, drawer, or scrollable region, verify that it can extend past its trigger container without being cut off.
+Before placing an overlay inside a split view, compact sidebar, drawer, or scrollable region, verify that it can extend past its trigger container without being cut off. An overlay opened from a modal must escape the modal's scrollable body while remaining inside the modal panel so the modal focus trap still owns it (`packages/ui/src/components/workspace/WorkspaceCreateSplitButton.svelte::portalMenu`).
 
 Popover surface chrome (background, border, radius, shadow) comes from `kit-popover-card`; do not re-declare it in component-scoped styles. Scoped rules outrank the kit class, and a `var()` referencing an undefined token (there is no `--bg-elevated`) computes to transparent with no build-time error.
 

--- a/docs/superpowers/specs/2026-07-27-workspace-create-launch-split-button-design.md
+++ b/docs/superpowers/specs/2026-07-27-workspace-create-launch-split-button-design.md
@@ -28,8 +28,8 @@ targets, a create-only callback, and a create-and-launch callback.
 
 - The primary segment retains the current create-only behavior.
 - The chevron exposes `aria-haspopup="menu"` and `aria-expanded`.
-- The menu is headed `Create and launch` and lists visible targets whose kind
-  is `agent`, including enabled custom agents.
+- The menu has the accessible name `Create and launch` and lists visible targets whose kind
+  is `agent`, including enabled custom agents, without repeating that name as visible chrome.
 - Available agents are selectable. Unavailable agents remain visible but
   disabled and expose their existing disabled reason.
 - Shell and non-agent run configurations are not creation choices; they remain

--- a/frontend/src/WorkspaceCreateSplitButton.browser.svelte.ts
+++ b/frontend/src/WorkspaceCreateSplitButton.browser.svelte.ts
@@ -1,10 +1,13 @@
-import { mount, unmount } from "svelte";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { page } from "vite-plus/test/browser";
+import { cleanup, render } from "vitest-browser-svelte";
 import "./app.css";
 
 import { setThemeMode } from "@kenn-io/kit-ui";
-import { WorkspaceCreateSplitButton } from "@kenn-forge/ui";
-import type { LaunchTarget } from "@kenn-forge/ui/api/types";
+import { STORES_KEY } from "../../packages/ui/src/context.js";
+import type { LaunchTarget } from "../../packages/ui/src/api/types.js";
+import NewWorkspaceDialog from "./lib/components/terminal/NewWorkspaceDialog.svelte";
+import { createMockApiFetch, jsonResponse } from "./test/mockApiFetch.js";
 
 const launchTargets: LaunchTarget[] = [
   {
@@ -27,94 +30,89 @@ function resolvedColor(value: string): string {
   return color;
 }
 
-function mountInScrollableModal(onCreate = vi.fn()): {
-  app: Record<string, unknown>;
-  overlay: HTMLElement;
-  target: HTMLElement;
-  onCreate: ReturnType<typeof vi.fn>;
-} {
-  const overlay = document.createElement("div");
-  overlay.style.cssText = "position: fixed; inset: 0; z-index: 1000;";
+describe("workspace create split button in the New workspace dialog", () => {
+  const originalFetch = globalThis.fetch;
 
-  const panel = document.createElement("div");
-  panel.className = "kit-modal-panel";
-  panel.style.cssText = "position: fixed; left: 80px; top: 80px; width: 440px; background: var(--bg-surface);";
-
-  const body = document.createElement("div");
-  body.className = "kit-modal-body";
-  body.style.cssText = "height: 210px; overflow-y: auto;";
-
-  const target = document.createElement("div");
-  target.style.cssText = "display: flex; justify-content: flex-end; margin-top: 165px; padding-right: 16px;";
-  body.append(target);
-  panel.append(body);
-  overlay.append(panel);
-  document.body.append(overlay);
-
-  const app = mount(WorkspaceCreateSplitButton, {
-    target,
-    props: {
-      label: "Create workspace",
-      launchTargets,
-      surface: "solid",
-      onCreate,
-    },
-  });
-
-  return { app, overlay, target, onCreate };
-}
-
-describe("workspace create split button in a modal", () => {
-  let mounted: ReturnType<typeof mountInScrollableModal> | null = null;
-
-  afterEach(() => {
-    if (mounted) {
-      unmount(mounted.app);
-      mounted.overlay.remove();
-      mounted = null;
-    }
+  afterEach(async () => {
+    cleanup();
+    globalThis.fetch = originalFetch;
     setThemeMode("light");
   });
 
-  it("renders the launch menu outside the scrollable modal body and keeps its items clickable", async () => {
-    mounted = mountInScrollableModal();
-    const trigger = mounted.target.querySelector<HTMLButtonElement>("button[aria-label='Create workspace options']");
-    expect(trigger).not.toBeNull();
+  it("renders the launch menu outside the real modal body and keeps its items clickable", async () => {
+    const api = createMockApiFetch([
+      ({ method, url }) =>
+        method === "POST" && url.pathname.endsWith("/workspaces") ? jsonResponse({ id: "ws-new" }, 202) : undefined,
+    ]);
+    globalThis.fetch = api.fetch;
+    const onCreated = vi.fn();
 
-    trigger!.click();
-
-    const menu = await vi.waitFor(() => {
-      const element = document.querySelector<HTMLUListElement>("[role='menu'][aria-label='Create and launch']");
-      expect(element).not.toBeNull();
-      expect(element!.getBoundingClientRect().height).toBeGreaterThan(0);
-      return element!;
+    render(NewWorkspaceDialog, {
+      props: { open: true, onClose: vi.fn(), onCreated },
+      context: new Map([
+        [
+          STORES_KEY,
+          {
+            settings: { getLaunchTargets: () => launchTargets },
+          },
+        ],
+      ]),
     });
-    expect(menu.parentElement).toBe(mounted.overlay.querySelector(".kit-modal-panel"));
-    expect(menu.parentElement).not.toBe(mounted.overlay.querySelector(".kit-modal-body"));
 
-    const item = menu.querySelector<HTMLButtonElement>("[role='menuitem']");
-    expect(item).not.toBeNull();
-    const rect = item!.getBoundingClientRect();
-    const hit = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
-    expect(item === hit || item!.contains(hit)).toBe(true);
+    const dialog = page.getByRole("dialog", { name: "New workspace" });
+    await expect.element(dialog).toBeVisible();
+    await vi.waitFor(() =>
+      expect(dialog.getByRole("button", { name: "Create workspace", exact: true }).element()).not.toBeDisabled(),
+    );
 
-    item!.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
-    expect(document.body.contains(item)).toBe(true);
-    item!.click();
-    expect(mounted.onCreate).toHaveBeenCalledWith("codex");
+    const options = dialog.getByRole("button", { name: "Create workspace options" });
+    await options.click();
+    const item = page.getByRole("menuitem", { name: "Codex" });
+    await expect.element(item).toBeVisible();
+
+    const menu = item.element().closest<HTMLElement>("[role='menu']");
+    const panel = document.querySelector<HTMLElement>(".kit-modal-panel");
+    const body = document.querySelector<HTMLElement>(".kit-modal-body");
+    expect(menu?.parentElement).toBe(panel);
+    expect(menu?.parentElement).not.toBe(body);
+
+    const itemRect = item.element().getBoundingClientRect();
+    const hit = document.elementFromPoint(itemRect.left + itemRect.width / 2, itemRect.top + itemRect.height / 2);
+    expect(item.element() === hit || item.element().contains(hit)).toBe(true);
+
+    await item.click();
+    await vi.waitFor(() => expect(onCreated).toHaveBeenCalledWith("ws-new"));
   });
 
-  it("styles both solid segments as one themed primary action", () => {
+  it("uses kit-ui primary colors for both solid segments", async () => {
+    globalThis.fetch = createMockApiFetch().fetch;
     setThemeMode("dark");
-    mounted = mountInScrollableModal();
 
-    const primary = mounted.target.querySelector<HTMLButtonElement>(".create-primary");
-    const options = mounted.target.querySelector<HTMLButtonElement>(".create-options");
-    expect(primary).not.toBeNull();
-    expect(options).not.toBeNull();
+    render(NewWorkspaceDialog, {
+      props: { open: true, onClose: vi.fn(), onCreated: vi.fn() },
+      context: new Map([
+        [
+          STORES_KEY,
+          {
+            settings: { getLaunchTargets: () => launchTargets },
+          },
+        ],
+      ]),
+    });
 
-    const primaryStyle = getComputedStyle(primary!);
-    const optionsStyle = getComputedStyle(options!);
+    const dialog = page.getByRole("dialog", { name: "New workspace" });
+    await expect.element(dialog).toBeVisible();
+    await vi.waitFor(() =>
+      expect(dialog.getByRole("button", { name: "Create workspace", exact: true }).element()).not.toBeDisabled(),
+    );
+
+    const primary = dialog.getByRole("button", { name: "Create workspace", exact: true }).element();
+    const options = dialog.getByRole("button", { name: "Create workspace options" }).element();
+    expect(primary.classList.contains("kit-button")).toBe(true);
+    expect(options.classList.contains("kit-button")).toBe(true);
+
+    const primaryStyle = getComputedStyle(primary);
+    const optionsStyle = getComputedStyle(options);
     const rootStyle = getComputedStyle(document.documentElement);
     const accent = resolvedColor(rootStyle.getPropertyValue("--accent-blue").trim());
     const foreground = resolvedColor(rootStyle.getPropertyValue("--bg-surface").trim());
@@ -123,8 +121,5 @@ describe("workspace create split button in a modal", () => {
     expect(optionsStyle.backgroundColor).toBe(accent);
     expect(primaryStyle.color).toBe(foreground);
     expect(optionsStyle.color).toBe(foreground);
-
-    options!.focus();
-    expect(getComputedStyle(options!).color).toBe(foreground);
   });
 });

--- a/frontend/src/WorkspaceCreateSplitButton.browser.svelte.ts
+++ b/frontend/src/WorkspaceCreateSplitButton.browser.svelte.ts
@@ -1,0 +1,130 @@
+import { mount, unmount } from "svelte";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import "./app.css";
+
+import { setThemeMode } from "@kenn-io/kit-ui";
+import { WorkspaceCreateSplitButton } from "@kenn-forge/ui";
+import type { LaunchTarget } from "@kenn-forge/ui/api/types";
+
+const launchTargets: LaunchTarget[] = [
+  {
+    key: "codex",
+    label: "Codex",
+    kind: "agent",
+    source: "builtin",
+    command: ["codex"],
+    available: true,
+    disabled_reason: "",
+  },
+];
+
+function resolvedColor(value: string): string {
+  const probe = document.createElement("span");
+  probe.style.color = value;
+  document.body.append(probe);
+  const color = getComputedStyle(probe).color;
+  probe.remove();
+  return color;
+}
+
+function mountInScrollableModal(onCreate = vi.fn()): {
+  app: Record<string, unknown>;
+  overlay: HTMLElement;
+  target: HTMLElement;
+  onCreate: ReturnType<typeof vi.fn>;
+} {
+  const overlay = document.createElement("div");
+  overlay.style.cssText = "position: fixed; inset: 0; z-index: 1000;";
+
+  const panel = document.createElement("div");
+  panel.className = "kit-modal-panel";
+  panel.style.cssText = "position: fixed; left: 80px; top: 80px; width: 440px; background: var(--bg-surface);";
+
+  const body = document.createElement("div");
+  body.className = "kit-modal-body";
+  body.style.cssText = "height: 210px; overflow-y: auto;";
+
+  const target = document.createElement("div");
+  target.style.cssText = "display: flex; justify-content: flex-end; margin-top: 165px; padding-right: 16px;";
+  body.append(target);
+  panel.append(body);
+  overlay.append(panel);
+  document.body.append(overlay);
+
+  const app = mount(WorkspaceCreateSplitButton, {
+    target,
+    props: {
+      label: "Create workspace",
+      launchTargets,
+      surface: "solid",
+      onCreate,
+    },
+  });
+
+  return { app, overlay, target, onCreate };
+}
+
+describe("workspace create split button in a modal", () => {
+  let mounted: ReturnType<typeof mountInScrollableModal> | null = null;
+
+  afterEach(() => {
+    if (mounted) {
+      unmount(mounted.app);
+      mounted.overlay.remove();
+      mounted = null;
+    }
+    setThemeMode("light");
+  });
+
+  it("renders the launch menu outside the scrollable modal body and keeps its items clickable", async () => {
+    mounted = mountInScrollableModal();
+    const trigger = mounted.target.querySelector<HTMLButtonElement>("button[aria-label='Create workspace options']");
+    expect(trigger).not.toBeNull();
+
+    trigger!.click();
+
+    const menu = await vi.waitFor(() => {
+      const element = document.querySelector<HTMLUListElement>("[role='menu'][aria-label='Create and launch']");
+      expect(element).not.toBeNull();
+      expect(element!.getBoundingClientRect().height).toBeGreaterThan(0);
+      return element!;
+    });
+    expect(menu.parentElement).toBe(mounted.overlay.querySelector(".kit-modal-panel"));
+    expect(menu.parentElement).not.toBe(mounted.overlay.querySelector(".kit-modal-body"));
+
+    const item = menu.querySelector<HTMLButtonElement>("[role='menuitem']");
+    expect(item).not.toBeNull();
+    const rect = item!.getBoundingClientRect();
+    const hit = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+    expect(item === hit || item!.contains(hit)).toBe(true);
+
+    item!.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+    expect(document.body.contains(item)).toBe(true);
+    item!.click();
+    expect(mounted.onCreate).toHaveBeenCalledWith("codex");
+  });
+
+  it("styles both solid segments as one themed primary action", () => {
+    setThemeMode("dark");
+    mounted = mountInScrollableModal();
+
+    const primary = mounted.target.querySelector<HTMLButtonElement>(".create-primary");
+    const options = mounted.target.querySelector<HTMLButtonElement>(".create-options");
+    expect(primary).not.toBeNull();
+    expect(options).not.toBeNull();
+
+    const primaryStyle = getComputedStyle(primary!);
+    const optionsStyle = getComputedStyle(options!);
+    const rootStyle = getComputedStyle(document.documentElement);
+    const accent = resolvedColor(rootStyle.getPropertyValue("--accent-blue").trim());
+    const foreground = resolvedColor(rootStyle.getPropertyValue("--bg-surface").trim());
+
+    expect(primaryStyle.backgroundColor).toBe(accent);
+    expect(optionsStyle.backgroundColor).toBe(accent);
+    expect(primaryStyle.color).toBe(foreground);
+    expect(optionsStyle.color).toBe(foreground);
+
+    options!.focus();
+    expect(getComputedStyle(options!).color).toBe(foreground);
+  });
+});

--- a/frontend/tests/e2e-full/00-workspace-create-and-launch.spec.ts
+++ b/frontend/tests/e2e-full/00-workspace-create-and-launch.spec.ts
@@ -346,6 +346,58 @@ test.describe("workspace create-and-launch full stack", () => {
     }
   });
 
+  test("New workspace dialog creates and persists the selected agent launch", async ({ page }) => {
+    test.skip(
+      !hasCommand("git") || !hasCommand("tmux", ["-V"]) || !hasCommand("sh", ["-c", ":"]),
+      "git, tmux, and sh are required for the real workspace runtime flow",
+    );
+
+    let server: IsolatedE2EServer | null = null;
+    let api: APIRequestContext | null = null;
+    try {
+      server = await startIsolatedWorkspaceE2EServer();
+      api = await playwrightRequest.newContext({
+        baseURL: server.info.base_url,
+      });
+      await configureAgent(page, server.info.base_url);
+
+      const createResponsePromise = page.waitForResponse(
+        (response) =>
+          response.request().method() === "POST" &&
+          /\/api\/v1\/repo\/github\/acme\/widgets\/workspaces$/.test(response.url()),
+      );
+      const launchResponsePromise = page.waitForResponse(
+        (response) =>
+          response.request().method() === "POST" &&
+          /\/api\/v1\/workspaces\/[^/]+\/runtime\/sessions$/.test(response.url()),
+      );
+
+      await page.goto(`${server.info.base_url}/workspaces`);
+      await page.getByRole("button", { name: "New workspace" }).click();
+      const dialog = page.getByRole("dialog", { name: "New workspace" });
+      await expect(dialog).toBeVisible();
+      await dialog.getByRole("button", { name: "Filter repositories" }).click();
+      await dialog.getByRole("option", { name: /acme\/widgets/ }).click();
+      await expect(dialog.getByRole("button", { name: "Filter repositories" })).toContainText("acme/widgets");
+      await dialog.getByRole("button", { name: "Create workspace options" }).click();
+      const agent = page.getByRole("menuitem", { name: agentLabel });
+      await expect(agent).toBeVisible();
+      await agent.click();
+
+      const createResponse = await createResponsePromise;
+      expect(createResponse.status(), await createResponse.text()).toBe(202);
+      const created = (await createResponse.json()) as WorkspaceResponse;
+      await waitForWorkspaceReady(api, created.id);
+      const launchResponse = await launchResponsePromise;
+      expect(launchResponse.status(), await launchResponse.text()).toBe(200);
+      await expect.poll(() => runtimeTargets(api!, created.id)).toContain(agentKey);
+      await expect.poll(() => persistedRuntimeTargets(api!, created.id)).toEqual([agentKey]);
+    } finally {
+      await api?.dispose();
+      await server?.stop();
+    }
+  });
+
   test("explicit fork-head selection launches through the ordinary manual Launch-menu trust boundary", async ({
     page,
   }) => {

--- a/packages/ui/src/components/workspace/WorkspaceCreateSplitButton.svelte
+++ b/packages/ui/src/components/workspace/WorkspaceCreateSplitButton.svelte
@@ -70,6 +70,12 @@
     open = false;
   }
 
+  function portalMenu(node: HTMLElement): () => void {
+    const host = root?.closest<HTMLElement>(".kit-modal-panel") ?? document.body;
+    host.appendChild(node);
+    return () => node.remove();
+  }
+
   function selectTarget(targetKey: string): void {
     closeMenu();
     void onCreate(targetKey);
@@ -103,7 +109,8 @@
 
     function dismissPointerDown(event: PointerEvent): void {
       const target = event.target;
-      if (target instanceof Node && root?.contains(target)) return;
+      if (!(target instanceof Node)) return;
+      if (root?.contains(target) || menu?.contains(target)) return;
       closeMenu();
     }
 
@@ -173,6 +180,7 @@
       role="menu"
       aria-label="Create and launch"
       style={menuStyle}
+      {@attach portalMenu}
     >
       <li role="none" class="create-menu-heading">
         <span aria-hidden="true">Create and launch</span>
@@ -239,10 +247,10 @@
     border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
   }
 
-  .workspace-create-split[data-surface="solid"] .create-primary {
+  .workspace-create-split[data-surface="solid"] > button {
     border-color: var(--accent-blue);
     background: var(--accent-blue);
-    color: var(--text-primary);
+    color: var(--bg-surface);
   }
 
   .workspace-create-split > button:hover:not(:disabled),
@@ -258,6 +266,19 @@
     outline-offset: -1px;
   }
 
+  .workspace-create-split[data-surface="solid"] > button:hover:not(:disabled),
+  .workspace-create-split[data-surface="solid"] > button:focus-visible {
+    border-color: color-mix(in srgb, var(--accent-blue) 88%, #000);
+    background: color-mix(in srgb, var(--accent-blue) 88%, #000);
+    color: var(--bg-surface);
+  }
+
+  .workspace-create-split[data-surface="solid"] > button[aria-expanded="true"] {
+    border-color: color-mix(in srgb, var(--accent-blue) 78%, #000);
+    background: color-mix(in srgb, var(--accent-blue) 78%, #000);
+    color: var(--bg-surface);
+  }
+
   .workspace-create-split > button:disabled {
     color: var(--text-faint);
     cursor: default;
@@ -265,7 +286,7 @@
 
   .create-menu {
     position: fixed;
-    z-index: var(--z-popover);
+    z-index: var(--z-popover, 1001);
     min-width: 180px;
     max-width: calc(100vw - 16px);
     margin: 0;

--- a/packages/ui/src/components/workspace/WorkspaceCreateSplitButton.svelte
+++ b/packages/ui/src/components/workspace/WorkspaceCreateSplitButton.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import { autoReposition, dismissable, floatingPopoverStyle } from "@kenn-io/kit-ui";
+  import {
+    autoReposition,
+    Button,
+    dismissable,
+    floatingPopoverStyle,
+  } from "@kenn-io/kit-ui";
   import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
   import PackagePlusIcon from "@lucide/svelte/icons/package-plus";
   import { tick } from "svelte";
@@ -60,6 +65,7 @@
 
   async function openMenu(): Promise<void> {
     if (blocked || agentTargets.length === 0) return;
+    trigger ??= root?.querySelector<HTMLButtonElement>(".create-options-button") ?? undefined;
     open = true;
     await tick();
     position();
@@ -74,6 +80,22 @@
     const host = root?.closest<HTMLElement>(".kit-modal-panel") ?? document.body;
     host.appendChild(node);
     return () => node.remove();
+  }
+
+  function optionsButton(node: HTMLElement): () => void {
+    const button = node.querySelector<HTMLButtonElement>(".create-options-button");
+    if (!button) return () => {};
+    button.setAttribute("aria-haspopup", "menu");
+    function handle(event: KeyboardEvent): void {
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        void openMenu();
+      } else if (event.key === "Tab" && open) {
+        closeMenu();
+      }
+    }
+    button.addEventListener("keydown", handle);
+    return () => button.removeEventListener("keydown", handle);
   }
 
   function selectTarget(targetKey: string): void {
@@ -134,12 +156,14 @@
   });
 </script>
 
-<div class="workspace-create-split" bind:this={root} data-surface={surface}>
-  <button
+<div class="workspace-create-split" bind:this={root}>
+  <Button
     type={primaryType}
     class="create-primary"
-    aria-label={busy ? busyLabel : label}
-    aria-describedby={descriptionId || undefined}
+    tone="info"
+    {surface}
+    ariaLabel={busy ? busyLabel : label}
+    ariaDescribedby={descriptionId || undefined}
     title={disabledReason || label}
     disabled={blocked}
     onclick={() => {
@@ -148,31 +172,24 @@
   >
     <PackagePlusIcon size="14" strokeWidth="2.2" aria-hidden="true" />
     <span>{busy ? busyLabel : label}</span>
-  </button>
-  <button
-    bind:this={trigger}
-    type="button"
-    class="create-options"
-    aria-label={`${label} options`}
-    title={disabledReason || "Create and launch an agent"}
-    aria-haspopup="menu"
-    aria-expanded={open}
-    disabled={blocked || agentTargets.length === 0}
-    onclick={() => {
-      if (open) closeMenu();
-      else void openMenu();
-    }}
-    onkeydown={(event) => {
-      if (event.key === "ArrowDown") {
-        event.preventDefault();
-        void openMenu();
-      } else if (event.key === "Tab" && open) {
-        closeMenu();
-      }
-    }}
-  >
-    <ChevronDownIcon size="12" strokeWidth="2" aria-hidden="true" />
-  </button>
+  </Button>
+  <span class="create-options" {@attach optionsButton}>
+    <Button
+      surface={surface === "solid" ? "solid" : "soft"}
+      tone="info"
+      class="create-options-button"
+      ariaLabel={`${label} options`}
+      title={disabledReason || "Create and launch an agent"}
+      ariaExpanded={open}
+      disabled={blocked || agentTargets.length === 0}
+      onclick={() => {
+        if (open) closeMenu();
+        else void openMenu();
+      }}
+    >
+      <ChevronDownIcon size="12" strokeWidth="2" aria-hidden="true" />
+    </Button>
+  </span>
   {#if open}
     <ul
       bind:this={menu}
@@ -207,78 +224,34 @@
     max-width: 100%;
   }
 
-  .workspace-create-split > button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 30px;
-    border: 1px solid var(--border-default);
-    background: var(--bg-surface);
-    color: var(--text-secondary);
-    font: inherit;
-    font-size: var(--font-size-xs);
-    font-weight: 600;
-    cursor: pointer;
-  }
-
-  .create-primary {
+  .workspace-create-split :global(.create-primary) {
     flex: 1 1 auto;
-    gap: var(--space-2);
     min-width: 0;
+    min-height: 30px;
     overflow: hidden;
-    padding: 0 var(--space-4);
+    padding-inline: var(--space-4);
     border-radius: var(--radius-sm) 0 0 var(--radius-sm);
   }
 
-  .create-primary span {
+  .workspace-create-split :global(.create-primary span) {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
   .create-options {
+    display: inline-flex;
     flex: 0 0 30px;
     width: 30px;
+  }
+
+  .create-options :global(.create-options-button) {
+    flex-shrink: 0;
+    width: 30px;
+    min-height: 30px;
     padding: 0;
     border-left: 0;
     border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
-  }
-
-  .workspace-create-split[data-surface="solid"] > button {
-    border-color: var(--accent-blue);
-    background: var(--accent-blue);
-    color: var(--bg-surface);
-  }
-
-  .workspace-create-split > button:hover:not(:disabled),
-  .workspace-create-split > button:focus-visible,
-  .workspace-create-split > button[aria-expanded="true"] {
-    border-color: var(--accent-blue);
-    color: var(--text-primary);
-  }
-
-  .workspace-create-split > button:focus-visible {
-    position: relative;
-    outline: 2px solid var(--accent-blue);
-    outline-offset: -1px;
-  }
-
-  .workspace-create-split[data-surface="solid"] > button:hover:not(:disabled),
-  .workspace-create-split[data-surface="solid"] > button:focus-visible {
-    border-color: color-mix(in srgb, var(--accent-blue) 88%, #000);
-    background: color-mix(in srgb, var(--accent-blue) 88%, #000);
-    color: var(--bg-surface);
-  }
-
-  .workspace-create-split[data-surface="solid"] > button[aria-expanded="true"] {
-    border-color: color-mix(in srgb, var(--accent-blue) 78%, #000);
-    background: color-mix(in srgb, var(--accent-blue) 78%, #000);
-    color: var(--bg-surface);
-  }
-
-  .workspace-create-split > button:disabled {
-    color: var(--text-faint);
-    cursor: default;
   }
 
   .create-menu {

--- a/packages/ui/src/components/workspace/WorkspaceCreateSplitButton.svelte
+++ b/packages/ui/src/components/workspace/WorkspaceCreateSplitButton.svelte
@@ -182,9 +182,6 @@
       style={menuStyle}
       {@attach portalMenu}
     >
-      <li role="none" class="create-menu-heading">
-        <span aria-hidden="true">Create and launch</span>
-      </li>
       {#each agentTargets as target (target.key)}
         <li role="none">
           <button
@@ -292,15 +289,6 @@
     margin: 0;
     padding: var(--space-2);
     list-style: none;
-  }
-
-  .create-menu-heading {
-    padding: var(--space-2) var(--space-3);
-    color: var(--text-faint);
-    font-size: var(--font-size-3xs);
-    font-weight: 600;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
   }
 
   .create-menu button {

--- a/packages/ui/src/components/workspace/WorkspaceCreateSplitButton.test.ts
+++ b/packages/ui/src/components/workspace/WorkspaceCreateSplitButton.test.ts
@@ -47,13 +47,18 @@ describe("WorkspaceCreateSplitButton", () => {
     cleanup();
   });
 
-  it("keeps the primary action create-only", async () => {
+  it("composes kit-ui buttons and keeps the primary action create-only", async () => {
     const onCreate = vi.fn();
     render(WorkspaceCreateSplitButton, {
       props: { label: "Create Workspace", launchTargets: targets, onCreate },
     });
 
-    await fireEvent.click(screen.getByRole("button", { name: "Create Workspace" }));
+    const primary = screen.getByRole("button", { name: "Create Workspace" });
+    const options = screen.getByRole("button", { name: "Create Workspace options" });
+    expect(primary.classList.contains("kit-button")).toBe(true);
+    expect(options.classList.contains("kit-button")).toBe(true);
+
+    await fireEvent.click(primary);
 
     expect(onCreate).toHaveBeenCalledWith(undefined);
   });

--- a/packages/ui/src/components/workspace/WorkspaceCreateSplitButton.test.ts
+++ b/packages/ui/src/components/workspace/WorkspaceCreateSplitButton.test.ts
@@ -79,7 +79,7 @@ describe("WorkspaceCreateSplitButton", () => {
     expect(screen.getByRole("menuitem", { name: "Codex" }).getAttribute("aria-describedby")).toBeNull();
   });
 
-  it("offers only agents and passes the chosen target", async () => {
+  it("offers only agents without a redundant visible heading and passes the chosen target", async () => {
     const onCreate = vi.fn();
     render(WorkspaceCreateSplitButton, {
       props: { label: "Create Workspace", launchTargets: targets, onCreate },
@@ -87,6 +87,7 @@ describe("WorkspaceCreateSplitButton", () => {
 
     await fireEvent.click(screen.getByRole("button", { name: "Create Workspace options" }));
 
+    expect(screen.queryByText("Create and launch")).toBeNull();
     expect(screen.queryByRole("menuitem", { name: "Shell" })).toBeNull();
 
     await fireEvent.click(screen.getByRole("menuitem", { name: "Codex" }));


### PR DESCRIPTION
## Why

The New workspace dialog showed a valid create-and-launch chevron, but its menu was clipped by the modal body and appeared inert. The split action had also duplicated shared button theming instead of using kit-ui, making the two segments inconsistent and harder to maintain.

## Summary

- Compose both split-action segments from kit-ui `Button` primitives.
- Keep launch choices visible and clickable inside the real kit-ui modal focus boundary.
- Cover the actual New workspace dialog in a real browser.
- Verify agent selection through the full API and persisted SQLite runtime-session path in Chromium and Firefox.

Screenshot pending attachment approval.

🤖 Generated with OpenAI