### PR TITLE
fix: allow quota ceiling note to wrap

### DIFF
--- a/frontend/src/lib/components/layout/BudgetPopover.svelte
+++ b/frontend/src/lib/components/layout/BudgetPopover.svelte
@@ -284,6 +284,7 @@
     color: var(--text-muted);
     font-size: 0.9em;
     line-height: 1.2;
+    white-space: normal;
   }
   .row-unknown {
     color: var(--text-muted);

--- a/frontend/src/lib/components/layout/StatusBar.budget.browser.svelte.ts
+++ b/frontend/src/lib/components/layout/StatusBar.budget.browser.svelte.ts
@@ -234,6 +234,11 @@ describe("budget display", () => {
     expect(popover.textContent).toContain("provider quota above is authoritative");
     expect(popover.querySelector(".budget-spent")?.textContent).toBe("42");
 
+    const ceilingNote = popover.querySelector<HTMLElement>(".budget-row--ceiling .row-note");
+    expect(ceilingNote).not.toBeNull();
+    const noteLineHeight = Number.parseFloat(getComputedStyle(ceilingNote!).lineHeight);
+    expect(ceilingNote!.getBoundingClientRect().height).toBeGreaterThan(noteLineHeight * 1.5);
+
     const ceilingLabel = popover.querySelector<HTMLElement>(".budget-row--ceiling .row-label");
     const ceilingValue = popover.querySelector<HTMLElement>(".budget-row--ceiling .row-value");
     expect(ceilingLabel).not.toBeNull();


### PR DESCRIPTION
The provider quota popover inherits the status bar's single-line text behavior. This caused the local sync ceiling explanation to overflow the fixed-width panel and hid guidance that helps maintainers distinguish the local guard from provider quota.

The explanation now wraps inside its value column while the compact quota values stay on one line. A browser layout regression verifies that the note renders across multiple lines.

<details>
<summary>Validation</summary>

- Full Vitest suite: 4,105 passed, 2 skipped.
- Focused mocked Playwright screenshot capture: 1 passed.
- Frontend formatting, lint, Svelte checks, and Effect diagnostics passed.
- Push hooks passed.

</details>

<sup>generated by a clanker</sup>