### PR TITLE
fix: show the detected pull request on ad-hoc workspace rows

### DIFF
--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -49,7 +49,11 @@ embedder protocol for arbitrary host state.
   item key is `adhoc:<branch>` and `item_number` stays 0, so item-key fallbacks
   derived from the number must exclude this type
   (`internal/db/queries.go::workspaceItemTypeKeysByNumber`). Requesting the same
-  branch twice returns the existing workspace.
+  branch twice returns the existing workspace. Once its branch is pushed the
+  monitor links a PR into `associated_pr_number`
+  (`internal/workspace/monitor.go::workspacePRMonitorEligible`); that number is
+  the workspace's item identity for display, links, and search, so surfaces must
+  never gate PR affordances on `item_type == "pull_request"` alone.
 - `GET /kata/tasks/snapshot`: the browser's sole Kata task authority. Daemon,
   scope, project, status authority, selected task, and graph source form request
   identity; selected detail, history, graph, and workspace target belong to the
@@ -360,7 +364,7 @@ Workspace diffs compare against local `HEAD`, the pushed branch, or a merge
 target. The merge-target scope exists only when the server can resolve a real
 merge target branch, not merely when the workspace carries a PR identity.
 Resolution requires all of: a positive PR number (PR-backed workspaces use their
-own `item_number`; issue-backed and Kata-backed workspaces use
+own `item_number`; issue-backed, Kata-backed, and ad-hoc workspaces use
 `associated_pr_number`), a synced repo row, a synced merge request row, and a
 non-empty base branch on that row. When any of those is missing the API returns
 "workspace merge target branch not available" and treats it as the

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -89,6 +89,7 @@
     mr_deletions?: number | null;
     commits_ahead?: number | null;
     commits_behind?: number | null;
+    associated_pr_number?: number | null;
     fleet_host_key?: string;
     fleet_host_name?: string;
   }
@@ -523,9 +524,27 @@
     );
   }
 
+  // An ad-hoc workspace has no provider item at creation, but the daemon links
+  // one once its branch is pushed and a PR appears. That detected PR is the
+  // workspace's item number for display, opening, and search.
+  function adHocPRNumber(ws: Workspace): number | null {
+    if (ws.item_type !== "adhoc") return null;
+    const number = ws.associated_pr_number;
+    return number && number > 0 ? number : null;
+  }
+
+  function itemBubbleNumber(ws: Workspace): number | null {
+    return ws.item_type === "adhoc" ? adHocPRNumber(ws) : ws.item_number;
+  }
+
+  function hasItemBubble(ws: Workspace): boolean {
+    if (ws.item_type === "kata_task") return true;
+    return itemBubbleNumber(ws) !== null;
+  }
+
   function itemBubbleLabel(ws: Workspace): string {
     if (ws.item_type === "kata_task") return kataIdentityLabel(ws);
-    return `#${ws.item_number}`;
+    return `#${itemBubbleNumber(ws)}`;
   }
 
   function itemBubbleTitle(ws: Workspace): string {
@@ -535,8 +554,8 @@
       return title ? `Open Kata task ${identity}: ${title}` : `Open Kata task ${identity}`;
     }
     return ws.item_type === "issue"
-      ? `Open issue #${ws.item_number}`
-      : `Open PR #${ws.item_number}`;
+      ? `Open issue #${itemBubbleNumber(ws)}`
+      : `Open PR #${itemBubbleNumber(ws)}`;
   }
 
   function updateSearch(value: string): void {
@@ -574,9 +593,19 @@
         ws.item_key,
       );
     } else if (ws.item_type === "adhoc") {
-      // No number or item title to match on: the branch (already in the
-      // haystack) plus the kind keywords are what a user would type.
+      // Without a detected PR there is no number or item title to match on:
+      // the branch (already in the haystack) plus the kind keywords are what
+      // a user would type.
       haystack.push("adhoc", "new work");
+      const prNumber = adHocPRNumber(ws);
+      if (prNumber !== null) {
+        haystack.push(
+          String(prNumber),
+          `#${prNumber}`,
+          `pr ${prNumber}`,
+          `pr #${prNumber}`,
+        );
+      }
     } else {
       const itemKind = ws.item_type === "issue" ? "issue" : "pr";
       const itemNumber = String(ws.item_number);
@@ -766,9 +795,11 @@
   }
 
   function providerItemURL(ws: Workspace): string | null {
-    // Kata and ad-hoc workspaces are not backed by a provider PR/issue, so
-    // there is no provider item URL (item_number is 0).
-    if (ws.item_type === "kata_task" || ws.item_type === "adhoc") return null;
+    // Kata workspaces are not backed by a provider item, and an ad-hoc
+    // workspace only has one once a PR has been detected for its branch.
+    if (ws.item_type === "kata_task") return null;
+    const itemNumber = itemBubbleNumber(ws);
+    if (itemNumber === null) return null;
     const provider = workspaceProvider(ws)?.toLowerCase();
     const repoPath = ws.repo?.repo_path ?? `${ws.repo_owner}/${ws.repo_name}`;
     const encodedPath = repoPath
@@ -779,15 +810,15 @@
     if (!host || !encodedPath) return null;
     if (provider === "github") {
       const kind = ws.item_type === "issue" ? "issues" : "pull";
-      return `https://${host}/${encodedPath}/${kind}/${ws.item_number}`;
+      return `https://${host}/${encodedPath}/${kind}/${itemNumber}`;
     }
     if (provider === "gitlab") {
       const kind = ws.item_type === "issue" ? "issues" : "merge_requests";
-      return `https://${host}/${encodedPath}/-/${kind}/${ws.item_number}`;
+      return `https://${host}/${encodedPath}/-/${kind}/${itemNumber}`;
     }
     if (provider === "gitea" || provider === "forgejo") {
       const kind = ws.item_type === "issue" ? "issues" : "pulls";
-      return `https://${host}/${encodedPath}/${kind}/${ws.item_number}`;
+      return `https://${host}/${encodedPath}/${kind}/${itemNumber}`;
     }
     return null;
   }
