### PR TITLE
feat: hide repositories from the UI via a per-repo gear menu

### DIFF
--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -68,7 +68,11 @@ combining repository-owned history
   preference on every configuration-change path — startup, TOML hot reload,
   and the DELETE handler (detached from request cancellation): globs can keep
   the repository tracked but expose no visibility controls
-  (`internal/server/settings_handlers.go::reconcileOrphanedRepoVisibility`). Filtering is
+  (`internal/server/settings_handlers.go::reconcileOrphanedRepoVisibility`).
+  Visibility mutations serialize with that sweep on a shared lock and
+  revalidate exact-entry membership inside it, so a mutation racing an
+  exact-entry removal cannot recreate an orphaned preference
+  (`internal/server/settings_handlers.go::updateConfiguredRepoUIVisibilityState`). Filtering is
   server-owned and scoped to interactive repository catalogs; item feeds, direct
   routes, and the settings surface stay unfiltered
   (`internal/server/helpers.go::filterHiddenRepos`).

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -54,6 +54,24 @@ combining repository-owned history
 - Assigning a historically occupied route to another verified repository clears
   route-scoped state even without an active occupant; migration 47 applies the same
   cleanup to preexisting reuse, while legacy adoption remains in-place (`internal/db/repository_catalog.go::ReconcileRepositoryObservation`, `internal/db/migrations/000047_repository_route_generation.up.sql:1`).
+- Hidden-from-UI is an operator preference keyed by the stable internal catalog
+  row, never by mutable config routes — renames keep it, route reuse must not
+  inherit it, and only exact configured repositories can be hidden. Correlating
+  hidden rows with configured entries and resolving visibility mutations must
+  also use the stable provider id, not route keys: a displaced row keeps its
+  old display route. Mutations resolve, validate lifecycle, and write in one
+  critical section under the repository-reconciliation read lock, rejecting
+  non-active rows — a tracked snapshot lagging reconciliation still names the
+  displaced repository
+  (`internal/server/settings_handlers.go::applyVisibilityUnderReconciliationRead`).
+  Removing the last exact entry for a repository releases its hidden
+  preference on every configuration-change path — startup, TOML hot reload,
+  and the DELETE handler (detached from request cancellation): globs can keep
+  the repository tracked but expose no visibility controls
+  (`internal/server/settings_handlers.go::reconcileOrphanedRepoVisibility`). Filtering is
+  server-owned and scoped to interactive repository catalogs; item feeds, direct
+  routes, and the settings surface stay unfiltered
+  (`internal/server/helpers.go::filterHiddenRepos`).
 
 GitLab nested namespaces make `repo_path` mandatory for reliable addressing:
 `group/subgroup/project` has owner `group/subgroup` and name `project`.

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -23,3 +23,7 @@ fixtures, or changing shell-script coverage.
 - Use provider live or container fixtures only when fake transports cannot
   catch endpoint or authentication drift. GitHub GraphQL validation is gated by
   `KENN_FORGE_LIVE_GITHUB_TESTS=1`.
