### PR TITLE
Prevent terminated e2e runs from leaking tmux

### DIFF
--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -54,6 +54,8 @@ import (
 // always passes -roborev explicitly to the dockerized seeded daemon.
 const defaultRoborevEndpoint = "http://127.0.0.1:1"
 
+const e2eTmuxDirEnv = "PLAYWRIGHT_E2E_TMUX_DIR"
+
 func main() {
 	port := flag.Int("port", 0, "port to listen on (0 selects a random free port)")
 	roborev := flag.String(
@@ -825,16 +827,17 @@ type appOptions struct {
 // Playwright tests can reuse the process (and its port) instead of
 // paying a full spawn/teardown per test.
 type appState struct {
-	tmpDir      string
-	database    *db.DB
-	srv         *server.Server
-	handler     http.Handler
-	cfgPath     string
-	worktreeDir string
-	tmuxCommand []string
-	ptyOwner    bool
-	clones      *gitclone.Manager
-	handlerWG   sync.WaitGroup
+	tmpDir       string
+	database     *db.DB
+	srv          *server.Server
+	handler      http.Handler
+	cfgPath      string
+	worktreeDir  string
+	tmuxCommand  []string
+	ptyOwner     bool
+	clones       *gitclone.Manager
+	handlerWG    sync.WaitGroup
+	tmuxStopOnce sync.Once
 }
 
 type appStateRegistry struct {
@@ -889,8 +892,18 @@ func (st *appState) finishRequest() {
 	st.handlerWG.Done()
 }
 
-func (st *appState) waitForHandlers() {
-	st.handlerWG.Wait()
+func (st *appState) waitForHandlers(ctx context.Context) error {
+	done := make(chan struct{})
+	go func() {
+		st.handlerWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // tmuxSocketCounter feeds per-instance tmux socket names so
@@ -908,27 +921,26 @@ func instanceTmuxCommand() []string {
 		// states apart, only crash+pid-reuse protection degrades.
 		slog.Warn("tmux socket random suffix", "err", err)
 	}
-	return []string{
-		"tmux",
-		"-f",
-		"/dev/null",
-		"-L",
-		fmt.Sprintf(
-			"mm-e2e-%d-%d-%s",
-			os.Getpid(),
-			tmuxSocketCounter.Add(1),
-			hex.EncodeToString(randSuffix[:]),
-		),
+	name := fmt.Sprintf(
+		"mm-e2e-%d-%d-%s",
+		os.Getpid(),
+		tmuxSocketCounter.Add(1),
+		hex.EncodeToString(randSuffix[:]),
+	)
+	if root := strings.TrimSpace(os.Getenv(e2eTmuxDirEnv)); root != "" {
+		return []string{
+			"tmux", "-f", "/dev/null", "-S",
+			filepath.Join(root, name+".sock"),
+		}
 	}
+	return []string{"tmux", "-f", "/dev/null", "-L", name}
 }
 
 // killTmuxServer tears down the per-instance tmux server. It only
 // acts on sockets named by instanceTmuxCommand so a misconfigured
 // command can never kill a developer's real tmux server.
 func killTmuxServer(tmuxCmd []string) {
-	idx := slices.Index(tmuxCmd, "-L")
-	if idx < 0 || idx+1 >= len(tmuxCmd) ||
-		!strings.HasPrefix(tmuxCmd[idx+1], "mm-e2e-") {
+	if !isOwnedE2ETmuxCommand(tmuxCmd) {
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -937,10 +949,44 @@ func killTmuxServer(tmuxCmd []string) {
 	_ = procutil.CommandContext(ctx, tmuxCmd[0], args...).Run()
 }
 
+func isOwnedE2ETmuxCommand(tmuxCmd []string) bool {
+	for _, flag := range []string{"-L", "-S"} {
+		idx := slices.Index(tmuxCmd, flag)
+		if idx < 0 || idx+1 >= len(tmuxCmd) {
+			continue
+		}
+		name := tmuxCmd[idx+1]
+		if flag == "-S" {
+			if !strings.HasPrefix(
+				filepath.Base(filepath.Dir(name)),
+				"kf-e2e-tmux-",
+			) {
+				return false
+			}
+			name = filepath.Base(name)
+			if !strings.HasSuffix(name, ".sock") {
+				return false
+			}
+		}
+		return strings.HasPrefix(name, "mm-e2e-")
+	}
+	return false
+}
+
+func (st *appState) stopTmux() {
+	st.tmuxStopOnce.Do(func() {
+		killTmuxServer(st.tmuxCommand)
+	})
+}
+
 // close releases everything the state owns. Shutdown drains HTTP
 // handlers and background goroutines before the workspace cleanup
 // and database close, mirroring the old process-exit defer ordering.
 func (st *appState) close() {
+	// tmux is an isolated test resource, not durable product state. Tear it
+	// down before graceful HTTP draining so a stuck handler cannot strand the
+	// daemon after SIGTERM or a reset.
+	st.stopTmux()
 	shutdownCtx, cancel := context.WithTimeout(
 		context.Background(), 10*time.Second,
 	)
@@ -948,11 +994,9 @@ func (st *appState) close() {
 	if err := st.srv.Shutdown(shutdownCtx); err != nil {
 		slog.Warn("server shutdown", "err", err)
 	}
-	st.waitForHandlers()
-	// The private tmux daemon outlives this process unless it is stopped
-	// explicitly. Retired reset states can still have slower workspace cleanup
-	// ahead of them, so release the daemon as soon as no handler can use it.
-	killTmuxServer(st.tmuxCommand)
+	if err := st.waitForHandlers(shutdownCtx); err != nil {
+		slog.Warn("drain e2e handlers", "err", err)
+	}
 	cleanupE2EWorkspaces(st.database, st.clones, st.worktreeDir, st.tmuxCommand, st.ptyOwner)
 	if err := st.database.Close(); err != nil {
 		slog.Warn("close database", "err", err)
@@ -2626,12 +2670,12 @@ func run(
 				return
 			}
 			old := states.Swap(newState)
-			// The retired state owns a private tmux server that must not
-			// outlive the reset, even if the runner exits before its slower
-			// workspace cleanup goroutine completes.
-			killTmuxServer(old.tmuxCommand)
-			// Old-state teardown (handler drain, tmux kill, temp
-			// dir removal) happens off the request path, matching
+			// Stop the old state's private tmux server synchronously. Its
+			// remaining handler/database cleanup may continue off-request,
+			// but a process exit cannot strand this test-owned daemon.
+			old.stopTmux()
+			// Remaining old-state teardown (handler drain and temp-dir
+			// removal) happens off the request path, matching
 			// the old SIGTERM-and-return stop() semantics.
 			states.closeAsync(old.close)
 
@@ -2682,7 +2726,7 @@ func run(
 		// Runner exit can close inherited stdio immediately after sending
 		// SIGTERM. Release the private daemon before logging or draining so
 		// that abrupt parent teardown cannot orphan it.
-		killTmuxServer(states.Load().tmuxCommand)
+		states.Load().stopTmux()
 		slog.Info("shutting down")
 		// Trigger Shutdown so Serve unblocks (the defer is a
 		// safety net for other exit paths and is idempotent).

--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -834,6 +834,7 @@ type appState struct {
 	cfgPath      string
 	worktreeDir  string
 	tmuxCommand  []string
+	tmuxGate     *tmuxCreationGate
 	ptyOwner     bool
 	clones       *gitclone.Manager
 	handlerWG    sync.WaitGroup
@@ -936,6 +937,80 @@ func instanceTmuxCommand() []string {
 	return []string{"tmux", "-f", "/dev/null", "-L", name}
 }
 
+type tmuxCreationGate struct {
+	dir string
+}
+
+func newTmuxCreationGate(root string, tmuxCmd []string) (*tmuxCreationGate, []string, error) {
+	dir := filepath.Join(root, "tmux-gate")
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		return nil, nil, fmt.Errorf("create e2e tmux gate: %w", err)
+	}
+	script := filepath.Join(dir, "tmux")
+	content := `#!/bin/sh
+gate=$1
+shift
+case " $* " in
+  *" new-session "*) ;;
+  *) exec "$@" ;;
+esac
+if [ -e "$gate/killing" ]; then
+  echo "e2e tmux shutdown has started" >&2
+  exit 75
+fi
+while ! mkdir "$gate/creation.lock" 2>/dev/null; do
+  if [ -e "$gate/killing" ]; then
+    echo "e2e tmux shutdown has started" >&2
+    exit 75
+  fi
+  sleep 0.01
+done
+trap 'rmdir "$gate/creation.lock"' EXIT HUP INT TERM
+if [ -e "$gate/killing" ]; then
+  echo "e2e tmux shutdown has started" >&2
+  exit 75
+fi
+"$@"
+`
+	if err := os.WriteFile(script, []byte(content), 0o700); err != nil {
+		return nil, nil, fmt.Errorf("write e2e tmux gate: %w", err)
+	}
+	command := make([]string, 0, 2+len(tmuxCmd))
+	command = append(command, script, dir)
+	command = append(command, tmuxCmd...)
+	return &tmuxCreationGate{dir: dir}, command, nil
+}
+
+func (g *tmuxCreationGate) stop(kill func()) {
+	if g == nil {
+		kill()
+		return
+	}
+	marker := filepath.Join(g.dir, "killing")
+	if err := os.WriteFile(marker, nil, 0o600); err != nil {
+		slog.Warn("mark e2e tmux killing", "err", err)
+	}
+	lock := filepath.Join(g.dir, "creation.lock")
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		err := os.Mkdir(lock, 0o700)
+		if err == nil {
+			defer os.Remove(lock)
+			break
+		}
+		if !errors.Is(err, os.ErrExist) {
+			slog.Warn("acquire e2e tmux creation gate", "err", err)
+			break
+		}
+		if time.Now().After(deadline) {
+			slog.Warn("wait for e2e tmux creation gate", "err", context.DeadlineExceeded)
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	kill()
+}
+
 // killTmuxServer tears down the per-instance tmux server. It only
 // acts on sockets named by instanceTmuxCommand so a misconfigured
 // command can never kill a developer's real tmux server.
@@ -975,7 +1050,9 @@ func isOwnedE2ETmuxCommand(tmuxCmd []string) bool {
 
 func (st *appState) stopTmux() {
 	st.tmuxStopOnce.Do(func() {
-		killTmuxServer(st.tmuxCommand)
+		st.tmuxGate.stop(func() {
+			killTmuxServer(st.tmuxCommand)
+		})
 	})
 }
 
@@ -1118,6 +1195,10 @@ func buildAppState(
 	if opts.preferPtyOwner {
 		tmuxCommand = []string{filepath.Join(tmpDir, "missing-tmux")}
 	}
+	tmuxGate, guardedTmuxCommand, err := newTmuxCreationGate(tmpDir, tmuxCommand)
+	if err != nil {
+		return nil, err
+	}
 	cfg := &config.Config{
 		SyncInterval:        "5m",
 		GitHubTokenEnv:      "KENN_FORGE_GITHUB_TOKEN",
@@ -1134,7 +1215,7 @@ func buildAppState(
 		// (parallel Playwright workers, multiple worktrees) never
 		// contend on one tmux server. This is what lets workspace
 		// tests run unserialized.
-		Tmux: config.Tmux{Command: tmuxCommand},
+		Tmux: config.Tmux{Command: guardedTmuxCommand},
 	}
 	cfg.Fleet.Key = strings.TrimSpace(opts.fleetKey)
 	if opts.visibleImportedModes {
@@ -2492,7 +2573,8 @@ func buildAppState(
 		handler:     rootHandler,
 		cfgPath:     cfgPath,
 		worktreeDir: e2eWorktreeDir,
-		tmuxCommand: cfg.TmuxCommand(),
+		tmuxCommand: tmuxCommand,
+		tmuxGate:    tmuxGate,
 		ptyOwner:    opts.preferPtyOwner,
 		clones:      diffRepo.Manager,
 	}, nil

--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -1195,9 +1195,13 @@ func buildAppState(
 	if opts.preferPtyOwner {
 		tmuxCommand = []string{filepath.Join(tmpDir, "missing-tmux")}
 	}
-	tmuxGate, guardedTmuxCommand, err := newTmuxCreationGate(tmpDir, tmuxCommand)
-	if err != nil {
-		return nil, err
+	var tmuxGate *tmuxCreationGate
+	guardedTmuxCommand := tmuxCommand
+	if !opts.preferPtyOwner {
+		tmuxGate, guardedTmuxCommand, err = newTmuxCreationGate(tmpDir, tmuxCommand)
+		if err != nil {
+			return nil, err
+		}
 	}
 	cfg := &config.Config{
 		SyncInterval:        "5m",

--- a/cmd/e2e-server/main_test.go
+++ b/cmd/e2e-server/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -10,8 +11,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
+	"sync"
+	"syscall"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -23,8 +27,55 @@ import (
 	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/procutil"
 	"go.kenn.io/forge/internal/testutil"
+	"go.kenn.io/forge/internal/testutil/testsignal"
 	"go.kenn.io/forge/internal/web"
 )
+
+var (
+	testTmuxMu       sync.Mutex
+	testTmuxCommands = make(map[string][]string)
+)
+
+func TestMain(m *testing.M) {
+	runCleanup, stopSignalCleanup := testsignal.Install(cleanupTrackedTestTmux, func(err error) {
+		fmt.Fprintf(os.Stderr, "cleanup e2e-server test tmux: %v\n", err)
+	})
+	code := m.Run()
+	if err := runCleanup(); err != nil {
+		fmt.Fprintf(os.Stderr, "cleanup e2e-server test tmux: %v\n", err)
+		if code == 0 {
+			code = 1
+		}
+	}
+	stopSignalCleanup()
+	os.Exit(code)
+}
+
+func trackTestTmux(tmuxCommand []string) func() {
+	key := strings.Join(tmuxCommand, "\x00")
+	testTmuxMu.Lock()
+	testTmuxCommands[key] = append([]string{}, tmuxCommand...)
+	testTmuxMu.Unlock()
+	return func() {
+		testTmuxMu.Lock()
+		delete(testTmuxCommands, key)
+		testTmuxMu.Unlock()
+	}
+}
+
+func cleanupTrackedTestTmux() error {
+	testTmuxMu.Lock()
+	commands := make([][]string, 0, len(testTmuxCommands))
+	for _, command := range testTmuxCommands {
+		commands = append(commands, command)
+	}
+	clear(testTmuxCommands)
+	testTmuxMu.Unlock()
+	for _, command := range commands {
+		killTmuxServer(command)
+	}
+	return nil
+}
 
 func TestWriteServerInfoFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "server-info.json")
@@ -461,6 +512,73 @@ func TestRunCancellationStopsPrivateTmuxBeforeShutdown(t *testing.T) {
 	requirePrivateTmuxServerStopped(t, tmuxCommand)
 }
 
+func TestE2EServerTestMainStopsPrivateTmuxOnSIGTERM(t *testing.T) {
+	if os.Getenv("KENN_FORGE_E2E_SIGNAL_HELPER") == "1" {
+		tmuxCommand := instanceTmuxCommand()
+		args := append([]string{}, tmuxCommand[1:]...)
+		args = append(args, "new-session", "-d", "-s", "signal-cleanup", "sleep 30")
+		if output, err := procutil.Command(tmuxCommand[0], args...).CombinedOutput(); err != nil {
+			_, _ = os.Stderr.Write(output)
+			os.Exit(2)
+		}
+		trackTestTmux(tmuxCommand)
+		encoded, err := json.Marshal(tmuxCommand)
+		if err != nil {
+			os.Exit(3)
+		}
+		if err := os.WriteFile(os.Getenv("KENN_FORGE_E2E_SIGNAL_READY"), encoded, 0o600); err != nil {
+			os.Exit(4)
+		}
+		select {}
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not support the tmux signal-cleanup probe")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not available")
+	}
+
+	require := require.New(t)
+	tmuxDir, err := os.MkdirTemp("/tmp", "kf-e2e-tmux-")
+	require.NoError(err)
+	t.Cleanup(func() { _ = os.RemoveAll(tmuxDir) })
+	readyFile := filepath.Join(t.TempDir(), "ready.json")
+	cmd := procutil.Command(os.Args[0], "-test.run=^TestE2EServerTestMainStopsPrivateTmuxOnSIGTERM$")
+	cmd.Env = append(os.Environ(),
+		"KENN_FORGE_E2E_SIGNAL_HELPER=1",
+		"KENN_FORGE_E2E_SIGNAL_READY="+readyFile,
+		e2eTmuxDirEnv+"="+tmuxDir,
+	)
+	require.NoError(cmd.Start())
+	t.Cleanup(func() {
+		if cmd.ProcessState == nil {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		}
+	})
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		data, readErr := os.ReadFile(readyFile)
+		if readErr == nil {
+			var tmuxCommand []string
+			require.NoError(json.Unmarshal(data, &tmuxCommand))
+			t.Cleanup(func() { killTmuxServer(tmuxCommand) })
+			require.NoError(cmd.Process.Signal(syscall.SIGTERM))
+			waitErr := cmd.Wait()
+			var exitErr *exec.ExitError
+			require.ErrorAs(waitErr, &exitErr)
+			require.Equal(143, exitErr.ExitCode())
+			requirePrivateTmuxServerStopped(t, tmuxCommand)
+			return
+		}
+		if time.Now().After(deadline) {
+			require.FailNow("signal helper did not create its private tmux server")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 // TestResetSwapsFixtureState pins the /__e2e/reset contract that the
 // Playwright server pool depends on: a reset discards mutations made
 // against the old state, serves the rebuilt state on the same port,
@@ -595,7 +713,11 @@ func startPrivateE2ETmuxServer(t *testing.T, configPath string) []string {
 	args = append(args, "new-session", "-d", "-s", "forge-e2e-shutdown-test", "sleep 30")
 	output, err := procutil.Command(tmuxCommand[0], args...).CombinedOutput()
 	require.NoError(t, err, string(output))
-	t.Cleanup(func() { killTmuxServer(tmuxCommand) })
+	untrack := trackTestTmux(tmuxCommand)
+	t.Cleanup(func() {
+		killTmuxServer(tmuxCommand)
+		untrack()
+	})
 	return tmuxCommand
 }
 

--- a/cmd/e2e-server/main_test.go
+++ b/cmd/e2e-server/main_test.go
@@ -112,6 +112,9 @@ func (tracker *testTmuxTracker) stop(key string, tmuxCommand []string) error {
 	if !errors.As(listErr, &listExitErr) {
 		return fmt.Errorf("verify e2e-server test tmux stopped: %w: %s", listErr, listOutput)
 	}
+	if !strings.HasPrefix(strings.TrimSpace(string(listOutput)), "no server running on ") {
+		return fmt.Errorf("verify e2e-server test tmux stopped: %w: %s", listErr, listOutput)
+	}
 	tracker.mu.Lock()
 	if current, ok := tracker.commands[key]; ok && strings.Join(current, "\x00") == key {
 		delete(tracker.commands, key)
@@ -137,7 +140,13 @@ case "$*" in
     [ ! -e "$KF_TEST_TMUX_FAIL" ] || exit 1
     rm -f "$KF_TEST_TMUX_STATE"
     ;;
-  *list-sessions*) [ -e "$KF_TEST_TMUX_STATE" ] ;;
+  *list-sessions*)
+    if [ -e "$KF_TEST_TMUX_STATE" ]; then
+      exit 0
+    fi
+    echo "no server running on test socket" >&2
+    exit 1
+    ;;
 esac
 `), 0o700))
 	t.Setenv("KF_TEST_TMUX_STATE", stateFile)
@@ -152,6 +161,30 @@ esac
 	require.NoError(os.Remove(failFile))
 	require.NoError(tracker.cleanup())
 	assert.NoFileExists(stateFile)
+}
+
+func TestTestTmuxTrackerRetainsUnverifiedListFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell tmux tracker probe is not supported on Windows")
+	}
+	require := require.New(t)
+	dir := t.TempDir()
+	stateFile := filepath.Join(dir, "state")
+	command := filepath.Join(dir, "tmux-probe")
+	require.NoError(os.WriteFile(command, []byte(`#!/bin/sh
+case "$*" in
+  *new-session*) : > "$KF_TEST_TMUX_STATE" ;;
+  *kill-server*) exit 1 ;;
+  *list-sessions*) echo "permission denied" >&2; exit 2 ;;
+esac
+`), 0o700))
+	t.Setenv("KF_TEST_TMUX_STATE", stateFile)
+
+	tracker := newTestTmuxTracker()
+	_, err := tracker.start([]string{command}, []string{"new-session"}, nil)
+	require.NoError(err)
+	require.Error(tracker.cleanup())
+	require.FileExists(stateFile)
 }
 
 func TestWriteServerInfoFile(t *testing.T) {

--- a/cmd/e2e-server/main_test.go
+++ b/cmd/e2e-server/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -31,13 +32,20 @@ import (
 	"go.kenn.io/forge/internal/web"
 )
 
-var (
-	testTmuxMu       sync.Mutex
-	testTmuxCommands = make(map[string][]string)
-)
+var testTmux = newTestTmuxTracker()
+
+type testTmuxTracker struct {
+	mu           sync.Mutex
+	commands     map[string][]string
+	shuttingDown bool
+}
+
+func newTestTmuxTracker() *testTmuxTracker {
+	return &testTmuxTracker{commands: make(map[string][]string)}
+}
 
 func TestMain(m *testing.M) {
-	runCleanup, stopSignalCleanup := testsignal.Install(cleanupTrackedTestTmux, func(err error) {
+	runCleanup, stopSignalCleanup := testsignal.Install(testTmux.cleanup, func(err error) {
 		fmt.Fprintf(os.Stderr, "cleanup e2e-server test tmux: %v\n", err)
 	})
 	code := m.Run()
@@ -51,30 +59,99 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func trackTestTmux(tmuxCommand []string) func() {
+func (tracker *testTmuxTracker) start(
+	tmuxCommand, args []string,
+	afterStart func(),
+) (func() error, error) {
 	key := strings.Join(tmuxCommand, "\x00")
-	testTmuxMu.Lock()
-	testTmuxCommands[key] = append([]string{}, tmuxCommand...)
-	testTmuxMu.Unlock()
-	return func() {
-		testTmuxMu.Lock()
-		delete(testTmuxCommands, key)
-		testTmuxMu.Unlock()
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	if tracker.shuttingDown {
+		return nil, errors.New("e2e-server test tmux cleanup has started")
 	}
+	tracker.commands[key] = append([]string{}, tmuxCommand...)
+	output, err := procutil.Command(tmuxCommand[0], args...).CombinedOutput()
+	if err != nil {
+		delete(tracker.commands, key)
+		return nil, fmt.Errorf("start e2e-server test tmux: %w: %s", err, output)
+	}
+	if afterStart != nil {
+		afterStart()
+	}
+	return func() error { return tracker.stop(key, tmuxCommand) }, nil
 }
 
-func cleanupTrackedTestTmux() error {
-	testTmuxMu.Lock()
-	commands := make([][]string, 0, len(testTmuxCommands))
-	for _, command := range testTmuxCommands {
-		commands = append(commands, command)
+func (tracker *testTmuxTracker) cleanup() error {
+	tracker.mu.Lock()
+	tracker.shuttingDown = true
+	commands := make(map[string][]string, len(tracker.commands))
+	for key, command := range tracker.commands {
+		commands[key] = append([]string{}, command...)
 	}
-	clear(testTmuxCommands)
-	testTmuxMu.Unlock()
-	for _, command := range commands {
-		killTmuxServer(command)
+	tracker.mu.Unlock()
+	var cleanupErr error
+	for key, command := range commands {
+		cleanupErr = errors.Join(cleanupErr, tracker.stop(key, command))
 	}
+	return cleanupErr
+}
+
+func (tracker *testTmuxTracker) stop(key string, tmuxCommand []string) error {
+	args := append([]string{}, tmuxCommand[1:]...)
+	args = append(args, "kill-server")
+	killOutput, killErr := procutil.Command(tmuxCommand[0], args...).CombinedOutput()
+	args[len(args)-1] = "list-sessions"
+	listOutput, listErr := procutil.Command(tmuxCommand[0], args...).CombinedOutput()
+	if listErr == nil {
+		return fmt.Errorf(
+			"stop e2e-server test tmux: %v: %s; server still accepts commands: %s",
+			killErr, killOutput, listOutput,
+		)
+	}
+	var listExitErr *exec.ExitError
+	if !errors.As(listErr, &listExitErr) {
+		return fmt.Errorf("verify e2e-server test tmux stopped: %w: %s", listErr, listOutput)
+	}
+	tracker.mu.Lock()
+	if current, ok := tracker.commands[key]; ok && strings.Join(current, "\x00") == key {
+		delete(tracker.commands, key)
+	}
+	tracker.mu.Unlock()
 	return nil
+}
+
+func TestTestTmuxTrackerRetainsFailedCleanupForRetry(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell tmux tracker probe is not supported on Windows")
+	}
+	require := require.New(t)
+	assert := assert.New(t)
+	dir := t.TempDir()
+	stateFile := filepath.Join(dir, "state")
+	failFile := filepath.Join(dir, "fail")
+	command := filepath.Join(dir, "tmux-probe")
+	require.NoError(os.WriteFile(command, []byte(`#!/bin/sh
+case "$*" in
+  *new-session*) : > "$KF_TEST_TMUX_STATE" ;;
+  *kill-server*)
+    [ ! -e "$KF_TEST_TMUX_FAIL" ] || exit 1
+    rm -f "$KF_TEST_TMUX_STATE"
+    ;;
+  *list-sessions*) [ -e "$KF_TEST_TMUX_STATE" ] ;;
+esac
+`), 0o700))
+	t.Setenv("KF_TEST_TMUX_STATE", stateFile)
+	t.Setenv("KF_TEST_TMUX_FAIL", failFile)
+	require.NoError(os.WriteFile(failFile, nil, 0o600))
+
+	tracker := newTestTmuxTracker()
+	_, err := tracker.start([]string{command}, []string{"new-session"}, nil)
+	require.NoError(err)
+	require.Error(tracker.cleanup())
+	require.FileExists(stateFile)
+	require.NoError(os.Remove(failFile))
+	require.NoError(tracker.cleanup())
+	assert.NoFileExists(stateFile)
 }
 
 func TestWriteServerInfoFile(t *testing.T) {
@@ -517,17 +594,19 @@ func TestE2EServerTestMainStopsPrivateTmuxOnSIGTERM(t *testing.T) {
 		tmuxCommand := instanceTmuxCommand()
 		args := append([]string{}, tmuxCommand[1:]...)
 		args = append(args, "new-session", "-d", "-s", "signal-cleanup", "sleep 30")
-		if output, err := procutil.Command(tmuxCommand[0], args...).CombinedOutput(); err != nil {
-			_, _ = os.Stderr.Write(output)
-			os.Exit(2)
-		}
-		trackTestTmux(tmuxCommand)
 		encoded, err := json.Marshal(tmuxCommand)
 		if err != nil {
 			os.Exit(3)
 		}
-		if err := os.WriteFile(os.Getenv("KENN_FORGE_E2E_SIGNAL_READY"), encoded, 0o600); err != nil {
-			os.Exit(4)
+		_, err = testTmux.start(tmuxCommand, args, func() {
+			if writeErr := os.WriteFile(os.Getenv("KENN_FORGE_E2E_SIGNAL_READY"), encoded, 0o600); writeErr != nil {
+				os.Exit(4)
+			}
+			time.Sleep(250 * time.Millisecond)
+		})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
 		}
 		select {}
 	}
@@ -711,12 +790,10 @@ func startPrivateE2ETmuxServer(t *testing.T, configPath string) []string {
 	require.True(t, isOwnedE2ETmuxCommand(tmuxCommand))
 	args := append([]string{}, tmuxCommand[1:]...)
 	args = append(args, "new-session", "-d", "-s", "forge-e2e-shutdown-test", "sleep 30")
-	output, err := procutil.Command(tmuxCommand[0], args...).CombinedOutput()
-	require.NoError(t, err, string(output))
-	untrack := trackTestTmux(tmuxCommand)
+	stop, err := testTmux.start(tmuxCommand, args, nil)
+	require.NoError(t, err)
 	t.Cleanup(func() {
-		killTmuxServer(tmuxCommand)
-		untrack()
+		require.NoError(t, stop())
 	})
 	return tmuxCommand
 }

--- a/cmd/e2e-server/main_test.go
+++ b/cmd/e2e-server/main_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -18,7 +19,9 @@ import (
 	gh "github.com/google/go-github/v89/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/procutil"
 	"go.kenn.io/forge/internal/testutil"
 	"go.kenn.io/forge/internal/web"
 )
@@ -55,6 +58,7 @@ func TestCleanupServerInfoFileRemovesFile(t *testing.T) {
 }
 
 func TestInstanceTmuxCommandUsesPrivateSocketAndDefaultConfig(t *testing.T) {
+	t.Setenv(e2eTmuxDirEnv, "")
 	command := instanceTmuxCommand()
 
 	require.Len(t, command, 5)
@@ -64,6 +68,23 @@ func TestInstanceTmuxCommandUsesPrivateSocketAndDefaultConfig(t *testing.T) {
 	assert.Equal("/dev/null", command[2])
 	assert.Equal("-L", command[3])
 	assert.Regexp(`^mm-e2e-\d+-\d+-[0-9a-f]{8}$`, command[4])
+}
+
+func TestInstanceTmuxCommandUsesPlaywrightOwnedSocketDirectory(t *testing.T) {
+	dir, err := os.MkdirTemp("", "kf-e2e-tmux-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	t.Setenv(e2eTmuxDirEnv, dir)
+
+	command := instanceTmuxCommand()
+
+	require.Len(t, command, 5)
+	assert := assert.New(t)
+	assert.Equal("tmux", command[0])
+	assert.Equal("-S", command[3])
+	assert.Equal(dir, filepath.Dir(command[4]))
+	assert.Regexp(`^mm-e2e-\d+-\d+-[0-9a-f]{8}\.sock$`, filepath.Base(command[4]))
+	assert.True(isOwnedE2ETmuxCommand(command))
 }
 
 func TestPatchFixturePRSHAsUpdatesOpenPRs(t *testing.T) {
@@ -142,7 +163,7 @@ func TestAppStateRegistryWaitsForInFlightHandlersAfterSwap(t *testing.T) {
 	drained := make(chan struct{})
 	go func() {
 		defer close(drained)
-		swapped.waitForHandlers()
+		_ = swapped.waitForHandlers(context.Background())
 	}()
 
 	select {
@@ -411,6 +432,35 @@ func TestRunPprofListenerFromEnv(t *testing.T) {
 	}
 }
 
+func TestRunCancellationStopsPrivateTmuxBeforeShutdown(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not available")
+	}
+	tmuxDir, err := os.MkdirTemp("/tmp", "kf-e2e-tmux-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tmuxDir) })
+	t.Setenv(e2eTmuxDirEnv, tmuxDir)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	serverInfoFile := filepath.Join(t.TempDir(), "server-info.json")
+	done := make(chan error, 1)
+	go func() {
+		done <- run(ctx, 0, defaultRoborevEndpoint, serverInfoFile, "github.com", "", false, false)
+	}()
+	info := waitForServerInfo(t, serverInfoFile, done)
+	tmuxCommand := startPrivateE2ETmuxServer(t, info.ConfigPath)
+
+	cancel()
+	select {
+	case runErr := <-done:
+		require.NoError(t, runErr)
+	case <-time.After(10 * time.Second):
+		require.Fail(t, "run() did not exit within 10s of cancellation")
+	}
+	requirePrivateTmuxServerStopped(t, tmuxCommand)
+}
+
 // TestResetSwapsFixtureState pins the /__e2e/reset contract that the
 // Playwright server pool depends on: a reset discards mutations made
 // against the old state, serves the rebuilt state on the same port,
@@ -498,6 +548,63 @@ func TestResetSwapsFixtureState(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		require.Fail("run() did not exit within 10s of cancellation")
 	}
+}
+
+func TestResetStopsOldPrivateTmuxServerBeforeReturning(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not available")
+	}
+	require := require.New(t)
+	tmuxDir, err := os.MkdirTemp("/tmp", "kf-e2e-tmux-")
+	require.NoError(err)
+	t.Cleanup(func() { _ = os.RemoveAll(tmuxDir) })
+	t.Setenv(e2eTmuxDirEnv, tmuxDir)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	serverInfoFile := filepath.Join(t.TempDir(), "server-info.json")
+	done := make(chan error, 1)
+	go func() {
+		done <- run(ctx, 0, defaultRoborevEndpoint, serverInfoFile, "github.com", "", false, false)
+	}()
+	info := waitForServerInfo(t, serverInfoFile, done)
+	oldTmuxCommand := startPrivateE2ETmuxServer(t, info.ConfigPath)
+
+	resp, err := http.Post(info.BaseURL+"/__e2e/reset", "application/json", nil)
+	require.NoError(err)
+	resp.Body.Close()
+	require.Equal(http.StatusOK, resp.StatusCode)
+	requirePrivateTmuxServerStopped(t, oldTmuxCommand)
+
+	cancel()
+	select {
+	case runErr := <-done:
+		require.NoError(runErr)
+	case <-time.After(10 * time.Second):
+		require.Fail("run() did not exit within 10s of cancellation")
+	}
+}
+
+func startPrivateE2ETmuxServer(t *testing.T, configPath string) []string {
+	t.Helper()
+	cfg, err := config.Load(configPath)
+	require.NoError(t, err)
+	tmuxCommand := cfg.TmuxCommand()
+	require.True(t, isOwnedE2ETmuxCommand(tmuxCommand))
+	args := append([]string{}, tmuxCommand[1:]...)
+	args = append(args, "new-session", "-d", "-s", "forge-e2e-shutdown-test", "sleep 30")
+	output, err := procutil.Command(tmuxCommand[0], args...).CombinedOutput()
+	require.NoError(t, err, string(output))
+	t.Cleanup(func() { killTmuxServer(tmuxCommand) })
+	return tmuxCommand
+}
+
+func requirePrivateTmuxServerStopped(t *testing.T, tmuxCommand []string) {
+	t.Helper()
+	args := append([]string{}, tmuxCommand[1:]...)
+	args = append(args, "list-sessions")
+	output, err := procutil.Command(tmuxCommand[0], args...).CombinedOutput()
+	require.Error(t, err, "private tmux server still accepts commands: %s", output)
 }
 
 func readInfoFile(t *testing.T, path string) e2eServerInfo {

--- a/cmd/e2e-server/main_test.go
+++ b/cmd/e2e-server/main_test.go
@@ -63,13 +63,14 @@ func (tracker *testTmuxTracker) start(
 	tmuxCommand, args []string,
 	afterStart func(),
 ) (func() error, error) {
-	key := strings.Join(tmuxCommand, "\x00")
+	trackedCommand := testTmuxCommandIdentity(tmuxCommand)
+	key := strings.Join(trackedCommand, "\x00")
 	tracker.mu.Lock()
 	defer tracker.mu.Unlock()
 	if tracker.shuttingDown {
 		return nil, errors.New("e2e-server test tmux cleanup has started")
 	}
-	tracker.commands[key] = append([]string{}, tmuxCommand...)
+	tracker.commands[key] = append([]string{}, trackedCommand...)
 	output, err := procutil.Command(tmuxCommand[0], args...).CombinedOutput()
 	if err != nil {
 		delete(tracker.commands, key)
@@ -78,7 +79,14 @@ func (tracker *testTmuxTracker) start(
 	if afterStart != nil {
 		afterStart()
 	}
-	return func() error { return tracker.stop(key, tmuxCommand) }, nil
+	return func() error { return tracker.stop(key, trackedCommand) }, nil
+}
+
+func testTmuxCommandIdentity(tmuxCommand []string) []string {
+	if len(tmuxCommand) >= 3 && tmuxCommand[0] == filepath.Join(tmuxCommand[1], "tmux") {
+		return tmuxCommand[2:]
+	}
+	return tmuxCommand
 }
 
 func (tracker *testTmuxTracker) cleanup() error {
@@ -246,6 +254,72 @@ func TestInstanceTmuxCommandUsesPlaywrightOwnedSocketDirectory(t *testing.T) {
 	assert.Equal(dir, filepath.Dir(command[4]))
 	assert.Regexp(`^mm-e2e-\d+-\d+-[0-9a-f]{8}\.sock$`, filepath.Base(command[4]))
 	assert.True(isOwnedE2ETmuxCommand(command))
+}
+
+func TestTmuxCreationGateRejectsNewSessionsAfterShutdownStarts(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell tmux gate probe is not supported on Windows")
+	}
+	require := require.New(t)
+	assert := assert.New(t)
+	dir := t.TempDir()
+	started := filepath.Join(dir, "started")
+	release := filepath.Join(dir, "release")
+	logPath := filepath.Join(dir, "commands")
+	command := filepath.Join(dir, "tmux-probe")
+	require.NoError(os.WriteFile(command, []byte(`#!/bin/sh
+case " $* " in
+  *" new-session "*)
+    echo new-session >> "$KF_TEST_TMUX_LOG"
+    : > "$KF_TEST_TMUX_STARTED"
+    while [ ! -e "$KF_TEST_TMUX_RELEASE" ]; do sleep 0.01; done
+    ;;
+  *" kill-server "*) echo kill-server >> "$KF_TEST_TMUX_LOG" ;;
+esac
+`), 0o700))
+	t.Setenv("KF_TEST_TMUX_STARTED", started)
+	t.Setenv("KF_TEST_TMUX_RELEASE", release)
+	t.Setenv("KF_TEST_TMUX_LOG", logPath)
+
+	gate, guarded, err := newTmuxCreationGate(dir, []string{command})
+	require.NoError(err)
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- procutil.Command(guarded[0], append(guarded[1:], "new-session")...).Run()
+	}()
+	require.Eventually(func() bool {
+		_, statErr := os.Stat(started)
+		return statErr == nil
+	}, time.Second, 10*time.Millisecond)
+
+	stopDone := make(chan struct{})
+	go func() {
+		gate.stop(func() {
+			_ = procutil.Command(command, "kill-server").Run()
+		})
+		close(stopDone)
+	}()
+	require.Eventually(func() bool {
+		_, statErr := os.Stat(filepath.Join(gate.dir, "killing"))
+		return statErr == nil
+	}, time.Second, 10*time.Millisecond)
+
+	output, startErr := procutil.Command(
+		guarded[0], append(guarded[1:], "new-session")...,
+	).CombinedOutput()
+	require.Error(startErr)
+	assert.Contains(string(output), "e2e tmux shutdown has started")
+	require.NoError(os.WriteFile(release, nil, 0o600))
+	require.NoError(<-firstDone)
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		require.Fail("tmux stop did not acquire the creation gate")
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	require.NoError(err)
+	assert.Equal("new-session\nkill-server\n", string(logBytes))
 }
 
 func TestPatchFixturePRSHAsUpdatesOpenPRs(t *testing.T) {
@@ -828,7 +902,7 @@ func startPrivateE2ETmuxServer(t *testing.T, configPath string) []string {
 	t.Cleanup(func() {
 		require.NoError(t, stop())
 	})
-	return tmuxCommand
+	return testTmuxCommandIdentity(tmuxCommand)
 }
 
 func requirePrivateTmuxServerStopped(t *testing.T, tmuxCommand []string) {

--- a/cmd/kenn-forge/daemon_process_windows.go
+++ b/cmd/kenn-forge/daemon_process_windows.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 )
@@ -12,5 +13,7 @@ func signalDaemonProcess(pid int) error {
 	if err != nil {
 		return fmt.Errorf("find process %d: %w", pid, err)
 	}
-	return process.Kill()
+	killErr := process.Kill()
+	releaseErr := process.Release()
+	return errors.Join(killErr, releaseErr)
 }

--- a/context/testing.md
+++ b/context/testing.md
@@ -205,6 +205,8 @@ and must not be rebuilt or removed (`frontend/tests/e2e-full/support/e2eServer.t
   the root removes it only after every published child exits (`frontend/tests/e2e-full/support/e2eServer.ts::waitForSharedServerOwners`).
 - Once e2e-server tmux shutdown starts, no new session may be admitted; cleanup waits
   for an admitted creation before killing the private server (`cmd/e2e-server/main.go::tmuxCreationGate`).
+- Keep explicit PTY-owner test mode unwrapped so its missing tmux command remains
+  unavailable to backend selection (`cmd/e2e-server/main.go::buildAppState`).
 
 Mounting `KataWorkspace.svelte` in Vitest always fetches the daemon roster and
 opens the live SSE event stream; mock both fetch routes (see

--- a/context/testing.md
+++ b/context/testing.md
@@ -195,14 +195,11 @@ Timezone-sensitive Vitest tests must not mutate `process.env.TZ` after workers
 start; launch the test process with `TZ` or stub the locale formatter instead
 (`frontend/src/lib/components/detail/operation-gates.test.ts:8`).
 
-Full-stack e2e serves the frontend embedded in the e2e-server binary
-(`internal/web/dist`), not live sources: run `make frontend` before building
-`cmd/e2e-server` locally, or the suite silently validates a stale bundle and
-passes on frontend changes that CI then fails.
-Set `PLAYWRIGHT_E2E_SERVER_BINARY` to an explicit prebuilt `cmd/e2e-server`
-binary when startup must exclude `go run` compilation, such as Vercel's docs
-screenshot build. Build the frontend before compiling that binary so it embeds
-the current SPA.
+Full-stack e2e serves the frontend embedded in the e2e-server binary, not live
+sources. The Playwright runner must prepare those assets and build one run-owned
+`cmd/e2e-server`; workers inherit its direct path so signal cleanup targets the
+server instead of a `go run` wrapper. An explicit binary remains externally owned
+and must not be rebuilt or removed (`frontend/tests/e2e-full/support/e2eServer.ts::ensureE2EServerBinary`).
 
 Mounting `KataWorkspace.svelte` in Vitest always fetches the daemon roster and
 opens the live SSE event stream; mock both fetch routes (see

--- a/context/testing.md
+++ b/context/testing.md
@@ -373,6 +373,9 @@ instead of serializing the whole test.
 - Playwright workers share one run-owned socket directory; new runs reap those
   whose recorded owner PID is dead
   (`frontend/tests/e2e-full/support/e2eServer.ts::ensureE2ETmuxDir`).
+- Keep every child owned and the shared socket root intact through child exit;
+  terminating children can still daemonize tmux after the first cleanup sweep
+  (`frontend/tests/e2e-full/support/e2eServer.ts::shutdownOwnedServers`).
 - Stale recovery may connect only to tmux roots, owner files, and sockets owned
   by the current user; matching a private test name is not ownership
   (`frontend/tests/e2e-full/support/e2eServer.ts::cleanupE2ETmuxDir`).

--- a/context/testing.md
+++ b/context/testing.md
@@ -197,8 +197,9 @@ start; launch the test process with `TZ` or stub the locale formatter instead
 
 Full-stack e2e serves the frontend embedded in the e2e-server binary, not live
 sources. The Playwright runner must prepare those assets and build one run-owned
-`cmd/e2e-server`; workers inherit its direct path so signal cleanup targets the
-server instead of a `go run` wrapper. An explicit binary remains externally owned
+`cmd/e2e-server` with VCS stamping disabled; workers inherit its direct path so signal
+cleanup targets the server instead of a `go run` wrapper. An explicit binary remains
+externally owned
 and must not be rebuilt or removed (`frontend/tests/e2e-full/support/e2eServer.ts::ensureE2EServerBinary`).
 - Full-stack Playwright workers must publish child ownership in the shared tmux root;
   the root removes it only after every published child exits (`frontend/tests/e2e-full/support/e2eServer.ts::waitForSharedServerOwners`).

--- a/context/testing.md
+++ b/context/testing.md
@@ -373,6 +373,9 @@ instead of serializing the whole test.
 - Playwright workers share one run-owned socket directory; new runs reap those
   whose recorded owner PID is dead
   (`frontend/tests/e2e-full/support/e2eServer.ts::ensureE2ETmuxDir`).
+- Stale recovery may connect only to tmux roots, owner files, and sockets owned
+  by the current user; matching a private test name is not ownership
+  (`frontend/tests/e2e-full/support/e2eServer.ts::cleanupE2ETmuxDir`).
 - Real-tmux Go test binaries install signal cleanup because termination skips
   code after `m.Run` and `t.Cleanup` (`internal/testutil/testsignal.Install`).
 

--- a/context/testing.md
+++ b/context/testing.md
@@ -367,6 +367,15 @@ resource pressure rather than correctness, keep `t.Parallel()` and gate the
 expensive section with a package-level `golang.org/x/sync/semaphore.Weighted`
 instead of serializing the whole test.
 
+- E2e processes must stop private tmux servers before bounded graceful shutdown;
+  Go defers and Node `exit` callbacks cannot clean up after forced termination
+  (`cmd/e2e-server/main.go::appState.stopTmux`).
+- Playwright workers share one run-owned socket directory; new runs reap those
+  whose recorded owner PID is dead
+  (`frontend/tests/e2e-full/support/e2eServer.ts::ensureE2ETmuxDir`).
+- Real-tmux Go test binaries install signal cleanup because termination skips
+  code after `m.Run` and `t.Cleanup` (`internal/testutil/testsignal.Install`).
+
 Windows test binaries that launch restart-durable PTY processes must contain
 their descendants in a kill-on-close Job Object; test timeouts bypass normal
 Go cleanup (`internal/testutil/processjob/processjob_windows.go::ContainCurrentProcessTree`).

--- a/context/testing.md
+++ b/context/testing.md
@@ -200,6 +200,10 @@ sources. The Playwright runner must prepare those assets and build one run-owned
 `cmd/e2e-server`; workers inherit its direct path so signal cleanup targets the
 server instead of a `go run` wrapper. An explicit binary remains externally owned
 and must not be rebuilt or removed (`frontend/tests/e2e-full/support/e2eServer.ts::ensureE2EServerBinary`).
+- Full-stack Playwright workers must publish child ownership in the shared tmux root;
+  the root removes it only after every published child exits (`frontend/tests/e2e-full/support/e2eServer.ts::waitForSharedServerOwners`).
+- Once e2e-server tmux shutdown starts, no new session may be admitted; cleanup waits
+  for an admitted creation before killing the private server (`cmd/e2e-server/main.go::tmuxCreationGate`).
 
 Mounting `KataWorkspace.svelte` in Vitest always fetches the daemon roster and
 opens the live SSE event stream; mock both fetch routes (see

--- a/frontend/playwright-e2e.config.ts
+++ b/frontend/playwright-e2e.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
-import { ensureE2EServer } from "./tests/e2e-full/support/e2eServer";
+import { ensureE2EServer, ensureE2EServerBinary } from "./tests/e2e-full/support/e2eServer";
 
+await ensureE2EServerBinary();
 const serverInfo = await ensureE2EServer();
 
 // Chromium can use twice the configured CI baseline. Firefox's heavier

--- a/frontend/src/lib/utils/e2eServerOwnership.test.ts
+++ b/frontend/src/lib/utils/e2eServerOwnership.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { spawn } from "node:child_process";
 import { mkdirSync, mkdtempSync, utimesSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 import { readFile, stat } from "node:fs/promises";
@@ -514,6 +515,28 @@ describe("cleanupManagedServerProcess", () => {
 
     expect(killSpy).toHaveBeenCalledWith(99999, "SIGTERM");
     expect(killSpy).not.toHaveBeenCalledWith(11111, "SIGTERM");
+  });
+});
+
+describe("terminateServerProcess", () => {
+  it("waits for a SIGTERM-aware e2e child to finish", async () => {
+    const child = spawn(
+      process.execPath,
+      [
+        "-e",
+        "process.on('SIGTERM', () => setTimeout(() => process.exit(0), 100)); " +
+          "process.stdout.write('ready\\n'); setInterval(() => {}, 1000);",
+      ],
+      { stdio: ["ignore", "pipe", "ignore"] },
+    );
+    await new Promise<void>((resolve, reject) => {
+      child.once("error", reject);
+      child.stdout?.once("data", () => resolve());
+    });
+
+    await e2eServerModule.terminateServerProcess(child, child.pid);
+
+    expect(child.exitCode).toBe(0);
   });
 });
 

--- a/frontend/src/lib/utils/e2eServerOwnership.test.ts
+++ b/frontend/src/lib/utils/e2eServerOwnership.test.ts
@@ -826,6 +826,86 @@ describe("owned server lifecycle", () => {
     await rm(dir, { force: true, recursive: true });
   });
 
+  it("waits for a worker-owned server before removing the shared tmux root", async () => {
+    if (process.platform === "win32" || spawnSync("tmux", ["-V"], { stdio: "ignore" }).status !== 0) {
+      return;
+    }
+    const dir = mkdtempSync(path.join(os.tmpdir(), "e2e-server-test-"));
+    const helperFile = path.join(dir, "worker-helper.ts");
+    const workerReadyFile = path.join(dir, "worker-ready");
+    const workerStartedFile = path.join(dir, "worker-started");
+    const lateMarker = path.join(dir, "late-created");
+    const moduleURL = pathToFileURL(path.resolve("tests/e2e-full/support/e2eServer.ts")).href;
+    const fakeServer = writeFakeE2EServer(dir);
+    process.env.PLAYWRIGHT_E2E_SERVER_BINARY = fakeServer;
+    process.env.FAKE_E2E_STARTED_FILE = path.join(dir, "root-started");
+    delete process.env.PLAYWRIGHT_E2E_TMUX_DIR;
+
+    const rootServer = await e2eServerModule.startIsolatedE2EServerWithOptions({ freshProcess: true });
+    const tmuxDir = process.env.PLAYWRIGHT_E2E_TMUX_DIR;
+    expect(tmuxDir).toBeTruthy();
+    writeFileSync(
+      helperFile,
+      `import { writeFile } from "node:fs/promises";
+import process from "node:process";
+import { startIsolatedE2EServerWithOptions } from ${JSON.stringify(moduleURL)};
+await startIsolatedE2EServerWithOptions({ freshProcess: true, fleetKey: "slow" });
+await writeFile(process.env.FAKE_OWNER_READY_FILE, "ready");
+process.exit(0);
+`,
+    );
+    const owner = spawn("bun", [helperFile], {
+      env: {
+        ...process.env,
+        PLAYWRIGHT_E2E_SERVER_BINARY: fakeServer,
+        FAKE_E2E_STARTED_FILE: workerStartedFile,
+        FAKE_E2E_CREATE_LATE_TMUX: "1",
+        FAKE_E2E_LATE_MARKER: lateMarker,
+        FAKE_OWNER_READY_FILE: workerReadyFile,
+      },
+      stdio: "ignore",
+    });
+    let workerPID: number | null = null;
+
+    try {
+      const ownerExit = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+        owner.once("exit", (code, signal) => resolve({ code, signal }));
+      });
+      await waitForFile(workerReadyFile);
+      workerPID = Number.parseInt(await readFile(workerStartedFile, "utf8"), 10);
+      await expect(ownerExit).resolves.toEqual({ code: 0, signal: null });
+
+      const shutdown = e2eServerModule.shutdownOwnedServers();
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(await fileExists(tmuxDir ?? "")).toBe(true);
+      await shutdown;
+
+      await expect(readFile(lateMarker, "utf8")).resolves.toBe(JSON.stringify({ rootWasPreserved: true, status: 0 }));
+      expect(() => process.kill(workerPID ?? 0, 0)).toThrow();
+      expect(await fileExists(tmuxDir ?? "")).toBe(false);
+    } finally {
+      if (owner.exitCode === null && owner.signalCode === null) {
+        owner.kill("SIGKILL");
+        await new Promise<void>((resolve) => owner.once("exit", () => resolve()));
+      }
+      if (
+        workerPID &&
+        (() => {
+          try {
+            process.kill(workerPID, 0);
+            return true;
+          } catch {
+            return false;
+          }
+        })()
+      ) {
+        process.kill(workerPID, "SIGKILL");
+      }
+      await rootServer.stop();
+      await rm(dir, { force: true, recursive: true });
+    }
+  }, 20_000);
+
   it("keeps the shared tmux root until concurrent fresh-server stops have exited", async () => {
     const dir = mkdtempSync(path.join(os.tmpdir(), "e2e-server-test-"));
     process.env.PLAYWRIGHT_E2E_SERVER_BINARY = writeFakeE2EServer(dir);

--- a/frontend/src/lib/utils/e2eServerOwnership.test.ts
+++ b/frontend/src/lib/utils/e2eServerOwnership.test.ts
@@ -6,6 +6,7 @@ import { readFile, rm, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
+import { pathToFileURL } from "node:url";
 import * as e2eServerModule from "../../../tests/e2e-full/support/e2eServer";
 
 const { stopE2EServer } = e2eServerModule;
@@ -26,12 +27,14 @@ function writeFakeE2EServer(rootDir: string): string {
     serverPath,
     `#!/usr/bin/env node
 const { spawnSync } = require("node:child_process");
-const { mkdirSync, writeFileSync } = require("node:fs");
+const { existsSync, mkdirSync, writeFileSync } = require("node:fs");
 const { createServer } = require("node:http");
 const path = require("node:path");
 
 const infoFlag = process.argv.indexOf("-server-info-file");
 const infoFile = process.argv[infoFlag + 1];
+const fleetFlag = process.argv.indexOf("-fleet-key");
+const slowShutdown = fleetFlag >= 0 && process.argv[fleetFlag + 1] === "slow";
 const server = createServer((_req, response) => {
   response.writeHead(200);
   response.end("ok");
@@ -51,21 +54,20 @@ server.listen(0, "127.0.0.1", () => {
 
 process.on("SIGTERM", () => {
   const finish = () => server.close(() => process.exit(0));
-  if (process.env.FAKE_E2E_CREATE_LATE_TMUX === "1") {
+  if (process.env.FAKE_E2E_CREATE_LATE_TMUX === "1" && slowShutdown) {
     setTimeout(() => {
       const dir = process.env.PLAYWRIGHT_E2E_TMUX_DIR;
-      mkdirSync(dir, { recursive: true });
-      writeFileSync(path.join(dir, "owner.json"), JSON.stringify({ pid: process.ppid }));
+      const rootWasPreserved = existsSync(dir) && existsSync(path.join(dir, "owner.json"));
       const result = spawnSync("tmux", [
         "-f", "/dev/null", "-S", path.join(dir, "mm-e2e-late.sock"),
         "new-session", "-d", "-s", "late", "sleep", "30",
       ]);
-      writeFileSync(process.env.FAKE_E2E_LATE_MARKER, String(result.status));
+      writeFileSync(process.env.FAKE_E2E_LATE_MARKER, JSON.stringify({ rootWasPreserved, status: result.status }));
       finish();
     }, 100);
     return;
   }
-  finish();
+  setTimeout(finish, slowShutdown ? 250 : 0);
 });
 `,
   );
@@ -657,24 +659,65 @@ describe("private tmux ownership", () => {
       await rm(binDir, { force: true, recursive: true });
     }
   });
+
+  it("removes a stale socket after tmux verifies that its server is gone", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = mkdtempSync("/tmp/kf-e2e-tmux-");
+    const socket = path.join(dir, "mm-e2e-stale.sock");
+    writeFileSync(path.join(dir, "owner.json"), JSON.stringify({ pid: process.pid }), { mode: 0o600 });
+    const socketServer = createServer();
+    await new Promise<void>((resolve, reject) => {
+      socketServer.once("error", reject);
+      socketServer.listen(socket, () => resolve());
+    });
+
+    const binDir = mkdtempSync(path.join(os.tmpdir(), "e2e-fake-bin-"));
+    const fakeTmux = path.join(binDir, "tmux");
+    writeFileSync(
+      fakeTmux,
+      '#!/bin/sh\ncase "$*" in *list-sessions*) echo "no server running on test socket" >&2;; esac\nexit 1\n',
+    );
+    chmodSync(fakeTmux, 0o755);
+    process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH ?? ""}`;
+
+    try {
+      await e2eServerModule.cleanupE2ETmuxDir(dir);
+      expect(await fileExists(dir)).toBe(false);
+    } finally {
+      await new Promise<void>((resolve) => socketServer.close(() => resolve()));
+      await rm(dir, { force: true, recursive: true });
+      await rm(binDir, { force: true, recursive: true });
+    }
+  });
 });
 
 describe("owned server lifecycle", () => {
-  it("does not remove a shared tmux directory while another fresh server is active", async () => {
+  it("keeps the shared tmux root until concurrent fresh-server stops have exited", async () => {
     const dir = mkdtempSync(path.join(os.tmpdir(), "e2e-server-test-"));
     process.env.PLAYWRIGHT_E2E_SERVER_BINARY = writeFakeE2EServer(dir);
     process.env.FAKE_E2E_STARTED_FILE = path.join(dir, "started");
+    process.env.FAKE_E2E_CREATE_LATE_TMUX = "1";
+    const lateMarker = path.join(dir, "late-created");
+    process.env.FAKE_E2E_LATE_MARKER = lateMarker;
     delete process.env.PLAYWRIGHT_E2E_TMUX_DIR;
 
-    const first = await e2eServerModule.startIsolatedE2EServerWithOptions({ freshProcess: true });
+    const first = await e2eServerModule.startIsolatedE2EServerWithOptions({ freshProcess: true, fleetKey: "slow" });
     const second = await e2eServerModule.startIsolatedE2EServerWithOptions({ freshProcess: true });
     const tmuxDir = process.env.PLAYWRIGHT_E2E_TMUX_DIR;
     expect(tmuxDir).toBeTruthy();
+    let firstStop: Promise<void> | null = null;
 
     try {
-      await first.stop();
+      firstStop = first.stop();
+      await second.stop();
       expect(await fileExists(tmuxDir ?? "")).toBe(true);
+      await firstStop;
+      await expect(readFile(lateMarker, "utf8")).resolves.toBe(JSON.stringify({ rootWasPreserved: true, status: 0 }));
+      expect(await fileExists(tmuxDir ?? "")).toBe(false);
     } finally {
+      await firstStop;
       await second.stop();
       await rm(dir, { force: true, recursive: true });
     }
@@ -712,17 +755,67 @@ describe("owned server lifecycle", () => {
     process.env.FAKE_E2E_LATE_MARKER = lateMarker;
     delete process.env.PLAYWRIGHT_E2E_TMUX_DIR;
 
-    await e2eServerModule.startIsolatedE2EServerWithOptions({ freshProcess: true });
+    await e2eServerModule.startIsolatedE2EServerWithOptions({ freshProcess: true, fleetKey: "slow" });
     const tmuxDir = process.env.PLAYWRIGHT_E2E_TMUX_DIR;
     expect(tmuxDir).toBeTruthy();
 
     await e2eServerModule.shutdownOwnedServers();
 
-    await expect(readFile(lateMarker, "utf8")).resolves.toBe("0");
+    await expect(readFile(lateMarker, "utf8")).resolves.toBe(JSON.stringify({ rootWasPreserved: true, status: 0 }));
     expect(await fileExists(tmuxDir ?? "")).toBe(false);
     expect(process.env.PLAYWRIGHT_E2E_TMUX_DIR).toBeUndefined();
     await rm(dir, { force: true, recursive: true });
   });
+
+  it("keeps handling SIGTERM until asynchronous server cleanup finishes", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = mkdtempSync(path.join(os.tmpdir(), "e2e-server-test-"));
+    const helperFile = path.join(dir, "owner-helper.ts");
+    const readyFile = path.join(dir, "owner-ready.json");
+    const startedFile = path.join(dir, "server-started");
+    const moduleURL = pathToFileURL(path.resolve("tests/e2e-full/support/e2eServer.ts")).href;
+    writeFileSync(
+      helperFile,
+      `import { writeFile } from "node:fs/promises";
+import process from "node:process";
+import { startIsolatedE2EServerWithOptions } from ${JSON.stringify(moduleURL)};
+await startIsolatedE2EServerWithOptions({ freshProcess: true, fleetKey: "slow" });
+await writeFile(process.env.FAKE_OWNER_READY_FILE, JSON.stringify({ tmuxDir: process.env.PLAYWRIGHT_E2E_TMUX_DIR }));
+setInterval(() => {}, 1000);
+`,
+    );
+    const helperEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      PLAYWRIGHT_E2E_SERVER_BINARY: writeFakeE2EServer(dir),
+      FAKE_E2E_STARTED_FILE: startedFile,
+      FAKE_OWNER_READY_FILE: readyFile,
+    };
+    delete helperEnv.PLAYWRIGHT_E2E_TMUX_DIR;
+    const owner = spawn("bun", [helperFile], { env: helperEnv, stdio: "ignore" });
+
+    try {
+      await waitForFile(readyFile);
+      const { tmuxDir } = JSON.parse(await readFile(readyFile, "utf8"));
+      const outcomePromise = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+        owner.once("exit", (code, signal) => resolve({ code, signal }));
+      });
+      owner.kill("SIGTERM");
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      owner.kill("SIGTERM");
+      const outcome = await outcomePromise;
+
+      expect(outcome).toEqual({ code: 143, signal: null });
+      expect(await fileExists(tmuxDir)).toBe(false);
+    } finally {
+      if (owner.exitCode === null && owner.signalCode === null) {
+        owner.kill("SIGKILL");
+        await new Promise<void>((resolve) => owner.once("exit", () => resolve()));
+      }
+      await rm(dir, { force: true, recursive: true });
+    }
+  }, 10_000);
 });
 
 describe("stopE2EServer", () => {

--- a/frontend/src/lib/utils/e2eServerOwnership.test.ts
+++ b/frontend/src/lib/utils/e2eServerOwnership.test.ts
@@ -420,6 +420,91 @@ describe("e2eServerCommand", () => {
   });
 });
 
+describe("ensureE2EServerBinary", () => {
+  it("preserves an explicitly configured binary", async () => {
+    const ensureE2EServerBinary = (
+      e2eServerModule as {
+        ensureE2EServerBinary?: (rootDir?: string) => Promise<string>;
+      }
+    ).ensureE2EServerBinary;
+
+    expect(ensureE2EServerBinary).toBeTypeOf("function");
+    if (!ensureE2EServerBinary) {
+      return;
+    }
+
+    process.env.PLAYWRIGHT_E2E_SERVER_BINARY = "/tmp/configured-e2e-server";
+    await expect(ensureE2EServerBinary("/path/that/does/not/exist")).resolves.toBe("/tmp/configured-e2e-server");
+  });
+
+  it("builds a direct server binary after preparing embedded frontend assets", async () => {
+    const ensureE2EServerBinary = (
+      e2eServerModule as {
+        ensureE2EServerBinary?: (rootDir?: string) => Promise<string>;
+      }
+    ).ensureE2EServerBinary;
+    const cleanupE2ERunnerArtifacts = (
+      e2eServerModule as {
+        cleanupE2ERunnerArtifacts?: () => Promise<void>;
+      }
+    ).cleanupE2ERunnerArtifacts;
+
+    expect(ensureE2EServerBinary).toBeTypeOf("function");
+    expect(cleanupE2ERunnerArtifacts).toBeTypeOf("function");
+    if (!ensureE2EServerBinary || !cleanupE2ERunnerArtifacts) {
+      return;
+    }
+
+    const dir = mkdtempSync(path.join(os.tmpdir(), "e2e-server-build-test-"));
+    const frontendDist = path.join(dir, "frontend", "dist");
+    const embeddedDist = path.join(dir, "internal", "web", "dist");
+    const fakeBin = path.join(dir, "bin");
+    const buildArgsFile = path.join(dir, "go-build-args.json");
+    mkdirSync(frontendDist, { recursive: true });
+    mkdirSync(embeddedDist, { recursive: true });
+    mkdirSync(fakeBin, { recursive: true });
+    const frontendIndex = path.join(frontendDist, "index.html");
+    const embeddedIndex = path.join(embeddedDist, "index.html");
+    writeFileSync(frontendIndex, "current frontend");
+    writeFileSync(embeddedIndex, "stale frontend");
+    const staleTime = new Date("2026-01-01T00:00:00Z");
+    const currentTime = new Date("2026-01-01T00:00:10Z");
+    utimesSync(embeddedIndex, staleTime, staleTime);
+    utimesSync(frontendIndex, currentTime, currentTime);
+    writeFileSync(
+      path.join(fakeBin, "go"),
+      `#!/usr/bin/env node
+const { writeFileSync } = require("node:fs");
+const args = process.argv.slice(2);
+const outputIndex = args.indexOf("-o");
+writeFileSync(args[outputIndex + 1], "built e2e server");
+writeFileSync(process.env.FAKE_GO_BUILD_ARGS_FILE, JSON.stringify(args));
+`,
+    );
+    chmodSync(path.join(fakeBin, "go"), 0o755);
+    process.env.PATH = `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`;
+    process.env.FAKE_GO_BUILD_ARGS_FILE = buildArgsFile;
+    delete process.env.PLAYWRIGHT_E2E_SERVER_BINARY;
+    delete process.env.PLAYWRIGHT_E2E_FRONTEND_READY;
+
+    const binary = await ensureE2EServerBinary(dir);
+    expect(process.env.PLAYWRIGHT_E2E_SERVER_BINARY).toBe(binary);
+    await expect(readFile(binary, "utf8")).resolves.toBe("built e2e server");
+    await expect(readFile(embeddedIndex, "utf8")).resolves.toBe("current frontend");
+    await expect(readFile(buildArgsFile, "utf8")).resolves.toBe(
+      JSON.stringify(["build", "-o", binary, "./cmd/e2e-server"]),
+    );
+
+    process.env.PLAYWRIGHT_E2E_SERVER_BINARY_OWNER_PID = String(process.pid + 1);
+    await cleanupE2ERunnerArtifacts();
+    await expect(fileExists(binary)).resolves.toBe(true);
+
+    process.env.PLAYWRIGHT_E2E_SERVER_BINARY_OWNER_PID = String(process.pid);
+    await cleanupE2ERunnerArtifacts();
+    await expect(fileExists(path.dirname(binary))).resolves.toBe(false);
+  });
+});
+
 describe("getReusableServerInfo", () => {
   it("accepts a reachable server even when the response is slower than the poll interval", async () => {
     const getReusableServerInfo = (

--- a/frontend/src/lib/utils/e2eServerOwnership.test.ts
+++ b/frontend/src/lib/utils/e2eServerOwnership.test.ts
@@ -492,7 +492,7 @@ writeFileSync(process.env.FAKE_GO_BUILD_ARGS_FILE, JSON.stringify(args));
     await expect(readFile(binary, "utf8")).resolves.toBe("built e2e server");
     await expect(readFile(embeddedIndex, "utf8")).resolves.toBe("current frontend");
     await expect(readFile(buildArgsFile, "utf8")).resolves.toBe(
-      JSON.stringify(["build", "-o", binary, "./cmd/e2e-server"]),
+      JSON.stringify(["build", "-buildvcs=false", "-o", binary, "./cmd/e2e-server"]),
     );
 
     process.env.PLAYWRIGHT_E2E_SERVER_BINARY_OWNER_PID = String(process.pid + 1);

--- a/frontend/src/lib/utils/e2eServerOwnership.test.ts
+++ b/frontend/src/lib/utils/e2eServerOwnership.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
-import { spawn, spawnSync } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
 import { chmodSync, mkdirSync, mkdtempSync, utimesSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 import { readFile, rm, stat } from "node:fs/promises";
@@ -599,7 +600,7 @@ describe("terminateServerProcess", () => {
       child.stdout?.once("data", () => resolve());
     });
 
-    await e2eServerModule.terminateServerProcess(child, child.pid);
+    await expect(e2eServerModule.terminateServerProcess(child, child.pid)).resolves.toBe(true);
 
     expect(child.exitCode).toBe(0);
   });
@@ -617,9 +618,30 @@ describe("terminateServerProcess", () => {
     expect(child.signalCode).toBe("SIGTERM");
 
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
-    await e2eServerModule.terminateServerProcess(child, child.pid);
+    await expect(e2eServerModule.terminateServerProcess(child, child.pid)).resolves.toBe(true);
 
     expect(killSpy).not.toHaveBeenCalled();
+  });
+
+  it("reports when a child is still alive after forced termination", async () => {
+    vi.useFakeTimers();
+    const child = Object.assign(new EventEmitter(), {
+      exitCode: null,
+      pid: 12345,
+      signalCode: null,
+    }) as ChildProcess;
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    try {
+      const termination = e2eServerModule.terminateServerProcess(child, child.pid);
+      await vi.advanceTimersByTimeAsync(16_000);
+
+      await expect(termination).resolves.toBe(false);
+      expect(killSpy).toHaveBeenCalledWith(child.pid, "SIGTERM");
+      expect(killSpy).toHaveBeenCalledWith(child.pid, "SIGKILL");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -694,6 +716,31 @@ describe("private tmux ownership", () => {
 });
 
 describe("owned server lifecycle", () => {
+  it("serializes concurrent global shutdown while a child can still create tmux state", async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "e2e-server-test-"));
+    process.env.PLAYWRIGHT_E2E_SERVER_BINARY = writeFakeE2EServer(dir);
+    process.env.FAKE_E2E_STARTED_FILE = path.join(dir, "started");
+    process.env.FAKE_E2E_CREATE_LATE_TMUX = "1";
+    const lateMarker = path.join(dir, "late-created");
+    process.env.FAKE_E2E_LATE_MARKER = lateMarker;
+    delete process.env.PLAYWRIGHT_E2E_TMUX_DIR;
+
+    const server = await e2eServerModule.startIsolatedE2EServerWithOptions({ freshProcess: true, fleetKey: "slow" });
+    const tmuxDir = process.env.PLAYWRIGHT_E2E_TMUX_DIR;
+    expect(tmuxDir).toBeTruthy();
+
+    const firstShutdown = e2eServerModule.shutdownOwnedServers();
+    const secondShutdown = e2eServerModule.shutdownOwnedServers();
+    const individualStop = server.stop();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(await fileExists(tmuxDir ?? "")).toBe(true);
+    await Promise.all([firstShutdown, secondShutdown, individualStop]);
+
+    await expect(readFile(lateMarker, "utf8")).resolves.toBe(JSON.stringify({ rootWasPreserved: true, status: 0 }));
+    expect(await fileExists(tmuxDir ?? "")).toBe(false);
+    await rm(dir, { force: true, recursive: true });
+  });
+
   it("keeps the shared tmux root until concurrent fresh-server stops have exited", async () => {
     const dir = mkdtempSync(path.join(os.tmpdir(), "e2e-server-test-"));
     process.env.PLAYWRIGHT_E2E_SERVER_BINARY = writeFakeE2EServer(dir);
@@ -732,12 +779,13 @@ describe("owned server lifecycle", () => {
     delete process.env.PLAYWRIGHT_E2E_TMUX_DIR;
 
     const starting = e2eServerModule.startIsolatedE2EServerWithOptions({ freshProcess: true });
+    const rejectedStart = expect(starting).rejects.toThrow(/exited/);
     await waitForFile(startedFile);
     const childPID = Number.parseInt(await readFile(startedFile, "utf8"), 10);
 
     await e2eServerModule.shutdownOwnedServers();
 
-    await expect(starting).rejects.toThrow(/exited/);
+    await rejectedStart;
     expect(() => process.kill(childPID, 0)).toThrow();
     expect(process.env.PLAYWRIGHT_E2E_TMUX_DIR).toBeUndefined();
     await rm(dir, { force: true, recursive: true });

--- a/frontend/src/lib/utils/e2eServerOwnership.test.ts
+++ b/frontend/src/lib/utils/e2eServerOwnership.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
-import { spawn } from "node:child_process";
-import { mkdirSync, mkdtempSync, utimesSync, writeFileSync } from "node:fs";
+import { spawn, spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, utimesSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
-import { readFile, stat } from "node:fs/promises";
+import { readFile, rm, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
@@ -18,6 +18,69 @@ function writeFakeVitePlus(rootDir: string, body: string): void {
   writeFileSync(path.join(vitePlusBin, "vp"), body, {
     flag: "wx",
   });
+}
+
+function writeFakeE2EServer(rootDir: string): string {
+  const serverPath = path.join(rootDir, "fake-e2e-server");
+  writeFileSync(
+    serverPath,
+    `#!/usr/bin/env node
+const { spawnSync } = require("node:child_process");
+const { mkdirSync, writeFileSync } = require("node:fs");
+const { createServer } = require("node:http");
+const path = require("node:path");
+
+const infoFlag = process.argv.indexOf("-server-info-file");
+const infoFile = process.argv[infoFlag + 1];
+const server = createServer((_req, response) => {
+  response.writeHead(200);
+  response.end("ok");
+});
+
+writeFileSync(process.env.FAKE_E2E_STARTED_FILE, String(process.pid));
+server.listen(0, "127.0.0.1", () => {
+  const address = server.address();
+  const publish = () => writeFileSync(infoFile, JSON.stringify({
+    host: "127.0.0.1",
+    port: address.port,
+    base_url: "http://127.0.0.1:" + address.port,
+    pid: process.pid,
+  }));
+  setTimeout(publish, Number(process.env.FAKE_E2E_READY_DELAY_MS || "0"));
+});
+
+process.on("SIGTERM", () => {
+  const finish = () => server.close(() => process.exit(0));
+  if (process.env.FAKE_E2E_CREATE_LATE_TMUX === "1") {
+    setTimeout(() => {
+      const dir = process.env.PLAYWRIGHT_E2E_TMUX_DIR;
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(path.join(dir, "owner.json"), JSON.stringify({ pid: process.ppid }));
+      const result = spawnSync("tmux", [
+        "-f", "/dev/null", "-S", path.join(dir, "mm-e2e-late.sock"),
+        "new-session", "-d", "-s", "late", "sleep", "30",
+      ]);
+      writeFileSync(process.env.FAKE_E2E_LATE_MARKER, String(result.status));
+      finish();
+    }, 100);
+    return;
+  }
+  finish();
+});
+`,
+  );
+  chmodSync(serverPath, 0o755);
+  return serverPath;
+}
+
+async function waitForFile(filePath: string): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (!(await fileExists(filePath))) {
+    if (Date.now() >= deadline) {
+      throw new Error(`timed out waiting for ${filePath}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
 }
 
 async function fileExists(filePath: string): Promise<boolean> {
@@ -537,6 +600,128 @@ describe("terminateServerProcess", () => {
     await e2eServerModule.terminateServerProcess(child, child.pid);
 
     expect(child.exitCode).toBe(0);
+  });
+
+  it("does not signal a child that already exited from a signal", async () => {
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+    });
+    await new Promise<void>((resolve, reject) => {
+      child.once("spawn", resolve);
+      child.once("error", reject);
+    });
+    child.kill("SIGTERM");
+    await new Promise<void>((resolve) => child.once("exit", () => resolve()));
+    expect(child.signalCode).toBe("SIGTERM");
+
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    await e2eServerModule.terminateServerProcess(child, child.pid);
+
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("private tmux ownership", () => {
+  it("rejects a stale path owned by another local user", () => {
+    if (process.getuid === undefined) {
+      return;
+    }
+    expect(e2eServerModule.isCurrentUserOwned({ uid: process.getuid() + 1 })).toBe(false);
+  });
+
+  it("keeps the socket directory when tmux cleanup fails", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = mkdtempSync("/tmp/kf-e2e-tmux-");
+    const socket = path.join(dir, "mm-e2e-failed.sock");
+    writeFileSync(path.join(dir, "owner.json"), JSON.stringify({ pid: 999_999 }), { mode: 0o600 });
+    const socketServer = createServer();
+    await new Promise<void>((resolve, reject) => {
+      socketServer.once("error", reject);
+      socketServer.listen(socket, () => resolve());
+    });
+
+    const binDir = mkdtempSync(path.join(os.tmpdir(), "e2e-fake-bin-"));
+    const fakeTmux = path.join(binDir, "tmux");
+    writeFileSync(fakeTmux, "#!/bin/sh\nexit 1\n");
+    chmodSync(fakeTmux, 0o755);
+    process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH ?? ""}`;
+
+    try {
+      await e2eServerModule.cleanupE2ETmuxDir(dir);
+      expect(await fileExists(dir)).toBe(true);
+    } finally {
+      await new Promise<void>((resolve) => socketServer.close(() => resolve()));
+      await rm(dir, { force: true, recursive: true });
+      await rm(binDir, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("owned server lifecycle", () => {
+  it("does not remove a shared tmux directory while another fresh server is active", async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "e2e-server-test-"));
+    process.env.PLAYWRIGHT_E2E_SERVER_BINARY = writeFakeE2EServer(dir);
+    process.env.FAKE_E2E_STARTED_FILE = path.join(dir, "started");
+    delete process.env.PLAYWRIGHT_E2E_TMUX_DIR;
+
+    const first = await e2eServerModule.startIsolatedE2EServerWithOptions({ freshProcess: true });
+    const second = await e2eServerModule.startIsolatedE2EServerWithOptions({ freshProcess: true });
+    const tmuxDir = process.env.PLAYWRIGHT_E2E_TMUX_DIR;
+    expect(tmuxDir).toBeTruthy();
+
+    try {
+      await first.stop();
+      expect(await fileExists(tmuxDir ?? "")).toBe(true);
+    } finally {
+      await second.stop();
+      await rm(dir, { force: true, recursive: true });
+    }
+  });
+
+  it("terminates a fresh server that has not published readiness", async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "e2e-server-test-"));
+    const startedFile = path.join(dir, "started");
+    process.env.PLAYWRIGHT_E2E_SERVER_BINARY = writeFakeE2EServer(dir);
+    process.env.FAKE_E2E_STARTED_FILE = startedFile;
+    process.env.FAKE_E2E_READY_DELAY_MS = "60000";
+    delete process.env.PLAYWRIGHT_E2E_TMUX_DIR;
+
+    const starting = e2eServerModule.startIsolatedE2EServerWithOptions({ freshProcess: true });
+    await waitForFile(startedFile);
+    const childPID = Number.parseInt(await readFile(startedFile, "utf8"), 10);
+
+    await e2eServerModule.shutdownOwnedServers();
+
+    await expect(starting).rejects.toThrow(/exited/);
+    expect(() => process.kill(childPID, 0)).toThrow();
+    expect(process.env.PLAYWRIGHT_E2E_TMUX_DIR).toBeUndefined();
+    await rm(dir, { force: true, recursive: true });
+  });
+
+  it("reaps a tmux socket created while a server is shutting down", async () => {
+    if (process.platform === "win32" || spawnSync("tmux", ["-V"], { stdio: "ignore" }).status !== 0) {
+      return;
+    }
+    const dir = mkdtempSync(path.join(os.tmpdir(), "e2e-server-test-"));
+    process.env.PLAYWRIGHT_E2E_SERVER_BINARY = writeFakeE2EServer(dir);
+    process.env.FAKE_E2E_STARTED_FILE = path.join(dir, "started");
+    process.env.FAKE_E2E_CREATE_LATE_TMUX = "1";
+    const lateMarker = path.join(dir, "late-created");
+    process.env.FAKE_E2E_LATE_MARKER = lateMarker;
+    delete process.env.PLAYWRIGHT_E2E_TMUX_DIR;
+
+    await e2eServerModule.startIsolatedE2EServerWithOptions({ freshProcess: true });
+    const tmuxDir = process.env.PLAYWRIGHT_E2E_TMUX_DIR;
+    expect(tmuxDir).toBeTruthy();
+
+    await e2eServerModule.shutdownOwnedServers();
+
+    await expect(readFile(lateMarker, "utf8")).resolves.toBe("0");
+    expect(await fileExists(tmuxDir ?? "")).toBe(false);
+    expect(process.env.PLAYWRIGHT_E2E_TMUX_DIR).toBeUndefined();
+    await rm(dir, { force: true, recursive: true });
   });
 });
 

--- a/frontend/tests/e2e-full/00-e2e-server-signal-cleanup.spec.ts
+++ b/frontend/tests/e2e-full/00-e2e-server-signal-cleanup.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test } from "@playwright/test";
+import { spawn, spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { readFile, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+test("a repeatedly terminated e2e owner removes real workspace tmux state", async () => {
+  test.setTimeout(90_000);
+  test.skip(process.platform === "win32", "POSIX signals and tmux are required");
+  test.skip(spawnSync("tmux", ["-V"], { stdio: "ignore" }).status !== 0, "tmux is required");
+
+  const dir = mkdtempSync(path.join(os.tmpdir(), "e2e-owner-signal-"));
+  const helperFile = path.join(dir, "owner-helper.ts");
+  const readyFile = path.join(dir, "owner-ready.json");
+  const moduleURL = pathToFileURL(path.resolve("tests/e2e-full/support/e2eServer.ts")).href;
+  writeFileSync(
+    helperFile,
+    `import { readdir, writeFile } from "node:fs/promises";
+import process from "node:process";
+import { startIsolatedE2EServerWithOptions } from ${JSON.stringify(moduleURL)};
+
+const server = await startIsolatedE2EServerWithOptions({ freshProcess: true });
+const create = await fetch(server.info.base_url + "/api/v1/workspaces", {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ provider: "github", platform_host: "github.com", owner: "acme", name: "widgets", mr_number: 1 }),
+});
+if (create.status !== 202) throw new Error("create workspace failed: " + create.status + " " + await create.text());
+const workspace = await create.json();
+for (let attempt = 0; attempt < 100; attempt += 1) {
+  const response = await fetch(server.info.base_url + "/api/v1/workspaces/" + workspace.id);
+  const current = await response.json();
+  if (current.status === "ready") break;
+  if (current.status === "error") throw new Error(current.error_message || "workspace failed");
+  if (attempt === 99) throw new Error("workspace did not become ready");
+  await new Promise((resolve) => setTimeout(resolve, 100));
+}
+const launch = await fetch(server.info.base_url + "/api/v1/workspaces/" + workspace.id + "/runtime/sessions", {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ target_key: "plain_shell", display_region: "terminal" }),
+});
+if (!launch.ok) throw new Error("launch session failed: " + launch.status + " " + await launch.text());
+const tmuxDir = process.env.PLAYWRIGHT_E2E_TMUX_DIR;
+if (!tmuxDir) throw new Error("e2e owner did not publish its tmux root");
+for (let attempt = 0; attempt < 100; attempt += 1) {
+  const entries = await readdir(tmuxDir);
+  if (entries.some((entry) => entry.startsWith("mm-e2e-") && entry.endsWith(".sock"))) break;
+  if (attempt === 99) throw new Error("workspace tmux socket did not appear");
+  await new Promise((resolve) => setTimeout(resolve, 50));
+}
+await writeFile(process.env.KENN_FORGE_E2E_OWNER_READY, JSON.stringify({ tmuxDir }));
+setInterval(() => {}, 1000);
+`,
+  );
+
+  const helperEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    KENN_FORGE_E2E_OWNER_READY: readyFile,
+  };
+  delete helperEnv.PLAYWRIGHT_E2E_TMUX_DIR;
+  const owner = spawn("bun", [helperFile], {
+    env: helperEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let output = "";
+  owner.stdout?.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+  owner.stderr?.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+
+  try {
+    const deadline = Date.now() + 60_000;
+    let tmuxDir = "";
+    while (!tmuxDir) {
+      try {
+        tmuxDir = JSON.parse(await readFile(readyFile, "utf8")).tmuxDir;
+      } catch {
+        if (owner.exitCode !== null || owner.signalCode !== null) {
+          throw new Error(`e2e owner exited before readiness: ${output}`);
+        }
+        if (Date.now() >= deadline) {
+          throw new Error(`timed out waiting for e2e owner readiness: ${output}`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+    }
+
+    const outcomePromise = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+      owner.once("exit", (code, signal) => resolve({ code, signal }));
+    });
+    owner.kill("SIGTERM");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    owner.kill("SIGTERM");
+    const outcome = await outcomePromise;
+
+    expect(outcome, output).toEqual({ code: 143, signal: null });
+    await expect(stat(tmuxDir)).rejects.toThrow();
+  } finally {
+    if (owner.exitCode === null && owner.signalCode === null) {
+      const exited = new Promise<boolean>((resolve) => {
+        owner.once("exit", () => resolve(true));
+        setTimeout(() => resolve(false), 20_000);
+      });
+      owner.kill("SIGTERM");
+      if (!(await exited)) {
+        const forcedExit = new Promise<void>((resolve) => owner.once("exit", () => resolve()));
+        if (owner.exitCode === null && owner.signalCode === null) {
+          owner.kill("SIGKILL");
+          await forcedExit;
+        }
+      }
+    }
+    await rm(dir, { force: true, recursive: true });
+  }
+});

--- a/frontend/tests/e2e-full/support/e2eServer.ts
+++ b/frontend/tests/e2e-full/support/e2eServer.ts
@@ -48,16 +48,134 @@ const reachabilityTimeoutMs = 1_000;
 const ownedServerEnvVar = "PLAYWRIGHT_E2E_SERVER_OWNED";
 const frontendReadyEnvVar = "PLAYWRIGHT_E2E_FRONTEND_READY";
 const serverBinaryEnvVar = "PLAYWRIGHT_E2E_SERVER_BINARY";
+const tmuxDirEnvVar = "PLAYWRIGHT_E2E_TMUX_DIR";
 const defaultPlatformHost = "github.com";
+const tmuxDirPrefix = "kf-e2e-tmux-";
+const tmuxBaseDir = process.platform === "win32" ? os.tmpdir() : "/tmp";
+const tmuxOwnerFile = "owner.json";
+const gracefulStopTimeoutMs = 15_000;
 
 type ManagedChildLike = {
   pid?: number | undefined;
   exitCode: number | null;
 };
 
+type OwnedServerProcess = {
+  child: ChildProcess;
+  info: E2EServerInfo;
+};
+
 let serverPromise: Promise<E2EServerInfo> | null = null;
 let managedChild: ChildProcess | null = null;
 let cleanupInstalled = false;
+let ownedTmuxDir: string | null = null;
+let signalCleanupStarted = false;
+const standaloneServers = new Set<OwnedServerProcess>();
+
+type E2ETmuxOwner = {
+  pid: number;
+};
+
+function isLiveProcess(pid: number): boolean {
+  if (!Number.isSafeInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error instanceof Error && "code" in error && error.code === "EPERM";
+  }
+}
+
+function isPrivateE2ETmuxDir(dir: string): boolean {
+  return path.dirname(dir) === tmuxBaseDir && path.basename(dir).startsWith(tmuxDirPrefix);
+}
+
+async function killTmuxSocket(socket: string): Promise<boolean> {
+  return await new Promise<boolean>((resolve) => {
+    const child = spawn("tmux", ["-f", "/dev/null", "-S", socket, "kill-server"], {
+      stdio: "ignore",
+    });
+    let settled = false;
+    const finish = (completed: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(completed);
+    };
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      finish(false);
+    }, 5_000);
+    child.once("error", () => finish(false));
+    child.once("exit", () => finish(true));
+  });
+}
+
+async function cleanupE2ETmuxDir(dir: string): Promise<void> {
+  if (!isPrivateE2ETmuxDir(dir)) {
+    return;
+  }
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  const stopped = await Promise.all(
+    entries
+      .filter((entry) => entry.isSocket() && entry.name.startsWith("mm-e2e-") && entry.name.endsWith(".sock"))
+      .map((entry) => killTmuxSocket(path.join(dir, entry.name))),
+  );
+  if (stopped.every(Boolean)) {
+    await rm(dir, { force: true, recursive: true });
+  }
+}
+
+async function reapStaleE2ETmuxDirs(): Promise<void> {
+  let entries;
+  try {
+    entries = await readdir(tmuxBaseDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !entry.name.startsWith(tmuxDirPrefix)) {
+      continue;
+    }
+    const dir = path.join(tmuxBaseDir, entry.name);
+    let owner: E2ETmuxOwner;
+    try {
+      const parsed: unknown = JSON.parse(await readFile(path.join(dir, tmuxOwnerFile), "utf8"));
+      if (typeof parsed !== "object" || parsed === null || !("pid" in parsed) || typeof parsed.pid !== "number") {
+        continue;
+      }
+      owner = { pid: parsed.pid };
+    } catch {
+      continue;
+    }
+    if (!isLiveProcess(owner.pid)) {
+      await cleanupE2ETmuxDir(dir);
+    }
+  }
+}
+
+async function ensureE2ETmuxDir(): Promise<string> {
+  const inherited = process.env[tmuxDirEnvVar]?.trim();
+  if (inherited) {
+    if (!isPrivateE2ETmuxDir(inherited)) {
+      throw new Error(`${tmuxDirEnvVar} must name a private ${tmuxDirPrefix} directory under ${tmuxBaseDir}`);
+    }
+    return inherited;
+  }
+  await reapStaleE2ETmuxDirs();
+  const dir = mkdtempSync(path.join(tmuxBaseDir, tmuxDirPrefix));
+  await writeFile(path.join(dir, tmuxOwnerFile), JSON.stringify({ pid: process.pid }) + "\n", { mode: 0o600 });
+  process.env[tmuxDirEnvVar] = dir;
+  ownedTmuxDir = dir;
+  return dir;
+}
 
 async function fileMtimeMs(filePath: string): Promise<number | null> {
   try {
@@ -312,6 +430,7 @@ async function spawnServer(
   child: ChildProcess;
   info: E2EServerInfo;
 }> {
+  await ensureE2ETmuxDir();
   const invocation = e2eServerCommand(infoFile);
   if (!invocation.prebuilt) {
     await ensureEmbeddedFrontend();
@@ -364,25 +483,136 @@ export function cleanupManagedServerProcess(
   }
 }
 
+function waitForChildExit(child: ChildProcess, timeoutMs: number): Promise<boolean> {
+  if (child.exitCode !== null) {
+    return Promise.resolve(true);
+  }
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const finish = (exited: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.off("exit", onExit);
+      resolve(exited);
+    };
+    const onExit = () => finish(true);
+    const timer = setTimeout(() => finish(false), timeoutMs);
+    child.once("exit", onExit);
+  });
+}
+
+export async function terminateServerProcess(child: ChildProcess | null, serverPID: number | undefined): Promise<void> {
+  if (child && child.exitCode !== null) {
+    return;
+  }
+  if (serverPID) {
+    try {
+      process.kill(serverPID, "SIGTERM");
+    } catch {
+      return;
+    }
+  } else if (child?.pid) {
+    try {
+      process.kill(child.pid, "SIGTERM");
+    } catch {
+      return;
+    }
+  } else {
+    return;
+  }
+
+  if (!child || (await waitForChildExit(child, gracefulStopTimeoutMs))) {
+    return;
+  }
+  const pid = serverPID ?? child.pid;
+  if (pid) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // Process already exited.
+    }
+  }
+  await waitForChildExit(child, 1_000);
+}
+
+async function cleanupOwnedTmuxDir(): Promise<void> {
+  if (!ownedTmuxDir) {
+    return;
+  }
+  const dir = ownedTmuxDir;
+  ownedTmuxDir = null;
+  delete process.env[tmuxDirEnvVar];
+  await cleanupE2ETmuxDir(dir);
+}
+
+async function shutdownPooledServers(): Promise<void> {
+  const servers = isolatedPool.splice(0);
+  await Promise.all(servers.map((server) => terminateServerProcess(server.child, server.info.pid)));
+}
+
+async function shutdownStandaloneServers(): Promise<void> {
+  const servers = [...standaloneServers];
+  standaloneServers.clear();
+  await Promise.all(servers.map((server) => terminateServerProcess(server.child, server.info.pid)));
+}
+
+async function shutdownOwnedServers(): Promise<void> {
+  const filePath = managedChild ? process.env.PLAYWRIGHT_E2E_SERVER_INFO_FILE : undefined;
+  const info = filePath ? readServerInfoSync(filePath) : null;
+  // The shared socket directory is the outer Playwright process's
+  // authoritative ownership record. Reap it before waiting on child shutdown
+  // so a stuck or force-killed worker cannot strand a daemonized tmux server.
+  await cleanupOwnedTmuxDir();
+  await Promise.all([
+    managedChild ? terminateServerProcess(managedChild, info?.pid) : Promise.resolve(),
+    shutdownPooledServers(),
+    shutdownStandaloneServers(),
+  ]);
+  managedChild = null;
+  if (filePath) {
+    await removeServerInfo(filePath);
+  }
+}
+
 function installCleanup(infoFile: string): void {
   if (cleanupInstalled) {
     return;
   }
   cleanupInstalled = true;
 
-  const cleanup = () => {
+  const cleanupImmediately = () => {
     cleanupManagedServerProcess(managedChild, infoFile);
+    for (const server of isolatedPool) {
+      killPooledServerProcess(server);
+    }
+    for (const server of standaloneServers) {
+      if (server.child.exitCode === null) {
+        try {
+          process.kill(server.info.pid, "SIGTERM");
+        } catch {
+          // Process already exited.
+        }
+      }
+    }
   };
 
-  process.once("exit", cleanup);
+  process.once("exit", cleanupImmediately);
   process.once("SIGINT", () => {
-    cleanup();
-    process.exit(130);
+    void cleanupAfterSignal(130);
   });
   process.once("SIGTERM", () => {
-    cleanup();
-    process.exit(143);
+    void cleanupAfterSignal(143);
   });
+}
+
+async function cleanupAfterSignal(exitCode: number): Promise<void> {
+  if (signalCleanupStarted) {
+    return;
+  }
+  signalCleanupStarted = true;
+  await shutdownOwnedServers();
+  process.exit(exitCode);
 }
 
 async function startManagedServer(): Promise<E2EServerInfo> {
@@ -464,13 +694,8 @@ export async function stopE2EServer(): Promise<void> {
   }
 
   const info = await readServerInfo(filePath);
-  if (info?.pid) {
-    try {
-      process.kill(info.pid, "SIGTERM");
-    } catch {
-      // Process already exited.
-    }
-  }
+  await cleanupOwnedTmuxDir();
+  await terminateServerProcess(managedChild, info?.pid);
 
   await removeServerInfo(filePath);
   delete process.env[ownedServerEnvVar];
@@ -558,30 +783,9 @@ function samePooledOptions(a: PooledServerOptions, b: PooledServerOptions): bool
 }
 
 const isolatedPool: PooledServer[] = [];
-let poolCleanupInstalled = false;
 
 function installPoolCleanup(): void {
-  if (poolCleanupInstalled) {
-    return;
-  }
-  poolCleanupInstalled = true;
-
-  const killAll = () => {
-    for (const server of isolatedPool) {
-      killPooledServerProcess(server);
-    }
-    isolatedPool.length = 0;
-  };
-
-  process.once("exit", killAll);
-  process.once("SIGINT", () => {
-    killAll();
-    process.exit(130);
-  });
-  process.once("SIGTERM", () => {
-    killAll();
-    process.exit(143);
-  });
+  installCleanup(serverInfoFile);
 }
 
 async function postReset(baseURL: string, options: PooledServerOptions): Promise<E2EServerInfo> {
@@ -646,12 +850,12 @@ function killPooledServerProcess(server: PooledServer): void {
   }
 }
 
-function dropPooledServer(server: PooledServer): void {
+async function dropPooledServer(server: PooledServer): Promise<void> {
   const index = isolatedPool.indexOf(server);
   if (index >= 0) {
     isolatedPool.splice(index, 1);
   }
-  killPooledServerProcess(server);
+  await terminateServerProcess(server.child, server.info.pid);
 }
 
 async function spawnPooledServer(options: PooledServerOptions): Promise<PooledServer> {
@@ -695,12 +899,15 @@ export async function startIsolatedE2EServerWithOptions(
     if (options.preferPtyOwner) {
       started.info = await postReset(started.info.base_url, normalizedPooledOptions(options));
     }
+    standaloneServers.add(started);
     return {
       info: started.info,
       stop: async () => {
-        cleanupManagedServerProcess(started.child, infoFile);
+        standaloneServers.delete(started);
+        await terminateServerProcess(started.child, started.info.pid);
         await removeServerInfo(infoFile);
         await rm(infoDir, { force: true, recursive: true });
+        await cleanupOwnedTmuxDir();
       },
     };
   }
@@ -728,7 +935,7 @@ export async function startIsolatedE2EServerWithOptions(
       server = candidate;
     } catch {
       // Server crashed or its reset failed: replace it.
-      dropPooledServer(candidate);
+      await dropPooledServer(candidate);
     }
   }
 

--- a/frontend/tests/e2e-full/support/e2eServer.ts
+++ b/frontend/tests/e2e-full/support/e2eServer.ts
@@ -110,28 +110,44 @@ async function isCurrentUserOwnedPath(
   }
 }
 
-async function killTmuxSocket(socket: string): Promise<boolean> {
-  return await new Promise<boolean>((resolve) => {
-    const child = spawn("tmux", ["-f", "/dev/null", "-S", socket, "kill-server"], {
-      stdio: "ignore",
+async function runTmuxSocketCommand(
+  socket: string,
+  command: "kill-server" | "list-sessions",
+): Promise<{ exitCode: number | null; stderr: string }> {
+  return await new Promise((resolve) => {
+    const child = spawn("tmux", ["-f", "/dev/null", "-S", socket, command], {
+      stdio: ["ignore", "ignore", "pipe"],
     });
     let settled = false;
-    const finish = (completed: boolean) => {
+    let stderr = "";
+    child.stderr?.on("data", (chunk) => {
+      stderr = (stderr + chunk.toString()).slice(-4_096);
+    });
+    const finish = (exitCode: number | null) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      resolve(completed);
+      resolve({ exitCode, stderr });
     };
     const timer = setTimeout(() => {
       child.kill("SIGKILL");
-      finish(false);
+      finish(null);
     }, 5_000);
-    child.once("error", () => finish(false));
-    child.once("exit", (code) => finish(code === 0));
+    child.once("error", () => finish(null));
+    child.once("exit", (code) => finish(code));
   });
 }
 
-export async function cleanupE2ETmuxDir(dir: string): Promise<boolean> {
+async function killTmuxSocket(socket: string): Promise<boolean> {
+  const killed = await runTmuxSocketCommand(socket, "kill-server");
+  if (killed.exitCode === 0) {
+    return true;
+  }
+  const verified = await runTmuxSocketCommand(socket, "list-sessions");
+  return verified.exitCode === 1 && verified.stderr.trim().startsWith("no server running on ");
+}
+
+export async function cleanupE2ETmuxDir(dir: string, removeRoot = true): Promise<boolean> {
   if (!isPrivateE2ETmuxDir(dir)) {
     return false;
   }
@@ -164,11 +180,11 @@ export async function cleanupE2ETmuxDir(dir: string): Promise<boolean> {
       return await killTmuxSocket(socket);
     }),
   );
-  if (stopped.every(Boolean)) {
+  if (stopped.every(Boolean) && removeRoot) {
     await rm(dir, { force: true, recursive: true });
     return true;
   }
-  return false;
+  return stopped.every(Boolean);
 }
 
 async function reapStaleE2ETmuxDirs(): Promise<void> {
@@ -646,7 +662,7 @@ export async function shutdownOwnedServers(): Promise<void> {
     signalServerProcess(server.child, server.serverPID);
   }
   if (tmuxDir) {
-    await cleanupE2ETmuxDir(tmuxDir);
+    await cleanupE2ETmuxDir(tmuxDir, false);
   }
   await Promise.all(servers.map((server) => terminateServerProcess(server.child, server.serverPID, true)));
   if (tmuxDir) {
@@ -687,10 +703,10 @@ function installCleanup(): void {
   };
 
   process.once("exit", cleanupImmediately);
-  process.once("SIGINT", () => {
+  process.on("SIGINT", () => {
     void cleanupAfterSignal(130);
   });
-  process.once("SIGTERM", () => {
+  process.on("SIGTERM", () => {
     void cleanupAfterSignal(143);
   });
 }
@@ -991,14 +1007,21 @@ export async function startIsolatedE2EServerWithOptions(
     }
     standaloneServers.add(started);
     startingServers.delete(started.child);
+    let stopPromise: Promise<void> | null = null;
     return {
       info: started.info,
-      stop: async () => {
-        standaloneServers.delete(started);
-        await terminateServerProcess(started.child, started.info.pid);
-        await removeServerInfo(infoFile);
-        await rm(infoDir, { force: true, recursive: true });
-        await cleanupOwnedTmuxDirIfIdle();
+      stop: () => {
+        stopPromise ??= (async () => {
+          try {
+            await terminateServerProcess(started.child, started.info.pid);
+          } finally {
+            standaloneServers.delete(started);
+          }
+          await removeServerInfo(infoFile);
+          await rm(infoDir, { force: true, recursive: true });
+          await cleanupOwnedTmuxDirIfIdle();
+        })();
+        return stopPromise;
       },
     };
   }

--- a/frontend/tests/e2e-full/support/e2eServer.ts
+++ b/frontend/tests/e2e-full/support/e2eServer.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
-import { mkdtempSync, readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { request as httpRequest } from "node:http";
 import { request as httpsRequest } from "node:https";
 import { access, cp, lstat, mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
@@ -48,6 +48,8 @@ const reachabilityTimeoutMs = 1_000;
 const ownedServerEnvVar = "PLAYWRIGHT_E2E_SERVER_OWNED";
 const frontendReadyEnvVar = "PLAYWRIGHT_E2E_FRONTEND_READY";
 const serverBinaryEnvVar = "PLAYWRIGHT_E2E_SERVER_BINARY";
+const serverBinaryOwnedDirEnvVar = "PLAYWRIGHT_E2E_SERVER_BINARY_OWNED_DIR";
+const serverBinaryOwnerPIDEnvVar = "PLAYWRIGHT_E2E_SERVER_BINARY_OWNER_PID";
 const tmuxDirEnvVar = "PLAYWRIGHT_E2E_TMUX_DIR";
 const defaultPlatformHost = "github.com";
 const tmuxDirPrefix = "kf-e2e-tmux-";
@@ -72,6 +74,8 @@ let cleanupInstalled = false;
 let ownedTmuxDir: string | null = null;
 let signalCleanupStarted = false;
 let serverShutdownPromise: Promise<void> | null = null;
+let serverBinaryPromise: Promise<string> | null = null;
+let generatedServerBinaryDir: string | null = null;
 const standaloneServers = new Set<OwnedServerProcess>();
 const startingServers = new Set<ChildProcess>();
 
@@ -386,6 +390,98 @@ export async function ensureEmbeddedFrontend(rootDir: string = repoRoot): Promis
   await cp(frontendDist, embeddedDist, { recursive: true });
   await writeFile(path.join(embeddedDist, "stub.html"), "ok\n");
   process.env[frontendReadyEnvVar] = "1";
+}
+
+async function buildE2EServerBinary(rootDir: string): Promise<string> {
+  await ensureEmbeddedFrontend(rootDir);
+  const binaryDir = mkdtempSync(path.join(os.tmpdir(), "kenn-forge-e2e-server-"));
+  const binary = path.join(binaryDir, process.platform === "win32" ? "e2e-server.exe" : "e2e-server");
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const build = spawn("go", ["build", "-o", binary, "./cmd/e2e-server"], {
+        cwd: rootDir,
+        stdio: "inherit",
+        env: process.env,
+      });
+      let settled = false;
+      build.once("error", (error) => {
+        if (settled) return;
+        settled = true;
+        reject(error);
+      });
+      build.once("exit", (code) => {
+        if (settled) return;
+        settled = true;
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`e2e server build failed with exit code ${code ?? "null"}`));
+        }
+      });
+    });
+  } catch (error) {
+    await rm(binaryDir, { force: true, recursive: true });
+    throw error;
+  }
+
+  generatedServerBinaryDir = binaryDir;
+  process.env[serverBinaryEnvVar] = binary;
+  process.env[serverBinaryOwnedDirEnvVar] = binaryDir;
+  process.env[serverBinaryOwnerPIDEnvVar] = String(process.pid);
+  installCleanup();
+  return binary;
+}
+
+export async function ensureE2EServerBinary(rootDir: string = repoRoot): Promise<string> {
+  const configured = process.env[serverBinaryEnvVar]?.trim();
+  if (configured) {
+    return configured;
+  }
+  if (!serverBinaryPromise) {
+    const build = buildE2EServerBinary(rootDir).catch((error) => {
+      if (serverBinaryPromise === build) {
+        serverBinaryPromise = null;
+      }
+      throw error;
+    });
+    serverBinaryPromise = build;
+  }
+  return await serverBinaryPromise;
+}
+
+export async function cleanupE2ERunnerArtifacts(): Promise<void> {
+  const dir = generatedServerBinaryDir ?? process.env[serverBinaryOwnedDirEnvVar]?.trim();
+  if (!dir) {
+    return;
+  }
+  if (process.env[serverBinaryOwnerPIDEnvVar] !== String(process.pid)) {
+    return;
+  }
+  if (!generatedServerBinaryDir) {
+    const binary = process.env[serverBinaryEnvVar]?.trim();
+    const expectedName = process.platform === "win32" ? "e2e-server.exe" : "e2e-server";
+    if (
+      path.dirname(dir) !== os.tmpdir() ||
+      !path.basename(dir).startsWith("kenn-forge-e2e-server-") ||
+      !binary ||
+      path.dirname(binary) !== dir ||
+      path.basename(binary) !== expectedName ||
+      !(await isCurrentUserOwnedPath(dir, (stats) => stats.isDirectory()))
+    ) {
+      return;
+    }
+  }
+  await rm(dir, { force: true, recursive: true });
+  if (!generatedServerBinaryDir || generatedServerBinaryDir === dir) {
+    generatedServerBinaryDir = null;
+    serverBinaryPromise = null;
+    delete process.env[serverBinaryOwnedDirEnvVar];
+    delete process.env[serverBinaryOwnerPIDEnvVar];
+    if (process.env[serverBinaryEnvVar] && path.dirname(process.env[serverBinaryEnvVar]) === dir) {
+      delete process.env[serverBinaryEnvVar];
+    }
+  }
 }
 
 function delay(ms: number): Promise<void> {
@@ -757,6 +853,13 @@ function installCleanup(): void {
         }
       }
     }
+    if (generatedServerBinaryDir) {
+      try {
+        rmSync(generatedServerBinaryDir, { force: true, recursive: true });
+      } catch {
+        // Best-effort synchronous cleanup during process exit.
+      }
+    }
   };
 
   process.once("exit", cleanupImmediately);
@@ -774,6 +877,7 @@ async function cleanupAfterSignal(exitCode: number): Promise<void> {
   }
   signalCleanupStarted = true;
   await shutdownOwnedServers();
+  await cleanupE2ERunnerArtifacts();
   process.exit(exitCode);
 }
 
@@ -998,7 +1102,7 @@ async function resetPooledServer(server: PooledServer, options: PooledServerOpti
   server.options = options;
 }
 
-// Signal only while the spawned child is still alive: once `go run`
+// Signal only while the spawned child is still alive: once the child
 // has exited, the server's reported PID may already have been reused
 // by an unrelated process, and signalling it would be unsafe.
 function killPooledServerProcess(server: PooledServer): void {

--- a/frontend/tests/e2e-full/support/e2eServer.ts
+++ b/frontend/tests/e2e-full/support/e2eServer.ts
@@ -71,6 +71,7 @@ let managedChild: ChildProcess | null = null;
 let cleanupInstalled = false;
 let ownedTmuxDir: string | null = null;
 let signalCleanupStarted = false;
+let serverShutdownPromise: Promise<void> | null = null;
 const standaloneServers = new Set<OwnedServerProcess>();
 const startingServers = new Set<ChildProcess>();
 
@@ -492,6 +493,15 @@ async function spawnServer(
   info: E2EServerInfo;
 }> {
   installCleanup();
+  if (signalCleanupStarted) {
+    throw new Error("e2e server shutdown started before spawn");
+  }
+  if (serverShutdownPromise) {
+    await serverShutdownPromise;
+  }
+  if (signalCleanupStarted) {
+    throw new Error("e2e server shutdown started before spawn");
+  }
   await ensureE2ETmuxDir();
   if (signalCleanupStarted) {
     throw new Error("e2e server shutdown started before spawn");
@@ -533,8 +543,9 @@ async function spawnServer(
     }
     return { child, info };
   } catch (error) {
-    startingServers.delete(child);
-    await terminateServerProcess(child, undefined);
+    if (await terminateServerProcess(child, undefined)) {
+      startingServers.delete(child);
+    }
     throw error;
   }
 }
@@ -600,16 +611,19 @@ export async function terminateServerProcess(
   child: ChildProcess | null,
   serverPID: number | undefined,
   alreadySignaled = false,
-): Promise<void> {
+): Promise<boolean> {
   if (child && childHasExited(child)) {
-    return;
+    return true;
   }
   if (!alreadySignaled && !signalServerProcess(child, serverPID)) {
-    return;
+    return child !== null && childHasExited(child);
   }
 
-  if (!child || (await waitForChildExit(child, gracefulStopTimeoutMs))) {
-    return;
+  if (!child) {
+    return false;
+  }
+  if (await waitForChildExit(child, gracefulStopTimeoutMs)) {
+    return true;
   }
   const pid = serverPID ?? child.pid;
   if (pid) {
@@ -619,7 +633,7 @@ export async function terminateServerProcess(
       // Process already exited.
     }
   }
-  await waitForChildExit(child, 1_000);
+  return await waitForChildExit(child, 1_000);
 }
 
 async function cleanupOwnedTmuxDir(): Promise<void> {
@@ -643,38 +657,81 @@ async function cleanupOwnedTmuxDirIfIdle(): Promise<void> {
   }
 }
 
-export async function shutdownOwnedServers(): Promise<void> {
+function releaseOwnedChild(child: ChildProcess): void {
+  startingServers.delete(child);
+  if (managedChild === child) {
+    managedChild = null;
+  }
+  for (let index = isolatedPool.length - 1; index >= 0; index -= 1) {
+    if (isolatedPool[index]?.child === child) {
+      isolatedPool.splice(index, 1);
+    }
+  }
+  for (const server of standaloneServers) {
+    if (server.child === child) {
+      standaloneServers.delete(server);
+    }
+  }
+}
+
+async function shutdownOwnedServersOnce(): Promise<void> {
   const filePath = managedChild ? process.env.PLAYWRIGHT_E2E_SERVER_INFO_FILE : undefined;
   const info = filePath ? readServerInfoSync(filePath) : null;
   const tmuxDir = ownedTmuxDir;
-  const servers = [
-    ...[...startingServers].map((child) => ({ child, serverPID: undefined })),
-    ...(managedChild ? [{ child: managedChild, serverPID: info?.pid }] : []),
-    ...isolatedPool.map((server) => ({ child: server.child, serverPID: server.info.pid })),
-    ...[...standaloneServers].map((server) => ({ child: server.child, serverPID: server.info.pid })),
-  ];
+  const servers = new Map<ChildProcess, number | undefined>();
+  for (const child of startingServers) {
+    servers.set(child, undefined);
+  }
+  if (managedChild) {
+    servers.set(managedChild, info?.pid);
+  }
+  for (const server of isolatedPool) {
+    servers.set(server.child, server.info.pid);
+  }
+  for (const server of standaloneServers) {
+    servers.set(server.child, server.info.pid);
+  }
 
-  startingServers.clear();
-  isolatedPool.length = 0;
-  standaloneServers.clear();
-  managedChild = null;
-  for (const server of servers) {
-    signalServerProcess(server.child, server.serverPID);
+  for (const [child, serverPID] of servers) {
+    signalServerProcess(child, serverPID);
   }
   if (tmuxDir) {
     await cleanupE2ETmuxDir(tmuxDir, false);
   }
-  await Promise.all(servers.map((server) => terminateServerProcess(server.child, server.serverPID, true)));
-  if (tmuxDir) {
+  const stopped = await Promise.all(
+    [...servers].map(async ([child, serverPID]) => ({
+      child,
+      exited: await terminateServerProcess(child, serverPID, true),
+    })),
+  );
+  for (const result of stopped) {
+    if (result.exited) {
+      releaseOwnedChild(result.child);
+    }
+  }
+  if (tmuxDir && noOwnedServersRemain()) {
     const removed = await cleanupE2ETmuxDir(tmuxDir);
     if (removed && ownedTmuxDir === tmuxDir) {
       ownedTmuxDir = null;
       delete process.env[tmuxDirEnvVar];
     }
   }
-  if (filePath) {
+  if (filePath && !managedChild) {
     await removeServerInfo(filePath);
   }
+}
+
+export function shutdownOwnedServers(): Promise<void> {
+  if (serverShutdownPromise) {
+    return serverShutdownPromise;
+  }
+  const current = shutdownOwnedServersOnce().finally(() => {
+    if (serverShutdownPromise === current) {
+      serverShutdownPromise = null;
+    }
+  });
+  serverShutdownPromise = current;
+  return current;
 }
 
 function installCleanup(): void {
@@ -956,11 +1013,10 @@ function killPooledServerProcess(server: PooledServer): void {
 }
 
 async function dropPooledServer(server: PooledServer): Promise<void> {
-  const index = isolatedPool.indexOf(server);
-  if (index >= 0) {
-    isolatedPool.splice(index, 1);
+  if (!(await terminateServerProcess(server.child, server.info.pid))) {
+    throw new Error(`e2e server ${server.info.pid} did not exit after forced termination`);
   }
-  await terminateServerProcess(server.child, server.info.pid);
+  releaseOwnedChild(server.child);
 }
 
 async function spawnPooledServer(options: PooledServerOptions): Promise<PooledServer> {
@@ -1012,11 +1068,10 @@ export async function startIsolatedE2EServerWithOptions(
       info: started.info,
       stop: () => {
         stopPromise ??= (async () => {
-          try {
-            await terminateServerProcess(started.child, started.info.pid);
-          } finally {
-            standaloneServers.delete(started);
+          if (!(await terminateServerProcess(started.child, started.info.pid))) {
+            throw new Error(`e2e server ${started.info.pid} did not exit after forced termination`);
           }
+          standaloneServers.delete(started);
           await removeServerInfo(infoFile);
           await rm(infoDir, { force: true, recursive: true });
           await cleanupOwnedTmuxDirIfIdle();

--- a/frontend/tests/e2e-full/support/e2eServer.ts
+++ b/frontend/tests/e2e-full/support/e2eServer.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { request as httpRequest } from "node:http";
 import { request as httpsRequest } from "node:https";
@@ -55,6 +56,7 @@ const defaultPlatformHost = "github.com";
 const tmuxDirPrefix = "kf-e2e-tmux-";
 const tmuxBaseDir = process.platform === "win32" ? os.tmpdir() : "/tmp";
 const tmuxOwnerFile = "owner.json";
+const serverOwnerFilePrefix = "server-owner-";
 const gracefulStopTimeoutMs = 15_000;
 
 type ManagedChildLike = {
@@ -78,6 +80,7 @@ let serverBinaryPromise: Promise<string> | null = null;
 let generatedServerBinaryDir: string | null = null;
 const standaloneServers = new Set<OwnedServerProcess>();
 const startingServers = new Set<ChildProcess>();
+const serverOwnerFiles = new WeakMap<ChildProcess, string>();
 
 type E2ETmuxOwner = {
   pid: number;
@@ -240,6 +243,70 @@ async function ensureE2ETmuxDir(): Promise<string> {
   process.env[tmuxDirEnvVar] = dir;
   ownedTmuxDir = dir;
   return dir;
+}
+
+async function registerSharedServerOwner(dir: string, child: ChildProcess): Promise<void> {
+  if (!child.pid) {
+    throw new Error("e2e server process has no pid");
+  }
+  const ownerFile = path.join(dir, `${serverOwnerFilePrefix}${randomUUID()}.json`);
+  await writeFile(ownerFile, JSON.stringify({ pid: child.pid }) + "\n", { flag: "wx", mode: 0o600 });
+  serverOwnerFiles.set(child, ownerFile);
+}
+
+async function removeSharedServerOwner(child: ChildProcess): Promise<void> {
+  const ownerFile = serverOwnerFiles.get(child);
+  if (!ownerFile) {
+    return;
+  }
+  await rm(ownerFile, { force: true });
+  serverOwnerFiles.delete(child);
+}
+
+async function waitForSharedServerOwners(dir: string, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch (error) {
+      return error instanceof Error && "code" in error && error.code === "ENOENT";
+    }
+
+    let liveOwner = false;
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.startsWith(serverOwnerFilePrefix) || !entry.name.endsWith(".json")) {
+        continue;
+      }
+      const ownerFile = path.join(dir, entry.name);
+      if (!(await isCurrentUserOwnedPath(ownerFile, (stats) => stats.isFile()))) {
+        return false;
+      }
+      let owner: E2ETmuxOwner;
+      try {
+        const parsed: unknown = JSON.parse(await readFile(ownerFile, "utf8"));
+        if (typeof parsed !== "object" || parsed === null || !("pid" in parsed) || typeof parsed.pid !== "number") {
+          return false;
+        }
+        owner = { pid: parsed.pid };
+      } catch {
+        return false;
+      }
+      if (isLiveProcess(owner.pid)) {
+        liveOwner = true;
+      } else {
+        await rm(ownerFile, { force: true });
+      }
+    }
+
+    if (!liveOwner) {
+      return true;
+    }
+    if (Date.now() >= deadline) {
+      return false;
+    }
+    await delay(25);
+  }
 }
 
 async function fileMtimeMs(filePath: string): Promise<number | null> {
@@ -598,7 +665,7 @@ async function spawnServer(
   if (signalCleanupStarted) {
     throw new Error("e2e server shutdown started before spawn");
   }
-  await ensureE2ETmuxDir();
+  const tmuxDir = await ensureE2ETmuxDir();
   if (signalCleanupStarted) {
     throw new Error("e2e server shutdown started before spawn");
   }
@@ -632,6 +699,7 @@ async function spawnServer(
   startingServers.add(child);
 
   try {
+    await registerSharedServerOwner(tmuxDir, child);
     const info = await waitForServerInfo(infoFile, child);
     if (signalCleanupStarted) {
       await terminateServerProcess(child, info.pid);
@@ -640,7 +708,7 @@ async function spawnServer(
     return { child, info };
   } catch (error) {
     if (await terminateServerProcess(child, undefined)) {
-      startingServers.delete(child);
+      await releaseOwnedChild(child);
     }
     throw error;
   }
@@ -753,7 +821,8 @@ async function cleanupOwnedTmuxDirIfIdle(): Promise<void> {
   }
 }
 
-function releaseOwnedChild(child: ChildProcess): void {
+async function releaseOwnedChild(child: ChildProcess): Promise<void> {
+  await removeSharedServerOwner(child);
   startingServers.delete(child);
   if (managedChild === child) {
     managedChild = null;
@@ -802,10 +871,11 @@ async function shutdownOwnedServersOnce(): Promise<void> {
   );
   for (const result of stopped) {
     if (result.exited) {
-      releaseOwnedChild(result.child);
+      await releaseOwnedChild(result.child);
     }
   }
-  if (tmuxDir && noOwnedServersRemain()) {
+  const sharedServersExited = tmuxDir ? await waitForSharedServerOwners(tmuxDir, gracefulStopTimeoutMs) : true;
+  if (tmuxDir && noOwnedServersRemain() && sharedServersExited) {
     const removed = await cleanupE2ETmuxDir(tmuxDir);
     if (removed && ownedTmuxDir === tmuxDir) {
       ownedTmuxDir = null;
@@ -876,9 +946,14 @@ async function cleanupAfterSignal(exitCode: number): Promise<void> {
     return;
   }
   signalCleanupStarted = true;
-  await shutdownOwnedServers();
-  await cleanupE2ERunnerArtifacts();
-  process.exit(exitCode);
+  try {
+    await shutdownOwnedServers();
+    await cleanupE2ERunnerArtifacts();
+  } catch (error) {
+    console.error("[e2e] signal cleanup failed", error);
+  } finally {
+    process.exit(exitCode);
+  }
 }
 
 async function startManagedServer(): Promise<E2EServerInfo> {
@@ -1120,7 +1195,7 @@ async function dropPooledServer(server: PooledServer): Promise<void> {
   if (!(await terminateServerProcess(server.child, server.info.pid))) {
     throw new Error(`e2e server ${server.info.pid} did not exit after forced termination`);
   }
-  releaseOwnedChild(server.child);
+  await releaseOwnedChild(server.child);
 }
 
 async function spawnPooledServer(options: PooledServerOptions): Promise<PooledServer> {
@@ -1175,7 +1250,7 @@ export async function startIsolatedE2EServerWithOptions(
           if (!(await terminateServerProcess(started.child, started.info.pid))) {
             throw new Error(`e2e server ${started.info.pid} did not exit after forced termination`);
           }
-          standaloneServers.delete(started);
+          await releaseOwnedChild(started.child);
           await removeServerInfo(infoFile);
           await rm(infoDir, { force: true, recursive: true });
           await cleanupOwnedTmuxDirIfIdle();

--- a/frontend/tests/e2e-full/support/e2eServer.ts
+++ b/frontend/tests/e2e-full/support/e2eServer.ts
@@ -466,7 +466,7 @@ async function buildE2EServerBinary(rootDir: string): Promise<string> {
 
   try {
     await new Promise<void>((resolve, reject) => {
-      const build = spawn("go", ["build", "-o", binary, "./cmd/e2e-server"], {
+      const build = spawn("go", ["build", "-buildvcs=false", "-o", binary, "./cmd/e2e-server"], {
         cwd: rootDir,
         stdio: "inherit",
         env: process.env,

--- a/frontend/tests/e2e-full/support/e2eServer.ts
+++ b/frontend/tests/e2e-full/support/e2eServer.ts
@@ -2,7 +2,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { mkdtempSync, readFileSync } from "node:fs";
 import { request as httpRequest } from "node:http";
 import { request as httpsRequest } from "node:https";
-import { access, cp, mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { access, cp, lstat, mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
@@ -58,6 +58,7 @@ const gracefulStopTimeoutMs = 15_000;
 type ManagedChildLike = {
   pid?: number | undefined;
   exitCode: number | null;
+  signalCode?: NodeJS.Signals | null | undefined;
 };
 
 type OwnedServerProcess = {
@@ -71,6 +72,7 @@ let cleanupInstalled = false;
 let ownedTmuxDir: string | null = null;
 let signalCleanupStarted = false;
 const standaloneServers = new Set<OwnedServerProcess>();
+const startingServers = new Set<ChildProcess>();
 
 type E2ETmuxOwner = {
   pid: number;
@@ -92,6 +94,22 @@ function isPrivateE2ETmuxDir(dir: string): boolean {
   return path.dirname(dir) === tmuxBaseDir && path.basename(dir).startsWith(tmuxDirPrefix);
 }
 
+export function isCurrentUserOwned(stats: { uid: number }): boolean {
+  return process.getuid === undefined || stats.uid === process.getuid();
+}
+
+async function isCurrentUserOwnedPath(
+  candidate: string,
+  matchesType: (stats: Awaited<ReturnType<typeof lstat>>) => boolean,
+): Promise<boolean> {
+  try {
+    const stats = await lstat(candidate);
+    return isCurrentUserOwned(stats) && matchesType(stats);
+  } catch {
+    return false;
+  }
+}
+
 async function killTmuxSocket(socket: string): Promise<boolean> {
   return await new Promise<boolean>((resolve) => {
     const child = spawn("tmux", ["-f", "/dev/null", "-S", socket, "kill-server"], {
@@ -109,28 +127,48 @@ async function killTmuxSocket(socket: string): Promise<boolean> {
       finish(false);
     }, 5_000);
     child.once("error", () => finish(false));
-    child.once("exit", () => finish(true));
+    child.once("exit", (code) => finish(code === 0));
   });
 }
 
-async function cleanupE2ETmuxDir(dir: string): Promise<void> {
+export async function cleanupE2ETmuxDir(dir: string): Promise<boolean> {
   if (!isPrivateE2ETmuxDir(dir)) {
-    return;
+    return false;
+  }
+  try {
+    const stats = await lstat(dir);
+    if (!isCurrentUserOwned(stats) || !stats.isDirectory()) {
+      return false;
+    }
+  } catch (error) {
+    return error instanceof Error && "code" in error && error.code === "ENOENT";
+  }
+  if (!(await isCurrentUserOwnedPath(path.join(dir, tmuxOwnerFile), (stats) => stats.isFile()))) {
+    return false;
   }
   let entries;
   try {
     entries = await readdir(dir, { withFileTypes: true });
   } catch {
-    return;
+    return false;
   }
+  const sockets = entries.filter(
+    (entry) => entry.isSocket() && entry.name.startsWith("mm-e2e-") && entry.name.endsWith(".sock"),
+  );
   const stopped = await Promise.all(
-    entries
-      .filter((entry) => entry.isSocket() && entry.name.startsWith("mm-e2e-") && entry.name.endsWith(".sock"))
-      .map((entry) => killTmuxSocket(path.join(dir, entry.name))),
+    sockets.map(async (entry) => {
+      const socket = path.join(dir, entry.name);
+      if (!(await isCurrentUserOwnedPath(socket, (stats) => stats.isSocket()))) {
+        return false;
+      }
+      return await killTmuxSocket(socket);
+    }),
   );
   if (stopped.every(Boolean)) {
     await rm(dir, { force: true, recursive: true });
+    return true;
   }
+  return false;
 }
 
 async function reapStaleE2ETmuxDirs(): Promise<void> {
@@ -145,8 +183,14 @@ async function reapStaleE2ETmuxDirs(): Promise<void> {
       continue;
     }
     const dir = path.join(tmuxBaseDir, entry.name);
+    if (!(await isCurrentUserOwnedPath(dir, (stats) => stats.isDirectory()))) {
+      continue;
+    }
     let owner: E2ETmuxOwner;
     try {
+      if (!(await isCurrentUserOwnedPath(path.join(dir, tmuxOwnerFile), (stats) => stats.isFile()))) {
+        continue;
+      }
       const parsed: unknown = JSON.parse(await readFile(path.join(dir, tmuxOwnerFile), "utf8"));
       if (typeof parsed !== "object" || parsed === null || !("pid" in parsed) || typeof parsed.pid !== "number") {
         continue;
@@ -164,7 +208,7 @@ async function reapStaleE2ETmuxDirs(): Promise<void> {
 async function ensureE2ETmuxDir(): Promise<string> {
   const inherited = process.env[tmuxDirEnvVar]?.trim();
   if (inherited) {
-    if (!isPrivateE2ETmuxDir(inherited)) {
+    if (!isPrivateE2ETmuxDir(inherited) || !(await isCurrentUserOwnedPath(inherited, (stats) => stats.isDirectory()))) {
       throw new Error(`${tmuxDirEnvVar} must name a private ${tmuxDirPrefix} directory under ${tmuxBaseDir}`);
     }
     return inherited;
@@ -383,7 +427,7 @@ export async function getReusableServerInfo(filePath: string): Promise<E2EServer
 
 export async function waitForServerInfo(
   filePath: string,
-  child: Pick<ManagedChildLike, "exitCode">,
+  child: Pick<ManagedChildLike, "exitCode" | "signalCode">,
 ): Promise<E2EServerInfo> {
   const deadline = Date.now() + startupTimeoutMs;
   while (Date.now() < deadline) {
@@ -391,8 +435,9 @@ export async function waitForServerInfo(
     if (info && (await isServerReachable(info.base_url))) {
       return info;
     }
-    if (child.exitCode !== null) {
-      throw new Error(`e2e server exited with code ${child.exitCode} before becoming ready from ${filePath}`);
+    if (childHasExited(child)) {
+      const outcome = child.exitCode ?? child.signalCode ?? "unknown";
+      throw new Error(`e2e server exited with ${outcome} before becoming ready from ${filePath}`);
     }
     await delay(pollIntervalMs);
   }
@@ -430,7 +475,11 @@ async function spawnServer(
   child: ChildProcess;
   info: E2EServerInfo;
 }> {
+  installCleanup();
   await ensureE2ETmuxDir();
+  if (signalCleanupStarted) {
+    throw new Error("e2e server shutdown started before spawn");
+  }
   const invocation = e2eServerCommand(infoFile);
   if (!invocation.prebuilt) {
     await ensureEmbeddedFrontend();
@@ -458,11 +507,24 @@ async function spawnServer(
     stdio: "inherit",
     env: process.env,
   });
+  startingServers.add(child);
 
-  return {
-    child,
-    info: await waitForServerInfo(infoFile, child),
-  };
+  try {
+    const info = await waitForServerInfo(infoFile, child);
+    if (signalCleanupStarted) {
+      await terminateServerProcess(child, info.pid);
+      throw new Error("e2e server shutdown started during spawn");
+    }
+    return { child, info };
+  } catch (error) {
+    startingServers.delete(child);
+    await terminateServerProcess(child, undefined);
+    throw error;
+  }
+}
+
+function childHasExited(child: ManagedChildLike): boolean {
+  return child.exitCode !== null || child.signalCode != null;
 }
 
 export function cleanupManagedServerProcess(
@@ -470,7 +532,7 @@ export function cleanupManagedServerProcess(
   infoFile: string | undefined = process.env.PLAYWRIGHT_E2E_SERVER_INFO_FILE,
 ): void {
   const serverPID = infoFile ? readServerInfoSync(infoFile)?.pid : undefined;
-  const fallbackPID = child?.exitCode === null ? child.pid : undefined;
+  const fallbackPID = child && !childHasExited(child) ? child.pid : undefined;
   const pid = serverPID ?? fallbackPID;
   if (!pid) {
     return;
@@ -484,7 +546,7 @@ export function cleanupManagedServerProcess(
 }
 
 function waitForChildExit(child: ChildProcess, timeoutMs: number): Promise<boolean> {
-  if (child.exitCode !== null) {
+  if (childHasExited(child)) {
     return Promise.resolve(true);
   }
   return new Promise<boolean>((resolve) => {
@@ -502,23 +564,31 @@ function waitForChildExit(child: ChildProcess, timeoutMs: number): Promise<boole
   });
 }
 
-export async function terminateServerProcess(child: ChildProcess | null, serverPID: number | undefined): Promise<void> {
-  if (child && child.exitCode !== null) {
+function signalServerProcess(child: ChildProcess | null, serverPID: number | undefined): boolean {
+  if (child && childHasExited(child)) {
+    return false;
+  }
+  const pid = serverPID ?? child?.pid;
+  if (!pid) {
+    return false;
+  }
+  try {
+    process.kill(pid, "SIGTERM");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function terminateServerProcess(
+  child: ChildProcess | null,
+  serverPID: number | undefined,
+  alreadySignaled = false,
+): Promise<void> {
+  if (child && childHasExited(child)) {
     return;
   }
-  if (serverPID) {
-    try {
-      process.kill(serverPID, "SIGTERM");
-    } catch {
-      return;
-    }
-  } else if (child?.pid) {
-    try {
-      process.kill(child.pid, "SIGTERM");
-    } catch {
-      return;
-    }
-  } else {
+  if (!alreadySignaled && !signalServerProcess(child, serverPID)) {
     return;
   }
 
@@ -541,53 +611,72 @@ async function cleanupOwnedTmuxDir(): Promise<void> {
     return;
   }
   const dir = ownedTmuxDir;
-  ownedTmuxDir = null;
-  delete process.env[tmuxDirEnvVar];
-  await cleanupE2ETmuxDir(dir);
+  if (await cleanupE2ETmuxDir(dir)) {
+    ownedTmuxDir = null;
+    delete process.env[tmuxDirEnvVar];
+  }
 }
 
-async function shutdownPooledServers(): Promise<void> {
-  const servers = isolatedPool.splice(0);
-  await Promise.all(servers.map((server) => terminateServerProcess(server.child, server.info.pid)));
+function noOwnedServersRemain(): boolean {
+  return !managedChild && startingServers.size === 0 && isolatedPool.length === 0 && standaloneServers.size === 0;
 }
 
-async function shutdownStandaloneServers(): Promise<void> {
-  const servers = [...standaloneServers];
-  standaloneServers.clear();
-  await Promise.all(servers.map((server) => terminateServerProcess(server.child, server.info.pid)));
+async function cleanupOwnedTmuxDirIfIdle(): Promise<void> {
+  if (noOwnedServersRemain()) {
+    await cleanupOwnedTmuxDir();
+  }
 }
 
-async function shutdownOwnedServers(): Promise<void> {
+export async function shutdownOwnedServers(): Promise<void> {
   const filePath = managedChild ? process.env.PLAYWRIGHT_E2E_SERVER_INFO_FILE : undefined;
   const info = filePath ? readServerInfoSync(filePath) : null;
-  // The shared socket directory is the outer Playwright process's
-  // authoritative ownership record. Reap it before waiting on child shutdown
-  // so a stuck or force-killed worker cannot strand a daemonized tmux server.
-  await cleanupOwnedTmuxDir();
-  await Promise.all([
-    managedChild ? terminateServerProcess(managedChild, info?.pid) : Promise.resolve(),
-    shutdownPooledServers(),
-    shutdownStandaloneServers(),
-  ]);
+  const tmuxDir = ownedTmuxDir;
+  const servers = [
+    ...[...startingServers].map((child) => ({ child, serverPID: undefined })),
+    ...(managedChild ? [{ child: managedChild, serverPID: info?.pid }] : []),
+    ...isolatedPool.map((server) => ({ child: server.child, serverPID: server.info.pid })),
+    ...[...standaloneServers].map((server) => ({ child: server.child, serverPID: server.info.pid })),
+  ];
+
+  startingServers.clear();
+  isolatedPool.length = 0;
+  standaloneServers.clear();
   managedChild = null;
+  for (const server of servers) {
+    signalServerProcess(server.child, server.serverPID);
+  }
+  if (tmuxDir) {
+    await cleanupE2ETmuxDir(tmuxDir);
+  }
+  await Promise.all(servers.map((server) => terminateServerProcess(server.child, server.serverPID, true)));
+  if (tmuxDir) {
+    const removed = await cleanupE2ETmuxDir(tmuxDir);
+    if (removed && ownedTmuxDir === tmuxDir) {
+      ownedTmuxDir = null;
+      delete process.env[tmuxDirEnvVar];
+    }
+  }
   if (filePath) {
     await removeServerInfo(filePath);
   }
 }
 
-function installCleanup(infoFile: string): void {
+function installCleanup(): void {
   if (cleanupInstalled) {
     return;
   }
   cleanupInstalled = true;
 
   const cleanupImmediately = () => {
-    cleanupManagedServerProcess(managedChild, infoFile);
+    cleanupManagedServerProcess(managedChild);
+    for (const child of startingServers) {
+      signalServerProcess(child, undefined);
+    }
     for (const server of isolatedPool) {
       killPooledServerProcess(server);
     }
     for (const server of standaloneServers) {
-      if (server.child.exitCode === null) {
+      if (!childHasExited(server.child)) {
         try {
           process.kill(server.info.pid, "SIGTERM");
         } catch {
@@ -618,8 +707,7 @@ async function cleanupAfterSignal(exitCode: number): Promise<void> {
 async function startManagedServer(): Promise<E2EServerInfo> {
   const started = await spawnServer(serverInfoFile, { visibleImportedModes: true });
   managedChild = started.child;
-
-  installCleanup(serverInfoFile);
+  startingServers.delete(started.child);
 
   const info = started.info;
   process.env.PLAYWRIGHT_E2E_BASE_URL = info.base_url;
@@ -693,9 +781,10 @@ export async function stopE2EServer(): Promise<void> {
     return;
   }
 
-  const info = await readServerInfo(filePath);
-  await cleanupOwnedTmuxDir();
-  await terminateServerProcess(managedChild, info?.pid);
+  if (!managedChild) {
+    await terminateServerProcess(null, (await readServerInfo(filePath))?.pid);
+  }
+  await shutdownOwnedServers();
 
   await removeServerInfo(filePath);
   delete process.env[ownedServerEnvVar];
@@ -785,7 +874,7 @@ function samePooledOptions(a: PooledServerOptions, b: PooledServerOptions): bool
 const isolatedPool: PooledServer[] = [];
 
 function installPoolCleanup(): void {
-  installCleanup(serverInfoFile);
+  installCleanup();
 }
 
 async function postReset(baseURL: string, options: PooledServerOptions): Promise<E2EServerInfo> {
@@ -840,7 +929,7 @@ async function resetPooledServer(server: PooledServer, options: PooledServerOpti
 // has exited, the server's reported PID may already have been reused
 // by an unrelated process, and signalling it would be unsafe.
 function killPooledServerProcess(server: PooledServer): void {
-  if (server.child.exitCode !== null) {
+  if (childHasExited(server.child)) {
     return;
   }
   try {
@@ -881,6 +970,7 @@ async function spawnPooledServer(options: PooledServerOptions): Promise<PooledSe
     options,
   };
   isolatedPool.push(server);
+  startingServers.delete(started.child);
   installPoolCleanup();
   return server;
 }
@@ -900,6 +990,7 @@ export async function startIsolatedE2EServerWithOptions(
       started.info = await postReset(started.info.base_url, normalizedPooledOptions(options));
     }
     standaloneServers.add(started);
+    startingServers.delete(started.child);
     return {
       info: started.info,
       stop: async () => {
@@ -907,7 +998,7 @@ export async function startIsolatedE2EServerWithOptions(
         await terminateServerProcess(started.child, started.info.pid);
         await removeServerInfo(infoFile);
         await rm(infoDir, { force: true, recursive: true });
-        await cleanupOwnedTmuxDir();
+        await cleanupOwnedTmuxDirIfIdle();
       },
     };
   }
@@ -926,7 +1017,7 @@ export async function startIsolatedE2EServerWithOptions(
       }
       // The server may have died while idle (crash, OOM, external
       // kill); never hand out a dead base_url.
-      if (candidate.child.exitCode !== null || !(await isServerReachable(candidate.info.base_url))) {
+      if (childHasExited(candidate.child) || !(await isServerReachable(candidate.info.base_url))) {
         throw new Error("pooled e2e server is no longer reachable");
       }
       if (!samePooledOptions(candidate.options, desired)) {

--- a/frontend/tests/e2e-full/support/e2eServerTeardown.ts
+++ b/frontend/tests/e2e-full/support/e2eServerTeardown.ts
@@ -1,5 +1,9 @@
-import { stopE2EServer } from "./e2eServer";
+import { cleanupE2ERunnerArtifacts, stopE2EServer } from "./e2eServer";
 
 export default async function globalTeardown(): Promise<void> {
-  await stopE2EServer();
+  try {
+    await stopE2EServer();
+  } finally {
+    await cleanupE2ERunnerArtifacts();
+  }
 }

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -99,13 +99,13 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "cleanup kenn-forge test tmux sessions: %v\n", err)
 	})
 	code := gitsafe.RunIsolatedMain(m)
-	stopSignalCleanup()
 	if err := runCleanup(); err != nil {
 		fmt.Fprintf(os.Stderr, "cleanup kenn-forge test tmux sessions: %v\n", err)
 		if code == 0 {
 			code = 1
 		}
 	}
+	stopSignalCleanup()
 	if envDirErr == nil {
 		_ = os.RemoveAll(envDir)
 	}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -61,6 +61,7 @@ import (
 	"go.kenn.io/forge/internal/testutil/gitfake"
 	"go.kenn.io/forge/internal/testutil/gitsafe"
 	"go.kenn.io/forge/internal/testutil/processjob"
+	"go.kenn.io/forge/internal/testutil/testsignal"
 	"go.kenn.io/forge/internal/tokenauth"
 	"go.kenn.io/forge/internal/workspace"
 	"go.kenn.io/forge/internal/workspace/localruntime"
@@ -90,15 +91,21 @@ func TestMain(m *testing.M) {
 	if envDirErr == nil {
 		_ = os.Setenv("KENN_FORGE_TMUX_ENV_DIR", envDir)
 	}
+	runCleanup, stopSignalCleanup := testsignal.Install(func() error {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		return cleanupForgeTestTmuxSessionsWithContext(ctx)
+	}, func(err error) {
+		fmt.Fprintf(os.Stderr, "cleanup kenn-forge test tmux sessions: %v\n", err)
+	})
 	code := gitsafe.RunIsolatedMain(m)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	if err := cleanupForgeTestTmuxSessionsWithContext(ctx); err != nil {
+	stopSignalCleanup()
+	if err := runCleanup(); err != nil {
 		fmt.Fprintf(os.Stderr, "cleanup kenn-forge test tmux sessions: %v\n", err)
 		if code == 0 {
 			code = 1
 		}
 	}
-	cancel()
 	if envDirErr == nil {
 		_ = os.RemoveAll(envDir)
 	}

--- a/internal/server/kataapi/testmain_test.go
+++ b/internal/server/kataapi/testmain_test.go
@@ -13,6 +13,7 @@ import (
 
 	"go.kenn.io/forge/internal/procutil"
 	"go.kenn.io/forge/internal/testutil/gitsafe"
+	"go.kenn.io/forge/internal/testutil/testsignal"
 )
 
 var kataAPITestTmuxCommand []string
@@ -23,8 +24,12 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "configure isolated Kata API test tmux: %v\n", err)
 		os.Exit(1)
 	}
+	runCleanup, stopSignalCleanup := testsignal.Install(cleanupTmux, func(err error) {
+		fmt.Fprintf(os.Stderr, "cleanup isolated Kata API test tmux: %v\n", err)
+	})
 	code := gitsafe.RunIsolatedMain(m)
-	if err := cleanupTmux(); err != nil {
+	stopSignalCleanup()
+	if err := runCleanup(); err != nil {
 		fmt.Fprintf(os.Stderr, "cleanup isolated Kata API test tmux: %v\n", err)
 		if code == 0 {
 			code = 1

--- a/internal/server/kataapi/testmain_test.go
+++ b/internal/server/kataapi/testmain_test.go
@@ -28,13 +28,13 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "cleanup isolated Kata API test tmux: %v\n", err)
 	})
 	code := gitsafe.RunIsolatedMain(m)
-	stopSignalCleanup()
 	if err := runCleanup(); err != nil {
 		fmt.Fprintf(os.Stderr, "cleanup isolated Kata API test tmux: %v\n", err)
 		if code == 0 {
 			code = 1
 		}
 	}
+	stopSignalCleanup()
 	os.Exit(code)
 }
 

--- a/internal/server/workspacetest/testmain_test.go
+++ b/internal/server/workspacetest/testmain_test.go
@@ -15,6 +15,7 @@ import (
 	"go.kenn.io/forge/internal/procutil"
 	"go.kenn.io/forge/internal/testutil/gitsafe"
 	"go.kenn.io/forge/internal/testutil/processjob"
+	"go.kenn.io/forge/internal/testutil/testsignal"
 )
 
 var workspaceTestTmuxCommand []string
@@ -32,8 +33,12 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "configure isolated workspace test tmux: %v\n", err)
 		os.Exit(1)
 	}
+	runCleanup, stopSignalCleanup := testsignal.Install(cleanupTmux, func(err error) {
+		fmt.Fprintf(os.Stderr, "cleanup isolated workspace test tmux: %v\n", err)
+	})
 	code := gitsafe.RunIsolatedMain(m)
-	if err := cleanupTmux(); err != nil {
+	stopSignalCleanup()
+	if err := runCleanup(); err != nil {
 		fmt.Fprintf(os.Stderr, "cleanup isolated workspace test tmux: %v\n", err)
 		if code == 0 {
 			code = 1

--- a/internal/server/workspacetest/testmain_test.go
+++ b/internal/server/workspacetest/testmain_test.go
@@ -37,13 +37,13 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "cleanup isolated workspace test tmux: %v\n", err)
 	})
 	code := gitsafe.RunIsolatedMain(m)
-	stopSignalCleanup()
 	if err := runCleanup(); err != nil {
 		fmt.Fprintf(os.Stderr, "cleanup isolated workspace test tmux: %v\n", err)
 		if code == 0 {
 			code = 1
 		}
 	}
+	stopSignalCleanup()
 	os.Exit(code)
 }
 

--- a/internal/testutil/testsignal/testsignal.go
+++ b/internal/testutil/testsignal/testsignal.go
@@ -1,0 +1,56 @@
+// Package testsignal installs bounded process-signal cleanup for test binaries
+// that own external resources which outlive the Go process.
+package testsignal
+
+import (
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+)
+
+// Install registers cleanup for interrupt and termination signals. The returned
+// cleanup function is shared with the normal TestMain exit path and runs at most
+// once. stop removes the signal handler after m.Run completes.
+func Install(
+	cleanup func() error,
+	report func(error),
+) (runCleanup func() error, stop func()) {
+	var cleanupOnce sync.Once
+	var cleanupErr error
+	runCleanup = func() error {
+		cleanupOnce.Do(func() {
+			if cleanup != nil {
+				cleanupErr = cleanup()
+			}
+		})
+		return cleanupErr
+	}
+
+	signals := make(chan os.Signal, 1)
+	done := make(chan struct{})
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		select {
+		case received := <-signals:
+			if err := runCleanup(); err != nil && report != nil {
+				report(err)
+			}
+			signal.Stop(signals)
+			if received == os.Interrupt {
+				os.Exit(130)
+			}
+			os.Exit(143)
+		case <-done:
+		}
+	}()
+
+	var stopOnce sync.Once
+	stop = func() {
+		stopOnce.Do(func() {
+			signal.Stop(signals)
+			close(done)
+		})
+	}
+	return runCleanup, stop
+}

--- a/internal/testutil/testsignal/testsignal_test.go
+++ b/internal/testutil/testsignal/testsignal_test.go
@@ -1,0 +1,76 @@
+package testsignal
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"runtime"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/procutil"
+)
+
+func TestInstallRunsCleanupBeforeSIGTERMExit(t *testing.T) {
+	if os.Getenv("KENN_FORGE_TEST_SIGNAL_HELPER") == "1" {
+		cleanupPath := os.Getenv("KENN_FORGE_TEST_SIGNAL_CLEANUP")
+		Install(func() error {
+			return os.WriteFile(cleanupPath, []byte("cleaned\n"), 0o600)
+		}, nil)
+		if err := os.WriteFile(
+			os.Getenv("KENN_FORGE_TEST_SIGNAL_READY"),
+			[]byte("ready\n"),
+			0o600,
+		); err != nil {
+			os.Exit(2)
+		}
+		select {}
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not support sending SIGTERM to the helper process")
+	}
+
+	dir := t.TempDir()
+	assert := assert.New(t)
+	require := require.New(t)
+	readyPath := dir + "/ready"
+	cleanupPath := dir + "/cleanup"
+	cmd := procutil.Command(os.Args[0], "-test.run=^TestInstallRunsCleanupBeforeSIGTERMExit$")
+	cmd.Env = append(os.Environ(),
+		"KENN_FORGE_TEST_SIGNAL_HELPER=1",
+		"KENN_FORGE_TEST_SIGNAL_READY="+readyPath,
+		"KENN_FORGE_TEST_SIGNAL_CLEANUP="+cleanupPath,
+	)
+	require.NoError(cmd.Start())
+	t.Cleanup(func() {
+		if cmd.ProcessState == nil {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		}
+	})
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(readyPath); err == nil {
+			break
+		} else if !errors.Is(err, os.ErrNotExist) {
+			require.NoError(err)
+		}
+		if time.Now().After(deadline) {
+			require.FailNow("signal helper did not become ready")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	require.NoError(cmd.Process.Signal(syscall.SIGTERM))
+	err := cmd.Wait()
+	var exitErr *exec.ExitError
+	require.ErrorAs(err, &exitErr)
+	assert.Equal(143, exitErr.ExitCode())
+	content, readErr := os.ReadFile(cleanupPath)
+	require.NoError(readErr)
+	assert.Equal("cleaned\n", string(content))
+}


### PR DESCRIPTION
Terminated e2e runners can leave daemonized tmux servers behind because tmux outlives its parent, while ordinary defers, exit callbacks, and late graceful cleanup are skipped or cut short by signals.\n\n- Stop each Go e2e server's private tmux server before bounded handler draining, including reset and termination paths.\n- Track Playwright-owned children from spawn through confirmed exit, preserve the shared socket root while a child can still create tmux state, and keep repeated SIGINT/SIGTERM handling active during cleanup.\n- Build one run-owned e2e-server binary before Playwright starts, share it with every worker, and let only the builder remove it. This keeps the real server process in the runner's signal path instead of a go run wrapper.\n- Sweep sockets before and after child exit, removing stale sockets only when tmux verifies their server is gone and retaining ambiguous failures for recovery.\n- Synchronize Go test tmux startup with signal cleanup so termination cannot land between daemonization and ownership registration.\n- Recover dead-owner directories only when their resources belong to the current local user. Developer tmux servers remain outside the cleanup boundary.\n\n<sup>generated by a clanker</sup>