### PR TITLE
fix: prevent concurrent daemon startup failure

### DIFF
--- a/cmd/kenn-forge/lock_e2e_test.go
+++ b/cmd/kenn-forge/lock_e2e_test.go
@@ -383,6 +383,37 @@ func TestDaemonStartReusesForegroundDuringStartupE2E(t *testing.T) {
 	}
 }
 
+// TestDaemonStartPreservesUnauthenticatedLiveRuntimeE2E protects the
+// fail-closed lifecycle boundary. If an unprovable record is treated as stale
+// while its data-directory lock is held, daemon start can replace an ambiguous
+// live owner instead of requiring authoritative identity proof.
+func TestDaemonStartPreservesUnauthenticatedLiveRuntimeE2E(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := newDaemonLifecycleFixture(t, buildForge(t))
+	dataDir := fixture.dataDir("data")
+	fixture.writeConfig(dataDir)
+
+	lockHandle, err := runtimelock.Acquire(dataDir)
+	require.NoError(err)
+	t.Cleanup(func() {
+		assert.NoError(lockHandle.Release())
+	})
+	liveRecord := fixture.writeUnauthenticatedRuntime(dataDir)
+
+	_, stderr, err := fixture.run("start")
+	require.Error(err)
+	assert.Contains(stderr, "no authoritative match")
+	records, err := fixture.store.List()
+	require.NoError(err)
+	require.Len(records, 1)
+	assert.Equal(liveRecord.PID, records[0].PID)
+	assert.Equal(liveRecord.Address, records[0].Address)
+	status, err := runtimelock.Read(dataDir)
+	require.NoError(err)
+	assert.True(status.Running)
+}
+
 // TestForegroundAndBackgroundStartShareAuthToken protects a fresh data
 // directory started through both lifecycle paths at once. If token creation
 // has multiple winners, discovery cannot authenticate the runtime that won the