+- Fixtures asserted through windowed endpoints (activity's default 7d range)
+  must seed now-relative instants, not absolute calendar dates — pinned dates
+  age out and the test starts failing on a later calendar day
+  (`internal/server/e2etest/notifications_test.go::TestNotificationSyncReconcilesReusedRouteE2E`).

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -658,6 +658,19 @@ Rows that contain buttons, links, or toggles need clear event ownership.
   Background freshness work is not a navigation transaction and must not block
   link selection or Forge-owned actions
   (`frontend/src/lib/components/kata/KataLinksPanel.svelte`).
+- An explicitly seeded target (for example the repository a workspace dialog
+  was opened for) must never silently fall back to a last-used or first option
+  when the seed cannot be resolved — leave the selection empty and require a
+  choice (`frontend/src/lib/components/terminal/NewWorkspaceDialog.svelte`).
+- Repository selectors consume server-filtered catalogs; configured-entry
+  consumers gate on the server's `hidden_from_ui` flag and must not reimplement
+  visibility matching client-side. Selection normalization must drop hidden
+  selections explicitly — general normalization preserves unknown values for
+  glob-resolved repositories, so a hidden repo would otherwise keep filtering —
+  and must clear against both the configured path and the server-provided
+  `tracked_repo_path`, because selections created from catalog rows use the
+  current route, which diverges after a provider-side rename
+  (`frontend/src/lib/utils/repo-filter-values.ts::normalizeInteractiveRepoFilterSelection`).
 - Roborev has no event replay cursor: reconnect after authoritative job-list reconciliation; a lost
   mutation response retains and fences its original target until authoritative observation, never
   replays the write. A confirmed POST stays acknowledged when its follow-up refresh fails; report

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -671,6 +671,10 @@ Rows that contain buttons, links, or toggles need clear event ownership.
   `tracked_repo_path`, because selections created from catalog rows use the
   current route, which diverges after a provider-side rename
   (`frontend/src/lib/utils/repo-filter-values.ts::normalizeInteractiveRepoFilterSelection`).
+  A host-pinned scope (`ui.hideRepoSelector`) is exempt: with no picker to
+  rescope, dropping it would unscope every request, so pinned selections pass
+  through normalization untouched
+  (`frontend/src/lib/utils/repo-filter-values.ts::normalizeGlobalRepoSelection`).
 - Roborev has no event replay cursor: reconnect after authoritative job-list reconciliation; a lost
   mutation response retains and fences its original target until authoritative observation, never
   replays the write. A confirmed POST stays acknowledged when its follow-up refresh fails; report

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,11 @@ repo_path = "group/subgroup/project"
 Repository identity includes `platform`, `platform_host`, `owner`, and `name`.
 Keep `repo_path` when the provider uses nested namespaces or canonical casing.
 
+To hide a repository from lists and pickers without removing it, open the gear
+menu on its Settings row and choose "Hide from UI". Syncing continues and
+direct links keep working; choose "Show in UI" to bring it back. Hiding
+applies to exact repositories, not glob patterns.
+
 ## Credentials
 
 Credentials are scoped by provider and host:

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -1074,6 +1074,8 @@ components:
     ConfiguredRepoStatus:
       additionalProperties: false
       properties:
+        hidden_from_ui:
+          type: boolean
         is_glob:
           type: boolean
         matched_repo_count:
@@ -1089,6 +1091,8 @@ components:
           type: string
         repo_path:
           type: string
+        tracked_repo_path:
+          type: string
         worktree_base_path:
           type: string
       required:
@@ -1099,6 +1103,7 @@ components:
         - repo_path
         - is_glob
         - matched_repo_count
+        - hidden_from_ui
       type: object
     CreateAdHocWorkspaceHostInputBody:
       additionalProperties: false
@@ -6301,6 +6306,21 @@ components:
         - active_authors
         - recent_issues
         - operations
+      type: object
+    RepoUIVisibilityRequest:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/RepoUIVisibilityRequest.json
+          format: uri
+          readOnly: true
+          type: string
+        hidden:
+          type: boolean
+      required:
+        - hidden
       type: object
     RepoWorktreeBaseRequest:
       additionalProperties: false
@@ -13842,6 +13862,52 @@ paths:
       summary: Resolve repository item
       tags:
         - Repositories
+  /host/{platform_host}/repo/{provider}/{owner}/{name}/ui-visibility:
+    put:
+      operationId: update-repo-ui-visibility-on-host
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: platform_host
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RepoUIVisibilityRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SettingsResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Update repository UI visibility
+      tags:
+        - Settings
   /host/{platform_host}/repo/{provider}/{owner}/{name}/workspaces:
     post:
       operationId: create-repo-workspace-on-host
@@ -18398,6 +18464,47 @@ paths:
       summary: Resolve repository item
       tags:
         - Repositories
+  /repo/{provider}/{owner}/{name}/ui-visibility:
+    put:
+      operationId: update-repo-ui-visibility
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RepoUIVisibilityRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SettingsResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Update repository UI visibility
+      tags:
+        - Settings
   /repo/{provider}/{owner}/{name}/workspaces:
     post:
       operationId: create-repo-workspace

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -12,7 +12,7 @@
   import MobileActivityView from "./lib/views/MobileActivityView.svelte";
   import ReviewsView from "./lib/views/ReviewsView.svelte";
   import FocusListView from "./lib/views/FocusListView.svelte";
-  import { normalizeRepoFilterSelection } from "./lib/utils/repo-filter-values.js";
+  import { normalizeInteractiveRepoFilterSelection } from "./lib/utils/repo-filter-values.js";
   import type { ActionRegistry, NavigateCallback, StoreInstances } from "./lib/types.js";
   import type { ActivityItem, ModeVisibility } from "./lib/api/types.js";
   import {
@@ -647,15 +647,7 @@
   }
 
   function getNormalizedGlobalRepo(repo: string | undefined = getGlobalRepo()): string | undefined {
-    return normalizeRepoFilterSelection(
-      repo,
-      (stores?.settings.getConfiguredRepos?.() ?? []).map((configuredRepo) => ({
-        provider: configuredRepo.provider,
-        platformHost: configuredRepo.platform_host,
-        repoPath: configuredRepo.repo_path,
-        isGlob: configuredRepo.is_glob,
-      })),
-    );
+    return normalizeInteractiveRepoFilterSelection(repo, stores?.settings.getConfiguredRepos?.() ?? []);
   }
 
   onDestroy(() => {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -12,7 +12,7 @@
   import MobileActivityView from "./lib/views/MobileActivityView.svelte";
   import ReviewsView from "./lib/views/ReviewsView.svelte";
   import FocusListView from "./lib/views/FocusListView.svelte";
-  import { normalizeInteractiveRepoFilterSelection } from "./lib/utils/repo-filter-values.js";
+  import { normalizeGlobalRepoSelection } from "./lib/utils/repo-filter-values.js";
   import type { ActionRegistry, NavigateCallback, StoreInstances } from "./lib/types.js";
   import type { ActivityItem, ModeVisibility } from "./lib/api/types.js";
   import {
@@ -647,7 +647,11 @@
   }
 
   function getNormalizedGlobalRepo(repo: string | undefined = getGlobalRepo()): string | undefined {
-    return normalizeInteractiveRepoFilterSelection(repo, stores?.settings.getConfiguredRepos?.() ?? []);
+    return normalizeGlobalRepoSelection(
+      repo,
+      stores?.settings.getConfiguredRepos?.() ?? [],
+      getUIConfig().hideRepoSelector,
+    );
   }
 
   onDestroy(() => {

--- a/frontend/src/lib/api/generated/schema.ts
+++ b/frontend/src/lib/api/generated/schema.ts
@@ -2100,6 +2100,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/host/{platform_host}/repo/{provider}/{owner}/{name}/ui-visibility": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Update repository UI visibility */
+        put: operations["update-repo-ui-visibility-on-host"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/host/{platform_host}/repo/{provider}/{owner}/{name}/workspaces": {
         parameters: {
             query?: never;
@@ -3764,6 +3781,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/repo/{provider}/{owner}/{name}/ui-visibility": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Update repository UI visibility */
+        put: operations["update-repo-ui-visibility"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/repo/{provider}/{owner}/{name}/workspaces": {
         parameters: {
             query?: never;
@@ -4979,6 +5013,7 @@ export interface components {
             commits: components["schemas"]["CommitResponse"][] | null;
         };
         ConfiguredRepoStatus: {
+            hidden_from_ui: boolean;
             is_glob: boolean;
             /** Format: int64 */
             matched_repo_count: number;
@@ -4987,6 +5022,7 @@ export interface components {
             platform_host: string;
             provider: string;
             repo_path: string;
+            tracked_repo_path?: string;
             worktree_base_path?: string;
         };
         CreateAdHocWorkspaceHostInputBody: {
@@ -7341,6 +7377,15 @@ export interface components {
             releases: components["schemas"]["RepoSummaryReleaseResponse"][] | null;
             repo: components["schemas"]["RepoRefResponse"];
             timeline_updated_at?: string;
+        };
+        RepoUIVisibilityRequest: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/RepoUIVisibilityRequest.json
+             */
+            readonly $schema?: string;
+            hidden: boolean;
         };
         RepoWorktreeBaseRequest: {
             /**
@@ -12887,6 +12932,44 @@ export interface operations {
             };
         };
     };
+    "update-repo-ui-visibility-on-host": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                provider: string;
+                platform_host: string;
+                owner: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RepoUIVisibilityRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SettingsResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
     "create-repo-workspace-on-host": {
         parameters: {
             query?: never;
@@ -16715,6 +16798,43 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ResolveItemResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "update-repo-ui-visibility": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                provider: string;
+                owner: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RepoUIVisibilityRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SettingsResponse"];
                 };
             };
             /** @description Error */

--- a/frontend/src/lib/api/provider-routes.ts
+++ b/frontend/src/lib/api/provider-routes.ts
@@ -141,6 +141,7 @@ type RepoSuffix =
   | "/labels"
   | "/markdown-image"
   | "/refresh"
+  | "/ui-visibility"
   | "/worktree-base"
   | "/workspaces"
   | "/resolve/{number}";

--- a/frontend/src/lib/components/RepoTypeahead.svelte
+++ b/frontend/src/lib/components/RepoTypeahead.svelte
@@ -129,7 +129,7 @@
   }
 
   function optionFromConfigRepo(repo: ConfigRepo): RepoOption | null {
-    if (repo.is_glob) return null;
+    if (repo.is_glob || repo.hidden_from_ui) return null;
     const path = repo.repo_path || `${repo.owner}/${repo.name}`;
     if (!repo.platform_host || !path) return null;
     return {

--- a/frontend/src/lib/components/RepoTypeahead.test.ts
+++ b/frontend/src/lib/components/RepoTypeahead.test.ts
@@ -72,6 +72,44 @@ describe("RepoTypeahead", () => {
     });
   });
 
+  it("omits configured repos the server marked hidden from the UI", async () => {
+    render(RepoTypeahead, {
+      props: {
+        selected: undefined,
+        onchange: vi.fn(),
+      },
+    });
+
+    settingsStore.setConfiguredRepos([
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "api",
+        repo_path: "acme/api",
+        is_glob: false,
+        matched_repo_count: 1,
+        hidden_from_ui: false,
+      },
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "archive",
+        repo_path: "acme/archive",
+        is_glob: false,
+        matched_repo_count: 1,
+        hidden_from_ui: true,
+      },
+    ]);
+
+    await fireEvent.click(screen.getByRole("button", { name: /all repos/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: /acme\/api/i })).toBeTruthy();
+    });
+    expect(screen.queryByRole("option", { name: /acme\/archive/i })).toBeNull();
+  });
+
   it("aborts the repository request when the component unmounts", async () => {
     let signal: AbortSignal | undefined;
     getRepos.mockImplementation((_path, options) => {

--- a/frontend/src/lib/components/settings/RepoConfigMenu.svelte
+++ b/frontend/src/lib/components/settings/RepoConfigMenu.svelte
@@ -1,0 +1,156 @@
+<script lang="ts">
+  import { IconButton, autoReposition, dismissable, floatingPopoverStyle } from "@kenn-io/kit-ui";
+  import SettingsIcon from "@lucide/svelte/icons/settings";
+  import { tick } from "svelte";
+
+  interface Props {
+    repoLabel: string;
+    hidden: boolean;
+    embedded: boolean;
+    visibilityPending: boolean;
+    onEditLocalClone: () => void;
+    onToggleVisibility: () => void;
+  }
+
+  let { repoLabel, hidden, embedded, visibilityPending, onEditLocalClone, onToggleVisibility }: Props =
+    $props();
+
+  let open = $state(false);
+  let root = $state<HTMLDivElement>();
+  let panel = $state<HTMLUListElement>();
+  let panelStyle = $state("");
+
+  function trigger(): HTMLButtonElement | null {
+    return root?.querySelector<HTMLButtonElement>(".repo-config-trigger") ?? null;
+  }
+
+  function close(): void {
+    open = false;
+  }
+
+  async function toggle(): Promise<void> {
+    open = !open;
+    if (!open) return;
+    await tick();
+    position();
+    await tick();
+    position();
+    panel?.querySelector<HTMLButtonElement>('[role="menuitem"]:not(:disabled)')?.focus();
+  }
+
+  function position(): void {
+    const triggerElement = trigger();
+    if (!triggerElement || !panel) return;
+    panelStyle = floatingPopoverStyle({
+      trigger: triggerElement.getBoundingClientRect(),
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      popoverWidth: panel.offsetWidth,
+      popoverHeight: panel.offsetHeight,
+      align: "end",
+    });
+  }
+
+  function editLocalClone(): void {
+    close();
+    onEditLocalClone();
+  }
+
+  function toggleVisibility(): void {
+    close();
+    onToggleVisibility();
+  }
+
+  $effect(() => {
+    if (!open) return;
+    const cleanups = [
+      dismissable({
+        owners: () => [panel, trigger()],
+        dismiss: close,
+        escapeFocus: trigger,
+      }),
+      autoReposition(() => panel, position),
+    ];
+    return () => cleanups.forEach((cleanup) => cleanup());
+  });
+</script>
+
+<div class="repo-config-menu" bind:this={root}>
+  <IconButton
+    class="repo-config-trigger"
+    size="sm"
+    tone="info"
+    ariaLabel={`Configure ${repoLabel}`}
+    ariaHaspopup="menu"
+    ariaExpanded={open}
+    onclick={() => void toggle()}
+  ><SettingsIcon size={14} aria-hidden="true" /></IconButton>
+  {#if open}
+    <ul
+      bind:this={panel}
+      class="repo-config-popover kit-popover-card"
+      style={panelStyle}
+      role="menu"
+      aria-label={`Configure ${repoLabel}`}
+    >
+      <li>
+        <button type="button" role="menuitem" disabled={embedded} onclick={editLocalClone}>
+          Edit local clone path…
+        </button>
+      </li>
+      <li>
+        <button
+          type="button"
+          role="menuitem"
+          disabled={embedded || visibilityPending}
+          onclick={toggleVisibility}
+        >
+          {hidden ? "Show in UI" : "Hide from UI"}
+        </button>
+      </li>
+    </ul>
+  {/if}
+</div>
+
+<style>
+  .repo-config-menu {
+    position: relative;
+  }
+
+  .repo-config-popover {
+    position: fixed;
+    z-index: var(--z-popover);
+    min-width: 180px;
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 16px);
+    overflow-y: auto;
+    margin: 0;
+    padding: var(--space-2);
+    list-style: none;
+  }
+
+  .repo-config-popover button {
+    width: 100%;
+    padding: var(--space-3) var(--space-4);
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--text-secondary);
+    font: inherit;
+    font-size: var(--font-size-sm);
+    text-align: left;
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  .repo-config-popover button:hover:not(:disabled),
+  .repo-config-popover button:focus-visible {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
+  }
+
+  .repo-config-popover button:disabled {
+    color: var(--text-faint);
+    cursor: default;
+  }
+</style>

--- a/frontend/src/lib/components/settings/RepoSettings.svelte
+++ b/frontend/src/lib/components/settings/RepoSettings.svelte
@@ -7,9 +7,9 @@
   import { getAppRuntime } from "../../app/runtime-context.js";
   import { showFlash } from "../../stores/flash.svelte.js";
   import { SettingsWorkflow, settingsErrorMessage } from "../../stores/settings-workflow.js";
-  import SettingsIcon from "@lucide/svelte/icons/settings";
   import XIcon from "@lucide/svelte/icons/x";
   import ProviderIcon from "../provider/ProviderIcon.svelte";
+  import RepoConfigMenu from "./RepoConfigMenu.svelte";
   import RepoImportModal from "./RepoImportModal.svelte";
   import RepoPromoteModal from "./RepoPromoteModal.svelte";
 
@@ -36,6 +36,7 @@
   let worktreeBaseDrafts = $state<Record<string, string>>({});
   let savingWorktreeBaseByKey = $state<Record<string, boolean>>({});
   let cloneEditorOpen = $state<Record<string, boolean>>({});
+  let savingVisibilityByKey = $state<Record<string, boolean>>({});
   let promoteRepo = $state<ConfigRepo | null>(null);
 
   const showProviderIcons = $derived.by(() => {
@@ -198,6 +199,41 @@
     );
   }
 
+  function handleToggleVisibility(repo: ConfigRepo): void {
+    if (embedded || repo.is_glob) return;
+    const key = repoKey(repo);
+    const hidden = !repo.hidden_from_ui;
+    savingVisibilityByKey = { ...savingVisibilityByKey, [key]: true };
+    runtime.runCommand(
+      Effect.gen(function* () {
+        const workflow = yield* SettingsWorkflow;
+        return yield* workflow.updateRepoUIVisibility(
+          repo.owner,
+          repo.name,
+          { provider: repo.provider, host: repo.platform_host },
+          hidden,
+        );
+      }).pipe(
+        Effect.matchEffect({
+          onFailure: (failure) =>
+            Effect.sync(() => showFlash(settingsErrorMessage(failure), { tone: "danger" })),
+          onSuccess: (settings) =>
+            Effect.sync(() => {
+              onUpdate(settings.repos);
+            }),
+        }),
+        Effect.ensuring(Effect.sync(() => {
+          savingVisibilityByKey = { ...savingVisibilityByKey, [key]: false };
+        })),
+      ),
+      {
+        operation: "save repository UI visibility",
+        safeContext: { provider: repo.provider, host: repo.platform_host, repoPath: repoLabel(repo) },
+        onFailure: () => {},
+      },
+    );
+  }
+
   function handleInputKeydown(e: KeyboardEvent): void {
     if (e.key === "Enter") {
       e.preventDefault();
@@ -294,17 +330,16 @@
                 {refreshingByKey[key] ? "Refreshing..." : "Refresh"}
               </Button>
             {:else}
-              <IconButton
-                size="sm"
-                tone="info"
-                ariaLabel={`Local clone for ${repoDisplayLabel(repo)}`}
-                ariaExpanded={Boolean(cloneEditorOpen[key])}
-                ariaPressed={Boolean(repo.worktree_base_path) || Boolean(cloneEditorOpen[key])}
-                title={repo.worktree_base_path ? `Local clone: ${repo.worktree_base_path}` : "Set local clone"}
-                onclick={() => {
+              <RepoConfigMenu
+                repoLabel={repoDisplayLabel(repo)}
+                hidden={repo.hidden_from_ui}
+                {embedded}
+                visibilityPending={Boolean(savingVisibilityByKey[key])}
+                onEditLocalClone={() => {
                   cloneEditorOpen = { ...cloneEditorOpen, [key]: !cloneEditorOpen[key] };
                 }}
-              ><SettingsIcon size={14} aria-hidden="true" /></IconButton>
+                onToggleVisibility={() => handleToggleVisibility(repo)}
+              />
             {/if}
             <IconButton
               size="sm"

--- a/frontend/src/lib/components/settings/RepoSettings.test.ts
+++ b/frontend/src/lib/components/settings/RepoSettings.test.ts
@@ -11,6 +11,7 @@ const {
   mockPromoteRepo,
   mockRefreshRepo,
   mockRefreshSyncStatus,
+  mockUpdateRepoUIVisibility,
   mockUpdateRepoWorktreeBasePath,
 } = vi.hoisted(() => ({
   mockAddRepo: vi.fn(),
@@ -19,6 +20,7 @@ const {
   mockPromoteRepo: vi.fn(),
   mockRefreshRepo: vi.fn(),
   mockRefreshSyncStatus: vi.fn(),
+  mockUpdateRepoUIVisibility: vi.fn(),
   mockUpdateRepoWorktreeBasePath: vi.fn(),
 }));
 
@@ -54,6 +56,8 @@ vi.mock("../../stores/settings-workflow.js", async (importOriginal) => {
       refreshRepo: (owner, name, options) => runMock("refresh repository", () => mockRefreshRepo(owner, name, options)),
       updateRepoWorktreeBasePath: (owner, name, options, path) =>
         runMock("save repository clone path", () => mockUpdateRepoWorktreeBasePath(owner, name, options, path)),
+      updateRepoUIVisibility: (owner, name, options, hidden) =>
+        runMock("save repository visibility", () => mockUpdateRepoUIVisibility(owner, name, options, hidden)),
       previewRepos: (owner, pattern, options) =>
         runMock("preview repositories", () => mockPreviewRepos(owner, pattern, options)),
       bulkAddRepos: (repos) => runMock("add repositories", () => mockBulkAddRepos(repos)),
@@ -89,6 +93,7 @@ describe("RepoSettings", () => {
     mockRefreshSyncStatus.mockReset();
     mockAddRepo.mockReset();
     mockRefreshRepo.mockReset();
+    mockUpdateRepoUIVisibility.mockReset();
     mockUpdateRepoWorktreeBasePath.mockReset();
     mockPreviewRepos.mockReset();
     mockBulkAddRepos.mockReset();
@@ -356,7 +361,8 @@ describe("RepoSettings", () => {
     });
 
     expect(screen.queryByPlaceholderText("/path/to/existing/clone")).toBeNull();
-    await fireEvent.click(screen.getByRole("button", { name: "Local clone for acme/api" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Configure acme/api" }));
+    await fireEvent.click(screen.getByRole("menuitem", { name: "Edit local clone path…" }));
 
     await fireEvent.input(screen.getByPlaceholderText("/path/to/existing/clone"), {
       target: { value: "/Users/acme/api" },
@@ -373,6 +379,134 @@ describe("RepoSettings", () => {
       "/Users/acme/api",
     );
     await waitFor(() => expect(onUpdate).toHaveBeenCalledWith(updatedRepos));
+  });
+
+  it("offers no configure menu on glob rows because visibility and clones are exact-repo settings", () => {
+    renderRepoSettings({
+      repos: [
+        {
+          provider: "github",
+          platform_host: "github.com",
+          owner: "acme",
+          name: "*",
+          repo_path: "acme/*",
+          is_glob: true,
+          matched_repo_count: 3,
+          hidden_from_ui: false,
+        },
+      ],
+      onUpdate: vi.fn(),
+    });
+
+    expect(screen.queryByRole("button", { name: "Configure acme/* (3)" })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Configure / })).toBeNull();
+  });
+
+  it("hides a repository through the settings workflow", async () => {
+    const onUpdate = vi.fn();
+    const repo = {
+      provider: "github",
+      platform_host: "github.com",
+      owner: "acme",
+      name: "archive",
+      repo_path: "acme/archive",
+      is_glob: false,
+      matched_repo_count: 1,
+      hidden_from_ui: false,
+    };
+    const updatedRepos = [{ ...repo, hidden_from_ui: true }];
+    mockUpdateRepoUIVisibility.mockResolvedValue({ repos: updatedRepos });
+
+    renderRepoSettings({ repos: [repo], onUpdate });
+    await fireEvent.click(screen.getByRole("button", { name: "Configure acme/archive" }));
+    await fireEvent.click(screen.getByRole("menuitem", { name: "Hide from UI" }));
+
+    expect(mockUpdateRepoUIVisibility).toHaveBeenCalledWith(
+      "acme",
+      "archive",
+      { provider: "github", host: "github.com" },
+      true,
+    );
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledWith(updatedRepos));
+  });
+
+  it("preserves confirmed visibility after a failed update", async () => {
+    mockUpdateRepoUIVisibility.mockRejectedValue(new Error("could not save visibility"));
+    const onUpdate = vi.fn();
+    const repo = {
+      provider: "github",
+      platform_host: "github.com",
+      owner: "acme",
+      name: "archive",
+      repo_path: "acme/archive",
+      is_glob: false,
+      matched_repo_count: 1,
+      hidden_from_ui: true,
+    };
+
+    renderRepoSettings({ repos: [repo], onUpdate });
+    const gear = screen.getByRole("button", { name: "Configure acme/archive" });
+    await fireEvent.click(gear);
+    await fireEvent.click(screen.getByRole("menuitem", { name: "Show in UI" }));
+
+    await waitFor(() =>
+      expect(flash.getFlash()).toMatchObject({ message: "could not save visibility", tone: "danger" }),
+    );
+    expect(onUpdate).not.toHaveBeenCalled();
+    await fireEvent.click(gear);
+    expect(screen.getByRole("menuitem", { name: "Show in UI" })).toBeTruthy();
+  });
+
+  it("keeps the gear available while disabling a pending visibility action", async () => {
+    mockUpdateRepoUIVisibility.mockReturnValue(new Promise(() => {}));
+    const repo = {
+      provider: "github",
+      platform_host: "github.com",
+      owner: "acme",
+      name: "archive",
+      repo_path: "acme/archive",
+      is_glob: false,
+      matched_repo_count: 1,
+      hidden_from_ui: false,
+    };
+
+    renderRepoSettings({ repos: [repo], onUpdate: vi.fn() });
+    const gear = screen.getByRole("button", { name: "Configure acme/archive" });
+    await fireEvent.click(gear);
+    await fireEvent.click(screen.getByRole("menuitem", { name: "Hide from UI" }));
+
+    expect((gear as HTMLButtonElement).disabled).toBe(false);
+    await fireEvent.click(gear);
+    expect((screen.getByRole("menuitem", { name: "Hide from UI" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("keeps repository configuration inspectable but disabled when embedded", async () => {
+    window.__kenn_forge_config = { embed: {} };
+    window.__kenn_forge_notify_config_changed?.();
+    try {
+      const repo = {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "archive",
+        repo_path: "acme/archive",
+        is_glob: false,
+        matched_repo_count: 1,
+        hidden_from_ui: false,
+      };
+
+      renderRepoSettings({ repos: [repo], onUpdate: vi.fn() });
+      const gear = screen.getByRole("button", { name: "Configure acme/archive" });
+      expect((gear as HTMLButtonElement).disabled).toBe(false);
+      await fireEvent.click(gear);
+      expect((screen.getByRole("menuitem", { name: "Edit local clone path…" }) as HTMLButtonElement).disabled).toBe(
+        true,
+      );
+      expect((screen.getByRole("menuitem", { name: "Hide from UI" }) as HTMLButtonElement).disabled).toBe(true);
+    } finally {
+      delete window.__kenn_forge_config;
+      window.__kenn_forge_notify_config_changed?.();
+    }
   });
 
   it("promotes a glob match to an exact repository with a local clone path", async () => {

--- a/frontend/src/lib/components/terminal/NewWorkspaceDialog.svelte
+++ b/frontend/src/lib/components/terminal/NewWorkspaceDialog.svelte
@@ -195,13 +195,18 @@
             if (activeSession !== session) return;
             reposLoading = false;
             repos = (loaded ?? []).map(repoOption);
-            // Prefer the repo the caller pointed at, then the last one work was
-            // started in, then whatever is first in the list.
-            const candidates = [seededRepoKey, getLastUsedNewWorkspaceRepoKey()];
-            selectedKey =
-              candidates.find((key) => key && repos.some((repo) => repo.key === key)) ??
-              repos[0]?.key ??
-              "";
+            // An explicit seed is a promise about which repository the
+            // workspace targets. When it cannot be resolved (for example a
+            // repository hidden from the UI), require a choice instead of
+            // silently diverting to another repository. Without a seed,
+            // prefer the last repo work was started in, then the first.
+            if (seededRepoKey) {
+              selectedKey = repos.some((repo) => repo.key === seededRepoKey) ? seededRepoKey : "";
+            } else {
+              const lastUsed = getLastUsedNewWorkspaceRepoKey();
+              selectedKey =
+                (lastUsed && repos.some((repo) => repo.key === lastUsed) ? lastUsed : repos[0]?.key) ?? "";
+            }
           }),
         ),
       ),

--- a/frontend/src/lib/components/terminal/NewWorkspaceDialog.svelte
+++ b/frontend/src/lib/components/terminal/NewWorkspaceDialog.svelte
@@ -146,6 +146,20 @@
     return `${canonicalProvider(seed.provider)}/${seed.platformHost}/${seed.owner}/${seed.name}`;
   }
 
+  // An explicit seed is a promise about which repository the workspace
+  // targets. When it cannot be resolved (for example a repository hidden
+  // from the UI), require a choice instead of silently diverting to another
+  // repository. Without a seed, prefer the last repo work was started in,
+  // then the first.
+  function defaultRepoSelection(): string {
+    const seededRepoKey = seedKey(seedRepo);
+    if (seededRepoKey) {
+      return repos.some((repo) => repo.key === seededRepoKey) ? seededRepoKey : "";
+    }
+    const lastUsed = getLastUsedNewWorkspaceRepoKey();
+    return (lastUsed && repos.some((repo) => repo.key === lastUsed) ? lastUsed : repos[0]?.key) ?? "";
+  }
+
   // Each open starts a fresh request and fresh form state; a stale response
   // from a previous open must not repopulate the list. The previous list and
   // selection are dropped up front so a reopen cannot submit against the repo
@@ -160,7 +174,6 @@
       return;
     }
     const session = {};
-    const seededRepoKey = seedKey(seedRepo);
     const requestedSource = initialSource;
     activeSession = session;
     source = requestedSource;
@@ -195,18 +208,7 @@
             if (activeSession !== session) return;
             reposLoading = false;
             repos = (loaded ?? []).map(repoOption);
-            // An explicit seed is a promise about which repository the
-            // workspace targets. When it cannot be resolved (for example a
-            // repository hidden from the UI), require a choice instead of
-            // silently diverting to another repository. Without a seed,
-            // prefer the last repo work was started in, then the first.
-            if (seededRepoKey) {
-              selectedKey = repos.some((repo) => repo.key === seededRepoKey) ? seededRepoKey : "";
-            } else {
-              const lastUsed = getLastUsedNewWorkspaceRepoKey();
-              selectedKey =
-                (lastUsed && repos.some((repo) => repo.key === lastUsed) ? lastUsed : repos[0]?.key) ?? "";
-            }
+            selectedKey = defaultRepoSelection();
           }),
         ),
       ),
@@ -263,8 +265,7 @@
           if (activeSession !== session) return;
           reposLoading = false;
           repos = (loaded ?? []).map(repoOption);
-          const candidates = [seedKey(seedRepo), getLastUsedNewWorkspaceRepoKey()];
-          selectedKey = candidates.find((key) => key && repos.some((repo) => repo.key === key)) ?? repos[0]?.key ?? "";
+          selectedKey = defaultRepoSelection();
         })),
         Effect.asVoid,
       ),

--- a/frontend/src/lib/components/terminal/NewWorkspaceDialog.test.ts
+++ b/frontend/src/lib/components/terminal/NewWorkspaceDialog.test.ts
@@ -267,6 +267,35 @@ describe("NewWorkspaceDialog", () => {
     expect(repoPicker().textContent).not.toContain("acme/gadget");
   });
 
+  it("keeps requiring a choice for an unavailable seed after switching sources", async () => {
+    // The seed promise holds across source switches: leaving for Kata and
+    // returning to the repository source must not divert to the last-used
+    // or first repository when the seed is still unavailable.
+    localStorage.setItem("kenn-forge:workspace:new_repo", "github/github.com/acme/gadget");
+    await renderDialog({
+      seedRepo: { provider: "github", platformHost: "github.com", owner: "acme", name: "concealed" },
+    });
+    await waitFor(() =>
+      expect((screen.getByRole("button", { name: "Create workspace" }) as HTMLButtonElement).disabled).toBe(true),
+    );
+
+    await fireEvent.click(screen.getByRole("button", { name: "Kata issue" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Repository" }));
+    await waitFor(() => expect(mockGet.mock.calls.filter((c) => c[0] === "/repos")).toHaveLength(2));
+
+    // Once the reload settles, a wrong automatic selection would surface in
+    // the picker trigger and enable submission. The trigger renders as a
+    // button while closed and a combobox while open, so accept either.
+    await waitFor(() => {
+      const trigger =
+        screen.queryByRole("button", { name: "Filter repositories" }) ??
+        screen.getByRole("combobox", { name: "Filter repositories" });
+      expect(trigger.textContent).not.toContain("Loading repositories");
+      expect(trigger.textContent).not.toContain("acme/gadget");
+      expect((screen.getByRole("button", { name: "Create workspace" }) as HTMLButtonElement).disabled).toBe(true);
+    });
+  });
+
   it("routes non-default hosts through the host-scoped path", async () => {
     mockGet.mockResolvedValue({ data: [repoFixture("acme", "widget", "git.example.test", "forgejo")] });
     await renderDialog();

--- a/frontend/src/lib/components/terminal/NewWorkspaceDialog.test.ts
+++ b/frontend/src/lib/components/terminal/NewWorkspaceDialog.test.ts
@@ -251,6 +251,22 @@ describe("NewWorkspaceDialog", () => {
     await waitFor(() => expect(repoPicker().textContent).toContain("acme/gadget"));
   });
 
+  it("requires an explicit choice when the seeded repo is not offered", async () => {
+    // A seed that no longer resolves (for example a repository hidden from
+    // the UI) must not silently divert the workspace to another repository,
+    // even when a last-used repo is remembered.
+    localStorage.setItem("kenn-forge:workspace:new_repo", "github/github.com/acme/gadget");
+    await renderDialog({
+      seedRepo: { provider: "github", platformHost: "github.com", owner: "acme", name: "concealed" },
+    });
+
+    await waitFor(() =>
+      expect((screen.getByRole("button", { name: "Create workspace" }) as HTMLButtonElement).disabled).toBe(true),
+    );
+    expect(repoPicker().textContent).not.toContain("acme/widget");
+    expect(repoPicker().textContent).not.toContain("acme/gadget");
+  });
+
   it("routes non-default hosts through the host-scoped path", async () => {
     mockGet.mockResolvedValue({ data: [repoFixture("acme", "widget", "git.example.test", "forgejo")] });
     await renderDialog();

--- a/frontend/src/lib/stores/settings-workflow.test.ts
+++ b/frontend/src/lib/stores/settings-workflow.test.ts
@@ -724,4 +724,41 @@ it.layer(SettingsTestLayer)("ordered settings writes", (it) => {
       assert.deepStrictEqual(observedRequests, ["POST /api/v1/repo/github/acme/api/refresh"]);
     }),
   );
+
+  it.effect("saves repository UI visibility through the provider route", () =>
+    Effect.gen(function* () {
+      const repo = {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "api",
+        repo_path: "acme/api",
+        is_glob: false,
+        matched_repo_count: 1,
+        hidden_from_ui: false,
+      };
+      const saved = makeSettings([{ ...repo, hidden_from_ui: true }]);
+      const observedRequests: string[] = [];
+      const observedBodies: unknown[] = [];
+      const fetch: typeof globalThis.fetch = async (input, init) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        observedRequests.push(`${request.method} ${new URL(request.url).pathname}`);
+        observedBodies.push(JSON.parse(await request.text()));
+        return Response.json(saved);
+      };
+      vi.stubGlobal("fetch", fetch);
+
+      const workflow = yield* SettingsWorkflow;
+      const result = yield* workflow.updateRepoUIVisibility(
+        "acme",
+        "api",
+        { provider: "github", host: "github.com" },
+        true,
+      );
+
+      assert.strictEqual(result.repos[0]?.hidden_from_ui, true);
+      assert.deepStrictEqual(observedRequests, ["PUT /api/v1/repo/github/acme/api/ui-visibility"]);
+      assert.deepStrictEqual(observedBodies, [{ hidden: true }]);
+    }),
+  );
 });

--- a/frontend/src/lib/stores/settings-workflow.ts
+++ b/frontend/src/lib/stores/settings-workflow.ts
@@ -39,6 +39,13 @@ type SettingsCommand =
       readonly options: RepoRequestOptions;
       readonly worktreeBasePath: string;
     }
+  | {
+      readonly _tag: "UpdateRepoUIVisibility";
+      readonly owner: string;
+      readonly name: string;
+      readonly options: RepoRequestOptions;
+      readonly hidden: boolean;
+    }
   | { readonly _tag: "BulkAddRepos"; readonly repos: readonly RepoInput[] }
   | {
       readonly _tag: "PromoteRepo";
@@ -120,6 +127,12 @@ export class SettingsWorkflow extends Context.Service<
       name: string,
       options: RepoRequestOptions,
       worktreeBasePath: string,
+    ) => Effect.Effect<SettingsSnapshot, SettingsError>;
+    readonly updateRepoUIVisibility: (
+      owner: string,
+      name: string,
+      options: RepoRequestOptions,
+      hidden: boolean,
     ) => Effect.Effect<SettingsSnapshot, SettingsError>;
     readonly previewRepos: (
       owner: string,
@@ -218,6 +231,25 @@ function exactRepoWorktreeBaseMatches(
       repo.owner === owner &&
       repo.name === name &&
       (repo.worktree_base_path ?? "") === worktreeBasePath,
+  );
+}
+
+function exactRepoUIVisibilityMatches(
+  settings: SettingsSnapshot,
+  owner: string,
+  name: string,
+  options: RepoRequestOptions,
+  hidden: boolean,
+): boolean {
+  return settings.repos.some(
+    (repo) =>
+      !repo.is_glob &&
+      canonicalProvider(repo.provider) === canonicalProvider(options.provider) &&
+      resolvedPlatformHost(repo.provider, repo.platform_host) ===
+        resolvedPlatformHost(options.provider, options.host) &&
+      repo.owner === owner &&
+      repo.name === name &&
+      repo.hidden_from_ui === hidden,
   );
 }
 
@@ -424,6 +456,24 @@ export const SettingsWorkflowLive = Layer.effect(SettingsWorkflow)(
             );
             return settingsCommandResult(settings);
           }
+          case "UpdateRepoUIVisibility": {
+            const ref = repoRef(command.owner, command.name, command.options);
+            const settings = yield* runRecoverableSettingsMutation(
+              "repository UI visibility save",
+              [repoMutationKey(command.owner, command.name, command.options)],
+              api.execute("PUT repository UI visibility", (signal) =>
+                api.client.PUT(providerRepoPath(ref, "/ui-visibility"), {
+                  params: { path: providerRouteParams(ref) },
+                  body: { hidden: command.hidden },
+                  signal,
+                }),
+              ),
+              (snapshot) =>
+                exactRepoUIVisibilityMatches(snapshot, command.owner, command.name, command.options, command.hidden),
+              (snapshot) => snapshot,
+            );
+            return settingsCommandResult(settings);
+          }
           case "BulkAddRepos": {
             const settings = yield* runRecoverableSettingsMutation(
               "bulk repository add",
@@ -567,6 +617,8 @@ export const SettingsWorkflowLive = Layer.effect(SettingsWorkflow)(
       refreshRepo: (owner, name, options) => submitSettings({ _tag: "RefreshRepo", owner, name, options }),
       updateRepoWorktreeBasePath: (owner, name, options, worktreeBasePath) =>
         submitSettings({ _tag: "UpdateRepoWorktreeBase", owner, name, options, worktreeBasePath }),
+      updateRepoUIVisibility: (owner, name, options, hidden) =>
+        submitSettings({ _tag: "UpdateRepoUIVisibility", owner, name, options, hidden }),
       previewRepos: (owner, pattern, options) =>
         api.execute("POST /repos/preview", (signal) =>
           api.client.POST("/repos/preview", { body: { ...options, owner, pattern }, signal }),

--- a/frontend/src/lib/utils/repo-filter-values.test.ts
+++ b/frontend/src/lib/utils/repo-filter-values.test.ts
@@ -4,6 +4,7 @@ import {
   canonicalRepoFilterValue,
   displayRepoFilterValue,
   interactiveRepoFilterIdentities,
+  normalizeGlobalRepoSelection,
   normalizeInteractiveRepoFilterSelection,
   normalizeRepoFilterSelection,
   normalizeRepoFilterValue,
@@ -129,6 +130,28 @@ describe("repo filter values", () => {
       normalizeInteractiveRepoFilterSelection("github|github.com/acme-renamed/archive-renamed", repos),
     ).toBeUndefined();
     expect(normalizeInteractiveRepoFilterSelection("github|github.com/acme/archive", repos)).toBeUndefined();
+  });
+
+  it("preserves a host-pinned scope even when the pinned repository is hidden", () => {
+    // With ui.hideRepoSelector there is no picker to rescope with; dropping
+    // the pinned selection would silently unscope every request.
+    const repos = [
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "archive",
+        repo_path: "acme/archive",
+        is_glob: false,
+        matched_repo_count: 1,
+        hidden_from_ui: true,
+      },
+    ];
+
+    expect(normalizeGlobalRepoSelection("github|github.com/acme/archive", repos, true)).toBe(
+      "github|github.com/acme/archive",
+    );
+    expect(normalizeGlobalRepoSelection("github|github.com/acme/archive", repos, false)).toBeUndefined();
   });
 
   it("keeps glob-resolved selections that have no configured entry", () => {

--- a/frontend/src/lib/utils/repo-filter-values.test.ts
+++ b/frontend/src/lib/utils/repo-filter-values.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   canonicalRepoFilterValue,
   displayRepoFilterValue,
+  interactiveRepoFilterIdentities,
+  normalizeInteractiveRepoFilterSelection,
   normalizeRepoFilterSelection,
   normalizeRepoFilterValue,
   type RepoFilterIdentity,
@@ -76,5 +78,109 @@ describe("repo filter values", () => {
 
   it("displays pipe-qualified values as slash-qualified labels", () => {
     expect(displayRepoFilterValue("gitea|github.com/acme/widgets")).toBe("gitea/github.com/acme/widgets");
+  });
+
+  it("clears selections that point at server-hidden repositories", () => {
+    const repos = [
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "widgets",
+        repo_path: "acme/widgets",
+        is_glob: false,
+        matched_repo_count: 1,
+        hidden_from_ui: false,
+      },
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "archive",
+        repo_path: "acme/archive",
+        is_glob: false,
+        matched_repo_count: 1,
+        hidden_from_ui: true,
+      },
+    ];
+
+    expect(normalizeInteractiveRepoFilterSelection("github|github.com/acme/archive", repos)).toBeUndefined();
+    expect(
+      normalizeInteractiveRepoFilterSelection("github|github.com/acme/archive,github|github.com/acme/widgets", repos),
+    ).toBe("github|github.com/acme/widgets");
+  });
+
+  it("clears selections keyed to a hidden repository's renamed current route", () => {
+    const repos = [
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "archive",
+        repo_path: "acme/archive",
+        tracked_repo_path: "acme-renamed/archive-renamed",
+        is_glob: false,
+        matched_repo_count: 1,
+        hidden_from_ui: true,
+      },
+    ];
+
+    expect(
+      normalizeInteractiveRepoFilterSelection("github|github.com/acme-renamed/archive-renamed", repos),
+    ).toBeUndefined();
+    expect(normalizeInteractiveRepoFilterSelection("github|github.com/acme/archive", repos)).toBeUndefined();
+  });
+
+  it("keeps glob-resolved selections that have no configured entry", () => {
+    const repos = [
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "archive",
+        repo_path: "acme/archive",
+        is_glob: false,
+        matched_repo_count: 1,
+        hidden_from_ui: true,
+      },
+    ];
+
+    expect(normalizeInteractiveRepoFilterSelection("github|github.com/acme/glob-child", repos)).toBe(
+      "github|github.com/acme/glob-child",
+    );
+  });
+
+  it("builds interactive filter identities without server-hidden entries", () => {
+    const identities = interactiveRepoFilterIdentities([
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "widgets",
+        repo_path: "acme/widgets",
+        is_glob: false,
+        matched_repo_count: 1,
+        hidden_from_ui: false,
+      },
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "archive",
+        repo_path: "acme/archive",
+        is_glob: false,
+        matched_repo_count: 1,
+        hidden_from_ui: true,
+      },
+    ]);
+
+    expect(identities).toEqual([
+      {
+        provider: "github",
+        platformHost: "github.com",
+        repoPath: "acme/widgets",
+        isGlob: false,
+      },
+    ]);
   });
 });

--- a/frontend/src/lib/utils/repo-filter-values.ts
+++ b/frontend/src/lib/utils/repo-filter-values.ts
@@ -1,4 +1,5 @@
 import { canonicalProvider } from "../api/provider-routes.js";
+import type { ConfigRepo } from "../api/types.js";
 
 export interface RepoFilterIdentity {
   provider?: string | null;
@@ -126,4 +127,57 @@ export function normalizeRepoFilterSelection(
   return serializeRepoFilterSelection(
     parseRepoFilterSelection(selected).map((value) => normalizeRepoFilterValue(value, repos)),
   );
+}
+
+// interactiveRepoFilterIdentities feeds selectors with the entries a user can
+// still pick: server-hidden repositories drop out.
+export function interactiveRepoFilterIdentities(repos: readonly ConfigRepo[]): RepoFilterIdentity[] {
+  const identities: RepoFilterIdentity[] = [];
+  for (const repo of repos) {
+    if (repo.hidden_from_ui) continue;
+    identities.push({
+      provider: repo.provider,
+      platformHost: repo.platform_host,
+      repoPath: repo.repo_path,
+      isGlob: repo.is_glob,
+    });
+  }
+  return identities;
+}
+
+function canonicalSelectionValue(value: string): string {
+  const separator = value.indexOf("|");
+  if (separator === -1) return value;
+  return `${normalizeProvider(value.slice(0, separator))}|${value.slice(separator + 1)}`;
+}
+
+// normalizeInteractiveRepoFilterSelection normalizes a stored selection
+// against the repositories a user can still pick. Selections naming a
+// server-hidden exact repository are dropped explicitly: general
+// normalization preserves unknown provider-qualified values because
+// glob-resolved repositories have no configured entry of their own, so a
+// hidden repo would otherwise keep filtering after vanishing from pickers.
+export function normalizeInteractiveRepoFilterSelection(
+  selected: string | undefined,
+  repos: readonly ConfigRepo[],
+): string | undefined {
+  const hidden = new Set<string>();
+  for (const repo of repos) {
+    if (!repo.hidden_from_ui || repo.is_glob) continue;
+    // Selections created from catalog rows use the provider-verified current
+    // route, which diverges from the configured path after a rename — clear
+    // against both.
+    for (const repoPath of [repo.repo_path, repo.tracked_repo_path]) {
+      if (!repoPath) continue;
+      const value = providerQualifiedRepoFilterValue({
+        provider: repo.provider,
+        platformHost: repo.platform_host,
+        repoPath,
+        isGlob: repo.is_glob,
+      });
+      if (value) hidden.add(value);
+    }
+  }
+  const remaining = parseRepoFilterSelection(selected).filter((value) => !hidden.has(canonicalSelectionValue(value)));
+  return normalizeRepoFilterSelection(serializeRepoFilterSelection(remaining), interactiveRepoFilterIdentities(repos));
 }

--- a/frontend/src/lib/utils/repo-filter-values.ts
+++ b/frontend/src/lib/utils/repo-filter-values.ts
@@ -181,3 +181,18 @@ export function normalizeInteractiveRepoFilterSelection(
   const remaining = parseRepoFilterSelection(selected).filter((value) => !hidden.has(canonicalSelectionValue(value)));
   return normalizeRepoFilterSelection(serializeRepoFilterSelection(remaining), interactiveRepoFilterIdentities(repos));
 }
+
+// normalizeGlobalRepoSelection applies interactive normalization only when
+// the selection is user-editable. A host-pinned scope (ui.hideRepoSelector)
+// offers no picker to rescope with, so dropping it — for example because the
+// pinned repository is hidden from interactive catalogs — would silently
+// unscope every pull, issue, and activity request. Pinned scopes pass
+// through untouched.
+export function normalizeGlobalRepoSelection(
+  selected: string | undefined,
+  repos: readonly ConfigRepo[],
+  pinnedScope: boolean,
+): string | undefined {
+  if (pinnedScope) return selected;
+  return normalizeInteractiveRepoFilterSelection(selected, repos);
+}

--- a/frontend/src/lib/views/mobileActivityRepoOptions.test.ts
+++ b/frontend/src/lib/views/mobileActivityRepoOptions.test.ts
@@ -129,4 +129,29 @@ describe("buildMobileActivityRepoOptions", () => {
       },
     ]);
   });
+
+  it("omits entries the server marked hidden from the interactive UI", () => {
+    const options = buildMobileActivityRepoOptions([
+      {
+        ...baseRepo,
+        platform_host: "github.com",
+        hidden_from_ui: true,
+      },
+      {
+        ...baseRepo,
+        platform_host: "github.com",
+        name: "api",
+        repo_path: "acme/api",
+        hidden_from_ui: false,
+      },
+    ]);
+
+    expect(options).toEqual([
+      {
+        value: "github|github.com/acme/api",
+        label: "github/github.com/acme/api",
+        triggerLabel: "acme/api",
+      },
+    ]);
+  });
 });

--- a/frontend/src/lib/views/mobileActivityRepoOptions.ts
+++ b/frontend/src/lib/views/mobileActivityRepoOptions.ts
@@ -21,7 +21,8 @@ function repoFilterIdentity(repo: ConfigRepo) {
   };
 }
 
-export function buildMobileActivityRepoOptions(repos: ConfigRepo[]): MobileActivityRepoOption[] {
+export function buildMobileActivityRepoOptions(allRepos: ConfigRepo[]): MobileActivityRepoOption[] {
+  const repos = allRepos.filter((repo) => !repo.hidden_from_ui);
   const valuesByRepoPath = new Map<string, Set<string>>();
   for (const repo of repos) {
     const value = concreteRepoFilterValue(repoFilterIdentity(repo));

--- a/frontend/src/test/mockApiFetch.ts
+++ b/frontend/src/test/mockApiFetch.ts
@@ -271,6 +271,7 @@ export const mockSettings = {
       repo_path: "acme/widgets",
       is_glob: false,
       matched_repo_count: 1,
+      hidden_from_ui: false,
     },
   ],
   activity: {

--- a/frontend/tests/e2e-full/settings-globs.spec.ts
+++ b/frontend/tests/e2e-full/settings-globs.spec.ts
@@ -253,9 +253,10 @@ test("settings promotes a glob match to a persisted exact repo with a local clon
   await expect(dialog).toHaveCount(0);
   const exactRow = page.locator(".repo-row", { hasText: "roborev-dev/kenn-forge" });
   await expect(exactRow).toBeVisible();
-  await expect(exactRow.getByRole("button", { name: "Local clone for roborev-dev/kenn-forge" })).toHaveAttribute(
-    "title",
-    `Local clone: ${localRepo}`,
+  await exactRow.getByRole("button", { name: "Configure roborev-dev/kenn-forge" }).click();
+  await exactRow.getByRole("menuitem", { name: "Edit local clone path" }).click();
+  await expect(exactRow.getByLabel("Local clone path for roborev-dev/kenn-forge", { exact: true })).toHaveValue(
+    localRepo,
   );
 
   if (!api) throw new Error("settings-globs API context not initialized");

--- a/frontend/tests/e2e-full/settings-visibility.spec.ts
+++ b/frontend/tests/e2e-full/settings-visibility.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test, type Page } from "@playwright/test";
+import { startIsolatedE2EServer, type IsolatedE2EServer } from "./support/e2eServer";
+
+// Hide/show is a settings-owned preference stored against the repository's
+// stable catalog identity. This walks the workflow through the real backend:
+// hiding via the row gear menu must drop the repository from interactive
+// catalogs and release a persisted global filter scoped to it, survive a
+// reload, and come back through "Show in UI".
+
+let server: IsolatedE2EServer | undefined;
+
+test.beforeEach(async () => {
+  server = await startIsolatedE2EServer();
+});
+
+test.afterEach(async () => {
+  await server?.stop();
+  server = undefined;
+});
+
+async function toggleVisibility(page: Page, item: "Hide from UI" | "Show in UI"): Promise<void> {
+  const row = page.locator(".repo-row", { hasText: "acme/widgets" });
+  await expect(row).toBeVisible();
+  const saveResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().endsWith("/api/v1/repo/github/acme/widgets/ui-visibility") &&
+      response.request().method() === "PUT",
+  );
+  await row.getByRole("button", { name: "Configure acme/widgets" }).click();
+  await row.getByRole("menuitem", { name: item }).click();
+  const saveResponse = await saveResponsePromise;
+  const saveBody = await saveResponse.text();
+  expect(saveResponse.status(), `PUT ui-visibility failed: ${saveBody}`).toBe(200);
+}
+
+test("hiding a repository empties interactive catalogs and its filter until shown again", async ({ page }) => {
+  await page.goto(`${server!.info.base_url}/settings`);
+  await page.locator(".settings-page").waitFor({ state: "visible", timeout: 10_000 });
+
+  // Scope the persisted global repo filter to the repository about to be
+  // hidden, so hiding also has to release the stale selection.
+  await page.evaluate(() => {
+    localStorage.setItem("kenn-forge-filter-repo", "github|github.com/acme/widgets");
+  });
+
+  await toggleVisibility(page, "Hide from UI");
+
+  // Settings stays the unfiltered management surface.
+  await expect(page.locator(".repo-row", { hasText: "acme/widgets" })).toBeVisible();
+
+  await page.goto(`${server!.info.base_url}/repos`);
+  const widgetsCard = page.locator(".repo-card").filter({
+    has: page.getByRole("button", { name: /acme\s*\/\s*widgets/ }),
+  });
+  const toolsCard = page.locator(".repo-card").filter({
+    has: page.getByRole("button", { name: /acme\s*\/\s*tools/ }),
+  });
+  await expect(toolsCard.first()).toBeVisible();
+  await expect(widgetsCard).toHaveCount(0);
+
+  // The persisted filter selection normalizes away instead of silently
+  // keeping lists scoped to the hidden repository.
+  await page.goto(`${server!.info.base_url}/issues`);
+  await expect(page.getByRole("button", { name: /^Select repository:/ })).toContainText("All repos");
+
+  // The preference survives a reload and reverses through the same menu.
+  await page.goto(`${server!.info.base_url}/settings`);
+  await page.locator(".settings-page").waitFor({ state: "visible", timeout: 10_000 });
+  await toggleVisibility(page, "Show in UI");
+
+  await page.goto(`${server!.info.base_url}/repos`);
+  await expect(widgetsCard.first()).toBeVisible();
+});

--- a/frontend/tests/e2e-full/settings-worktree-base.spec.ts
+++ b/frontend/tests/e2e-full/settings-worktree-base.spec.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, realpathSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { expect, test } from "@playwright/test";
+import { expect, test, type Locator } from "@playwright/test";
 import { startIsolatedE2EServer, type IsolatedE2EServer } from "./support/e2eServer";
 
 let isolatedServer: IsolatedE2EServer | undefined;
@@ -34,6 +34,11 @@ function git(dir: string, ...args: string[]): void {
   execFileSync("git", args, { cwd: dir, stdio: "ignore" });
 }
 
+async function toggleLocalCloneEditor(row: Locator): Promise<void> {
+  await row.getByRole("button", { name: "Configure acme/widgets" }).click();
+  await row.getByRole("menuitem", { name: "Edit local clone path" }).click();
+}
+
 test("local clone editor opens from the row gear and saves a valid path", async ({ page }) => {
   localRepo = realpathSync(mkdtempSync(path.join(os.tmpdir(), "mm-local-clone-")));
   git(localRepo, "init");
@@ -47,7 +52,7 @@ test("local clone editor opens from the row gear and saves a valid path", async 
   await expect(row).toBeVisible();
   await expect(input).toBeHidden();
 
-  await row.getByRole("button", { name: "Local clone for acme/widgets" }).click();
+  await toggleLocalCloneEditor(row);
   await expect(input).toBeVisible();
 
   await input.fill(localRepo);
@@ -65,10 +70,6 @@ test("local clone editor opens from the row gear and saves a valid path", async 
   await expect(row.locator(".row-error")).toHaveCount(0);
   await expect(input).toHaveValue(/mm-local-clone-/);
   await expect(saveButton).toBeDisabled();
-  await expect(row.getByRole("button", { name: "Local clone for acme/widgets" })).toHaveAttribute(
-    "title",
-    `Local clone: ${localRepo}`,
-  );
 
   await expect
     .poll(async () => {
@@ -86,15 +87,11 @@ test("local clone editor opens from the row gear and saves a valid path", async 
   await page.reload();
   await page.locator(".settings-page").waitFor({ state: "visible", timeout: 10_000 });
   const reloadedRow = page.locator(".repo-row", { hasText: "acme/widgets" });
-  await expect(reloadedRow.getByRole("button", { name: "Local clone for acme/widgets" })).toHaveAttribute(
-    "title",
-    `Local clone: ${localRepo}`,
-  );
-  await reloadedRow.getByRole("button", { name: "Local clone for acme/widgets" }).click();
+  await toggleLocalCloneEditor(reloadedRow);
   const reloadedInput = reloadedRow.getByLabel("Local clone path for acme/widgets", { exact: true });
   await expect(reloadedInput).toHaveValue(localRepo);
 
-  await reloadedRow.getByRole("button", { name: "Local clone for acme/widgets" }).click();
+  await toggleLocalCloneEditor(reloadedRow);
   await expect(reloadedInput).toBeHidden();
 });
 
@@ -103,7 +100,7 @@ test("local clone editor keeps its draft open after a validation failure", async
   await page.locator(".settings-page").waitFor({ state: "visible", timeout: 10_000 });
 
   const row = page.locator(".repo-row", { hasText: "acme/widgets" });
-  await row.getByRole("button", { name: "Local clone for acme/widgets" }).click();
+  await toggleLocalCloneEditor(row);
 
   const input = row.getByLabel("Local clone path for acme/widgets", { exact: true });
   await input.fill("/nonexistent/clone/path");

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -1476,6 +1476,7 @@ type CommitsResponse struct {
 
 // ConfiguredRepoStatus defines model for ConfiguredRepoStatus.
 type ConfiguredRepoStatus struct {
+	HiddenFromUi     bool    `json:"hidden_from_ui"`
 	IsGlob           bool    `json:"is_glob"`
 	MatchedRepoCount int64   `json:"matched_repo_count"`
 	Name             string  `json:"name"`
@@ -1483,6 +1484,7 @@ type ConfiguredRepoStatus struct {
 	PlatformHost     string  `json:"platform_host"`
 	Provider         string  `json:"provider"`
 	RepoPath         string  `json:"repo_path"`
+	TrackedRepoPath  *string `json:"tracked_repo_path,omitempty"`
 	WorktreeBasePath *string `json:"worktree_base_path,omitempty"`
 }
 
@@ -3584,6 +3586,13 @@ type RepoSummaryResponse struct {
 	TimelineUpdatedAt    *string                           `json:"timeline_updated_at,omitempty"`
 }
 
+// RepoUIVisibilityRequest defines model for RepoUIVisibilityRequest.
+type RepoUIVisibilityRequest struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema *string `json:"$schema,omitempty"`
+	Hidden bool    `json:"hidden"`
+}
+
 // RepoWorktreeBaseRequest defines model for RepoWorktreeBaseRequest.
 type RepoWorktreeBaseRequest struct {
 	// Schema A URL to the JSON Schema for this object.
@@ -5015,6 +5024,9 @@ type SetPrReviewersOnHostJSONRequestBody = SetReviewersRequest
 // SetKanbanStateOnHostJSONRequestBody defines body for SetKanbanStateOnHost for application/json ContentType.
 type SetKanbanStateOnHostJSONRequestBody = SetKanbanStateHostInputBody
 
+// UpdateRepoUiVisibilityOnHostJSONRequestBody defines body for UpdateRepoUiVisibilityOnHost for application/json ContentType.
+type UpdateRepoUiVisibilityOnHostJSONRequestBody = RepoUIVisibilityRequest
+
 // CreateRepoWorkspaceOnHostJSONRequestBody defines body for CreateRepoWorkspaceOnHost for application/json ContentType.
 type CreateRepoWorkspaceOnHostJSONRequestBody = CreateAdHocWorkspaceHostInputBody
 
@@ -5143,6 +5155,9 @@ type SetPrReviewersJSONRequestBody = SetReviewersRequest
 
 // SetKanbanStateJSONRequestBody defines body for SetKanbanState for application/json ContentType.
 type SetKanbanStateJSONRequestBody = SetKanbanStateInputBody
+
+// UpdateRepoUiVisibilityJSONRequestBody defines body for UpdateRepoUiVisibility for application/json ContentType.
+type UpdateRepoUiVisibilityJSONRequestBody = RepoUIVisibilityRequest
 
 // CreateRepoWorkspaceJSONRequestBody defines body for CreateRepoWorkspace for application/json ContentType.
 type CreateRepoWorkspaceJSONRequestBody = CreateAdHocWorkspaceInputBody
@@ -5948,6 +5963,11 @@ type ClientInterface interface {
 	// ResolveRepoItemOnHost request
 	ResolveRepoItemOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, params *ResolveRepoItemOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// UpdateRepoUiVisibilityOnHostWithBody request with any body
+	UpdateRepoUiVisibilityOnHostWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateRepoUiVisibilityOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, body UpdateRepoUiVisibilityOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// CreateRepoWorkspaceOnHostWithBody request with any body
 	CreateRepoWorkspaceOnHostWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -6360,6 +6380,11 @@ type ClientInterface interface {
 
 	// ResolveRepoItem request
 	ResolveRepoItem(ctx context.Context, provider string, owner string, name string, number int64, params *ResolveRepoItemParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateRepoUiVisibilityWithBody request with any body
+	UpdateRepoUiVisibilityWithBody(ctx context.Context, provider string, owner string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateRepoUiVisibility(ctx context.Context, provider string, owner string, name string, body UpdateRepoUiVisibilityJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CreateRepoWorkspaceWithBody request with any body
 	CreateRepoWorkspaceWithBody(ctx context.Context, provider string, owner string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -8864,6 +8889,30 @@ func (c *Client) ResolveRepoItemOnHost(ctx context.Context, platformHost string,
 	return c.Client.Do(req)
 }
 
+func (c *Client) UpdateRepoUiVisibilityOnHostWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateRepoUiVisibilityOnHostRequestWithBody(c.Server, platformHost, provider, owner, name, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateRepoUiVisibilityOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, body UpdateRepoUiVisibilityOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateRepoUiVisibilityOnHostRequest(c.Server, platformHost, provider, owner, name, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) CreateRepoWorkspaceOnHostWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewCreateRepoWorkspaceOnHostRequestWithBody(c.Server, platformHost, provider, owner, name, contentType, body)
 	if err != nil {
@@ -10678,6 +10727,30 @@ func (c *Client) RefreshRepo(ctx context.Context, provider string, owner string,
 
 func (c *Client) ResolveRepoItem(ctx context.Context, provider string, owner string, name string, number int64, params *ResolveRepoItemParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewResolveRepoItemRequest(c.Server, provider, owner, name, number, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateRepoUiVisibilityWithBody(ctx context.Context, provider string, owner string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateRepoUiVisibilityRequestWithBody(c.Server, provider, owner, name, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateRepoUiVisibility(ctx context.Context, provider string, owner string, name string, body UpdateRepoUiVisibilityJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateRepoUiVisibilityRequest(c.Server, provider, owner, name, body)
 	if err != nil {
 		return nil, err
 	}
@@ -20866,6 +20939,74 @@ func NewResolveRepoItemOnHostRequest(server string, platformHost string, provide
 	return req, nil
 }
 
+// NewUpdateRepoUiVisibilityOnHostRequest calls the generic UpdateRepoUiVisibilityOnHost builder with application/json body
+func NewUpdateRepoUiVisibilityOnHostRequest(server string, platformHost string, provider string, owner string, name string, body UpdateRepoUiVisibilityOnHostJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateRepoUiVisibilityOnHostRequestWithBody(server, platformHost, provider, owner, name, "application/json", bodyReader)
+}
+
+// NewUpdateRepoUiVisibilityOnHostRequestWithBody generates requests for UpdateRepoUiVisibilityOnHost with any type of body
+func NewUpdateRepoUiVisibilityOnHostRequestWithBody(server string, platformHost string, provider string, owner string, name string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "platform_host", platformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/host/%s/repo/%s/%s/%s/ui-visibility", pathParam0, pathParam1, pathParam2, pathParam3)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewCreateRepoWorkspaceOnHostRequest calls the generic CreateRepoWorkspaceOnHost builder with application/json body
 func NewCreateRepoWorkspaceOnHostRequest(server string, platformHost string, provider string, owner string, name string, body CreateRepoWorkspaceOnHostJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -27835,6 +27976,67 @@ func NewResolveRepoItemRequest(server string, provider string, owner string, nam
 	return req, nil
 }
 
+// NewUpdateRepoUiVisibilityRequest calls the generic UpdateRepoUiVisibility builder with application/json body
+func NewUpdateRepoUiVisibilityRequest(server string, provider string, owner string, name string, body UpdateRepoUiVisibilityJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateRepoUiVisibilityRequestWithBody(server, provider, owner, name, "application/json", bodyReader)
+}
+
+// NewUpdateRepoUiVisibilityRequestWithBody generates requests for UpdateRepoUiVisibility with any type of body
+func NewUpdateRepoUiVisibilityRequestWithBody(server string, provider string, owner string, name string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/repo/%s/%s/%s/ui-visibility", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewCreateRepoWorkspaceRequest calls the generic CreateRepoWorkspace builder with application/json body
 func NewCreateRepoWorkspaceRequest(server string, provider string, owner string, name string, body CreateRepoWorkspaceJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -30748,6 +30950,11 @@ type ClientWithResponsesInterface interface {
 	// ResolveRepoItemOnHostWithResponse request
 	ResolveRepoItemOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, params *ResolveRepoItemOnHostParams, reqEditors ...RequestEditorFn) (*ResolveRepoItemOnHostResponse, error)
 
+	// UpdateRepoUiVisibilityOnHostWithBodyWithResponse request with any body
+	UpdateRepoUiVisibilityOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateRepoUiVisibilityOnHostResponse, error)
+
+	UpdateRepoUiVisibilityOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, body UpdateRepoUiVisibilityOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateRepoUiVisibilityOnHostResponse, error)
+
 	// CreateRepoWorkspaceOnHostWithBodyWithResponse request with any body
 	CreateRepoWorkspaceOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateRepoWorkspaceOnHostResponse, error)
 
@@ -31160,6 +31367,11 @@ type ClientWithResponsesInterface interface {
 
 	// ResolveRepoItemWithResponse request
 	ResolveRepoItemWithResponse(ctx context.Context, provider string, owner string, name string, number int64, params *ResolveRepoItemParams, reqEditors ...RequestEditorFn) (*ResolveRepoItemResponse, error)
+
+	// UpdateRepoUiVisibilityWithBodyWithResponse request with any body
+	UpdateRepoUiVisibilityWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateRepoUiVisibilityResponse, error)
+
+	UpdateRepoUiVisibilityWithResponse(ctx context.Context, provider string, owner string, name string, body UpdateRepoUiVisibilityJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateRepoUiVisibilityResponse, error)
 
 	// CreateRepoWorkspaceWithBodyWithResponse request with any body
 	CreateRepoWorkspaceWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateRepoWorkspaceResponse, error)
@@ -34562,6 +34774,29 @@ func (r ResolveRepoItemOnHostResponse) StatusCode() int {
 	return 0
 }
 
+type UpdateRepoUiVisibilityOnHostResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *SettingsResponse
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateRepoUiVisibilityOnHostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateRepoUiVisibilityOnHostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type CreateRepoWorkspaceOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
@@ -37043,6 +37278,29 @@ func (r ResolveRepoItemResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ResolveRepoItemResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateRepoUiVisibilityResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *SettingsResponse
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateRepoUiVisibilityResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateRepoUiVisibilityResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -39950,6 +40208,23 @@ func (c *ClientWithResponses) ResolveRepoItemOnHostWithResponse(ctx context.Cont
 	return ParseResolveRepoItemOnHostResponse(rsp)
 }
 
+// UpdateRepoUiVisibilityOnHostWithBodyWithResponse request with arbitrary body returning *UpdateRepoUiVisibilityOnHostResponse
+func (c *ClientWithResponses) UpdateRepoUiVisibilityOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateRepoUiVisibilityOnHostResponse, error) {
+	rsp, err := c.UpdateRepoUiVisibilityOnHostWithBody(ctx, platformHost, provider, owner, name, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateRepoUiVisibilityOnHostResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateRepoUiVisibilityOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, body UpdateRepoUiVisibilityOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateRepoUiVisibilityOnHostResponse, error) {
+	rsp, err := c.UpdateRepoUiVisibilityOnHost(ctx, platformHost, provider, owner, name, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateRepoUiVisibilityOnHostResponse(rsp)
+}
+
 // CreateRepoWorkspaceOnHostWithBodyWithResponse request with arbitrary body returning *CreateRepoWorkspaceOnHostResponse
 func (c *ClientWithResponses) CreateRepoWorkspaceOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateRepoWorkspaceOnHostResponse, error) {
 	rsp, err := c.CreateRepoWorkspaceOnHostWithBody(ctx, platformHost, provider, owner, name, contentType, body, reqEditors...)
@@ -41273,6 +41548,23 @@ func (c *ClientWithResponses) ResolveRepoItemWithResponse(ctx context.Context, p
 		return nil, err
 	}
 	return ParseResolveRepoItemResponse(rsp)
+}
+
+// UpdateRepoUiVisibilityWithBodyWithResponse request with arbitrary body returning *UpdateRepoUiVisibilityResponse
+func (c *ClientWithResponses) UpdateRepoUiVisibilityWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateRepoUiVisibilityResponse, error) {
+	rsp, err := c.UpdateRepoUiVisibilityWithBody(ctx, provider, owner, name, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateRepoUiVisibilityResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateRepoUiVisibilityWithResponse(ctx context.Context, provider string, owner string, name string, body UpdateRepoUiVisibilityJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateRepoUiVisibilityResponse, error) {
+	rsp, err := c.UpdateRepoUiVisibility(ctx, provider, owner, name, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateRepoUiVisibilityResponse(rsp)
 }
 
 // CreateRepoWorkspaceWithBodyWithResponse request with arbitrary body returning *CreateRepoWorkspaceResponse
@@ -46399,6 +46691,39 @@ func ParseResolveRepoItemOnHostResponse(rsp *http.Response) (*ResolveRepoItemOnH
 	return response, nil
 }
 
+// ParseUpdateRepoUiVisibilityOnHostResponse parses an HTTP response from a UpdateRepoUiVisibilityOnHostWithResponse call
+func ParseUpdateRepoUiVisibilityOnHostResponse(rsp *http.Response) (*UpdateRepoUiVisibilityOnHostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateRepoUiVisibilityOnHostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest SettingsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseCreateRepoWorkspaceOnHostResponse parses an HTTP response from a CreateRepoWorkspaceOnHostWithResponse call
 func ParseCreateRepoWorkspaceOnHostResponse(rsp *http.Response) (*CreateRepoWorkspaceOnHostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -49839,6 +50164,39 @@ func ParseResolveRepoItemResponse(rsp *http.Response) (*ResolveRepoItemResponse,
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest ResolveItemResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateRepoUiVisibilityResponse parses an HTTP response from a UpdateRepoUiVisibilityWithResponse call
+func ParseUpdateRepoUiVisibilityResponse(rsp *http.Response) (*UpdateRepoUiVisibilityResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateRepoUiVisibilityResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest SettingsResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/db/migrations/000049_repo_ui_visibility.down.sql
+++ b/internal/db/migrations/000049_repo_ui_visibility.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE forge_hidden_repos;

--- a/internal/db/migrations/000049_repo_ui_visibility.up.sql
+++ b/internal/db/migrations/000049_repo_ui_visibility.up.sql
@@ -1,0 +1,3 @@
+CREATE TABLE forge_hidden_repos (
+    repo_id INTEGER PRIMARY KEY REFERENCES forge_repos(id) ON DELETE CASCADE
+);

--- a/internal/db/repo_ui_visibility.go
+++ b/internal/db/repo_ui_visibility.go
@@ -1,0 +1,67 @@
+package db
+
+import (
+	"context"
+	"fmt"
+)
+
+// SetRepoHiddenFromUI records or clears the operator preference that keeps a
+// catalog repository out of interactive repository catalogs. The preference is
+// keyed by the stable internal repository id, so provider-side renames leave
+// it attached to the same repository and route reuse never inherits it.
+// Hiding requires an existing catalog row; clearing is always a no-op when no
+// preference exists.
+func (d *DB) SetRepoHiddenFromUI(
+	ctx context.Context, repoID int64, hidden bool,
+) error {
+	if hidden {
+		if _, err := d.rw.ExecContext(ctx,
+			`INSERT INTO forge_hidden_repos (repo_id) VALUES (?)
+			 ON CONFLICT(repo_id) DO NOTHING`,
+			repoID,
+		); err != nil {
+			return fmt.Errorf("hide repo %d from UI: %w", repoID, err)
+		}
+		return nil
+	}
+	if _, err := d.rw.ExecContext(ctx,
+		`DELETE FROM forge_hidden_repos WHERE repo_id = ?`, repoID,
+	); err != nil {
+		return fmt.Errorf("show repo %d in UI: %w", repoID, err)
+	}
+	return nil
+}
+
+// HiddenRepos returns the catalog repositories with a hidden-from-UI
+// preference. Only identity and route fields are populated; callers use them
+// to exclude repositories from interactive catalogs and to mark configured
+// entries as hidden on the settings surface.
+func (d *DB) HiddenRepos(ctx context.Context) ([]Repo, error) {
+	rows, err := d.ro.QueryContext(ctx,
+		`SELECT r.id, r.platform, r.platform_host, r.platform_repo_id,
+		        r.owner, r.name, r.repo_path
+		 FROM forge_repos r
+		 JOIN forge_hidden_repos h ON h.repo_id = r.id
+		 ORDER BY r.id`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list hidden repos: %w", err)
+	}
+	defer rows.Close()
+
+	var repos []Repo
+	for rows.Next() {
+		var r Repo
+		if err := rows.Scan(
+			&r.ID, &r.Platform, &r.PlatformHost, &r.PlatformRepoID,
+			&r.Owner, &r.Name, &r.RepoPath,
+		); err != nil {
+			return nil, fmt.Errorf("scan hidden repo: %w", err)
+		}
+		repos = append(repos, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate hidden repos: %w", err)
+	}
+	return repos, nil
+}

--- a/internal/db/repo_ui_visibility_test.go
+++ b/internal/db/repo_ui_visibility_test.go
@@ -1,0 +1,140 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func hiddenRepoIDs(t *testing.T, d *DB) []int64 {
+	t.Helper()
+	hidden, err := d.HiddenRepos(t.Context())
+	require.NoError(t, err)
+	ids := make([]int64, 0, len(hidden))
+	for _, repo := range hidden {
+		ids = append(ids, repo.ID)
+	}
+	return ids
+}
+
+func TestSetRepoHiddenFromUIRoundTrip(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repoID, err := d.UpsertRepo(ctx, GitHubRepoIdentity("github.com", "acme", "widget"))
+	require.NoError(err)
+	otherID, err := d.UpsertRepo(ctx, GitHubRepoIdentity("github.com", "acme", "gadget"))
+	require.NoError(err)
+
+	assert.Empty(hiddenRepoIDs(t, d))
+
+	require.NoError(d.SetRepoHiddenFromUI(ctx, repoID, true))
+	assert.Equal([]int64{repoID}, hiddenRepoIDs(t, d))
+
+	hidden, err := d.HiddenRepos(ctx)
+	require.NoError(err)
+	require.Len(hidden, 1)
+	assert.Equal("acme", hidden[0].Owner)
+	assert.Equal("widget", hidden[0].Name)
+
+	// Hiding again and hiding a second repo are both allowed.
+	require.NoError(d.SetRepoHiddenFromUI(ctx, repoID, true))
+	require.NoError(d.SetRepoHiddenFromUI(ctx, otherID, true))
+	assert.ElementsMatch([]int64{repoID, otherID}, hiddenRepoIDs(t, d))
+
+	require.NoError(d.SetRepoHiddenFromUI(ctx, repoID, false))
+	assert.Equal([]int64{otherID}, hiddenRepoIDs(t, d))
+
+	// Showing an already-visible repo is a no-op.
+	require.NoError(d.SetRepoHiddenFromUI(ctx, repoID, false))
+	assert.Equal([]int64{otherID}, hiddenRepoIDs(t, d))
+}
+
+func TestSetRepoHiddenFromUIUnknownRepo(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	require.Error(d.SetRepoHiddenFromUI(ctx, 12345, true))
+
+	// Clearing a preference for an unknown repo has nothing to remove.
+	require.NoError(d.SetRepoHiddenFromUI(ctx, 12345, false))
+}
+
+// TestSetRepoHiddenFromUIUnderReadLockExcludesDisplacement pins the locking
+// contract the visibility mutation relies on: while a caller holds the
+// repository-reconciliation read lock, a displacing reconciliation must wait,
+// so resolving the row's lifecycle and writing the preference cannot
+// interleave with the displacement.
+func TestSetRepoHiddenFromUIUnderReadLockExcludesDisplacement(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	observedAt := time.Now().UTC()
+	oldIdentity := GitHubRepoIdentity("github.com", "acme", "widget")
+	oldIdentity.PlatformRepoID = "R_old"
+	entry, _, err := d.ReconcileRepositoryObservation(ctx, oldIdentity, observedAt)
+	require.NoError(err)
+	require.NotNil(entry)
+
+	release, err := d.LockRepositoryReconciliationRead(ctx)
+	require.NoError(err)
+
+	// A different repository takes over the route while the lock is held.
+	displaced := make(chan error, 1)
+	go func() {
+		newIdentity := GitHubRepoIdentity("github.com", "acme", "widget")
+		newIdentity.PlatformRepoID = "R_new"
+		_, _, err := d.ReconcileRepositoryObservation(
+			ctx, newIdentity, observedAt.Add(time.Second),
+		)
+		displaced <- err
+	}()
+
+	select {
+	case err := <-displaced:
+		release()
+		require.Failf("displacement ran despite the read lock", "err: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	resolved, err := d.GetRepositoryByProviderIDUnderRepositoryReconciliationRead(
+		ctx, "github", "github.com", "R_old",
+	)
+	require.NoError(err)
+	require.NotNil(resolved)
+	require.Equal(RepositoryLifecycleActive, resolved.Lifecycle,
+		"the row stays active for the whole critical section")
+	require.NoError(d.SetRepoHiddenFromUI(ctx, resolved.Repository.ID, true))
+	release()
+
+	require.NoError(<-displaced)
+	after, err := d.GetRepositoryByProviderID(ctx, "github", "github.com", "R_old")
+	require.NoError(err)
+	require.NotNil(after)
+	assert.Equal(RepositoryLifecycleInactive, after.Lifecycle,
+		"displacement completed only after the critical section")
+	assert.Equal([]int64{resolved.Repository.ID}, hiddenRepoIDs(t, d))
+}
+
+func TestHiddenRepoPreferenceCascadesOnRepoDelete(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repoID, err := d.UpsertRepo(ctx, GitHubRepoIdentity("github.com", "acme", "widget"))
+	require.NoError(err)
+	require.NoError(d.SetRepoHiddenFromUI(ctx, repoID, true))
+
+	_, err = d.WriteDB().Exec("DELETE FROM forge_repos WHERE id = ?", repoID)
+	require.NoError(err)
+
+	assert.Empty(hiddenRepoIDs(t, d))
+}

--- a/internal/db/repository_catalog.go
+++ b/internal/db/repository_catalog.go
@@ -108,6 +108,21 @@ func (d *DB) GetRepositoryByProviderID(
 	)
 }
 
+// GetRepositoryByProviderIDUnderRepositoryReconciliationRead is
+// GetRepositoryByProviderID for callers that already hold
+// LockRepositoryReconciliationRead — acquiring the lock again deadlocks
+// behind a queued reconciliation writer.
+func (d *DB) GetRepositoryByProviderIDUnderRepositoryReconciliationRead(
+	ctx context.Context,
+	platform string,
+	platformHost string,
+	platformRepoID string,
+) (*RepositoryCatalogEntry, error) {
+	return d.getRepositoryByProviderID(
+		ctx, platform, platformHost, platformRepoID,
+	)
+}
+
 func (d *DB) getRepositoryByProviderID(
 	ctx context.Context,
 	platform string,

--- a/internal/github/repo_config_resolver.go
+++ b/internal/github/repo_config_resolver.go
@@ -59,14 +59,21 @@ func canonicalRepoPattern(pattern string) string {
 }
 
 type ConfiguredRepoStatus struct {
-	Provider         string `json:"provider"`
-	PlatformHost     string `json:"platform_host"`
-	Owner            string `json:"owner"`
-	Name             string `json:"name"`
-	RepoPath         string `json:"repo_path"`
+	Provider     string `json:"provider"`
+	PlatformHost string `json:"platform_host"`
+	Owner        string `json:"owner"`
+	Name         string `json:"name"`
+	RepoPath     string `json:"repo_path"`
+	// TrackedRepoPath is the provider-verified current route of the tracked
+	// repository backing an exact entry. After a provider-side rename it
+	// differs from the configured RepoPath, and clients need it to release
+	// state keyed to the current route (for example filter selections of a
+	// repository being hidden). Empty for globs and untracked entries.
+	TrackedRepoPath  string `json:"tracked_repo_path,omitempty"`
 	WorktreeBasePath string `json:"worktree_base_path,omitempty"`
 	IsGlob           bool   `json:"is_glob"`
 	MatchedRepoCount int    `json:"matched_repo_count"`
+	HiddenFromUI     bool   `json:"hidden_from_ui"`
 }
 
 type ResolveConfiguredReposResult struct {

--- a/internal/server/config_reload.go
+++ b/internal/server/config_reload.go
@@ -451,6 +451,17 @@ func (s *Server) applyConfigChange(ctx context.Context) configChangedEvent {
 		nativeStacksPrevious, newCfg.PullRequests.PreferGitHubNativeStacks,
 	)
 
+	// Removing an exact entry from the TOML file must release its
+	// hidden-from-UI preference just like the DELETE handler; otherwise a
+	// glob can keep the repository tracked and filtered with no exact row
+	// offering a "Show in UI" control.
+	if err := s.reconcileOrphanedRepoVisibility(ctx); err != nil {
+		slog.Warn(
+			"release orphaned hidden-from-UI preferences after config reload",
+			"err", err,
+		)
+	}
+
 	slog.Info(
 		"config reload applied",
 		"path", s.cfgPath,

--- a/internal/server/e2etest/notifications_test.go
+++ b/internal/server/e2etest/notifications_test.go
@@ -174,6 +174,8 @@ func TestNotificationSyncReconcilesReusedRouteE2E(t *testing.T) {
 	assert := assert.New(t)
 	ctx := t.Context()
 	number := 7
+	// Relative to now so the seeded activity stays inside the activity
+	// endpoint's default 7d window regardless of the calendar date.
 	firstActivityAt := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
 	var activityAt atomic.Int64
 	activityAt.Store(firstActivityAt.UnixNano())

--- a/internal/server/e2etest/settings_test.go
+++ b/internal/server/e2etest/settings_test.go
@@ -764,6 +764,71 @@ func TestRepoConfigAPIE2EUpdatesWorktreeBasePath(t *testing.T) {
 	assert.Empty(cfgAfterClear.Repos[0].WorktreeBasePath)
 }
 
+func TestRepoConfigAPIE2EUpdatesUIVisibility(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv, database, _ := setupTestServerWithConfig(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	entry, _, err := database.ReconcileRepositoryObservation(
+		t.Context(), db.RepoIdentity{
+			Platform:       "github",
+			PlatformHost:   "github.com",
+			PlatformRepoID: "repo-acme-widget",
+			Owner:          "acme",
+			Name:           "widget",
+		}, time.Now().UTC(),
+	)
+	require.NoError(err)
+	require.NotNil(entry)
+
+	summaryNames := func() []string {
+		resp, err := ts.Client().Get(ts.URL + "/api/v1/repos/summary")
+		require.NoError(err)
+		defer resp.Body.Close()
+		require.Equal(http.StatusOK, resp.StatusCode)
+		var summaries []generated.RepoSummaryResponse
+		require.NoError(json.NewDecoder(resp.Body).Decode(&summaries))
+		names := make([]string, 0, len(summaries))
+		for _, summary := range summaries {
+			names = append(names, summary.Name)
+		}
+		return names
+	}
+	require.Equal([]string{"widget"}, summaryNames())
+
+	hideResp := doServerJSON(
+		t, ts.Client(), http.MethodPut,
+		ts.URL+"/api/v1/repo/github/acme/widget/ui-visibility",
+		generated.RepoUIVisibilityRequest{Hidden: true},
+	)
+	defer hideResp.Body.Close()
+	require.Equal(http.StatusOK, hideResp.StatusCode)
+
+	var hidden generated.SettingsResponse
+	require.NoError(json.NewDecoder(hideResp.Body).Decode(&hidden))
+	require.Len(hidden.Repos, 1)
+	assert.True(hidden.Repos[0].HiddenFromUi)
+	assert.Empty(summaryNames(),
+		"hidden repo leaves the repository overview summaries")
+
+	showResp := doServerJSON(
+		t, ts.Client(), http.MethodPut,
+		ts.URL+"/api/v1/repo/github/acme/widget/ui-visibility",
+		generated.RepoUIVisibilityRequest{Hidden: false},
+	)
+	defer showResp.Body.Close()
+	require.Equal(http.StatusOK, showResp.StatusCode)
+
+	var shown generated.SettingsResponse
+	require.NoError(json.NewDecoder(showResp.Body).Decode(&shown))
+	require.Len(shown.Repos, 1)
+	assert.False(shown.Repos[0].HiddenFromUi)
+	assert.Equal([]string{"widget"}, summaryNames(),
+		"showing restores the repo in the repository overview summaries")
+}
+
 func TestRepoConfigAPIE2ERejectsUnsafeWorktreeScopedBaseConfig(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -79,6 +81,66 @@ func (s *Server) filterConfiguredRepoSummaries(
 		}
 	}
 	return filtered
+}
+
+// filterHiddenRepos removes repositories with a hidden-from-UI preference.
+// It applies only to interactive repository catalogs (selectors, pickers);
+// item feeds, direct routes, and the settings surface stay unfiltered.
+func (s *Server) filterHiddenRepos(
+	ctx context.Context, repos []db.Repo,
+) ([]db.Repo, error) {
+	hiddenIDs, err := s.hiddenRepoIDSet(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(hiddenIDs) == 0 {
+		return repos, nil
+	}
+	filtered := make([]db.Repo, 0, len(repos))
+	for _, repo := range repos {
+		if _, ok := hiddenIDs[repo.ID]; ok {
+			continue
+		}
+		filtered = append(filtered, repo)
+	}
+	return filtered, nil
+}
+
+func (s *Server) filterHiddenRepoSummaries(
+	ctx context.Context, summaries []db.RepoSummary,
+) ([]db.RepoSummary, error) {
+	hiddenIDs, err := s.hiddenRepoIDSet(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(hiddenIDs) == 0 {
+		return summaries, nil
+	}
+	filtered := make([]db.RepoSummary, 0, len(summaries))
+	for _, summary := range summaries {
+		if _, ok := hiddenIDs[summary.Repo.ID]; ok {
+			continue
+		}
+		filtered = append(filtered, summary)
+	}
+	return filtered, nil
+}
+
+func (s *Server) hiddenRepoIDSet(
+	ctx context.Context,
+) (map[int64]struct{}, error) {
+	if s.db == nil {
+		return nil, nil
+	}
+	hidden, err := s.db.HiddenRepos(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list hidden repos: %w", err)
+	}
+	ids := make(map[int64]struct{}, len(hidden))
+	for _, repo := range hidden {
+		ids[repo.ID] = struct{}{}
+	}
+	return ids, nil
 }
 
 func (s *Server) trackedConfiguredRepoSet() map[string]struct{} {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -665,6 +665,10 @@ func (s *Server) listRepos(ctx context.Context, _ *struct{}) (*listReposOutput, 
 	if s.cfg != nil {
 		repos = s.filterConfiguredRepos(repos)
 	}
+	repos, err = s.filterHiddenRepos(ctx, repos)
+	if err != nil {
+		return nil, httpapi.Internal(err.Error())
+	}
 
 	out := make([]repoResponse, 0, len(repos))
 	for _, repo := range repos {
@@ -683,6 +687,10 @@ func (s *Server) listRepoSummaries(
 	}
 	if s.cfg != nil {
 		summaries = s.filterConfiguredRepoSummaries(summaries)
+	}
+	summaries, err = s.filterHiddenRepoSummaries(ctx, summaries)
+	if err != nil {
+		return nil, httpapi.Internal(err.Error())
 	}
 
 	defaultPlatformHost := s.defaultPlatformHost()

--- a/internal/server/repo_import_handlers.go
+++ b/internal/server/repo_import_handlers.go
@@ -594,7 +594,13 @@ func (s *Server) applyBulkExactRepos(
 	s.applyWorkspaceConfigLocked()
 	s.cfgMu.Unlock()
 
-	return s.buildLocalSettingsResponse(), nil
+	body, err := s.buildLocalSettingsResponse(ctx)
+	if err != nil {
+		return settingsResponse{}, &bulkApplyError{
+			problem: httpapi.Internal(err.Error()),
+		}
+	}
+	return body, nil
 }
 
 func (s *Server) bulkAddRepos(

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1133,6 +1133,17 @@ func newServer(
 		otelhttp.WithFilter(otelTraceable(basePath)),
 		otelhttp.WithSpanNameFormatter(otelSpanName))
 
+	// Exact entries removed from the TOML file while the daemon was stopped
+	// must release their hidden-from-UI preferences; boot restores tracked
+	// refs from provider snapshots before the server is constructed, so
+	// exact-owned preferences resolve and survive the sweep.
+	if err := s.reconcileOrphanedRepoVisibility(s.bgCtx); err != nil {
+		slog.Warn(
+			"release orphaned hidden-from-UI preferences at startup",
+			"err", err,
+		)
+	}
+
 	return s
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -171,6 +171,10 @@ type Server struct {
 	tokenSources   *tokenauth.SourceSet
 	cfgMu          sync.Mutex
 	configReloadMu sync.Mutex
+	// repoVisibilityMu serializes hidden-from-UI mutations with the orphan
+	// sweep so a visibility write cannot interleave with a concurrent
+	// exact-entry removal and recreate an orphaned preference.
+	repoVisibilityMu sync.Mutex
 	// bootCfgSnapshot freezes the subset of config fields that are
 	// bound at startup (registry, listeners, clone manager, etc.) so a
 	// config-file watcher reload can detect when those changed and

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -97,15 +97,22 @@ func (s *Server) buildLocalSettingsResponse(
 		launchTargets = []localruntime.LaunchTarget{}
 	}
 
-	hiddenKeys, err := s.hiddenTrackedRepoKeys(ctx)
+	hiddenSet, err := s.hiddenRepoCorrelationSet(ctx)
 	if err != nil {
 		return settingsResponse{}, err
 	}
-	tracked := s.syncer.TrackedRepos()
+	var tracked []ghclient.RepoRef
+	if s.syncer != nil {
+		tracked = s.syncer.TrackedRepos()
+	}
 	configured := make(
 		[]ghclient.ConfiguredRepoStatus, len(repos),
 	)
 	for i, raw := range repos {
+		hiddenFromUI, err := s.configEntryHidden(ctx, raw, tracked, hiddenSet)
+		if err != nil {
+			return settingsResponse{}, err
+		}
 		configured[i] = ghclient.ConfiguredRepoStatus{
 			Provider:         raw.PlatformOrDefault(),
 			PlatformHost:     raw.PlatformHostOrDefault(),
@@ -116,7 +123,7 @@ func (s *Server) buildLocalSettingsResponse(
 			WorktreeBasePath: raw.WorktreeBasePath,
 			IsGlob:           raw.HasNameGlob(),
 			MatchedRepoCount: matchedRepoCount(raw, tracked),
-			HiddenFromUI:     configEntryHidden(raw, tracked, hiddenKeys),
+			HiddenFromUI:     hiddenFromUI,
 		}
 	}
 	return settingsResponse{
@@ -137,23 +144,36 @@ func (s *Server) buildLocalSettingsResponse(
 	}, nil
 }
 
-// hiddenTrackedRepoKeys returns the stable identity keys of catalog
+// hiddenRepoCorrelation carries the two addresses of every catalog row with a
+// hidden-from-UI preference: stable provider identity keys for correlating
+// tracked refs, and catalog row ids for entries whose tracked stable identity
+// is unavailable.
+type hiddenRepoCorrelation struct {
+	keys map[string]struct{}
+	ids  map[int64]struct{}
+}
+
+// hiddenRepoCorrelationSet returns the identity keys and catalog row ids of
 // repositories with a hidden-from-UI preference, for correlating configured
 // entries with their tracked repositories. Routes are mutable and reusable, so
 // correlation must never key on them: a displaced row keeps its old display
 // route, and a replacement repository at that route is a different repository.
-func (s *Server) hiddenTrackedRepoKeys(
+func (s *Server) hiddenRepoCorrelationSet(
 	ctx context.Context,
-) (map[string]struct{}, error) {
+) (hiddenRepoCorrelation, error) {
 	if s.db == nil {
-		return nil, nil
+		return hiddenRepoCorrelation{}, nil
 	}
 	hidden, err := s.db.HiddenRepos(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("list hidden repos: %w", err)
+		return hiddenRepoCorrelation{}, fmt.Errorf("list hidden repos: %w", err)
 	}
-	keys := make(map[string]struct{}, len(hidden))
+	set := hiddenRepoCorrelation{
+		keys: make(map[string]struct{}, len(hidden)),
+		ids:  make(map[int64]struct{}, len(hidden)),
+	}
 	for _, repo := range hidden {
+		set.ids[repo.ID] = struct{}{}
 		key := trackedRepoIdentityKey(ghclient.RepoRef{
 			Platform:           httpapi.ProviderKind(repo),
 			PlatformHost:       httpapi.ProviderHost(repo),
@@ -162,21 +182,25 @@ func (s *Server) hiddenTrackedRepoKeys(
 		if key == "" {
 			continue
 		}
-		keys[key] = struct{}{}
+		set.keys[key] = struct{}{}
 	}
-	return keys, nil
+	return set, nil
 }
 
-// configEntryHidden reports whether the exact configured entry's tracked
-// repository carries a hidden-from-UI preference. Glob entries have no
-// visibility of their own: the preference belongs to exact repositories.
-func configEntryHidden(
+// configEntryHidden reports whether the exact configured entry's repository
+// carries a hidden-from-UI preference. Glob entries have no visibility of
+// their own: the preference belongs to exact repositories. Tracked refs with
+// a stable provider identity answer directly; without one (a route-only ref
+// or a server without a syncer), the entry resolves to its catalog row the
+// same way the mutation path does.
+func (s *Server) configEntryHidden(
+	ctx context.Context,
 	raw config.Repo,
 	tracked []ghclient.RepoRef,
-	hiddenKeys map[string]struct{},
-) bool {
-	if raw.HasNameGlob() || len(hiddenKeys) == 0 {
-		return false
+	hidden hiddenRepoCorrelation,
+) (bool, error) {
+	if raw.HasNameGlob() || len(hidden.ids) == 0 {
+		return false, nil
 	}
 	for _, repo := range tracked {
 		if !repoMatchesConfig(repo, raw) {
@@ -186,11 +210,23 @@ func configEntryHidden(
 		if key == "" {
 			continue
 		}
-		if _, ok := hiddenKeys[key]; ok {
-			return true
-		}
+		_, ok := hidden.keys[key]
+		return ok, nil
 	}
-	return false
+	repo, err := s.lookupRepoForVisibilityRelease(
+		ctx, s.visibilityLookupIdentity(raw),
+	)
+	if err != nil {
+		return false, fmt.Errorf(
+			"resolve configured repo %s for hidden state: %w",
+			configRepoPath(raw), err,
+		)
+	}
+	if repo == nil {
+		return false, nil
+	}
+	_, ok := hidden.ids[repo.ID]
+	return ok, nil
 }
 
 // trackedPathForConfig returns the provider-verified current route of the
@@ -1156,6 +1192,14 @@ func (s *Server) updateConfiguredRepoUIVisibilityState(
 		Name:         ref.Name,
 	}
 
+	// Membership is validated and the preference written under the same
+	// visibility lock the orphan sweep takes: a concurrent exact-entry
+	// removal either completes first (the check below then rejects the
+	// mutation) or waits for the write and sweeps it, so the preference can
+	// never outlive its exact entry unreachable behind a glob.
+	s.repoVisibilityMu.Lock()
+	defer s.repoVisibilityMu.Unlock()
+
 	s.cfgMu.Lock()
 	var target *config.Repo
 	for i := range s.cfg.Repos {
@@ -1355,6 +1399,8 @@ func (s *Server) reconcileOrphanedRepoVisibility(ctx context.Context) error {
 	if s.db == nil {
 		return nil
 	}
+	s.repoVisibilityMu.Lock()
+	defer s.repoVisibilityMu.Unlock()
 	hidden, err := s.db.HiddenRepos(ctx)
 	if err != nil {
 		return err

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -1246,10 +1246,15 @@ func (s *Server) resolveVisibilityRepoLocked(
 
 // visibilityLookupIdentity names the catalog repository an exact configured
 // entry currently resolves to. A tracked ref carries the provider-verified
-// stable id and the current route after renames; without one, the configured
-// route itself is the only address.
+// stable id and the current route after renames; without one (including on
+// servers constructed without a syncer), the configured route itself is the
+// only address.
 func (s *Server) visibilityLookupIdentity(raw config.Repo) db.RepoIdentity {
-	for _, repo := range s.syncer.TrackedRepos() {
+	var tracked []ghclient.RepoRef
+	if s.syncer != nil {
+		tracked = s.syncer.TrackedRepos()
+	}
+	for _, repo := range tracked {
 		if !repoMatchesConfig(repo, raw) {
 			continue
 		}

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"path"
 	"slices"
 	"strings"
@@ -66,9 +67,12 @@ func (s *Server) configuredClients(
 	return clients
 }
 
-// buildLocalSettingsResponse builds the settings response from
-// in-memory state (syncer tracked repos) without calling GitHub.
-func (s *Server) buildLocalSettingsResponse() settingsResponse {
+// buildLocalSettingsResponse builds the settings response from in-memory
+// state (syncer tracked repos) plus the hidden-from-UI preferences persisted
+// in SQLite, without calling the provider.
+func (s *Server) buildLocalSettingsResponse(
+	ctx context.Context,
+) (settingsResponse, error) {
 	s.cfgMu.Lock()
 	repos := slices.Clone(s.cfg.Repos)
 	activity := s.cfg.Activity
@@ -93,6 +97,10 @@ func (s *Server) buildLocalSettingsResponse() settingsResponse {
 		launchTargets = []localruntime.LaunchTarget{}
 	}
 
+	hiddenKeys, err := s.hiddenTrackedRepoKeys(ctx)
+	if err != nil {
+		return settingsResponse{}, err
+	}
 	tracked := s.syncer.TrackedRepos()
 	configured := make(
 		[]ghclient.ConfiguredRepoStatus, len(repos),
@@ -104,9 +112,11 @@ func (s *Server) buildLocalSettingsResponse() settingsResponse {
 			Owner:            raw.Owner,
 			Name:             raw.Name,
 			RepoPath:         configRepoPath(raw),
+			TrackedRepoPath:  trackedPathForConfig(raw, tracked),
 			WorktreeBasePath: raw.WorktreeBasePath,
 			IsGlob:           raw.HasNameGlob(),
 			MatchedRepoCount: matchedRepoCount(raw, tracked),
+			HiddenFromUI:     configEntryHidden(raw, tracked, hiddenKeys),
 		}
 	}
 	return settingsResponse{
@@ -124,7 +134,82 @@ func (s *Server) buildLocalSettingsResponse() settingsResponse {
 		KataProjects:  kataProjects,
 		LaunchTargets: launchTargets,
 		Fleet:         fleetSettings,
+	}, nil
+}
+
+// hiddenTrackedRepoKeys returns the stable identity keys of catalog
+// repositories with a hidden-from-UI preference, for correlating configured
+// entries with their tracked repositories. Routes are mutable and reusable, so
+// correlation must never key on them: a displaced row keeps its old display
+// route, and a replacement repository at that route is a different repository.
+func (s *Server) hiddenTrackedRepoKeys(
+	ctx context.Context,
+) (map[string]struct{}, error) {
+	if s.db == nil {
+		return nil, nil
 	}
+	hidden, err := s.db.HiddenRepos(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list hidden repos: %w", err)
+	}
+	keys := make(map[string]struct{}, len(hidden))
+	for _, repo := range hidden {
+		key := trackedRepoIdentityKey(ghclient.RepoRef{
+			Platform:           httpapi.ProviderKind(repo),
+			PlatformHost:       httpapi.ProviderHost(repo),
+			PlatformExternalID: repo.PlatformRepoID,
+		})
+		if key == "" {
+			continue
+		}
+		keys[key] = struct{}{}
+	}
+	return keys, nil
+}
+
+// configEntryHidden reports whether the exact configured entry's tracked
+// repository carries a hidden-from-UI preference. Glob entries have no
+// visibility of their own: the preference belongs to exact repositories.
+func configEntryHidden(
+	raw config.Repo,
+	tracked []ghclient.RepoRef,
+	hiddenKeys map[string]struct{},
+) bool {
+	if raw.HasNameGlob() || len(hiddenKeys) == 0 {
+		return false
+	}
+	for _, repo := range tracked {
+		if !repoMatchesConfig(repo, raw) {
+			continue
+		}
+		key := trackedRepoIdentityKey(repo)
+		if key == "" {
+			continue
+		}
+		if _, ok := hiddenKeys[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// trackedPathForConfig returns the provider-verified current route of the
+// tracked repository backing an exact configured entry, or empty for globs
+// and untracked entries. Renames move the route while the entry keeps its
+// configured address, and clients release route-keyed state through this
+// value.
+func trackedPathForConfig(
+	raw config.Repo, tracked []ghclient.RepoRef,
+) string {
+	if raw.HasNameGlob() {
+		return ""
+	}
+	for _, repo := range tracked {
+		if repoMatchesConfig(repo, raw) {
+			return trackedRepoPath(repo)
+		}
+	}
+	return ""
 }
 
 func matchedRepoCount(
@@ -575,13 +660,25 @@ func classifyResolveProblem(err error) huma.StatusError {
 }
 
 func (s *Server) getSettings(
-	_ context.Context, _ *struct{},
+	ctx context.Context, _ *struct{},
 ) (*getSettingsOutput, error) {
 	if s.cfg == nil {
 		return nil, httpapi.NotFound(httpapi.CodeSettingsUnavailable, "settings not available", nil)
 	}
 
-	return &getSettingsOutput{Body: s.buildLocalSettingsResponse()}, nil
+	return s.settingsOutputResponse(ctx)
+}
+
+// settingsOutputResponse wraps buildLocalSettingsResponse for handlers that
+// answer with the full settings payload.
+func (s *Server) settingsOutputResponse(
+	ctx context.Context,
+) (*settingsOutput, error) {
+	body, err := s.buildLocalSettingsResponse(ctx)
+	if err != nil {
+		return nil, httpapi.Internal(err.Error())
+	}
+	return &settingsOutput{Body: body}, nil
 }
 
 func (s *Server) updateSettings(
@@ -669,7 +766,7 @@ func (s *Server) updateSettings(
 	s.cfgMu.Unlock()
 	s.reconcileGitHubNativeStackProjection(nativeStacksPrevious, nativeStacksEnabled)
 
-	return &settingsOutput{Body: s.buildLocalSettingsResponse()}, nil
+	return s.settingsOutputResponse(ctx)
 }
 
 func cloneModeVisibility(modes config.ModeVisibility) config.ModeVisibility {
@@ -827,7 +924,7 @@ func (s *Server) addConfiguredRepo(
 	s.cfgMu.Unlock()
 
 	s.syncer.TriggerRun(context.WithoutCancel(ctx))
-	return &settingsOutput{Body: s.buildLocalSettingsResponse()}, nil
+	return s.settingsOutputResponse(ctx)
 }
 
 func (s *Server) refreshConfiguredRepo(
@@ -910,7 +1007,7 @@ func (s *Server) refreshConfiguredRepo(
 	s.cfgMu.Unlock()
 
 	s.syncer.TriggerRun(context.WithoutCancel(ctx))
-	return &settingsOutput{Body: s.buildLocalSettingsResponse()}, nil
+	return s.settingsOutputResponse(ctx)
 }
 
 func (s *Server) refreshConfiguredRepoOnHost(
@@ -1012,11 +1109,170 @@ func (s *Server) updateConfiguredRepoWorktreeBasePath(
 	}
 	s.cfgMu.Unlock()
 
-	return &settingsOutput{Body: s.buildLocalSettingsResponse()}, nil
+	return s.settingsOutputResponse(ctx)
+}
+
+func (s *Server) updateConfiguredRepoUIVisibility(
+	ctx context.Context, input *repoUIVisibilityInput,
+) (*settingsOutput, error) {
+	return s.updateConfiguredRepoUIVisibilityState(ctx, repoConfigInput{
+		Provider:     input.Provider,
+		PlatformHost: input.PlatformHost,
+		Owner:        input.Owner,
+		Name:         input.Name,
+	}, input.Body.Hidden)
+}
+
+func (s *Server) updateConfiguredRepoUIVisibilityOnHost(
+	ctx context.Context, input *repoUIVisibilityHostInput,
+) (*settingsOutput, error) {
+	return s.updateConfiguredRepoUIVisibilityState(ctx, repoConfigInput{
+		Provider:     input.Provider,
+		PlatformHost: input.PlatformHost,
+		Owner:        input.Owner,
+		Name:         input.Name,
+	}, input.Body.Hidden)
+}
+
+// updateConfiguredRepoUIVisibilityState persists the hidden-from-UI
+// preference for the exact configured repository named by ref. The preference
+// attaches to the catalog row's stable identity, so the entry must resolve to
+// a provider-verified repository before it can be hidden.
+func (s *Server) updateConfiguredRepoUIVisibilityState(
+	ctx context.Context, ref repoConfigInput, hidden bool,
+) (*settingsOutput, error) {
+	if s.cfg == nil || s.db == nil {
+		return nil, httpapi.NotFound(httpapi.CodeSettingsUnavailable, "settings not available", nil)
+	}
+
+	provider, err := normalizeRouteProvider(ref.Provider)
+	if err != nil {
+		return nil, httpapi.Validation("path.provider", err.Error())
+	}
+	targetRef := config.Repo{
+		Platform:     provider,
+		PlatformHost: ref.PlatformHost,
+		Owner:        ref.Owner,
+		Name:         ref.Name,
+	}
+
+	s.cfgMu.Lock()
+	var target *config.Repo
+	for i := range s.cfg.Repos {
+		if sameConfiguredRepo(s.cfg.Repos[i], targetRef) {
+			raw := s.cfg.Repos[i]
+			target = &raw
+			break
+		}
+	}
+	s.cfgMu.Unlock()
+	if target == nil {
+		return nil, httpapi.NotFound(httpapi.CodeRepoNotFound,
+			ref.Owner+"/"+ref.Name+" is not configured", nil)
+	}
+	if target.HasNameGlob() {
+		return nil, httpapi.BadRequest(
+			httpapi.CodeBadRequest,
+			"UI visibility is only supported for exact repositories",
+			nil,
+		)
+	}
+
+	repo, err := s.applyVisibilityUnderReconciliationRead(
+		ctx, s.visibilityLookupIdentity(*target), hidden,
+	)
+	if err != nil {
+		return nil, httpapi.Internal("save visibility: " + err.Error())
+	}
+	if repo == nil {
+		return nil, httpapi.Conflict(httpapi.CodeConflict,
+			ref.Owner+"/"+ref.Name+
+				" does not resolve to an active provider-verified repository yet; retry after sync",
+			nil)
+	}
+
+	return s.settingsOutputResponse(ctx)
+}
+
+// applyVisibilityUnderReconciliationRead resolves the target catalog row and
+// writes the preference in one critical section under the
+// repository-reconciliation read lock, so reconciliation cannot displace the
+// row between lifecycle validation and the write. Returns nil without error
+// when no active provider-verified row resolves.
+func (s *Server) applyVisibilityUnderReconciliationRead(
+	ctx context.Context, identity db.RepoIdentity, hidden bool,
+) (*db.Repo, error) {
+	release, err := s.db.LockRepositoryReconciliationRead(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+	repo, err := s.resolveVisibilityRepoLocked(ctx, identity)
+	if err != nil || repo == nil {
+		return repo, err
+	}
+	if err := s.db.SetRepoHiddenFromUI(ctx, repo.ID, hidden); err != nil {
+		return nil, err
+	}
+	return repo, nil
+}
+
+// resolveVisibilityRepoLocked resolves the catalog row a visibility mutation
+// targets; the caller must hold the repository-reconciliation read lock. The
+// stable provider id wins when the tracked ref carries one: route resolution
+// would hand the mutation to whichever repository currently occupies the
+// route, which after route reuse is a different repository. Inactive rows are
+// rejected the same as unresolved ones — a tracked snapshot that lags
+// reconciliation still names a displaced repository, and hiding it would
+// leave the active replacement visible while consuming the request.
+func (s *Server) resolveVisibilityRepoLocked(
+	ctx context.Context, identity db.RepoIdentity,
+) (*db.Repo, error) {
+	if strings.TrimSpace(identity.PlatformRepoID) == "" {
+		return s.db.GetRepoByIdentityUnderRepositoryReconciliationRead(ctx, identity)
+	}
+	entry, err := s.db.GetRepositoryByProviderIDUnderRepositoryReconciliationRead(
+		ctx, identity.Platform, identity.PlatformHost, identity.PlatformRepoID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil || entry.Lifecycle != db.RepositoryLifecycleActive {
+		return nil, nil
+	}
+	repo := entry.Repository
+	return &repo, nil
+}
+
+// visibilityLookupIdentity names the catalog repository an exact configured
+// entry currently resolves to. A tracked ref carries the provider-verified
+// stable id and the current route after renames; without one, the configured
+// route itself is the only address.
+func (s *Server) visibilityLookupIdentity(raw config.Repo) db.RepoIdentity {
+	for _, repo := range s.syncer.TrackedRepos() {
+		if !repoMatchesConfig(repo, raw) {
+			continue
+		}
+		return db.RepoIdentity{
+			Platform:       repoProvider(repo),
+			PlatformHost:   trackedRepoHost(repo),
+			PlatformRepoID: repo.PlatformExternalID,
+			Owner:          repo.Owner,
+			Name:           repo.Name,
+			RepoPath:       repo.RepoPath,
+		}
+	}
+	return db.RepoIdentity{
+		Platform:     raw.PlatformOrDefault(),
+		PlatformHost: raw.PlatformHostOrDefault(),
+		Owner:        raw.Owner,
+		Name:         raw.Name,
+		RepoPath:     raw.RepoPath,
+	}
 }
 
 func (s *Server) deleteConfiguredRepo(
-	_ context.Context, input *repoConfigInput,
+	ctx context.Context, input *repoConfigInput,
 ) (*struct{}, error) {
 	if s.cfgPath == "" {
 		return nil, httpapi.NotFound(httpapi.CodeSettingsUnavailable, "settings not available", nil)
@@ -1053,6 +1309,7 @@ func (s *Server) deleteConfiguredRepo(
 	}
 
 	prevRepos := slices.Clone(s.cfg.Repos)
+	removed := prevRepos[idx]
 	s.cfg.Repos = append(
 		s.cfg.Repos[:idx], s.cfg.Repos[idx+1:]...,
 	)
@@ -1065,7 +1322,96 @@ func (s *Server) deleteConfiguredRepo(
 	s.applyWorkspaceConfigLocked()
 	s.cfgMu.Unlock()
 
+	// The hidden-from-UI preference belongs to an exact entry. Without one, a
+	// glob can keep the repository tracked and filtered while glob rows expose
+	// no visibility controls, so the preference would be unreachable. The
+	// config change already committed and clients may abandon the request, so
+	// the sweep runs detached from request cancellation; a failed sweep is
+	// reported without failing the delete and heals on the next reload or
+	// startup.
+	if err := s.reconcileOrphanedRepoVisibility(
+		context.WithoutCancel(ctx),
+	); err != nil {
+		slog.Warn("release hidden-from-UI preference on repo removal",
+			"repo", configRepoPath(removed), "err", err)
+	}
+
 	return nil, nil
+}
+
+// reconcileOrphanedRepoVisibility clears every hidden-from-UI preference whose
+// repository no longer resolves from an exact configured entry. It runs
+// whenever the effective repository configuration changes: server startup,
+// config hot reload, and exact-entry deletion. Inactive rows are accepted on
+// the keep side and cleared like any other orphan: clearing a preference on a
+// displaced row is safe and keeps it from lingering unreachable. Resolution
+// errors abort the sweep without clearing anything.
+func (s *Server) reconcileOrphanedRepoVisibility(ctx context.Context) error {
+	if s.db == nil {
+		return nil
+	}
+	hidden, err := s.db.HiddenRepos(ctx)
+	if err != nil {
+		return err
+	}
+	if len(hidden) == 0 {
+		return nil
+	}
+	var exact []config.Repo
+	s.cfgMu.Lock()
+	hasConfig := s.cfg != nil
+	if hasConfig {
+		for _, raw := range s.cfg.Repos {
+			if raw.HasNameGlob() {
+				continue
+			}
+			exact = append(exact, raw)
+		}
+	}
+	s.cfgMu.Unlock()
+	if !hasConfig {
+		return nil
+	}
+	keep := make(map[int64]struct{}, len(exact))
+	for _, raw := range exact {
+		repo, err := s.lookupRepoForVisibilityRelease(
+			ctx, s.visibilityLookupIdentity(raw),
+		)
+		if err != nil {
+			return err
+		}
+		if repo != nil {
+			keep[repo.ID] = struct{}{}
+		}
+	}
+	for _, repo := range hidden {
+		if _, kept := keep[repo.ID]; kept {
+			continue
+		}
+		if err := s.db.SetRepoHiddenFromUI(ctx, repo.ID, false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Server) lookupRepoForVisibilityRelease(
+	ctx context.Context, identity db.RepoIdentity,
+) (*db.Repo, error) {
+	if strings.TrimSpace(identity.PlatformRepoID) == "" {
+		return s.db.GetRepoByIdentity(ctx, identity)
+	}
+	entry, err := s.db.GetRepositoryByProviderID(
+		ctx, identity.Platform, identity.PlatformHost, identity.PlatformRepoID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, nil
+	}
+	repo := entry.Repository
+	return &repo, nil
 }
 
 func normalizeRouteProvider(raw string) (string, error) {

--- a/internal/server/settings_routes.go
+++ b/internal/server/settings_routes.go
@@ -60,6 +60,26 @@ type repoWorktreeBaseHostInput struct {
 	Body         repoWorktreeBaseRequest
 }
 
+type repoUIVisibilityRequest struct {
+	Hidden bool `json:"hidden"`
+}
+
+type repoUIVisibilityInput struct {
+	Provider     string `path:"provider"`
+	PlatformHost string
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	Body         repoUIVisibilityRequest
+}
+
+type repoUIVisibilityHostInput struct {
+	Provider     string `path:"provider"`
+	PlatformHost string `path:"platform_host"`
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	Body         repoUIVisibilityRequest
+}
+
 type settingsOutput = httpapi.BodyOutput[settingsResponse]
 
 type setActiveWorktreeInput struct {
@@ -354,6 +374,20 @@ func (s *Server) registerSettingsAPI(api huma.API) {
 		Summary:     "Update repository worktree base",
 		Tags:        []string{"Settings"},
 	}, s.updateConfiguredRepoWorktreeBaseOnHost)
+	huma.Register(api, huma.Operation{
+		OperationID: "update-repo-ui-visibility",
+		Method:      http.MethodPut,
+		Path:        "/repo/{provider}/{owner}/{name}/ui-visibility",
+		Summary:     "Update repository UI visibility",
+		Tags:        []string{"Settings"},
+	}, s.updateConfiguredRepoUIVisibility)
+	huma.Register(api, huma.Operation{
+		OperationID: "update-repo-ui-visibility-on-host",
+		Method:      http.MethodPut,
+		Path:        "/host/{platform_host}/repo/{provider}/{owner}/{name}/ui-visibility",
+		Summary:     "Update repository UI visibility",
+		Tags:        []string{"Settings"},
+	}, s.updateConfiguredRepoUIVisibilityOnHost)
 	huma.Register(api, huma.Operation{
 		OperationID:   "delete-repo",
 		Method:        http.MethodDelete,

--- a/internal/server/settings_visibility_test.go
+++ b/internal/server/settings_visibility_test.go
@@ -535,6 +535,73 @@ name = "gadget"
 		"startup clears glob-only hidden state but keeps exact-owned state")
 }
 
+func TestStartupVisibilitySweepToleratesNilSyncer(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	// Servers can be constructed without a syncer. The startup sweep must
+	// then resolve exact entries by their configured route instead of
+	// panicking on tracked-repo lookup.
+	database := dbtest.Open(t)
+	widget, _, err := database.ReconcileRepositoryObservation(
+		t.Context(), db.RepoIdentity{
+			Platform:       "github",
+			PlatformHost:   "github.com",
+			PlatformRepoID: "R_widget",
+			Owner:          "acme",
+			Name:           "widget",
+		}, time.Now().UTC(),
+	)
+	require.NoError(err)
+	require.NotNil(widget)
+	gadget, _, err := database.ReconcileRepositoryObservation(
+		t.Context(), db.RepoIdentity{
+			Platform:       "github",
+			PlatformHost:   "github.com",
+			PlatformRepoID: "R_gadget",
+			Owner:          "acme",
+			Name:           "gadget",
+		}, time.Now().UTC(),
+	)
+	require.NoError(err)
+	require.NotNil(gadget)
+	require.NoError(database.SetRepoHiddenFromUI(
+		t.Context(), widget.Repository.ID, true,
+	))
+	require.NoError(database.SetRepoHiddenFromUI(
+		t.Context(), gadget.Repository.ID, true,
+	))
+
+	cfgPath := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(os.WriteFile(cfgPath, []byte(`
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+`), 0o644))
+	cfg, err := config.Load(cfgPath)
+	require.NoError(err)
+
+	srv := NewWithConfig(
+		database, nil, nil, nil, cfg, cfgPath,
+		ServerOptions{HostCheckAllowLoopbackAnyPort: true},
+	)
+	require.NotNil(srv)
+
+	hidden, err := database.HiddenRepos(t.Context())
+	require.NoError(err)
+	hiddenIDs := make([]string, 0, len(hidden))
+	for _, repo := range hidden {
+		hiddenIDs = append(hiddenIDs, repo.PlatformRepoID)
+	}
+	assert.Equal([]string{"R_widget"}, hiddenIDs,
+		"the configured route keeps its preference; the unconfigured repo is swept")
+}
+
 func TestHandleUpdateRepoUIVisibilityRejectsGlobEntries(t *testing.T) {
 	require := require.New(t)
 	srv, _, _ := setupTestServerWithConfigContent(t, `

--- a/internal/server/settings_visibility_test.go
+++ b/internal/server/settings_visibility_test.go
@@ -1,0 +1,581 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	gh "github.com/google/go-github/v89/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/config"
+	"go.kenn.io/forge/internal/db"
+	ghclient "go.kenn.io/forge/internal/github"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+)
+
+func seedVerifiedRepo(
+	t *testing.T, database *db.DB, identity db.RepoIdentity,
+) {
+	t.Helper()
+	entry, _, err := database.ReconcileRepositoryObservation(
+		t.Context(), identity, time.Now().UTC(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+}
+
+func settingsReposFromBody(t *testing.T, body []byte) []ghclient.ConfiguredRepoStatus {
+	t.Helper()
+	var resp struct {
+		Repos []ghclient.ConfiguredRepoStatus `json:"repos"`
+	}
+	require.NoError(t, json.Unmarshal(body, &resp))
+	return resp.Repos
+}
+
+func listRepoNames(t *testing.T, srv *Server) []string {
+	t.Helper()
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/repos", nil)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	var repos []struct {
+		Name string `json:"name"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &repos))
+	names := make([]string, 0, len(repos))
+	for _, repo := range repos {
+		names = append(names, repo.Name)
+	}
+	return names
+}
+
+func TestHandleUpdateRepoUIVisibilityHidesAndShows(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv, database, _ := setupTestServerWithConfig(t)
+
+	seedVerifiedRepo(t, database, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-acme-widget",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.Equal([]string{"widget"}, listRepoNames(t, srv))
+
+	rr := doJSON(t, srv, http.MethodPut,
+		"/api/v1/repo/github/acme/widget/ui-visibility",
+		map[string]bool{"hidden": true},
+	)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	repos := settingsReposFromBody(t, rr.Body.Bytes())
+	require.Len(repos, 1)
+	assert.True(repos[0].HiddenFromUI,
+		"settings response marks the hidden entry")
+	assert.Empty(listRepoNames(t, srv),
+		"interactive catalog omits the hidden repo")
+
+	// Settings remains the unfiltered management surface.
+	rr = doJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	repos = settingsReposFromBody(t, rr.Body.Bytes())
+	require.Len(repos, 1)
+	assert.True(repos[0].HiddenFromUI)
+
+	rr = doJSON(t, srv, http.MethodPut,
+		"/api/v1/repo/github/acme/widget/ui-visibility",
+		map[string]bool{"hidden": false},
+	)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	repos = settingsReposFromBody(t, rr.Body.Bytes())
+	require.Len(repos, 1)
+	assert.False(repos[0].HiddenFromUI)
+	assert.Equal([]string{"widget"}, listRepoNames(t, srv))
+}
+
+func TestHandleUpdateRepoUIVisibilityFollowsRenamedRoute(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv, database, _ := setupTestServerWithConfig(t)
+
+	// The provider renamed acme/widget to acme-renamed/widget-renamed. The
+	// tracked ref carries the current route plus exact-entry provenance, and
+	// the catalog row holds the stable provider id.
+	seedVerifiedRepo(t, database, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_widget",
+		Owner:          "acme-renamed",
+		Name:           "widget-renamed",
+	})
+	srv.syncer.SetRepos([]ghclient.RepoRef{{
+		Owner:              "acme-renamed",
+		Name:               "widget-renamed",
+		PlatformHost:       "github.com",
+		PlatformExternalID: "R_widget",
+		ConfiguredRepoPath: "acme/widget",
+	}})
+
+	rr := doJSON(t, srv, http.MethodPut,
+		"/api/v1/repo/github/acme/widget/ui-visibility",
+		map[string]bool{"hidden": true},
+	)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	repos := settingsReposFromBody(t, rr.Body.Bytes())
+	require.Len(repos, 1)
+	assert.True(repos[0].HiddenFromUI,
+		"configured entry reports hidden through rename provenance")
+	assert.Equal("acme-renamed/widget-renamed", repos[0].TrackedRepoPath,
+		"settings expose the current provider route for selection cleanup")
+	assert.Empty(listRepoNames(t, srv),
+		"renamed hidden repo stays out of the catalog")
+}
+
+func TestRepoUIVisibilityDoesNotFollowReusedRoute(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv, database, _ := setupTestServerWithConfig(t)
+
+	// R_old was verified at acme/widget and hidden there.
+	seedVerifiedRepo(t, database, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_old",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	srv.syncer.SetRepos([]ghclient.RepoRef{{
+		Owner:              "acme",
+		Name:               "widget",
+		PlatformHost:       "github.com",
+		PlatformExternalID: "R_old",
+		ConfiguredRepoPath: "acme/widget",
+	}})
+	rr := doJSON(t, srv, http.MethodPut,
+		"/api/v1/repo/github/acme/widget/ui-visibility",
+		map[string]bool{"hidden": true},
+	)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	// The provider deleted acme/widget and a different repository took over
+	// the route. The displaced row keeps its old display route without being
+	// the current occupant.
+	entry, _, err := database.ReconcileRepositoryObservation(
+		t.Context(), db.RepoIdentity{
+			Platform:       "github",
+			PlatformHost:   "github.com",
+			PlatformRepoID: "R_new",
+			Owner:          "acme",
+			Name:           "widget",
+		}, time.Now().UTC().Add(time.Second),
+	)
+	require.NoError(err)
+	require.NotNil(entry)
+	srv.syncer.SetRepos([]ghclient.RepoRef{{
+		Owner:              "acme",
+		Name:               "widget",
+		PlatformHost:       "github.com",
+		PlatformExternalID: "R_new",
+		ConfiguredRepoPath: "acme/widget",
+	}})
+
+	rr = doJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	repos := settingsReposFromBody(t, rr.Body.Bytes())
+	require.Len(repos, 1)
+	assert.False(repos[0].HiddenFromUI,
+		"replacement repo must not inherit hidden state through the reused route")
+	assert.Equal([]string{"widget"}, listRepoNames(t, srv),
+		"replacement repo stays in the interactive catalog")
+
+	// Hiding the entry now targets the replacement's stable identity.
+	rr = doJSON(t, srv, http.MethodPut,
+		"/api/v1/repo/github/acme/widget/ui-visibility",
+		map[string]bool{"hidden": true},
+	)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	hidden, err := database.HiddenRepos(t.Context())
+	require.NoError(err)
+	hiddenIDs := make([]string, 0, len(hidden))
+	for _, repo := range hidden {
+		hiddenIDs = append(hiddenIDs, repo.PlatformRepoID)
+	}
+	assert.Contains(hiddenIDs, "R_new",
+		"mutation resolves the replacement by stable provider id")
+}
+
+func TestRepoUIVisibilityRejectsStaleTrackedIdentity(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv, database, _ := setupTestServerWithConfig(t)
+
+	// R_old owned acme/widget until a different repository took the route.
+	seedVerifiedRepo(t, database, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_old",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	entry, _, err := database.ReconcileRepositoryObservation(
+		t.Context(), db.RepoIdentity{
+			Platform:       "github",
+			PlatformHost:   "github.com",
+			PlatformRepoID: "R_new",
+			Owner:          "acme",
+			Name:           "widget",
+		}, time.Now().UTC().Add(time.Second),
+	)
+	require.NoError(err)
+	require.NotNil(entry)
+
+	// The tracked snapshot lags reconciliation and still references R_old.
+	srv.syncer.SetRepos([]ghclient.RepoRef{{
+		Owner:              "acme",
+		Name:               "widget",
+		PlatformHost:       "github.com",
+		PlatformExternalID: "R_old",
+		ConfiguredRepoPath: "acme/widget",
+	}})
+
+	rr := doJSON(t, srv, http.MethodPut,
+		"/api/v1/repo/github/acme/widget/ui-visibility",
+		map[string]bool{"hidden": true},
+	)
+	require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
+	hidden, err := database.HiddenRepos(t.Context())
+	require.NoError(err)
+	assert.Empty(hidden,
+		"a displaced row must not receive the visibility mutation")
+}
+
+func TestDeleteConfiguredRepoClearsOrphanedVisibility(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv, database, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+
+[[repos]]
+owner = "acme"
+name = "wid*"
+`, &mockGH{})
+
+	seedVerifiedRepo(t, database, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_widget",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	srv.syncer.SetRepos([]ghclient.RepoRef{{
+		Owner:              "acme",
+		Name:               "widget",
+		PlatformHost:       "github.com",
+		PlatformExternalID: "R_widget",
+		ConfiguredRepoPath: "acme/widget",
+	}})
+
+	rr := doJSON(t, srv, http.MethodPut,
+		"/api/v1/repo/github/acme/widget/ui-visibility",
+		map[string]bool{"hidden": true},
+	)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	require.Empty(listRepoNames(t, srv))
+
+	// Removing the exact entry orphans the preference: the glob keeps the
+	// repository tracked, but glob rows have no visibility controls, so the
+	// preference must be released with its owning exact entry.
+	rr = doJSON(t, srv, http.MethodDelete,
+		"/api/v1/repo/github/acme/widget", nil,
+	)
+	require.Equal(http.StatusNoContent, rr.Code, rr.Body.String())
+
+	hidden, err := database.HiddenRepos(t.Context())
+	require.NoError(err)
+	assert.Empty(hidden,
+		"deleting the last exact entry clears its hidden preference")
+	assert.Equal([]string{"widget"}, listRepoNames(t, srv),
+		"the glob-tracked repo returns to the interactive catalog")
+}
+
+func TestDeleteConfiguredRepoClearsVisibilityDespiteCanceledRequest(t *testing.T) {
+	require := require.New(t)
+	srv, database, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+
+[[repos]]
+owner = "acme"
+name = "wid*"
+`, &mockGH{})
+
+	seedVerifiedRepo(t, database, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_widget",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	srv.syncer.SetRepos([]ghclient.RepoRef{{
+		Owner:              "acme",
+		Name:               "widget",
+		PlatformHost:       "github.com",
+		PlatformExternalID: "R_widget",
+		ConfiguredRepoPath: "acme/widget",
+	}})
+
+	rr := doJSON(t, srv, http.MethodPut,
+		"/api/v1/repo/github/acme/widget/ui-visibility",
+		map[string]bool{"hidden": true},
+	)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	// A client can abandon the DELETE request after the config change
+	// commits; cleanup must still run rather than orphan the preference.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := srv.deleteConfiguredRepo(ctx, &repoConfigInput{
+		Provider: "github",
+		Owner:    "acme",
+		Name:     "widget",
+	})
+	require.NoError(err)
+
+	hidden, err := database.HiddenRepos(t.Context())
+	require.NoError(err)
+	assert.Empty(t, hidden,
+		"a canceled request context must not leave the preference orphaned")
+}
+
+func TestConfigReloadClearsOrphanedVisibility(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	// The provider lists acme/widget so the glob keeps resolving the
+	// repository after the exact entry is removed from the TOML file.
+	mock := &mockGH{
+		listReposByOwnerFn: func(
+			_ context.Context, owner string,
+		) ([]*gh.Repository, error) {
+			return []*gh.Repository{{
+				NodeID:   new("R_widget"),
+				Name:     new("widget"),
+				Owner:    &gh.User{Login: new(owner)},
+				Archived: new(false),
+			}}, nil
+		},
+	}
+	srv, database, cfgPath := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+
+[[repos]]
+owner = "acme"
+name = "wid*"
+`, mock)
+
+	seedVerifiedRepo(t, database, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_widget",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	srv.syncer.SetRepos([]ghclient.RepoRef{{
+		Owner:              "acme",
+		Name:               "widget",
+		PlatformHost:       "github.com",
+		PlatformExternalID: "R_widget",
+		ConfiguredRepoPath: "acme/widget",
+	}})
+
+	rr := doJSON(t, srv, http.MethodPut,
+		"/api/v1/repo/github/acme/widget/ui-visibility",
+		map[string]bool{"hidden": true},
+	)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	require.Empty(listRepoNames(t, srv))
+
+	// Editing the TOML file removes the exact entry while the glob keeps the
+	// repository tracked. The reload path must release the preference just
+	// like the DELETE handler does.
+	writeConfigToml(t, cfgPath, `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "wid*"
+`)
+	event := srv.applyConfigChange(t.Context())
+	require.True(event.Valid, event.Error)
+
+	hidden, err := database.HiddenRepos(t.Context())
+	require.NoError(err)
+	assert.Empty(hidden,
+		"reloading without the exact entry clears its hidden preference")
+	assert.Equal([]string{"widget"}, listRepoNames(t, srv),
+		"the glob-tracked repo returns to the interactive catalog")
+}
+
+func TestServerStartupClearsOrphanedVisibility(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	// The previous process hid acme/widget behind an exact entry and
+	// acme/gadget behind its own exact entry, then the maintainer removed the
+	// widget entry from the TOML file while the daemon was stopped.
+	database := dbtest.Open(t)
+	widget, _, err := database.ReconcileRepositoryObservation(
+		t.Context(), db.RepoIdentity{
+			Platform:       "github",
+			PlatformHost:   "github.com",
+			PlatformRepoID: "R_widget",
+			Owner:          "acme",
+			Name:           "widget",
+		}, time.Now().UTC(),
+	)
+	require.NoError(err)
+	require.NotNil(widget)
+	gadget, _, err := database.ReconcileRepositoryObservation(
+		t.Context(), db.RepoIdentity{
+			Platform:       "github",
+			PlatformHost:   "github.com",
+			PlatformRepoID: "R_gadget",
+			Owner:          "acme",
+			Name:           "gadget",
+		}, time.Now().UTC(),
+	)
+	require.NoError(err)
+	require.NotNil(gadget)
+	require.NoError(database.SetRepoHiddenFromUI(
+		t.Context(), widget.Repository.ID, true,
+	))
+	require.NoError(database.SetRepoHiddenFromUI(
+		t.Context(), gadget.Repository.ID, true,
+	))
+
+	cfgPath := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(os.WriteFile(cfgPath, []byte(`
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "wid*"
+
+[[repos]]
+owner = "acme"
+name = "gadget"
+`), 0o644))
+	cfg, err := config.Load(cfgPath)
+	require.NoError(err)
+
+	// Boot restores tracked refs from provider snapshots before the server
+	// is constructed; mirror that order here.
+	clients := map[string]ghclient.Client{"github.com": &mockGH{}}
+	syncer := ghclient.NewSyncer(
+		clients, database, nil, []ghclient.RepoRef{
+			{
+				Owner:              "acme",
+				Name:               "widget",
+				PlatformHost:       "github.com",
+				PlatformExternalID: "R_widget",
+				ConfiguredRepoPath: "acme/wid*",
+			},
+			{
+				Owner:              "acme",
+				Name:               "gadget",
+				PlatformHost:       "github.com",
+				PlatformExternalID: "R_gadget",
+				ConfiguredRepoPath: "acme/gadget",
+			},
+		}, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := NewWithConfig(
+		database, syncer, nil, nil, cfg, cfgPath,
+		ServerOptions{HostCheckAllowLoopbackAnyPort: true},
+	)
+	require.NotNil(srv)
+
+	hidden, err := database.HiddenRepos(t.Context())
+	require.NoError(err)
+	hiddenIDs := make([]string, 0, len(hidden))
+	for _, repo := range hidden {
+		hiddenIDs = append(hiddenIDs, repo.PlatformRepoID)
+	}
+	assert.Equal([]string{"R_gadget"}, hiddenIDs,
+		"startup clears glob-only hidden state but keeps exact-owned state")
+}
+
+func TestHandleUpdateRepoUIVisibilityRejectsGlobEntries(t *testing.T) {
+	require := require.New(t)
+	srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget-*"
+`, &mockGH{})
+
+	rr := doJSON(t, srv, http.MethodPut,
+		"/api/v1/repo/github/acme/widget-*/ui-visibility",
+		map[string]bool{"hidden": true},
+	)
+	require.Equal(http.StatusBadRequest, rr.Code, rr.Body.String())
+}
+
+func TestHandleUpdateRepoUIVisibilityUnknownRepo(t *testing.T) {
+	require := require.New(t)
+	srv, _, _ := setupTestServerWithConfig(t)
+
+	rr := doJSON(t, srv, http.MethodPut,
+		"/api/v1/repo/github/acme/unrelated/ui-visibility",
+		map[string]bool{"hidden": true},
+	)
+	require.Equal(http.StatusNotFound, rr.Code, rr.Body.String())
+}
+
+func TestHandleUpdateRepoUIVisibilityRequiresVerifiedRepo(t *testing.T) {
+	require := require.New(t)
+	srv, _, _ := setupTestServerWithConfig(t)
+
+	// acme/widget is configured and tracked but has no catalog row yet
+	// (first sync has not verified it), so there is no stable identity to
+	// attach the preference to.
+	rr := doJSON(t, srv, http.MethodPut,
+		"/api/v1/repo/github/acme/widget/ui-visibility",
+		map[string]bool{"hidden": true},
+	)
+	require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
+}

--- a/internal/server/settings_visibility_test.go
+++ b/internal/server/settings_visibility_test.go
@@ -1,9 +1,11 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -533,6 +535,172 @@ name = "gadget"
 	}
 	assert.Equal([]string{"R_gadget"}, hiddenIDs,
 		"startup clears glob-only hidden state but keeps exact-owned state")
+}
+
+func TestHandleUpdateRepoUIVisibilityWithoutSyncer(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	// A server without a syncer still owns visibility mutations; persisting
+	// the change and then failing to build the settings response would leave
+	// the client without the saved state.
+	database := dbtest.Open(t)
+	seedVerifiedRepo(t, database, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_widget",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+
+	cfgPath := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(os.WriteFile(cfgPath, []byte(`
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+`), 0o644))
+	cfg, err := config.Load(cfgPath)
+	require.NoError(err)
+	srv := NewWithConfig(
+		database, nil, nil, nil, cfg, cfgPath,
+		ServerOptions{HostCheckAllowLoopbackAnyPort: true},
+	)
+
+	rr := doJSON(t, srv, http.MethodPut,
+		"/api/v1/repo/github/acme/widget/ui-visibility",
+		map[string]bool{"hidden": true},
+	)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	repos := settingsReposFromBody(t, rr.Body.Bytes())
+	require.Len(repos, 1)
+	assert.True(repos[0].HiddenFromUI,
+		"the response reports the saved state without tracked refs")
+
+	hidden, err := database.HiddenRepos(t.Context())
+	require.NoError(err)
+	require.Len(hidden, 1)
+	assert.Equal("R_widget", hidden[0].PlatformRepoID)
+}
+
+func TestHandleUpdateRepoUIVisibilityReportsRouteOnlyTrackedRef(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv, database, _ := setupTestServerWithConfig(t)
+
+	seedVerifiedRepo(t, database, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_widget",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	// The tracked snapshot has not resolved a stable provider id yet; the
+	// route is the only address. Hidden correlation must still report the
+	// saved state instead of skipping identity-less refs.
+	srv.syncer.SetRepos([]ghclient.RepoRef{{
+		Owner:              "acme",
+		Name:               "widget",
+		PlatformHost:       "github.com",
+		ConfiguredRepoPath: "acme/widget",
+	}})
+
+	rr := doJSON(t, srv, http.MethodPut,
+		"/api/v1/repo/github/acme/widget/ui-visibility",
+		map[string]bool{"hidden": true},
+	)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	repos := settingsReposFromBody(t, rr.Body.Bytes())
+	require.Len(repos, 1)
+	assert.True(repos[0].HiddenFromUI,
+		"route-only tracked refs resolve through the catalog row")
+
+	hidden, err := database.HiddenRepos(t.Context())
+	require.NoError(err)
+	require.Len(hidden, 1)
+	assert.Equal("R_widget", hidden[0].PlatformRepoID)
+}
+
+func TestRepoUIVisibilityMutationSerializesWithOrphanSweep(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv, database, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+
+[[repos]]
+owner = "acme"
+name = "wid*"
+`, &mockGH{})
+
+	seedVerifiedRepo(t, database, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_widget",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	srv.syncer.SetRepos([]ghclient.RepoRef{{
+		Owner:              "acme",
+		Name:               "widget",
+		PlatformHost:       "github.com",
+		PlatformExternalID: "R_widget",
+		ConfiguredRepoPath: "acme/widget",
+	}})
+
+	// Hold the visibility lock the way a concurrent delete or hot-reload
+	// sweep would, and remove the exact entry while the PUT is blocked. The
+	// PUT must revalidate membership inside the critical section: writing
+	// against the pre-delete membership check would orphan the preference
+	// behind the glob.
+	srv.repoVisibilityMu.Lock()
+	result := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		var buf bytes.Buffer
+		buf.WriteString(`{"hidden":true}`)
+		req := httptest.NewRequest(http.MethodPut,
+			"/api/v1/repo/github/acme/widget/ui-visibility", &buf)
+		req.Host = "127.0.0.1:8091"
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		result <- rr
+	}()
+	select {
+	case <-result:
+		srv.repoVisibilityMu.Unlock()
+		require.FailNow("the visibility mutation ignored the sweep lock")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	srv.cfgMu.Lock()
+	kept := srv.cfg.Repos[:0:0]
+	for _, raw := range srv.cfg.Repos {
+		if !raw.HasNameGlob() {
+			continue
+		}
+		kept = append(kept, raw)
+	}
+	srv.cfg.Repos = kept
+	srv.cfgMu.Unlock()
+	srv.repoVisibilityMu.Unlock()
+
+	rr := <-result
+	require.Equal(http.StatusNotFound, rr.Code, rr.Body.String())
+	hidden, err := database.HiddenRepos(t.Context())
+	require.NoError(err)
+	assert.Empty(hidden,
+		"a PUT losing the race to a delete must not orphan the preference")
 }
 
 func TestStartupVisibilitySweepToleratesNilSyncer(t *testing.T) {


### PR DESCRIPTION
Repositories can now be hidden from the UI without removing them from configuration.

- Each exact repository row in Settings gains a gear menu holding the existing local clone path editor and a "Hide from UI" / "Show in UI" action.
- Hidden repositories drop out of the repository list, repository summaries, the repo typeahead, global repo filters, and the mobile activity selector. Direct links, item feeds, and the Settings page itself still show them, and syncing continues unchanged.
- The preference is stored against the provider-verified repository identity, so it survives renames and is not inherited by a different repository that later reuses the same owner/name route.
- Hiding applies to exact repositories only: glob rows have no gear menu and the API rejects glob targets; repositories not yet verified by their provider return a conflict until a sync completes.

![repo-gear-menu.png](https://github.com/user-attachments/assets/cf2a0e2d-3d4c-47f3-a0ed-be674f0210c7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)