### PR TITLE
fix: enable touch input in workspace terminals

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -279,6 +279,9 @@ Keyboard handlers must have one clear owner for each key press.
   `shouldReclaimFocus`)
   (`frontend/src/lib/components/terminal/terminal-focus.ts`,
   `frontend/src/lib/components/terminal/XtermTerminalPane.svelte::start`).
+- Active terminals must synchronously focus xterm on primary touch or pen
+  pointerdown; xterm's built-in focus path is mouse-only, so a delayed handoff
+  leaves the software keyboard closed (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::handleTerminalPointerDown`).
 - A maximized inline workspace reuses the live hosted shell and fills the pane
   edge-to-edge; never add outer chrome or mutate the shell's workflow/terminal
   layout state (`frontend/src/lib/components/terminal/WorkspaceHost.browser.svelte.ts`).

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -847,6 +847,27 @@ describe("TerminalPane", () => {
     expect(xtermInstances[0]!.focus).not.toHaveBeenCalled();
   });
 
+  it("focuses the terminal input when its active surface is touched", async () => {
+    render(TerminalPane, {
+      props: { workspaceId: "ws-123", active: true, autoFocus: false },
+    });
+
+    await waitFor(() => expect(xtermInstances.length).toBe(1));
+    const terminal = xtermInstances[0]!;
+    const container = document.querySelector<HTMLElement>(".terminal-container");
+    expect(container).not.toBeNull();
+
+    container!.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        button: 0,
+        pointerType: "touch",
+      }),
+    );
+
+    expect(terminal.focus).toHaveBeenCalledOnce();
+  });
+
   it("repaints after container resize without rebuilding the WebGL atlas", async () => {
     render(TerminalPane, { props: { workspaceId: "ws-123" } });
 

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -193,7 +193,14 @@
   };
 
   function handleTerminalPointerDown(event: PointerEvent): void {
-    if (disposed || disabled || event.button !== 0 || !event.isTrusted) return;
+    if (disposed || disabled || event.button !== 0) return;
+    // xterm focuses its hidden textarea from mousedown, but its touch gesture
+    // path only handles scrolling. Focus synchronously while the touch/pen
+    // activation is live so mobile browsers can open their software keyboard.
+    if (active && (event.pointerType === "touch" || event.pointerType === "pen")) {
+      terminal?.focus();
+    }
+    if (!event.isTrusted) return;
     if (activePointerId !== null) {
       cancelTerminalPointerGesture();
     }

--- a/frontend/tests/e2e-full/00-workspace-launcher.spec.ts
+++ b/frontend/tests/e2e-full/00-workspace-launcher.spec.ts
@@ -13,6 +13,7 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
 import {
+  devices,
   expect,
   request as playwrightRequest,
   test,
@@ -146,6 +147,54 @@ test.describe("embedded workspace launcher", () => {
       await api?.dispose();
       await isolatedServer?.stop();
     }
+  });
+
+  test.describe("touch terminal input", () => {
+    const iPhone13 = devices["iPhone 13"];
+    test.use({
+      viewport: iPhone13.viewport,
+      deviceScaleFactor: iPhone13.deviceScaleFactor,
+      userAgent: iPhone13.userAgent,
+      hasTouch: iPhone13.hasTouch,
+    });
+
+    test("focuses a workspace session when its terminal surface is tapped", async ({ page }) => {
+      test.skip(
+        !hasCommand("git") || !hasCommand("tmux", ["-V"]),
+        "git and tmux are required for the real workspace flow",
+      );
+
+      let isolatedServer: IsolatedE2EServer | null = null;
+      let api: APIRequestContext | null = null;
+      try {
+        isolatedServer = await startIsolatedWorkspaceE2EServer();
+        api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
+        const workspace = await createIssueWorkspace(api, 10);
+
+        await page.goto(`${isolatedServer.info.base_url}/terminal/${workspace.id}`);
+        await page.getByRole("region", { name: "Worktree Home" }).getByRole("button", { name: "Shell" }).click();
+
+        const terminal = page.locator(".workspace-tab-slot .terminal-container");
+        await expect(terminal).toBeVisible();
+        await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+        await expect
+          .poll(() => page.evaluate(() => document.activeElement?.classList.contains("xterm-helper-textarea")))
+          .toBe(false);
+
+        await terminal.tap({ position: { x: 10, y: 10 } });
+
+        await expect
+          .poll(() => page.evaluate(() => document.activeElement?.classList.contains("xterm-helper-textarea")))
+          .toBe(true);
+        const markerPath = path.join(workspace.worktree_path, "touch-input-marker");
+        await page.keyboard.type(`touch '${markerPath}'`);
+        await page.keyboard.press("Enter");
+        await expect.poll(() => existsSync(markerPath), { timeout: 15_000 }).toBe(true);
+      } finally {
+        await api?.dispose();
+        await isolatedServer?.stop();
+      }
+    });
   });
 
   test("the palette opens the launcher over a pane the user had put away", async ({ page }) => {


### PR DESCRIPTION
Workspace terminals and promoted agent sessions could not accept input on touch-only devices. xterm focuses its hidden input through a mouse-only path, so tapping the terminal did not summon the software keyboard.

Active terminals now focus that input synchronously during primary touch or pen activation. Mouse selection and clipboard gesture behavior remain unchanged.

<details>
<summary>Validation</summary>

- Full frontend unit suite: 3,510 passed, 2 skipped.
- Full workspace-launcher Playwright spec: 8 passed across Chromium and Firefox.
- iOS Simulator: typed a command through Safari, xterm, WebSocket, tmux, and the shell after tapping to restore focus.
- Android device: manually validated by the maintainer.
- Non-mutating lint check: 0 issues.

</details>