### PR TITLE
fix: load workspaces through remote HTTP proxies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -656,6 +656,8 @@ jobs:
         run: go build -buildvcs=false -o ./cmd/e2e-server/e2e-server ./cmd/e2e-server
 
       - name: Run E2E tests
+        env:
+          KENN_FORGE_E2E_INSECURE_ORIGIN: "1"
         run: cd frontend && ../node_modules/.bin/vp exec -- playwright test --config=playwright-e2e.config.ts --project=${{ matrix.browser }}
 
       # The GitHub App setup page suite runs Desktop Chrome only, so it

--- a/context/testing.md
+++ b/context/testing.md
@@ -207,6 +207,9 @@ and must not be rebuilt or removed (`frontend/tests/e2e-full/support/e2eServer.t
   for an admitted creation before killing the private server (`cmd/e2e-server/main.go::tmuxCreationGate`).
 - Keep explicit PTY-owner test mode unwrapped so its missing tmux command remains
   unavailable to backend selection (`cmd/e2e-server/main.go::buildAppState`).
+Playwright regressions that require a non-loopback listener must be opt-in only
+in the isolated CI container; local runs must skip before binding because the
+full-stack fixture exposes mutation and runtime endpoints (`frontend/tests/e2e-full/00-workspace-sidebar.spec.ts:172`).
 
 Mounting `KataWorkspace.svelte` in Vitest always fetches the daemon roster and
 opens the live SSE event stream; mock both fetch routes (see

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -167,7 +167,7 @@
     ),
   );
   let requestApplicationWorkspaceRefresh = refreshWorkspaces.request;
-  const workspaceRefreshOwner = crypto.randomUUID();
+  const workspaceRefreshOwner = $props.id();
 
   type WorkspaceGroup = {
     key: string;

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -225,6 +225,16 @@ describe("WorkspaceListSidebar", () => {
     vi.useRealTimers();
   });
 
+  it("loads without secure-context crypto APIs", async () => {
+    vi.stubGlobal("crypto", {});
+    mockGet.mockResolvedValue({ data: { workspaces: [] } });
+
+    render(WorkspaceListSidebar, { props: { selectedId: "" } });
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalledWith("/workspaces", expect.anything()));
+    expect(screen.getByText("Workspaces")).toBeTruthy();
+  });
+
   it("shows fleet hosts when peers are present", async () => {
     mockGet.mockImplementation((path: string) => {
       if (path === "/snapshot") {

--- a/frontend/src/lib/dev/viteConfig.test.ts
+++ b/frontend/src/lib/dev/viteConfig.test.ts
@@ -96,21 +96,21 @@ describe("vite config", () => {
     expect(resolveViteAllowedHosts({})).toBeUndefined();
     expect(
       resolveViteAllowedHosts({
-        KENN_FORGE_VITE_ALLOWED_HOSTS: "mariuss-macbook-pro.emperor-gopher.ts.net, another.ts.net",
+        KENN_FORGE_VITE_ALLOWED_HOSTS: "forge.example.test, another.example.test",
       }),
-    ).toEqual(["mariuss-macbook-pro.emperor-gopher.ts.net", "another.ts.net"]);
+    ).toEqual(["forge.example.test", "another.example.test"]);
   });
 
   it("can advertise HMR through the tailnet HTTPS endpoint", () => {
     expect(
       resolveViteHmr({
-        KENN_FORGE_VITE_HMR_HOST: "mariuss-macbook-pro.emperor-gopher.ts.net",
+        KENN_FORGE_VITE_HMR_HOST: "forge.example.test",
         KENN_FORGE_VITE_HMR_PROTOCOL: "wss",
         KENN_FORGE_VITE_HMR_CLIENT_PORT: "443",
       }),
     ).toEqual({
       protocol: "wss",
-      host: "mariuss-macbook-pro.emperor-gopher.ts.net",
+      host: "forge.example.test",
       clientPort: 443,
       path: "/__vite_hmr",
     });

--- a/frontend/src/lib/dev/viteConfig.test.ts
+++ b/frontend/src/lib/dev/viteConfig.test.ts
@@ -36,14 +36,11 @@ describe("vite config", () => {
     expect(includes).toContain("@lucide/svelte/icons/list-chevrons-up-down");
   });
 
-  it("pins the dev server host to IPv4 loopback", () => {
+  it("pins the dev server listener to loopback while HMR follows the page origin", () => {
     expect(config.server?.host).toBe("127.0.0.1");
     expect(config.server?.port).toBe(5174);
     expect(config.server?.strictPort).toBe(true);
     expect(config.server?.hmr).toEqual({
-      protocol: "ws",
-      host: "127.0.0.1",
-      clientPort: 5174,
       path: "/__vite_hmr",
     });
   });
@@ -89,7 +86,7 @@ describe("vite config", () => {
     expect(webSocketDebugEnabled({ KENN_FORGE_WS_DEBUG: "yes" })).toBe(true);
   });
 
-  it("uses the Vite CLI port for dev server HMR settings", () => {
+  it("uses the Vite CLI port for the dev server listener", () => {
     expect(resolveViteServerPort(["vite", "--port", "4173"])).toBe(4173);
     expect(resolveViteServerPort(["vite", "--port=4180"])).toBe(4180);
     expect(resolveViteServerPort(["vite"])).toBe(5174);
@@ -106,7 +103,7 @@ describe("vite config", () => {
 
   it("can advertise HMR through the tailnet HTTPS endpoint", () => {
     expect(
-      resolveViteHmr(5174, {
+      resolveViteHmr({
         KENN_FORGE_VITE_HMR_HOST: "mariuss-macbook-pro.emperor-gopher.ts.net",
         KENN_FORGE_VITE_HMR_PROTOCOL: "wss",
         KENN_FORGE_VITE_HMR_CLIENT_PORT: "443",

--- a/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
@@ -3,6 +3,8 @@
 // that start near the end of the run stretch the suite tail.
 
 import { expect, request as playwrightRequest, test, type APIRequestContext } from "@playwright/test";
+import { createServer, request as httpRequest, type Server } from "node:http";
+import { networkInterfaces } from "node:os";
 import {
   startIsolatedWorkspaceE2EServer,
   startIsolatedWorkspaceE2EServerWithOptions,
@@ -162,6 +164,85 @@ test.describe("workspace sidebar full-stack", () => {
         }),
       ).toHaveCount(1, { timeout: 7_000 });
     } finally {
+      await api?.dispose();
+      await isolatedServer?.stop();
+    }
+  });
+
+  test("loads a real workspace from an insecure HTTP origin", async ({ page }) => {
+    let isolatedServer: IsolatedE2EServer | null = null;
+    let api: APIRequestContext | null = null;
+    let proxyServer: Server | null = null;
+    try {
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
+      api = await playwrightRequest.newContext({
+        baseURL: isolatedServer.info.base_url,
+      });
+      await createIssueWorkspace(api, 10);
+
+      const upstreamOrigin = new URL(isolatedServer.info.base_url);
+      const proxyHost = Object.values(networkInterfaces())
+        .flat()
+        .find((address) => address?.family === "IPv4" && !address.internal)?.address;
+      if (!proxyHost) {
+        throw new Error("no non-loopback IPv4 address is available for the insecure-origin proxy");
+      }
+
+      proxyServer = createServer((request, response) => {
+        const upstreamRequest = httpRequest(
+          new URL(request.url ?? "/", upstreamOrigin),
+          {
+            method: request.method,
+            headers: {
+              ...request.headers,
+              host: upstreamOrigin.host,
+            },
+          },
+          (upstreamResponse) => {
+            response.writeHead(upstreamResponse.statusCode ?? 502, upstreamResponse.headers);
+            upstreamResponse.pipe(response);
+          },
+        );
+        upstreamRequest.on("error", (error) => {
+          if (!response.headersSent) {
+            response.writeHead(502);
+          }
+          response.end(error.message);
+        });
+        request.pipe(upstreamRequest);
+      });
+      await new Promise<void>((resolve, reject) => {
+        proxyServer?.once("error", reject);
+        proxyServer?.listen(0, proxyHost, resolve);
+      });
+      const proxyAddress = proxyServer.address();
+      if (!proxyAddress || typeof proxyAddress === "string") {
+        throw new Error("insecure-origin proxy did not publish a TCP address");
+      }
+
+      const insecureOrigin = `http://${proxyHost}:${proxyAddress.port}`;
+      await page.goto(`${insecureOrigin}/workspaces`);
+
+      expect(await page.evaluate(() => window.isSecureContext)).toBe(false);
+      expect(await page.evaluate(() => typeof crypto.randomUUID)).toBe("undefined");
+      await expect(
+        page.locator(".workspace-list-sidebar .ws-row").filter({
+          hasText: "Widget rendering broken on Safari",
+        }),
+      ).toHaveCount(1);
+    } finally {
+      if (proxyServer) {
+        proxyServer.closeAllConnections();
+        await new Promise<void>((resolve, reject) => {
+          proxyServer?.close((error) => {
+            if (error) {
+              reject(error);
+              return;
+            }
+            resolve();
+          });
+        });
+      }
       await api?.dispose();
       await isolatedServer?.stop();
     }

