### PR TITLE
fix: keep issue label chips readable

### DIFF
--- a/frontend/src/IssueItem.compact-label-shrink.browser.svelte.ts
+++ b/frontend/src/IssueItem.compact-label-shrink.browser.svelte.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { cleanup, render } from "vitest-browser-svelte";
+
+import type { Issue } from "../../packages/ui/src/api/types.js";
+import IssueItem from "../../packages/ui/src/components/sidebar/IssueItem.svelte";
+import { STORES_KEY } from "../../packages/ui/src/context.js";
+import "./app.css";
+
+describe("IssueItem compact label row", () => {
+  afterEach(() => {
+    cleanup();
+    document.querySelector("[data-issue-item-test]")?.remove();
+  });
+
+  it("keeps a short label chip intact beside a long title", () => {
+    const wrapper = document.createElement("div");
+    wrapper.dataset.issueItemTest = "";
+    wrapper.style.width = "420px";
+    document.body.appendChild(wrapper);
+
+    const issue = {
+      Number: 1351,
+      Title: "Investigate tool calls that do not identify long file references correctly",
+      Author: "alice",
+      State: "open",
+      LastActivityAt: new Date().toISOString(),
+      repo_owner: "acme",
+      repo_name: "widgets",
+      repo: {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "widgets",
+        repo_path: "acme/widgets",
+      },
+      Starred: false,
+      labels: [{ name: "bug", color: "d73a4a" }],
+    } as unknown as Issue;
+
+    render(IssueItem, {
+      target: wrapper,
+      props: {
+        issue,
+        selected: false,
+        showRepo: true,
+        repoLabel: "acme/widgets",
+        onclick: () => {},
+      },
+      context: new Map<symbol, unknown>([[STORES_KEY, { issues: { toggleIssueStar: vi.fn() } }]]),
+    });
+
+    const pill = document.querySelector<HTMLElement>(".issue-item .kit-color-label")!;
+
+    expect(pill.textContent).toBe("bug");
+    expect(pill.scrollWidth).toBeLessThanOrEqual(pill.clientWidth);
+  });
+});

--- a/packages/ui/src/components/shared/LabelRow.svelte
+++ b/packages/ui/src/components/shared/LabelRow.svelte
@@ -16,7 +16,7 @@
 </script>
 
 {#if labels.length > 0}
-  <span class={["label-row", compact && "label-row--compact"]}>
+  <span class={["label-row", compact && "label-row--compact", compact && labels.length === 1 && "label-row--single"]}>
     {#each visible as label (label.name)}
       {#if compact}
         <ColorLabel size="sm" name={label.name} color={label.color} />
@@ -47,6 +47,10 @@
      * author-vs-repo idiom on the meta line). */
     flex: 0 4 auto;
     min-width: 0;
+  }
+
+  .label-row--single {
+    flex-shrink: 0;
   }
 
   .label-row--compact :global(.kit-color-label) {


### PR DESCRIPTION
Long issue titles could compress a single short label until its text and rounded edge were clipped. This made labels harder to scan and left the item number competing with broken chip geometry.

A single compact label now keeps its capped width, so the title ellipsizes while the label and item number remain readable. Multi-label rows retain their existing narrow-width behavior.

<details>
<summary>Validation</summary>

- Full Vitest suite: 3,733 passed, 2 skipped.
- Issue and pull request browser layout tests: 3 passed.
- Frontend formatting, lint, kit-ui, Svelte checks, and repository hooks passed.

</details>

### Screenshot

![issue-label-chip-fix.png](https://github.com/user-attachments/assets/5e5dc217-7389-4527-b21b-716a7a14350b)

<sup>generated by a clanker</sup>