@@ -1408,9 +1439,9 @@
                 {/if}
               </div>
             </div>
-            <!-- Ad-hoc workspaces have no provider item or task to open, so
-                 they render no bubble at all rather than an empty one. -->
-            {#if ws.item_type !== "adhoc"}
+            <!-- An ad-hoc workspace with no detected PR has nothing for a
+                 bubble to open, so it renders none rather than an empty one. -->
+            {#if hasItemBubble(ws)}
             <button
               class={[
                 "item-bubble",

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -70,6 +70,7 @@ interface WorkspaceFixtureOptions {
   agentState?: "idle" | "working" | "input" | "approval" | "done" | null;
   agentStateUpdatedAt?: string | null;
   status?: string;
+  associatedPRNumber?: number | null;
 }
 
 function workspaceFixture({
@@ -98,6 +99,7 @@ function workspaceFixture({
   agentState = null,
   agentStateUpdatedAt = null,
   status = "ready",
+  associatedPRNumber = null,
 }: WorkspaceFixtureOptions) {
   // Kata and ad-hoc workspaces carry no joined provider item metadata.
   const noProviderItem = itemType === "kata_task" || itemType === "adhoc";
@@ -136,6 +138,7 @@ function workspaceFixture({
     mr_deletions: deletions,
     commits_ahead: commitsAhead,
     commits_behind: commitsBehind,
+    associated_pr_number: associatedPRNumber,
   };
 }
 
@@ -1968,6 +1971,79 @@ describe("WorkspaceListSidebar", () => {
     // open, and the row must never advertise #0.
     expect(container.querySelector(".item-bubble")).toBeNull();
     expect(container.textContent).not.toContain("#0");
+  });
+
+  it("shows the pull request detected for an ad-hoc workspace", async () => {
+    // A workspace created directly gains a PR once its branch is pushed and
+    // the backend links it. The detail pane already resolves that PR, so the
+    // row must advertise it instead of staying permanently bubble-less.
+    mockGet.mockResolvedValue({
+      data: {
+        workspaces: [adHocWorkspaceFixture({ associatedPRNumber: 840 })],
+      },
+    });
+    const onOpenItemSidebar = vi.fn();
+
+    const { container } = render(WorkspaceListSidebar, {
+      props: { selectedId: "ws-adhoc", onOpenItemSidebar },
+    });
+    await waitFor(() => expect(rowTitles(container)).toEqual(["spike/rate-limits"]));
+
+    const bubble = container.querySelector(".item-bubble");
+    expect(bubble).not.toBeNull();
+    expect(bubble!.textContent?.trim()).toBe("#840");
+    expect(bubble!.getAttribute("title")).toBe("Open PR #840");
+
+    await fireEvent.click(bubble!);
+    expect(onOpenItemSidebar).toHaveBeenCalledWith("ws-adhoc", "pr", undefined);
+  });
+
+  it("offers provider item actions for an ad-hoc workspace with a detected PR", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        workspaces: [adHocWorkspaceFixture({ associatedPRNumber: 840 })],
+      },
+    });
+
+    const { container } = render(WorkspaceListSidebar, {
+      props: { selectedId: "ws-adhoc" },
+    });
+    await waitFor(() => expect(rowTitles(container)).toEqual(["spike/rate-limits"]));
+
+    await fireEvent.contextMenu(container.querySelector(".ws-row")!);
+    await fireEvent.click(screen.getByRole("menuitem", { name: "Copy item URL" }));
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("https://github.com/kenn-io/kenn-forge/pull/840");
+  });
+
+  it("finds an ad-hoc workspace by its detected PR number", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        workspaces: [
+          adHocWorkspaceFixture({ associatedPRNumber: 840 }),
+          workspaceFixture({
+            id: "ws-pr",
+            provider: "github",
+            platformHost: "github.com",
+            owner: "kenn-io",
+            name: "kenn-forge",
+            number: 4,
+            title: "Some pull request",
+          }),
+        ],
+      },
+    });
+
+    const { container } = render(WorkspaceListSidebar, {
+      props: { selectedId: "ws-adhoc" },
+    });
+    await screen.findByText("Some pull request");
+
+    await fireEvent.input(screen.getByLabelText("Filter workspaces"), {
+      target: { value: "#840" },
+    });
+
+    await waitFor(() => expect(rowTitles(container)).toEqual(["spike/rate-limits"]));
   });
 
   it("finds an ad-hoc workspace by branch", async () => {


### PR DESCRIPTION
## Why

A workspace created directly has no source item, so its row showed no
number, could not open or copy a PR URL, and stayed unfindable by number
even after a pull request was opened from it. The detail pane already
resolved that PR, so the same workspace advertised a PR on the right and
nothing in the list.

## What changes

- An ad-hoc workspace row shows the pull request the daemon detected for
  its branch, and the bubble opens the PR the same way a PR-backed row
  does.
- Provider item actions (open, copy URL) and filter-by-number work for
  those rows.
- An ad-hoc workspace with no detected PR still shows no bubble.

<sup>generated by a clanker</sup>