--- a/cmd/kenn-forge/lock_e2e_test.go
+++ b/cmd/kenn-forge/lock_e2e_test.go
@@ -328,9 +328,15 @@ func TestDaemonStartSerializesConfigMoveBeforeRuntimePublicationE2E(t *testing.T
 func TestDaemonStartReusesForegroundDuringStartupE2E(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	gatePath := filepath.Join(t.TempDir(), "runtime-serve-gate")
-	require.NoError(os.WriteFile(gatePath, []byte("hold\n"), 0o600))
-	bin := buildForgeWithLDFlags(t, "-X main.runtimeServeGatePath="+gatePath)
+	gateDir := t.TempDir()
+	serveGatePath := filepath.Join(gateDir, "runtime-serve-gate")
+	readinessGatePath := filepath.Join(gateDir, "background-readiness-gate")
+	require.NoError(os.WriteFile(serveGatePath, []byte("hold\n"), 0o600))
+	require.NoError(os.WriteFile(readinessGatePath, []byte("hold\n"), 0o600))
+	bin := buildForgeWithLDFlags(t, fmt.Sprintf(
+		"-X main.runtimeServeGatePath=%s -X main.backgroundReadinessGatePath=%s",
+		serveGatePath, readinessGatePath,
+	))
 	fixture := newDaemonLifecycleFixture(t, bin)
 	dataDir := fixture.dataDir("data")
 	fixture.writeConfig(dataDir)
@@ -347,7 +353,8 @@ func TestDaemonStartReusesForegroundDuringStartupE2E(t *testing.T) {
 		close(foregroundDone)
 	}()
 	t.Cleanup(func() {
-		_ = os.Remove(gatePath)
+		_ = os.Remove(serveGatePath)
+		_ = os.Remove(readinessGatePath)
 		if foreground.Process != nil {
 			_ = foreground.Process.Kill()
 		}
@@ -357,29 +364,94 @@ func TestDaemonStartReusesForegroundDuringStartupE2E(t *testing.T) {
 		}
 	})
 
-	waitForFile(t, gatePath+".ready", 10*time.Second)
+	waitForFile(t, serveGatePath+".ready", 10*time.Second)
 	records, err := fixture.store.List()
 	require.NoError(err)
 	require.Len(records, 1)
 	liveRecord := records[0]
 	assert.True(daemon.ProcessAlive(liveRecord.PID))
 
-	_, stderr, err := fixture.run("start")
-	require.NoError(err, stderr)
+	type commandResult struct {
+		stderr string
+		err    error
+	}
+	startDone := make(chan commandResult, 1)
+	go func() {
+		_, stderr, startErr := fixture.run("start")
+		startDone <- commandResult{stderr: stderr, err: startErr}
+	}()
+	waitForFile(t, readinessGatePath+".ready", 10*time.Second)
+	select {
+	case result := <-startDone:
+		require.FailNow("daemon start returned before full readiness", result.stderr)
+	default:
+	}
+
+	require.NoError(os.Remove(serveGatePath))
+	waitForNoFile(t, serveGatePath+".ready", 10*time.Second)
+	require.NoError(os.Remove(readinessGatePath))
+	result := <-startDone
+	require.NoError(result.err, result.stderr)
 	records, err = fixture.store.List()
 	require.NoError(err)
 	require.Len(records, 1)
 	assert.Equal(liveRecord.PID, records[0].PID)
 
-	require.NoError(os.Remove(gatePath))
-	waitForNoFile(t, gatePath+".ready", 10*time.Second)
-	_, stderr, err = fixture.run("stop")
+	_, stderr, err := fixture.run("stop")
 	require.NoError(err, stderr)
 	select {
 	case <-foregroundDone:
 		require.NoError(foregroundErr, foregroundStderr.String())
 	case <-time.After(5 * time.Second):
 		require.Fail("foreground daemon did not stop")
+	}
+}
+
+// TestDaemonStartReportsFailureAfterAuthenticatedPublicationE2E protects
+// background startup readiness. If authenticated publication alone counts as
+// success, daemon start can report a running daemon before a later startup
+// error terminates it.
+func TestDaemonStartReportsFailureAfterAuthenticatedPublicationE2E(t *testing.T) {
+	require := require.New(t)
+	gateDir := t.TempDir()
+	serveGatePath := filepath.Join(gateDir, "runtime-serve-gate")
+	readinessGatePath := filepath.Join(gateDir, "background-readiness-gate")
+	require.NoError(os.WriteFile(serveGatePath, []byte("hold\n"), 0o600))
+	require.NoError(os.WriteFile(readinessGatePath, []byte("hold\n"), 0o600))
+	bin := buildForgeWithLDFlags(t, fmt.Sprintf(
+		"-X main.runtimeServeGatePath=%s -X main.backgroundReadinessGatePath=%s",
+		serveGatePath, readinessGatePath,
+	))
+	fixture := newDaemonLifecycleFixture(t, bin)
+	dataDir := fixture.dataDir("data")
+	fixture.writeConfig(dataDir)
+	require.NoError(os.Mkdir(filepath.Join(dataDir, "forge.db"), 0o700))
+	t.Cleanup(func() {
+		_ = os.Remove(serveGatePath)
+		_ = os.Remove(readinessGatePath)
+	})
+
+	type commandResult struct {
+		stderr string
+		err    error
+	}
+	startDone := make(chan commandResult, 1)
+	go func() {
+		_, stderr, startErr := fixture.run("start")
+		startDone <- commandResult{stderr: stderr, err: startErr}
+	}()
+	waitForFile(t, serveGatePath+".ready", 10*time.Second)
+	waitForFile(t, readinessGatePath+".ready", 10*time.Second)
+
+	require.NoError(os.Remove(serveGatePath))
+	waitForNoFile(t, serveGatePath+".ready", 10*time.Second)
+	require.NoError(os.Remove(readinessGatePath))
+	select {
+	case result := <-startDone:
+		require.Error(result.err)
+		require.Contains(result.stderr, "daemon exited before becoming ready")
+	case <-time.After(10 * time.Second):
+		require.Fail("daemon start did not report the startup failure")
 	}
 }
 

--- a/cmd/kenn-forge/lock_e2e_test.go
+++ b/cmd/kenn-forge/lock_e2e_test.go
@@ -321,7 +321,11 @@ func TestDaemonStartSerializesConfigMoveBeforeRuntimePublicationE2E(t *testing.T
 	require.NoError(err, stderr)
 }
 
-func TestDaemonStartPreservesUnauthenticatedLiveRuntimeE2E(t *testing.T) {
+// TestDaemonStartReusesForegroundDuringStartupE2E protects concurrent
+// foreground and background startup. If the foreground publishes before its
+// identity proof endpoint is ready, daemon start rejects the authoritative
+// lock holder instead of reusing it.
+func TestDaemonStartReusesForegroundDuringStartupE2E(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	gatePath := filepath.Join(t.TempDir(), "runtime-serve-gate")
@@ -361,20 +365,14 @@ func TestDaemonStartPreservesUnauthenticatedLiveRuntimeE2E(t *testing.T) {
 	assert.True(daemon.ProcessAlive(liveRecord.PID))
 
 	_, stderr, err := fixture.run("start")
-	require.Error(err)
-	assert.Contains(stderr, "no authoritative match")
+	require.NoError(err, stderr)
 	records, err = fixture.store.List()
 	require.NoError(err)
 	require.Len(records, 1)
 	assert.Equal(liveRecord.PID, records[0].PID)
 
 	require.NoError(os.Remove(gatePath))
-	require.Eventually(func() bool {
-		_, _, found, findErr := daemonruntime.FindVerified(
-			t.Context(), fixture.store, dataDir,
-		)
-		return findErr == nil && found
-	}, 10*time.Second, 20*time.Millisecond)
+	waitForNoFile(t, gatePath+".ready", 10*time.Second)
 	_, stderr, err = fixture.run("stop")
 	require.NoError(err, stderr)
 	select {

--- a/cmd/kenn-forge/main.go
+++ b/cmd/kenn-forge/main.go
@@ -45,6 +45,16 @@ type splitLogHandler struct {
 	handlers []slog.Handler
 }
 
+type serveReadyListener struct {
+	net.Listener
+	notifyReady func()
+}
+
+func (l serveReadyListener) Accept() (net.Conn, error) {
+	l.notifyReady()
+	return l.Listener.Accept()
+}
+
 func (h splitLogHandler) Enabled(ctx context.Context, level slog.Level) bool {
 	for _, handler := range h.handlers {
 		if handler.Enabled(ctx, level) {
@@ -366,20 +376,6 @@ func run(opts serve.Options) error {
 	if err := lockHandle.WriteMetadata(runtimeIdentity.LockMetadata); err != nil {
 		slog.Warn("write runtime metadata", "err", err)
 	}
-	if err := waitForRuntimeGate(ctx, runtimePublishGatePath, "publish"); err != nil {
-		_ = ln.Close()
-		return err
-	}
-	runtimePath, err := daemonruntime.Publish(runtimeIdentity.Record)
-	if err != nil {
-		_ = ln.Close()
-		return fmt.Errorf("write daemon runtime record: %w", err)
-	}
-	defer func() {
-		if err := os.Remove(runtimePath); err != nil && !errors.Is(err, os.ErrNotExist) {
-			slog.Warn("remove daemon runtime record", "err", err)
-		}
-	}()
 	proof, err := daemon.NewProof([]byte(authToken))
 	if err != nil {
 		_ = ln.Close()
@@ -390,13 +386,13 @@ func run(opts serve.Options) error {
 		_ = ln.Close()
 		return fmt.Errorf("initialize daemon ping: %w", err)
 	}
-	if err := waitForRuntimeGate(ctx, runtimeServeGatePath, "serve"); err != nil {
-		_ = ln.Close()
-		return err
+	daemonAccess := server.DaemonAccessOptions{
+		Token: authToken, RequireAPIAuth: cfg.API.RequireAuth,
+		ProofHandler: daemonProofHandler,
 	}
 
 	startupHandler := server.NewStartupHandler(
-		assets, cfg, server.ServerOptions{}, ln,
+		assets, cfg, server.ServerOptions{DaemonAccess: daemonAccess}, ln,
 	)
 	switcher := server.NewSwitchHandler(startupHandler)
 	httpSrv := &http.Server{
@@ -406,14 +402,17 @@ func run(opts serve.Options) error {
 		// responses are long-lived by design.
 		IdleTimeout: 60 * time.Second,
 	}
+	serveReady := make(chan struct{})
+	readyListener := serveReadyListener{
+		Listener:    ln,
+		notifyReady: sync.OnceFunc(func() { close(serveReady) }),
+	}
 	errCh := make(chan error, 1)
 	go func() {
-		if serveErr := httpSrv.Serve(ln); !errors.Is(serveErr, http.ErrServerClosed) {
+		if serveErr := httpSrv.Serve(readyListener); !errors.Is(serveErr, http.ErrServerClosed) {
 			errCh <- serveErr
 		}
 	}()
-
-	slog.Info(fmt.Sprintf("starting server at http://%s", ln.Addr().String()))
 
 	var database *db.DB
 	var srv *server.Server
@@ -469,6 +468,31 @@ func run(opts serve.Options) error {
 			slog.Warn(shutdownErr.message, "err", shutdownErr.err)
 		}
 	}()
+
+	select {
+	case <-serveReady:
+	case <-ctx.Done():
+		return fmt.Errorf("wait for HTTP server readiness: %w", ctx.Err())
+	case serveErr := <-errCh:
+		return fmt.Errorf("start HTTP server: %w", serveErr)
+	}
+	if err := waitForRuntimeGate(ctx, runtimePublishGatePath, "publish"); err != nil {
+		return err
+	}
+	runtimePath, err := daemonruntime.Publish(runtimeIdentity.Record)
+	if err != nil {
+		return fmt.Errorf("write daemon runtime record: %w", err)
+	}
+	defer func() {
+		if err := os.Remove(runtimePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			slog.Warn("remove daemon runtime record", "err", err)
+		}
+	}()
+	if err := waitForRuntimeGate(ctx, runtimeServeGatePath, "serve"); err != nil {
+		return err
+	}
+
+	slog.Info(fmt.Sprintf("starting server at http://%s", ln.Addr().String()))
 
 	if ctx.Err() != nil {
 		slog.Info("shutting down")
@@ -583,10 +607,7 @@ func run(opts serve.Options) error {
 	srv = server.NewWithConfig(
 		database, syncer, cloneMgr, assets,
 		cfg, configPath, server.ServerOptions{
-			DaemonAccess: server.DaemonAccessOptions{
-				Token: authToken, RequireAPIAuth: cfg.API.RequireAuth,
-				ProofHandler: daemonProofHandler,
-			},
+			DaemonAccess:        daemonAccess,
 			WorktreeDir:         filepath.Join(cfg.DataDir, "worktrees"),
 			PtyOwnerManagerPath: os.Getenv("KENN_FORGE_PTY_MANAGER"),
 			Telemetry:           telemetryReporter,
@@ -692,6 +713,7 @@ func waitForRuntimeGate(ctx context.Context, gatePath, phase string) error {
 	if err := os.WriteFile(gatePath+".ready", []byte("ready\n"), 0o600); err != nil {
 		return fmt.Errorf("%s runtime gate readiness: %w", phase, err)
 	}
+	defer func() { _ = os.Remove(gatePath + ".ready") }()
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
 	for {

--- a/cmd/kenn-forge/start_background.go
+++ b/cmd/kenn-forge/start_background.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 
 	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/daemonruntime"
+	"go.kenn.io/forge/internal/runtimelock"
 	"go.kenn.io/kit/daemon"
 )
 
@@ -18,11 +20,15 @@ const (
 	expectedDataDirEnv     = "KENN_FORGE_EXPECTED_DATA_DIR"
 )
 
+var backgroundReadinessGatePath string
+
 func ensureBackground(
 	ctx context.Context,
 	configPath string,
 	cfg *config.Config,
 ) (daemon.RuntimeRecord, error) {
+	ctx, cancel := context.WithTimeout(ctx, backgroundStartTimeout)
+	defer cancel()
 	if err := validateBackgroundConfig(cfg); err != nil {
 		return daemon.RuntimeRecord{}, err
 	}
@@ -45,7 +51,52 @@ func ensureBackground(
 		return daemon.RuntimeRecord{}, err
 	}
 	record, _, err := manager.Ensure(ctx, backgroundStartTimeout)
-	return record, err
+	if err != nil {
+		return daemon.RuntimeRecord{}, err
+	}
+	if err := waitForBackgroundReadiness(ctx, record, cfg.DataDir); err != nil {
+		return daemon.RuntimeRecord{}, err
+	}
+	return record, nil
+}
+
+func waitForBackgroundReadiness(
+	ctx context.Context,
+	record daemon.RuntimeRecord,
+	dataDir string,
+) error {
+	readinessGatePath := backgroundReadinessGatePath
+	for {
+		ready, err := daemonruntime.IsVerifiedReady(ctx, record, dataDir)
+		if err != nil {
+			return fmt.Errorf("verify daemon readiness: %w", err)
+		}
+		if ready {
+			return nil
+		}
+		status, err := runtimelock.Read(dataDir)
+		if err != nil {
+			return fmt.Errorf("inspect daemon readiness: %w", err)
+		}
+		if !status.Running {
+			return errors.New("daemon exited before becoming ready")
+		}
+		if readinessGatePath != "" {
+			if err := waitForRuntimeGate(
+				ctx, readinessGatePath, "background readiness",
+			); err != nil {
+				return err
+			}
+			readinessGatePath = ""
+		}
+		timer := time.NewTimer(50 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
 }
 
 func validateBackgroundConfig(cfg *config.Config) error {

--- a/context/server-runtime.md
+++ b/context/server-runtime.md
@@ -83,6 +83,9 @@ and the root event stream.
   config home, even when `config.toml` changes `data_dir`; the record is a
   discovery surface and does not replace the authoritative data-directory
   lock/status (`internal/daemonruntime/runtime.go::Publish`).
+- Publish a runtime record only after the startup handler is installed and the
+  HTTP server enters its listener accept loop; lifecycle discovery still proves
+  the published loopback identity exactly before reuse (`cmd/kenn-forge/main.go::serveReadyListener.Accept`).
 - Status uses authenticated config identity before TOML, including for moved runtimes;
   invalid config cannot strand an attributable daemon, while proof-unavailable state
   may report only the configured `data_dir` lock

--- a/context/server-runtime.md
+++ b/context/server-runtime.md
@@ -86,6 +86,9 @@ and the root event stream.
 - Publish a runtime record only after the startup handler is installed and the
   HTTP server enters its listener accept loop; lifecycle discovery still proves
   the published loopback identity exactly before reuse (`cmd/kenn-forge/main.go::serveReadyListener.Accept`).
+- Early identity proof establishes the startup owner, not application readiness;
+  background lifecycle success requires `/healthz` and then re-proves the exact
+  runtime record (`cmd/kenn-forge/start_background.go::waitForBackgroundReadiness`).
 - Status uses authenticated config identity before TOML, including for moved runtimes;
   invalid config cannot strand an attributable daemon, while proof-unavailable state
   may report only the configured `data_dir` lock

--- a/internal/daemonruntime/lifecycle.go
+++ b/internal/daemonruntime/lifecycle.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"go.kenn.io/forge/internal/config"
@@ -100,6 +101,47 @@ func FindVerifiedRecord(
 		return daemon.PingInfo{}, false, fmt.Errorf("initialize daemon proof: %w", err)
 	}
 	return (discovery{dataDir: dataDir}).probe(ctx, proof, record)
+}
+
+// IsVerifiedReady reports whether record serves the ready health endpoint and
+// still proves the same token-bound runtime identity afterward.
+func IsVerifiedReady(
+	ctx context.Context,
+	record daemon.RuntimeRecord,
+	dataDir string,
+) (bool, error) {
+	if !Compatible(record, dataDir) {
+		return false, nil
+	}
+	ep := record.Endpoint()
+	client := ep.HTTPClient(daemon.HTTPClientOptions{
+		Timeout:           probeTimeout,
+		DisableKeepAlives: true,
+	})
+	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodGet, ep.BaseURL()+"/healthz", nil,
+	)
+	if err != nil {
+		return false, fmt.Errorf("build daemon readiness request: %w", err)
+	}
+	response, err := client.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return false, ctx.Err()
+		}
+		return false, nil
+	}
+	if err := response.Body.Close(); err != nil {
+		return false, fmt.Errorf("close daemon readiness response: %w", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		return false, nil
+	}
+	_, found, err := FindVerifiedRecord(ctx, record, dataDir)
+	return found, err
 }
 
 func (d discovery) findVerified(

--- a/internal/server/startup_handler.go
+++ b/internal/server/startup_handler.go
@@ -41,16 +41,17 @@ func (h *SwitchHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 type startupHandler struct {
-	hostOpts     HostCheckOptions
-	allowedHosts map[string]struct{}
-	basePath     string
-	spa          http.Handler
+	hostOpts       HostCheckOptions
+	allowedHosts   map[string]struct{}
+	daemonRequests daemonRequestPolicy
+	basePath       string
+	spa            http.Handler
 }
 
 // NewStartupHandler returns a minimal handler for the window between listener
-// bind and full backend readiness. It serves the real SPA shell and frontend
-// assets immediately, while API and websocket routes report service unavailable
-// until the full server is swapped in.
+// bind and full backend readiness. It serves daemon identity proof, the real
+// SPA shell, and frontend assets immediately, while other API and websocket
+// routes report service unavailable until the full server is swapped in.
 func NewStartupHandler(
 	frontend fs.FS,
 	cfg *config.Config,
@@ -81,8 +82,13 @@ func NewStartupHandler(
 	return &startupHandler{
 		hostOpts:     hostOpts,
 		allowedHosts: allowedHostsForListener(ln),
-		basePath:     basePath,
-		spa:          spa,
+		daemonRequests: daemonRequestPolicy{
+			token:          options.DaemonAccess.Token,
+			requireAPIAuth: options.DaemonAccess.RequireAPIAuth,
+			proof:          options.DaemonAccess.ProofHandler,
+		},
+		basePath: basePath,
+		spa:      spa,
 	}
 }
 
@@ -96,6 +102,10 @@ func writeStartupUnavailable(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (h *startupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	admission := h.daemonRequests.admit(w, r, h.hostOpts, false)
+	if admission.handled {
+		return
+	}
 	if !checkHost(w, r, h.hostOpts) {
 		return
 	}


### PR DESCRIPTION
## What changed

- Publish the runtime record only after the local server starts accepting requests.
- Let a starting foreground process prove it owns that record.
- Make `daemon start` wait for full health, then verify the same process again.
- Keep ambiguous or unverified owners fail-closed.

## Why

Concurrent foreground and background startup could reject the real owner. Early proof fixes that race, while the health check prevents success from being reported before initialization finishes.

## Limit

- Background startup still uses the existing 90-second startup budget.
