### PR TITLE
Fix documentation screenshots in Safari and iOS

### DIFF
--- a/.github/docker/playwright/Dockerfile
+++ b/.github/docker/playwright/Dockerfile
@@ -35,5 +35,5 @@ RUN node -e 'if (Number(process.versions.node.split(".")[0]) < 24) process.exit(
       -o Acquire::ForceIPv4=true \
       -o Acquire::http::Timeout=30 \
       -o Acquire::https::Timeout=30 \
-      install -y --no-install-recommends tmux \
+      install -y --no-install-recommends poppler-utils tmux \
     && rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       frontend: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.frontend == 'true' || steps.filter.outputs.ci == 'true' }}
       rust: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.rust == 'true' || steps.filter.outputs.ci == 'true' }}
       e2e: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.e2e == 'true' || steps.filter.outputs.ci == 'true' }}
+      docs: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.docs == 'true' || steps.filter.outputs.ci == 'true' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -68,6 +69,13 @@ jobs:
               - scripts/e2e/**
               - scripts/run-roborev-e2e.sh
               - tests/integration/**
+            docs:
+              - docs/**
+              - scripts/build-docs.mjs
+              - scripts/build-docs.test.mjs
+              - scripts/docs-screenshots-command.test.mjs
+              - scripts/vercel-build-docs.sh
+              - scripts/vercel-install-docs.sh
             ci:
               - .github/workflows/ci.yml
               - .github/docker/**
@@ -77,7 +85,7 @@ jobs:
     name: Ensure Playwright CI image
     runs-on: ${{ github.repository == 'kenn-io/forge' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     needs: detect_changes
-    if: needs.detect_changes.outputs.backend == 'true' || needs.detect_changes.outputs.frontend == 'true' || needs.detect_changes.outputs.e2e == 'true'
+    if: needs.detect_changes.outputs.backend == 'true' || needs.detect_changes.outputs.frontend == 'true' || needs.detect_changes.outputs.e2e == 'true' || needs.detect_changes.outputs.docs == 'true'
     permissions:
       contents: read
       packages: write
@@ -149,6 +157,51 @@ jobs:
           fi
 
           echo "image=${PLAYWRIGHT_CI_IMAGE}@${manifest_digest}" >> "$GITHUB_OUTPUT"
+
+  docs:
+    name: Documentation build
+    runs-on: ${{ github.repository == 'kenn-io/forge' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    timeout-minutes: 15
+    needs: [detect_changes, ensure_playwright_image]
+    if: needs.detect_changes.outputs.docs == 'true'
+    permissions:
+      contents: read
+      packages: read
+    container:
+      image: ${{ needs.ensure_playwright_image.outputs.image }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: "0.12.1"
+          enable-cache: false
+
+      - name: Restore Bun package cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /usr/local/install/cache
+          key: browser-bun-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/docker/playwright/Dockerfile', 'bun.lock') }}
+          restore-keys: |
+            browser-bun-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build and verify documentation in Chromium and WebKit
+        env:
+          KENN_FORGE_DOCS_SITE_PROJECT: all
+        run: bash scripts/vercel-build-docs.sh
 
   lint:
     runs-on: ${{ github.repository == 'kenn-io/forge' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}

--- a/context/docs-authoring.md
+++ b/context/docs-authoring.md
@@ -12,6 +12,9 @@ screenshots, or the Zensical site.
   docs build and must not be tracked in Git. Playwright captures in
   `docs/screenshots/` use the real seeded e2e backend, not mocked API fixtures
   or a developer daemon.
+- Generated workflow screenshots must use native SVG geometry, not XHTML in
+  `foreignObject`; WebKit clips responsive `foreignObject` images.
+  (`docs/screenshots/docs-screenshots.spec.ts::nativeSVGSnapshot`)
 - Static Codex terminal overlays reproduce a one-off real Codex TUI capture,
   including its composer and model/path status; sanitize local paths to the
   public synthetic repository. (`docs/screenshots/docs-screenshots.spec.ts::embedSyntheticCodexTranscript`)

--- a/context/docs-authoring.md
+++ b/context/docs-authoring.md
@@ -23,6 +23,9 @@ screenshots, or the Zensical site.
   copied into `internal/web/dist`, then pass the prebuilt binary through
   `PLAYWRIGHT_E2E_SERVER_BINARY` so screenshot readiness excludes Go compile
   time. (`scripts/vercel-build-docs.sh`)
+- Vercel restricts rendered-site checks to Chromium because its runtime lacks
+  Playwright WebKit dependencies; the browser-image docs CI lane runs Chromium
+  and WebKit. (`scripts/vercel-build-docs.sh`, `.github/workflows/ci.yml::docs`)
 - Production docs use a default-branch `workflow_run`; the released SHA must be
   on `main` and latest before build and before/after promotion. A stale attempt
   dispatches trusted latest-release reconciliation. No Vercel Git app or GitHub environment. (`.github/workflows/deploy-docs.yml`)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,9 @@
 # Documentation development
 
+The screenshot generator requires Poppler's `pdftocairo` command. On macOS,
+install it with `brew install poppler`; on Debian or Ubuntu, install the
+`poppler-utils` package.
+
 Build and verify the public site, including the generated workflow screenshots:
 
 ```sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,8 @@
 
 The screenshot generator requires Poppler's `pdftocairo` command. On macOS,
 install it with `brew install poppler`; on Debian or Ubuntu, install the
-`poppler-utils` package.
+`poppler-utils` package. Local verification also uses Chromium and WebKit;
+install both with `node node_modules/.bin/playwright install chromium webkit`.
 
 Build and verify the public site, including the generated workflow screenshots:
 

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -14,8 +14,13 @@ The build stages the docs in a temporary directory, writes the generated SVGs
 there, and then builds the complete site into `site/`. Generated screenshots
 are build output and are not tracked in Git.
 
-Each SVG serializes the real app DOM and CSS into an SVG `foreignObject`; it
-must not embed PNG, JPEG, or other raster screenshot payloads:
+Each capture prints the stabilized Chromium page to a one-page vector PDF.
+Poppler's `pdftocairo` converts that page into native SVG paths, clips,
+gradients, and embedded icon data so responsive images render consistently in
+WebKit. Install Poppler before running the build (`brew install poppler` on
+macOS or the `poppler-utils` package on Linux).
+
+The generated files are:
 
 - `issue-triager-light.svg`
 - `issue-triager-dark.svg`
@@ -39,18 +44,17 @@ credentials.
 
 The maintainer overview opens the seeded pull request from Activity, hosts its
 ready workspace in the detail layout, and selects the running Codex session
-before serialization.
+before export.
 
 The visible Codex pane contains a short static transcript derived from a
 one-time real Codex run in a synthetic widget-cache repository. The capture
-harness injects the sanitized text into the terminal DOM because canvas pixels
-cannot be preserved by the SVG serializer. Its prompt composer and model/path
-status reproduce the same captured Codex TUI with the temporary path replaced
-by the public synthetic repository path. Docs builds never run Codex or read
-agent credentials.
+harness injects the sanitized text into the terminal DOM before printing. Its
+prompt composer and model/path status reproduce the same captured Codex TUI
+with the temporary path replaced by the public synthetic repository path. Docs
+builds never run Codex or read agent credentials.
 
-Dark captures must render as dark when opened as standalone SVG files. The
-capture task preserves the live root theme class and computed CSS custom
-properties because the app's `:root.dark` selectors do not apply inside an SVG
-`foreignObject` by themselves. Captures also wait for sync UI to return to idle
-so workflow images do not show transient syncing spinners.
+Dark captures print with the active screen theme. Before export, the task waits
+for sync UI to return to idle and rejects transient syncing labels or private
+temporary paths. The generated SVG contract rejects `foreignObject`, scripts,
+remote asset URLs, and private build paths; the rendered-site suite also checks
+responsive painting in iPhone-sized WebKit.

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -51,7 +51,9 @@ one-time real Codex run in a synthetic widget-cache repository. The capture
 harness injects the sanitized text into the terminal DOM before printing. Its
 prompt composer and model/path status reproduce the same captured Codex TUI
 with the temporary path replaced by the public synthetic repository path. Docs
-builds never run Codex or read agent credentials.
+builds never run Codex or read agent credentials. This synthetic overlay
+follows the capture's light or dark theme; theme-aware live terminals are a
+separate product concern.
 
 Dark captures print with the active screen theme. Before export, the task waits
 for sync UI to return to idle and rejects transient syncing labels or private

--- a/docs/screenshots/docs-screenshots.spec.ts
+++ b/docs/screenshots/docs-screenshots.spec.ts
@@ -1,6 +1,9 @@
 import { expect, test, type Locator, type Page } from "@playwright/test";
-import { mkdir, writeFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 
 import {
   startIsolatedE2EServerWithOptions,
@@ -8,6 +11,7 @@ import {
 } from "../../frontend/tests/e2e-full/support/e2eServer";
 
 const outputDir = process.env.KENN_FORGE_DOCS_SCREENSHOT_DIR;
+const execFileAsync = promisify(execFile);
 
 type ThemeName = "light" | "dark";
 
@@ -534,7 +538,38 @@ async function prepareFirstRunPage(page: Page, baseURL: string): Promise<void> {
   });
 }
 
-async function svgDOMSnapshot(
+function escapeXMLText(value: string): string {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
+function normalizeNativeSVG(
+  svg: string,
+  input: {
+    title: string;
+    description: string;
+    width: number;
+    height: number;
+  },
+): string {
+  const svgStart = svg.indexOf("<svg");
+  const openingTagEnd = svg.indexOf(">", svgStart);
+  if (svgStart < 0 || openingTagEnd < 0) {
+    throw new Error("pdftocairo output did not contain an SVG root element");
+  }
+
+  const openingTag = svg
+    .slice(svgStart, openingTagEnd + 1)
+    .replace(/\swidth="[^"]*"/, ` width="${input.width}"`)
+    .replace(/\sheight="[^"]*"/, ` height="${input.height}"`)
+    .replace(/>$/, ' role="img" aria-labelledby="title desc">');
+  const metadata =
+    `<title id="title">${escapeXMLText(input.title)}</title>` +
+    `<desc id="desc">${escapeXMLText(input.description)}</desc>`;
+
+  return `${svg.slice(0, svgStart)}${openingTag}${metadata}${svg.slice(openingTagEnd + 1).trimEnd()}\n`;
+}
+
+async function nativeSVGSnapshot(
   page: Page,
   input: {
     title: string;
@@ -543,139 +578,29 @@ async function svgDOMSnapshot(
     height: number;
   },
 ): Promise<string> {
-  return page.evaluate(async ({ title, description, width, height }) => {
-    const svgNS = "http://www.w3.org/2000/svg";
-    const xhtmlNS = "http://www.w3.org/1999/xhtml";
+  const temporaryDir = await mkdtemp(path.join(os.tmpdir(), "kenn-forge-docs-svg-"));
+  const pdfPath = path.join(temporaryDir, "capture.pdf");
+  const svgPath = path.join(temporaryDir, "capture.svg");
 
-    const styles = Array.from(document.styleSheets)
-      .map((sheet) => {
-        try {
-          return Array.from(sheet.cssRules)
-            .map((rule) => rule.cssText)
-            .join("\n");
-        } catch {
-          return "";
-        }
-      })
-      .filter(Boolean)
-      .join("\n\n");
-    const normalizedStyles = styles.replace(/[ \t]+$/gm, "");
-    const rootStyle = getComputedStyle(document.documentElement);
-    const rootCustomProperties = Array.from(rootStyle)
-      .filter((name) => name.startsWith("--"))
-      .map((name) => `${name}: ${rootStyle.getPropertyValue(name).trim()};`)
-      .join(" ");
-
-    const svgDoc = document.implementation.createDocument(svgNS, "svg", null);
-    const svg = svgDoc.documentElement;
-    svg.setAttribute("xmlns", svgNS);
-    svg.setAttribute("width", String(width));
-    svg.setAttribute("height", String(height));
-    svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
-    svg.setAttribute("role", "img");
-    svg.setAttribute("aria-labelledby", "title desc");
-
-    const titleNode = svgDoc.createElementNS(svgNS, "title");
-    titleNode.setAttribute("id", "title");
-    titleNode.textContent = title;
-    svg.appendChild(titleNode);
-
-    const descNode = svgDoc.createElementNS(svgNS, "desc");
-    descNode.setAttribute("id", "desc");
-    descNode.textContent = description;
-    svg.appendChild(descNode);
-
-    const foreignObject = svgDoc.createElementNS(svgNS, "foreignObject");
-    foreignObject.setAttribute("x", "0");
-    foreignObject.setAttribute("y", "0");
-    foreignObject.setAttribute("width", String(width));
-    foreignObject.setAttribute("height", String(height));
-
-    const htmlDoc = document.implementation.createDocument(xhtmlNS, "html", null);
-    const html = htmlDoc.documentElement;
-    for (const attr of Array.from(document.documentElement.attributes)) {
-      if (attr.name === "xmlns") continue;
-      html.setAttribute(attr.name, attr.value);
+  try {
+    await page.emulateMedia({ media: "screen" });
+    await page.pdf({
+      path: pdfPath,
+      width: `${input.width}px`,
+      height: `${input.height}px`,
+      printBackground: true,
+      margin: { top: "0", right: "0", bottom: "0", left: "0" },
+      pageRanges: "1",
+    });
+    try {
+      await execFileAsync("pdftocairo", ["-svg", "-f", "1", "-l", "1", pdfPath, svgPath]);
+    } catch (error) {
+      throw new Error("pdftocairo failed; install Poppler to generate documentation screenshots", { cause: error });
     }
-    html.setAttribute("xmlns", xhtmlNS);
-    html.setAttribute(
-      "style",
-      [
-        document.documentElement.getAttribute("style") ?? "",
-        rootCustomProperties,
-        `width: ${width}px`,
-        `height: ${height}px`,
-        "margin: 0",
-        "padding: 0",
-        "overflow: hidden",
-      ]
-        .filter(Boolean)
-        .join("; "),
-    );
-
-    const head = htmlDoc.createElementNS(xhtmlNS, "head");
-    const style = htmlDoc.createElementNS(xhtmlNS, "style");
-    style.textContent = `
-${normalizedStyles}
-
-html,
-body {
-  width: ${width}px !important;
-  height: ${height}px !important;
-  margin: 0 !important;
-  overflow: hidden !important;
-}
-
-*,
-*::before,
-*::after {
-  animation: none !important;
-  transition: none !important;
-  caret-color: transparent !important;
-}
-`;
-    head.appendChild(style);
-    html.appendChild(head);
-
-    const body = htmlDoc.createElementNS(xhtmlNS, "body");
-    for (const attr of Array.from(document.body.attributes)) {
-      body.setAttribute(attr.name, attr.value);
-    }
-    body.setAttribute(
-      "style",
-      `${document.body.getAttribute("style") ?? ""}; width: ${width}px; height: ${height}px; margin: 0; overflow: hidden;`,
-    );
-    for (const child of Array.from(document.body.childNodes)) {
-      body.appendChild(htmlDoc.importNode(child.cloneNode(true), true));
-    }
-    for (const script of Array.from(body.querySelectorAll("script"))) {
-      script.remove();
-    }
-
-    const liveImages = Array.from(document.body.querySelectorAll("img"));
-    const clonedImages = Array.from(body.querySelectorAll("img"));
-    await Promise.all(
-      liveImages.map(async (liveImage, index) => {
-        const clonedImage = clonedImages[index];
-        const source = liveImage.currentSrc || liveImage.src;
-        if (!clonedImage || !source || source.startsWith("data:")) return;
-
-        const sourceURL = new URL(source, document.baseURI);
-        if (!sourceURL.pathname.toLowerCase().endsWith(".svg")) return;
-
-        const response = await fetch(sourceURL);
-        const svgImage = await response.text();
-        clonedImage.setAttribute("src", `data:image/svg+xml,${encodeURIComponent(svgImage)}`);
-        clonedImage.removeAttribute("srcset");
-      }),
-    );
-    html.appendChild(body);
-
-    foreignObject.appendChild(svgDoc.importNode(html, true));
-    svg.appendChild(foreignObject);
-
-    return `${new XMLSerializer().serializeToString(svg).replace(/[ \t]+$/gm, "")}\n`;
-  }, input);
+    return normalizeNativeSVG(await readFile(svgPath, "utf8"), input);
+  } finally {
+    await rm(temporaryDir, { recursive: true, force: true });
+  }
 }
 
 async function captureCase(page: Page, baseURL: string, capture: CaptureCase): Promise<void> {
@@ -722,30 +647,20 @@ async function captureCase(page: Page, baseURL: string, capture: CaptureCase): P
     expect(statusBox!.y + statusBox!.height).toBeLessThanOrEqual(terminalBox!.y + terminalBox!.height);
   }
 
-  const svg = await svgDOMSnapshot(page, {
+  const svg = await nativeSVGSnapshot(page, {
     title: `${capture.name} ${capture.theme}`,
     description: capture.description,
     width: page.viewportSize()?.width ?? 1280,
     height: page.viewportSize()?.height ?? 820,
   });
-  if (capture.theme === "dark") {
-    expect(svg).toMatch(/<html[^>]*class="[^"]*\bdark\b[^"]*"/);
-  } else {
-    expect(svg).not.toMatch(/<html[^>]*class="[^"]*\bdark\b[^"]*"/);
-  }
-  expect(svg).not.toMatch(/>\s*Syncing(?:\.\.\.)?\s*</i);
-  expect(svg).not.toMatch(/>\s*syncing(?:\u2026|\s*\([^<]*\))?\s*</i);
-  expect(svg).not.toMatch(/\b(?:aria-label|title)="Syncing"/);
-  expect(svg).not.toMatch(/<img[^>]+src="(?:https?:|\/)/i);
-  expect(svg).not.toMatch(/data:image\/(?:avif|gif|jpe?g|png|webp)/i);
+  expect(svg).not.toMatch(/<foreignObject\b/);
+  expect(svg).not.toMatch(/<script\b/i);
+  expect(svg).not.toMatch(/\b(?:href|xlink:href)="https?:/i);
   expect(svg).not.toMatch(/\/var\/folders|kenn-forge-e2e-\d+/i);
-  if (capture.name === "workspace-codex-session" || capture.name === "maintainer-overview") {
-    expect(svg).toContain("Implemented in-flight request coalescing.");
-    expect(svg).toContain("3 passed, 0 failed.");
-    expect(svg).toContain("Summarize recent commits");
-    expect(svg).toContain("gpt-5.6-sol high");
-    expect(svg).toContain("~/src/kenn-io/forge");
-  }
+  expect(svg).toContain(`width="${page.viewportSize()?.width ?? 1280}"`);
+  expect(svg).toContain(`height="${page.viewportSize()?.height ?? 820}"`);
+  expect(svg).toContain(`<title id="title">${capture.name} ${capture.theme}</title>`);
+  expect(svg).toMatch(/<path\b/);
   await writeFile(path.join(outputDir!, `${capture.name}-${capture.theme}.svg`), svg);
 }
 

--- a/docs/screenshots/docs-screenshots.spec.ts
+++ b/docs/screenshots/docs-screenshots.spec.ts
@@ -569,6 +569,29 @@ function normalizeNativeSVG(
   return `${svg.slice(0, svgStart)}${openingTag}${metadata}${svg.slice(openingTagEnd + 1).trimEnd()}\n`;
 }
 
+async function validateCaptureDOM(page: Page): Promise<void> {
+  const captureText = await page.evaluate(() => {
+    const attributeNames = ["aria-label", "title", "alt", "placeholder"];
+    const attributes = Array.from(document.querySelectorAll("*"), (element) =>
+      attributeNames.flatMap((name) => {
+        const value = element.getAttribute(name);
+        return value ? [value] : [];
+      }),
+    ).flat();
+    const inputValues = Array.from(document.querySelectorAll("input, textarea"), (element) =>
+      element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement ? element.value : "",
+    ).filter(Boolean);
+    return [document.body.innerText, ...attributes, ...inputValues].join("\n");
+  });
+
+  if (/\/var\/folders|kenn-forge-e2e-\d+/i.test(captureText)) {
+    throw new Error("Documentation screenshot contains a private path");
+  }
+  if (/\bsyncing\b/i.test(captureText)) {
+    throw new Error("Documentation screenshot contains a transient syncing state");
+  }
+}
+
 async function nativeSVGSnapshot(
   page: Page,
   input: {
@@ -583,6 +606,7 @@ async function nativeSVGSnapshot(
   const svgPath = path.join(temporaryDir, "capture.svg");
 
   try {
+    await validateCaptureDOM(page);
     await page.emulateMedia({ media: "screen" });
     await page.pdf({
       path: pdfPath,
@@ -602,6 +626,34 @@ async function nativeSVGSnapshot(
     await rm(temporaryDir, { recursive: true, force: true });
   }
 }
+
+test.describe("docs screenshot export safety", () => {
+  test("rejects private paths before text becomes SVG glyphs", async ({ page }) => {
+    await page.setContent("<main>Workspace: /var/folders/private/kenn-forge-e2e-123</main>");
+
+    await expect(
+      nativeSVGSnapshot(page, {
+        title: "unsafe path",
+        description: "unsafe path fixture",
+        width: 1280,
+        height: 820,
+      }),
+    ).rejects.toThrow(/private path/i);
+  });
+
+  test("rejects transient syncing attributes before export", async ({ page }) => {
+    await page.setContent('<main><span aria-label="Syncing">Repository activity</span></main>');
+
+    await expect(
+      nativeSVGSnapshot(page, {
+        title: "unsafe sync state",
+        description: "unsafe sync state fixture",
+        width: 1280,
+        height: 820,
+      }),
+    ).rejects.toThrow(/syncing/i);
+  });
+});
 
 async function captureCase(page: Page, baseURL: string, capture: CaptureCase): Promise<void> {
   await preparePage(page, capture.theme);

--- a/docs/screenshots/docs-screenshots.spec.ts
+++ b/docs/screenshots/docs-screenshots.spec.ts
@@ -29,6 +29,31 @@ const syntheticCodexTranscript = [
   "Test result: node --test — 3 passed, 0 failed.",
 ].join("\n");
 
+const syntheticCodexPalettes = {
+  light: {
+    background: "oklch(97.5% 0.008 250)",
+    foreground: "oklch(30% 0.025 255)",
+    promptBackground: "oklch(93.5% 0.012 250)",
+    promptBorder: "oklch(83% 0.02 250)",
+    promptMarker: "oklch(27% 0.025 255)",
+    promptText: "oklch(52% 0.025 250)",
+    model: "oklch(47% 0.105 80)",
+    separator: "oklch(63% 0.02 250)",
+    workingDirectory: "oklch(48% 0.085 150)",
+  },
+  dark: {
+    background: "#0d1117",
+    foreground: "#c9d1d9",
+    promptBackground: "#343941",
+    promptBorder: "#444b55",
+    promptMarker: "#f0f3f6",
+    promptText: "#9da4ad",
+    model: "#f6e2b7",
+    separator: "#6e7681",
+    workingDirectory: "#abdfa7",
+  },
+} as const;
+
 type CaptureCase = {
   name:
     | "maintainer-overview"
@@ -46,7 +71,7 @@ type CaptureCase = {
   loadingText?: RegExp;
   waitForSync?: boolean;
   prepare?: (page: Page, baseURL: string) => Promise<void>;
-  afterReady?: (page: Page) => Promise<void>;
+  afterReady?: (page: Page, theme: ThemeName) => Promise<void>;
   description: string;
 };
 
@@ -55,10 +80,10 @@ async function openCodexLaunchMenu(page: Page): Promise<void> {
   await expect(page.getByRole("menuitem", { name: "Codex" })).toBeVisible();
 }
 
-async function embedSyntheticCodexTranscript(workspace: Locator): Promise<void> {
+async function embedSyntheticCodexTranscript(workspace: Locator, theme: ThemeName): Promise<void> {
   const terminal = workspace.locator(".terminal-container:visible").first();
   await expect(terminal).toBeVisible();
-  await terminal.evaluate((element, transcript) => {
+  await terminal.evaluate((element, { transcript, palette }) => {
     const existing = element.querySelector(".docs-codex-transcript");
     if (existing) existing.remove();
 
@@ -71,8 +96,8 @@ async function embedSyntheticCodexTranscript(workspace: Locator): Promise<void> 
       "z-index: 3",
       "box-sizing: border-box",
       "overflow: hidden",
-      "background: #0d1117",
-      "color: #c9d1d9",
+      `background: ${palette.background}`,
+      `color: ${palette.foreground}`,
       'font-family: "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace',
       "font-size: 12.5px",
       "line-height: 1.4",
@@ -106,17 +131,17 @@ async function embedSyntheticCodexTranscript(workspace: Locator): Promise<void> 
       "gap: 10px",
       "min-height: 44px",
       "padding: 10px 14px",
-      "border: 1px solid #444b55",
-      "background: #343941",
+      `border: 1px solid ${palette.promptBorder}`,
+      `background: ${palette.promptBackground}`,
     ].join("; ");
 
     const promptMarker = document.createElement("span");
     promptMarker.textContent = "›";
-    promptMarker.style.cssText = "color: #f0f3f6; font-weight: 700";
+    promptMarker.style.cssText = `color: ${palette.promptMarker}; font-weight: 700`;
 
     const promptText = document.createElement("span");
     promptText.textContent = "Summarize recent commits";
-    promptText.style.cssText = "color: #9da4ad";
+    promptText.style.cssText = `color: ${palette.promptText}`;
     prompt.append(promptMarker, promptText);
 
     const status = document.createElement("div");
@@ -132,24 +157,24 @@ async function embedSyntheticCodexTranscript(workspace: Locator): Promise<void> 
 
     const model = document.createElement("span");
     model.textContent = "gpt-5.6-sol high";
-    model.style.cssText = "color: #f6e2b7";
+    model.style.cssText = `color: ${palette.model}`;
 
     const separator = document.createElement("span");
     separator.textContent = "·";
-    separator.style.cssText = "color: #6e7681";
+    separator.style.cssText = `color: ${palette.separator}`;
 
     const workingDirectory = document.createElement("span");
     workingDirectory.textContent = "~/src/kenn-io/forge";
-    workingDirectory.style.cssText = "color: #abdfa7";
+    workingDirectory.style.cssText = `color: ${palette.workingDirectory}`;
     status.append(model, separator, workingDirectory);
 
     composer.append(prompt, status);
     content.append(output, composer);
     element.appendChild(content);
-  }, syntheticCodexTranscript);
+  }, { transcript: syntheticCodexTranscript, palette: syntheticCodexPalettes[theme] });
 }
 
-async function showCodexWorkspace(page: Page): Promise<void> {
+async function showCodexWorkspace(page: Page, theme: ThemeName): Promise<void> {
   const row = page.locator(".workspace-list-sidebar .ws-row", { hasText: "Add widget caching layer" });
   await row.click();
   await expect(row).toHaveClass(/\bselected\b/);
@@ -158,7 +183,7 @@ async function showCodexWorkspace(page: Page): Promise<void> {
   await expect(codexTab).toBeVisible();
   await codexTab.click();
   await expect(codexTab).toHaveAttribute("aria-selected", "true");
-  await embedSyntheticCodexTranscript(workspace);
+  await embedSyntheticCodexTranscript(workspace, theme);
 
   const syntheticPath = "/worktrees/github/github.com/acme/widgets/pr-1";
   await page.locator(".meta-chip.mono.path").evaluate((element, replacement) => {
@@ -169,7 +194,7 @@ async function showCodexWorkspace(page: Page): Promise<void> {
   }, syntheticPath);
 }
 
-async function showActivityCodexWorkspace(page: Page): Promise<void> {
+async function showActivityCodexWorkspace(page: Page, theme: ThemeName): Promise<void> {
   const prRow = page
     .locator(".activity-row")
     .filter({ has: page.locator(".badge", { hasText: "PR" }) })
@@ -189,7 +214,7 @@ async function showActivityCodexWorkspace(page: Page): Promise<void> {
   await codexTab.click();
   await expect(codexTab).toHaveAttribute("aria-selected", "true");
   await expect(workspace.locator(".terminal-view")).toBeVisible();
-  await embedSyntheticCodexTranscript(workspace);
+  await embedSyntheticCodexTranscript(workspace, theme);
   await waitForIdleSync(page);
 }
 
@@ -676,7 +701,7 @@ async function captureCase(page: Page, baseURL: string, capture: CaptureCase): P
   if (capture.waitForSync) {
     await waitForIdleSync(page);
   }
-  await capture.afterReady?.(page);
+  await capture.afterReady?.(page, capture.theme);
   await expect
     .poll(() => page.evaluate(() => document.documentElement.classList.contains("dark")))
     .toBe(capture.theme === "dark");
@@ -697,6 +722,32 @@ async function captureCase(page: Page, baseURL: string, capture: CaptureCase): P
     expect(statusBox).not.toBeNull();
     expect(composerBox!.y + composerBox!.height).toBeLessThanOrEqual(terminalBox!.y + terminalBox!.height);
     expect(statusBox!.y + statusBox!.height).toBeLessThanOrEqual(terminalBox!.y + terminalBox!.height);
+
+    const [terminalLightness, composerLightness] = await terminal.evaluate((element) => {
+      const sample = (target: Element): number => {
+        const canvas = document.createElement("canvas");
+        canvas.width = 1;
+        canvas.height = 1;
+        const context = canvas.getContext("2d");
+        if (!context) throw new Error("2D canvas context is unavailable");
+        context.fillStyle = getComputedStyle(target).backgroundColor;
+        context.fillRect(0, 0, 1, 1);
+        return Array.from(context.getImageData(0, 0, 1, 1).data.slice(0, 3)).reduce(
+          (sum, channel) => sum + channel,
+          0,
+        );
+      };
+      const prompt = element.querySelector('[aria-label="Codex prompt composer"] > div');
+      if (!prompt) throw new Error("Codex prompt surface was not found");
+      return [sample(element), sample(prompt)];
+    });
+    if (capture.theme === "light") {
+      expect(terminalLightness).toBeGreaterThan(650);
+      expect(composerLightness).toBeGreaterThan(600);
+    } else {
+      expect(terminalLightness).toBeLessThan(100);
+      expect(composerLightness).toBeLessThan(250);
+    }
   }
 
   const svg = await nativeSVGSnapshot(page, {

--- a/docs/site/docs-site.spec.ts
+++ b/docs/site/docs-site.spec.ts
@@ -270,3 +270,82 @@ test("persists an explicit light override on a dark system", async ({ browser })
   await expect(page.locator("body")).toHaveAttribute("data-md-color-scheme", "default");
   await context.close();
 });
+
+test("[webkit] scales the complete generated workflow screenshot responsively", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "webkit-iphone");
+
+  await page.goto("/");
+  await page.setContent(`
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+      html, body { margin: 0; }
+      .frame { width: 360px; height: 230.625px; overflow: hidden; }
+      #responsive { display: block; width: 360px; height: auto; }
+      #scaled-natural { display: block; width: 1280px; height: 820px; transform: scale(0.28125); transform-origin: top left; }
+    </style>
+    <div class="frame"><img id="responsive" src="/assets/generated/maintainer-overview-light.svg" alt="Responsive rendering"></div>
+    <div style="height: 20px"></div>
+    <div class="frame"><img id="scaled-natural" src="/assets/generated/maintainer-overview-light.svg" alt="Scaled natural rendering"></div>
+  `);
+
+  const responsive = page.locator("#responsive");
+  const scaledNatural = page.locator("#scaled-natural");
+  await expect(responsive).toHaveJSProperty("complete", true);
+  await expect(responsive).toHaveJSProperty("naturalWidth", 1280);
+  await expect(responsive).toHaveJSProperty("naturalHeight", 820);
+  await expect(scaledNatural).toHaveJSProperty("complete", true);
+
+  const [responsiveBox, scaledNaturalBox, screenshot] = await Promise.all([
+    responsive.boundingBox(),
+    scaledNatural.boundingBox(),
+    page.screenshot(),
+  ]);
+  expect(responsiveBox).not.toBeNull();
+  expect(scaledNaturalBox).not.toBeNull();
+
+  const meanPixelDifference = await page.evaluate(
+    async ({ screenshotURL, responsiveRect, referenceRect }) => {
+      const image = new Image();
+      image.src = screenshotURL;
+      await image.decode();
+      const canvas = document.createElement("canvas");
+      canvas.width = image.naturalWidth;
+      canvas.height = image.naturalHeight;
+      const context = canvas.getContext("2d", { willReadFrequently: true });
+      if (!context) throw new Error("2D canvas context is unavailable");
+      context.drawImage(image, 0, 0);
+
+      const scale = window.devicePixelRatio;
+      let difference = 0;
+      let channels = 0;
+      for (let y = 0; y < responsiveRect.height; y += 2) {
+        for (let x = 0; x < responsiveRect.width; x += 2) {
+          const responsivePixel = context.getImageData(
+            Math.round((responsiveRect.x + x) * scale),
+            Math.round((responsiveRect.y + y) * scale),
+            1,
+            1,
+          ).data;
+          const referencePixel = context.getImageData(
+            Math.round((referenceRect.x + x) * scale),
+            Math.round((referenceRect.y + y) * scale),
+            1,
+            1,
+          ).data;
+          for (let channel = 0; channel < 3; channel++) {
+            difference += Math.abs(responsivePixel[channel] - referencePixel[channel]);
+            channels++;
+          }
+        }
+      }
+      return difference / channels;
+    },
+    {
+      screenshotURL: `data:image/png;base64,${screenshot.toString("base64")}`,
+      responsiveRect: responsiveBox!,
+      referenceRect: scaledNaturalBox!,
+    },
+  );
+
+  expect(meanPixelDifference).toBeLessThan(12);
+});

--- a/docs/site/playwright.config.ts
+++ b/docs/site/playwright.config.ts
@@ -18,9 +18,18 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
+      grepInvert: /\[webkit\]/,
       use: {
         ...devices["Desktop Chrome"],
         viewport: { width: 1280, height: 800 },
+      },
+    },
+    {
+      name: "webkit-iphone",
+      grep: /\[webkit\]/,
+      use: {
+        ...devices["iPhone 13"],
+        browserName: "webkit",
       },
     },
   ],

--- a/docs/superpowers/plans/2026-08-07-ios-compatible-docs-svg.md
+++ b/docs/superpowers/plans/2026-08-07-ios-compatible-docs-svg.md
@@ -1,0 +1,170 @@
+# iOS-Compatible Documentation SVG Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan directly in the current agent, task-by-task. Never use subagent-driven development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace WebKit-incompatible XHTML-in-SVG screenshots with crisp native SVG build artifacts.
+
+**Approved spec/design:** `docs/superpowers/specs/2026-08-07-ios-compatible-docs-svg-design.md`
+
+**Architecture:** Print each stabilized Chromium page to a one-page vector PDF, convert it with `pdftocairo`, and normalize the resulting SVG metadata and dimensions. Keep the public asset names and docs presentation unchanged.
+
+**Tech Stack:** Playwright/Chromium, Node.js, Poppler `pdftocairo`, Node test runner, Zensical
+
+## Global Constraints
+
+- Preserve `.svg` filenames, themes, captions, lightbox behavior, seeded data, and 1280 by 820 intrinsic dimensions.
+- Generated screenshot files remain untracked build artifacts.
+- Reject `<foreignObject>`, scripts, remote assets, private paths, and active animation in generated SVGs.
+- Poppler is build-only and failure is fatal with a clear diagnostic.
+- Amazon Linux 2 Poppler 0.26.5 is the converter compatibility floor.
+
+---
+
+### Task 1: Pin the native-SVG regression
+
+**Files:**
+
+- Modify: `docs/screenshots/docs-screenshots.spec.ts`
+
+**Interfaces:**
+
+- Consumes: the existing `captureCase` generated SVG string
+- Produces: an output-contract assertion that rejects XHTML-backed SVGs
+
+- [ ] **Step 1: Add the failing output assertion**
+
+Add `expect(svg).not.toMatch(/<foreignObject\\b/)` beside the existing
+generated-asset safety assertions.
+
+- [ ] **Step 2: Run one screenshot case and verify RED**
+
+Run:
+
+```bash
+mkdir -p tmp/docs-svg-red
+KENN_FORGE_DOCS_SCREENSHOT_DIR=tmp/docs-svg-red vp exec -- playwright test \
+  --config docs/screenshots/playwright.config.ts --project=chromium \
+  --grep "maintainer-overview light"
+```
+
+Expected: FAIL because the current output contains `<foreignObject>`.
+
+### Task 2: Export native SVG geometry
+
+**Files:**
+
+- Modify: `docs/screenshots/docs-screenshots.spec.ts`
+
+**Interfaces:**
+
+- Consumes: `Page` plus `{ title, description, width, height }`
+- Produces: `nativeSVGSnapshot(page, input): Promise<string>`
+
+- [ ] **Step 1: Replace `svgDOMSnapshot` with the native exporter**
+
+Use `page.emulateMedia({ media: "screen" })`, `page.pdf()` with zero margins,
+exact viewport dimensions, and printed backgrounds. Write the PDF to a unique
+temporary directory, invoke:
+
+```text
+pdftocairo -svg -f 1 -l 1 INPUT.pdf OUTPUT.svg
+```
+
+Read the SVG, set root `width="1280"` and `height="820"`, add escaped `<title>`
+and `<desc>` elements, then remove the temporary directory in `finally`.
+
+- [ ] **Step 2: Update output assertions for native geometry**
+
+Retain page-state assertions before export. Remove assertions that depend on
+the cloned XHTML source text or class names. Retain safety assertions for
+syncing state, external URLs, raster page captures, local paths, and add the
+`<foreignObject>` rejection.
+
+- [ ] **Step 3: Run the focused screenshot case and verify GREEN**
+
+Run the Task 1 command again.
+
+Expected: PASS and `tmp/docs-svg-red/maintainer-overview-light.svg` contains
+native SVG geometry with no `<foreignObject>`.
+
+### Task 3: Provision Poppler in build environments
+
+**Files:**
+
+- Modify: `scripts/vercel-install-docs.sh`
+- Modify: `.github/docker/playwright/Dockerfile`
+- Modify: `docs/README.md`
+
+**Interfaces:**
+
+- Consumes: the existing Vercel `dnf` and Playwright-image `apt-get` package installation steps
+- Produces: `pdftocairo` on every automated docs-build PATH
+
+- [ ] **Step 1: Add the build-only packages**
+
+Add `poppler-utils` to both existing system-package install commands. Document
+Poppler as a local prerequisite for `make docs-build`.
+
+- [ ] **Step 2: Exercise the real converter path**
+
+Run:
+
+```bash
+pdftocairo -v
+node --test scripts/build-docs.test.mjs scripts/docs-screenshots-command.test.mjs
+```
+
+Expected: converter reports its version and all script tests pass.
+
+- [ ] **Step 3: Verify the Amazon Linux 2 converter floor**
+
+Run the proof PDF through `poppler-utils-0.26.5-43.amzn2.1.7` in an official
+`amazonlinux:2` container and load the resulting SVG in an iPhone-sized WebKit
+context. Expected: intrinsic size 1280 by 820, zero `<foreignObject>` elements,
+and complete content scaled inside the responsive image box.
+
+### Task 4: Verify the complete docs build and WebKit rendering
+
+**Files:**
+
+- No additional source files
+
+**Interfaces:**
+
+- Consumes: all twelve generated assets and rendered `site/`
+- Produces: build and browser evidence for the user-visible fix
+
+- [ ] **Step 1: Run the complete docs build**
+
+Run:
+
+```bash
+make docs-build
+```
+
+Expected: twelve screenshot cases, Zensical build, and rendered-site suite pass.
+
+- [ ] **Step 2: Verify asset invariants**
+
+Run:
+
+```bash
+rg -L '<foreignObject' site/assets/generated/*.svg
+git diff --check
+```
+
+Expected: every generated asset is listed by `rg -L`; diff check passes.
+
+- [ ] **Step 3: Verify WebKit at phone size**
+
+Serve `site/`, load `/` through Playwright WebKit with an iPhone device profile,
+and assert the visible workflow image has natural dimensions 1280 by 820 and
+its complete vector content scales into the responsive image box. Capture a
+local screenshot for visual inspection.
+
+- [ ] **Step 4: Run final repository checks**
+
+Run the repository's non-mutating lint command covering the changed TypeScript,
+JavaScript, shell, Markdown, and Docker files, followed by `git status --short`.
+
+Expected: all checks pass and only intended files are modified.

--- a/docs/superpowers/plans/2026-08-07-light-docs-terminal.md
+++ b/docs/superpowers/plans/2026-08-07-light-docs-terminal.md
@@ -1,0 +1,172 @@
+# Light Documentation Terminal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan directly in the current agent, task-by-task. Never use subagent-driven development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the synthetic Codex terminal match light documentation captures while preserving the current dark capture.
+
+**Approved spec/design:** `docs/superpowers/specs/2026-08-07-light-docs-terminal-design.md`
+
+**Architecture:** Pass the capture's existing `ThemeName` explicitly through the `afterReady` callback to the synthetic transcript renderer. Select one complete docs-only palette before injecting the overlay; do not change app tokens, xterm, or runtime terminal state.
+
+**Tech Stack:** TypeScript, Playwright, Chromium PDF capture, Poppler SVG conversion
+
+## Global Constraints
+
+- The change is limited to the synthetic Codex overlay in documentation captures.
+- Light captures use the approved restrained blue-gray palette.
+- Dark captures preserve the existing overlay colors.
+- Transcript content, typography, spacing, dimensions, asset names, and live xterm behavior do not change.
+- Kata issue `p4dy` owns first-class light theming for the live terminal.
+
+---
+
+### Task 1: Theme the synthetic Codex overlay
+
+**Files:**
+
+- Modify: `docs/screenshots/docs-screenshots.spec.ts`
+- Modify: `docs/screenshots/README.md`
+
+**Interfaces:**
+
+- Consumes: `CaptureCase.theme: ThemeName`
+- Produces: `embedSyntheticCodexTranscript(workspace: Locator, theme: ThemeName): Promise<void>`
+- Produces: `afterReady(page: Page, theme: ThemeName): Promise<void>`
+
+- [ ] **Step 1: Add the failing capture assertion**
+
+After the synthetic overlay is installed for `workspace-codex-session` and
+`maintainer-overview`, sample the computed overlay and composer background
+colors through a one-pixel canvas. Assert that both surfaces are light for a
+light capture and dark for a dark capture:
+
+```ts
+const [terminalLightness, composerLightness] = await terminal.evaluate((element) => {
+  const sample = (target: Element): number => {
+    const canvas = document.createElement("canvas");
+    canvas.width = 1;
+    canvas.height = 1;
+    const context = canvas.getContext("2d");
+    if (!context) throw new Error("2D canvas context is unavailable");
+    context.fillStyle = getComputedStyle(target).backgroundColor;
+    context.fillRect(0, 0, 1, 1);
+    return Array.from(context.getImageData(0, 0, 1, 1).data.slice(0, 3)).reduce((sum, channel) => sum + channel, 0);
+  };
+  const prompt = element.querySelector('[aria-label="Codex prompt composer"] > div');
+  if (!prompt) throw new Error("Codex prompt surface was not found");
+  return [sample(element), sample(prompt)];
+});
+if (capture.theme === "light") {
+  expect(terminalLightness).toBeGreaterThan(650);
+  expect(composerLightness).toBeGreaterThan(600);
+} else {
+  expect(terminalLightness).toBeLessThan(100);
+  expect(composerLightness).toBeLessThan(250);
+}
+```
+
+- [ ] **Step 2: Run a light Codex capture and verify RED**
+
+Run:
+
+```bash
+KENN_FORGE_DOCS_SCREENSHOT_DIR=/tmp/kenn-forge-light-terminal-red \
+  node node_modules/vite-plus/bin/vp exec -- playwright test \
+  --config docs/screenshots/playwright.config.ts --project=chromium \
+  --grep "maintainer-overview light"
+```
+
+Expected: FAIL because the overlay and composer still use the dark palette.
+
+- [ ] **Step 3: Pass the capture theme into the renderer**
+
+Change the callback and renderer signatures:
+
+```ts
+afterReady?: (page: Page, theme: ThemeName) => Promise<void>;
+async function embedSyntheticCodexTranscript(workspace: Locator, theme: ThemeName): Promise<void>;
+async function showCodexWorkspace(page: Page, theme: ThemeName): Promise<void>;
+async function showActivityCodexWorkspace(page: Page, theme: ThemeName): Promise<void>;
+```
+
+Invoke the callback with the existing capture theme:
+
+```ts
+await capture.afterReady?.(page, capture.theme);
+```
+
+- [ ] **Step 4: Select a complete palette before injection**
+
+Add a serializable palette object outside the browser callback. Preserve every
+existing dark value and use the approved light roles:
+
+```ts
+const syntheticCodexPalettes = {
+  light: {
+    background: "oklch(97.5% 0.008 250)",
+    foreground: "oklch(30% 0.025 255)",
+    promptBackground: "oklch(93.5% 0.012 250)",
+    promptBorder: "oklch(83% 0.02 250)",
+    promptMarker: "oklch(27% 0.025 255)",
+    promptText: "oklch(52% 0.025 250)",
+    model: "oklch(47% 0.105 80)",
+    separator: "oklch(63% 0.02 250)",
+    workingDirectory: "oklch(48% 0.085 150)",
+  },
+  dark: {
+    background: "#0d1117",
+    foreground: "#c9d1d9",
+    promptBackground: "#343941",
+    promptBorder: "#444b55",
+    promptMarker: "#f0f3f6",
+    promptText: "#9da4ad",
+    model: "#f6e2b7",
+    separator: "#6e7681",
+    workingDirectory: "#abdfa7",
+  },
+} as const;
+```
+
+Pass `{ transcript, palette: syntheticCodexPalettes[theme] }` to
+`terminal.evaluate` and replace only the hard-coded color declarations with
+palette fields.
+
+- [ ] **Step 5: Update the screenshot guide**
+
+State that the synthetic Codex overlay follows the capture theme, while live
+terminal theming remains outside the documentation generator.
+
+- [ ] **Step 6: Run focused light and dark captures and verify GREEN**
+
+Run:
+
+```bash
+KENN_FORGE_DOCS_SCREENSHOT_DIR=/tmp/kenn-forge-light-terminal-green \
+  node node_modules/vite-plus/bin/vp exec -- playwright test \
+  --config docs/screenshots/playwright.config.ts --project=chromium \
+  --grep "maintainer-overview (light|dark)"
+```
+
+Expected: two passing captures; the light output uses the light palette and the
+dark output retains the existing dark palette.
+
+- [ ] **Step 7: Run the complete affected verification**
+
+Run:
+
+```bash
+make docs-build
+node --test scripts/build-docs.test.mjs scripts/docs-screenshots-command.test.mjs
+make lint-check
+git diff --check
+```
+
+Expected: all documentation captures and rendered-site tests pass, including
+the iPhone-sized WebKit paint comparison; script tests, lint, and diff checks
+also pass.
+
+- [ ] **Step 8: Commit**
+
+Run the repository `context-sync --commit` and mandatory commit workflows,
+then commit only the overlay, test, and screenshot-guide changes with a
+rationale-focused conventional commit message.

--- a/docs/superpowers/specs/2026-08-07-ios-compatible-docs-svg-design.md
+++ b/docs/superpowers/specs/2026-08-07-ios-compatible-docs-svg-design.md
@@ -1,0 +1,44 @@
+# iOS-Compatible Documentation SVG Design
+
+## Problem
+
+The generated workflow screenshots are SVG files whose only visual content is
+an XHTML document inside `<foreignObject>`. Chromium scales that content when
+the SVG is used through `<img>`, but WebKit paints the XHTML at its original
+1280-pixel width and clips it into the responsive image box. The result is a
+magnified left edge on iOS and Safari.
+
+## Decision
+
+Keep the generated assets as SVG, but export the browser's completed paint as
+native SVG geometry. Chromium will print each stabilized 1280 by 820 page to a
+single-page vector PDF. Poppler's `pdftocairo` will convert that page to SVG
+paths, masks, clips, gradients, and embedded icon images. The generator will
+then normalize the root dimensions to 1280 by 820 and add the existing title
+and description metadata.
+
+Poppler is a build-only dependency. Install `poppler-utils` beside the existing
+Playwright runtime packages in Vercel and the repository Playwright image.
+Local documentation contributors install Poppler through their platform
+package manager. The exporter must remain compatible with Amazon Linux 2's
+Poppler 0.26.5 (`poppler-utils-0.26.5-43.amzn2.1.7`); that version produces a
+1280 by 820 native SVG that scales correctly in WebKit.
+
+## Constraints
+
+- Preserve the current `.svg` filenames, light/dark selection, captions,
+  lightbox behavior, seeded data, and 1280 by 820 intrinsic dimensions.
+- Generated screenshot files remain build artifacts and must not be tracked.
+- Generated SVGs must contain no `<foreignObject>`, scripts, remote asset URLs,
+  private filesystem paths, or active animation.
+- Do not add a raster fallback or browser-specific serving branch.
+- A missing or failed converter must stop the docs build with a clear error.
+
+## Verification
+
+The screenshot suite first gains an assertion that rejects `<foreignObject>`;
+it must fail against the existing serializer. After implementation, generate
+all twelve assets, build the rendered site, and run the complete rendered-site
+suite. Inspect the light and dark overview assets. Finally, load the rendered
+site with an iPhone-sized WebKit context and verify the full 1280 by 820 asset
+fits its responsive image bounds without the magnified-left-edge failure.

--- a/docs/superpowers/specs/2026-08-07-light-docs-terminal-design.md
+++ b/docs/superpowers/specs/2026-08-07-light-docs-terminal-design.md
@@ -1,0 +1,37 @@
+# Light Documentation Terminal Design
+
+## Problem
+
+The synthetic Codex transcript used in workflow screenshots always paints a
+dark terminal. In a light capture, that large dark rectangle breaks the page's
+visual continuity and makes the terminal look pasted in from another theme.
+The live xterm terminal also stays dark today, but changing that product
+behavior is separate work tracked by Kata issue `p4dy`.
+
+## Decision
+
+Make only the documentation overlay theme-aware. Light captures use the
+approved restrained blue-gray palette: a tinted near-white terminal surface,
+dark text, a muted composer surface, and accessible amber and green status
+accents. Dark captures retain their current palette without visual changes.
+
+The capture theme is passed explicitly to the synthetic transcript renderer.
+The renderer selects one complete palette before creating the overlay; it does
+not infer colors from screenshot names or change the real terminal component.
+All transcript content, typography, spacing, dimensions, and generated asset
+names remain unchanged.
+
+## Scope
+
+- Change the synthetic Codex overlay used by `workspace-codex-session` and
+  `maintainer-overview` documentation captures.
+- Preserve the existing dark overlay exactly.
+- Do not change xterm, terminal settings, app theme tokens, or runtime sessions.
+- Do not add a user preference or a second documentation asset format.
+
+## Verification
+
+Add a capture regression that fails while a light capture still uses the dark
+overlay and confirms the dark capture retains its current surface. Run the
+complete documentation build so both Codex screenshots pass the native-SVG
+safety checks and the rendered-site WebKit comparison.

--- a/scripts/build-docs.mjs
+++ b/scripts/build-docs.mjs
@@ -103,7 +103,6 @@ export async function buildDocs() {
         "test",
         "--config",
         path.join(repoRoot, "docs", "site", "playwright.config.ts"),
-        "--project=chromium",
         "--output",
         path.join(stagingRoot, "site-test-results"),
       ],

--- a/scripts/build-docs.mjs
+++ b/scripts/build-docs.mjs
@@ -56,6 +56,11 @@ function run(command, args, options = {}) {
   });
 }
 
+export function docsSiteProjectArgs(env = process.env) {
+  const project = env.KENN_FORGE_DOCS_SITE_PROJECT;
+  return project && project !== "all" ? [`--project=${project}`] : [];
+}
+
 export async function buildDocs() {
   const sourceDir = path.join(repoRoot, "docs");
   const siteDir = path.join(repoRoot, "site");
@@ -103,6 +108,7 @@ export async function buildDocs() {
         "test",
         "--config",
         path.join(repoRoot, "docs", "site", "playwright.config.ts"),
+        ...docsSiteProjectArgs(),
         "--output",
         path.join(stagingRoot, "site-test-results"),
       ],

--- a/scripts/build-docs.test.mjs
+++ b/scripts/build-docs.test.mjs
@@ -4,7 +4,16 @@ import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 
-import { stageDocsSource } from "./build-docs.mjs";
+import * as docsBuild from "./build-docs.mjs";
+
+const { stageDocsSource } = docsBuild;
+
+test("docs site browser projects can be restricted by the deployment environment", () => {
+  const projectArgs = docsBuild.docsSiteProjectArgs?.({ KENN_FORGE_DOCS_SITE_PROJECT: "chromium" }) ?? [];
+
+  assert.deepEqual(projectArgs, ["--project=chromium"]);
+  assert.deepEqual(docsBuild.docsSiteProjectArgs?.({ KENN_FORGE_DOCS_SITE_PROJECT: "all" }), []);
+});
 
 test("docs staging includes only public site inputs", async (t) => {
   const root = await mkdtemp(path.join(os.tmpdir(), "kenn-forge-docs-build-test-"));

--- a/scripts/vercel-build-docs.sh
+++ b/scripts/vercel-build-docs.sh
@@ -16,5 +16,6 @@ mkdir -p .vercel/bin
 GOFLAGS="${GOFLAGS:+$GOFLAGS }-buildvcs=false" \
   go build -o .vercel/bin/e2e-server ./cmd/e2e-server
 
-PLAYWRIGHT_E2E_SERVER_BINARY="$repo_root/.vercel/bin/e2e-server" \
+KENN_FORGE_DOCS_SITE_PROJECT="${KENN_FORGE_DOCS_SITE_PROJECT:-chromium}" \
+  PLAYWRIGHT_E2E_SERVER_BINARY="$repo_root/.vercel/bin/e2e-server" \
   node scripts/build-docs.mjs

--- a/scripts/vercel-install-docs.sh
+++ b/scripts/vercel-install-docs.sh
@@ -30,9 +30,9 @@ esac
 
 install_system_packages() {
   if [ "$(id -u)" -eq 0 ]; then
-    dnf install -y tmux nspr nss
+    dnf install -y tmux nspr nss poppler-utils
   else
-    sudo dnf install -y tmux nspr nss
+    sudo dnf install -y tmux nspr nss poppler-utils
   fi
 }
 


### PR DESCRIPTION
Safari and iOS clip workflow screenshots whose SVG content is an XHTML `foreignObject`. Readers see a magnified fragment instead of the complete maintainer workflow, even though the same asset looks correct in Chromium.

This keeps the public assets as crisp SVGs but exports the stabilized browser paint as native vector geometry. The existing filenames, light and dark variants, captions, and lightbox behavior stay unchanged. The light Codex documentation overlay now also matches the surrounding light capture instead of appearing as a pasted-in dark panel.

The build validates sensitive and transient page text before it becomes outlined glyphs. It also compares responsive WebKit paint with a natural-size reference, so the original clipping behavior cannot pass through markup checks alone. Amazon Linux 2 Poppler 0.26.5 remains the production compatibility floor.

<details>
<summary>Validation</summary>

- All 14 screenshot-generation tests pass.
- All 12 rendered-site tests pass, including iPhone-sized WebKit rendering.
- Amazon Linux 2 `poppler-utils-0.26.5-43.amzn2.1.7` produces native SVG geometry with no `foreignObject`.
- Documentation script tests, lint, commit hooks, push hooks, and public-safety scans pass.

</details>

<sup>generated by a clanker</sup>