--- a/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
@@ -170,6 +170,8 @@ test.describe("workspace sidebar full-stack", () => {
   });
 
   test("loads a real workspace from an insecure HTTP origin", async ({ page }) => {
+    test.skip(process.env.KENN_FORGE_E2E_INSECURE_ORIGIN !== "1", "Runs only in the isolated Playwright CI container");
+
     let isolatedServer: IsolatedE2EServer | null = null;
     let api: APIRequestContext | null = null;
     let proxyServer: Server | null = null;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -15,7 +15,7 @@ const testingLibrarySvelteEntry = require.resolve("@testing-library/svelte");
 const apiUrl = resolveDevApiUrl();
 const devServerPort = resolveViteServerPort();
 const devServerAllowedHosts = resolveViteAllowedHosts();
-const devServerHmr = resolveViteHmr(devServerPort);
+const devServerHmr = resolveViteHmr();
 const workspaceRoot = searchForWorkspaceRoot(process.cwd());
 
 function devApiUrlPlugin(url: string): Plugin {
@@ -72,15 +72,16 @@ export function resolveViteAllowedHosts(env: Record<string, string | undefined> 
   return hosts.length > 0 ? hosts : undefined;
 }
 
-export function resolveViteHmr(port = resolveViteServerPort(), env: Record<string, string | undefined> = process.env) {
-  const protocol = env.KENN_FORGE_VITE_HMR_PROTOCOL === "wss" ? "wss" : "ws";
-  const host = env.KENN_FORGE_VITE_HMR_HOST?.trim() || "127.0.0.1";
-  const clientPort = parsePort(env.KENN_FORGE_VITE_HMR_CLIENT_PORT) ?? port;
+export function resolveViteHmr(env: Record<string, string | undefined> = process.env) {
+  const configuredProtocol = env.KENN_FORGE_VITE_HMR_PROTOCOL;
+  const protocol = configuredProtocol === "ws" || configuredProtocol === "wss" ? configuredProtocol : undefined;
+  const host = env.KENN_FORGE_VITE_HMR_HOST?.trim() || undefined;
+  const clientPort = parsePort(env.KENN_FORGE_VITE_HMR_CLIENT_PORT) ?? undefined;
 
   return {
-    protocol,
-    host,
-    clientPort,
+    ...(protocol ? { protocol } : {}),
+    ...(host ? { host } : {}),
+    ...(clientPort ? { clientPort } : {}),
     path: "/__vite_hmr",
   };
 }


### PR DESCRIPTION
Opening kenn-forge through a plain-HTTP reverse proxy could leave the Workspaces view blank. The sidebar required a browser API that is unavailable on insecure origins. Vite also told remote browsers to connect hot module replacement to their own loopback address.

Use Svelte's component identity for workspace refresh ownership, and let Vite derive its development WebSocket endpoint from the page origin. Explicit HMR overrides remain available for proxies that expose a different host, protocol, or port. The full-stack insecure-origin regression opts in only inside the isolated Docker E2E job, so ordinary local runs never bind its non-loopback proxy.

<details>
<summary>Validation</summary>

- Frontend unit suite: 3,887 passed, 2 skipped.
- Local workspace-sidebar Playwright suite: 24 passed, 8 skipped across Chromium and Firefox.
- Frontend checks, non-mutating lint, commit hooks, push hooks, and public-safety scans passed.

</details>

<sup>generated by a clanker</sup>