### PR TITLE
Align stacked warning content with CI chips

### DIFF
--- a/frontend/src/App.stack-status.browser.svelte.ts
+++ b/frontend/src/App.stack-status.browser.svelte.ts
@@ -133,7 +133,17 @@ function toolsPullDetail(number: number, downstackFailure = false) {
       CommentCount: 0,
       ReviewDecision: member.review_decision,
       CIStatus: member.ci_status,
-      CIChecksJSON: "[]",
+      CIChecksJSON: downstackFailure
+        ? JSON.stringify([
+            {
+              name: "test",
+              status: "completed",
+              conclusion: "failure",
+              url: "",
+              app: "",
+            },
+          ])
+        : "[]",
       CreatedAt: "2026-03-29T14:00:00Z",
       UpdatedAt: "2026-03-30T14:00:00Z",
       LastActivityAt: "2026-03-30T14:00:00Z",
@@ -187,6 +197,12 @@ function stackSummaryText(): string {
   return document.querySelector(".stack-panel .stack-summary")?.textContent?.trim() ?? "";
 }
 
+function textRect(element: HTMLElement): DOMRect {
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  return range.getBoundingClientRect();
+}
+
 describe("stack status panel", () => {
   vi.setConfig({ testTimeout: 30_000 });
 
@@ -229,7 +245,7 @@ describe("stack status panel", () => {
     expect(window.location.pathname).toBe("/pulls/github/acme/tools/11");
   });
 
-  it("aligns the downstack failure count with the stack label", async () => {
+  it("matches the stack warning token to CI and keeps its count on the label baseline", async () => {
     mounted = await mountBrowserApp("/pulls/github/acme/tools/11", {
       overrides: [toolsStackRoutes(true)],
     });
@@ -237,10 +253,16 @@ describe("stack status panel", () => {
     await expect.element(page.getByTestId("stack-chip")).toBeVisible();
 
     const label = document.querySelector<HTMLElement>(".stack-chip-label");
-    const failure = document.querySelector<HTMLElement>(".stack-chip-failure");
+    const failureCount = document.querySelector<HTMLElement>(".stack-chip-failure > span");
+    const stackFailureIcon = document.querySelector<SVGElement>(".stack-chip-failure > svg");
+    const ciFailureIcon = document.querySelector<SVGElement>("[data-testid='ci-token-failed'] > svg");
     expect(label).not.toBeNull();
-    expect(failure).not.toBeNull();
-    expect(Math.abs(label!.getBoundingClientRect().bottom - failure!.getBoundingClientRect().bottom)).toBeLessThan(1);
+    expect(failureCount).not.toBeNull();
+    expect(stackFailureIcon).not.toBeNull();
+    expect(ciFailureIcon).not.toBeNull();
+
+    expect(Math.abs(textRect(label!).bottom - textRect(failureCount!).bottom)).toBeLessThanOrEqual(0.5);
+    expect(stackFailureIcon!.getBoundingClientRect().height).toBe(ciFailureIcon!.getBoundingClientRect().height);
   });
 
   it("preserves the focus route when navigating to a stack member", async () => {

--- a/frontend/src/App.stack-status.browser.svelte.ts
+++ b/frontend/src/App.stack-status.browser.svelte.ts
@@ -253,7 +253,7 @@ describe("stack status panel", () => {
     await expect.element(page.getByTestId("stack-chip")).toBeVisible();
 
     const label = document.querySelector<HTMLElement>(".stack-chip-label");
-    const failureCount = document.querySelector<HTMLElement>(".stack-chip-failure > span");
+    const failureCount = document.querySelector<HTMLElement>(".stack-chip-failure-count");
     const stackFailureIcon = document.querySelector<SVGElement>(".stack-chip-failure > svg");
     const ciFailureIcon = document.querySelector<SVGElement>("[data-testid='ci-token-failed'] > svg");
     expect(label).not.toBeNull();
@@ -262,7 +262,12 @@ describe("stack status panel", () => {
     expect(ciFailureIcon).not.toBeNull();
 
     expect(Math.abs(textRect(label!).bottom - textRect(failureCount!).bottom)).toBeLessThanOrEqual(0.5);
-    expect(stackFailureIcon!.getBoundingClientRect().height).toBe(ciFailureIcon!.getBoundingClientRect().height);
+    const stackIconRect = stackFailureIcon!.getBoundingClientRect();
+    const ciIconRect = ciFailureIcon!.getBoundingClientRect();
+    expect(stackIconRect.height).toBe(ciIconRect.height);
+    expect(
+      Math.abs(stackIconRect.top + stackIconRect.height / 2 - (ciIconRect.top + ciIconRect.height / 2)),
+    ).toBeLessThanOrEqual(0.5);
   });
 
   it("preserves the focus route when navigating to a stack member", async () => {

--- a/frontend/src/lib/components/detail/StackStatus.svelte
+++ b/frontend/src/lib/components/detail/StackStatus.svelte
@@ -363,7 +363,7 @@
     display: inline-flex;
     align-items: center;
     vertical-align: middle;
-    gap: 2px;
+    gap: var(--space-1);
     color: var(--accent-red);
     font-variant-numeric: tabular-nums;
     font-weight: 700;

--- a/frontend/src/lib/components/detail/StackStatus.svelte
+++ b/frontend/src/lib/components/detail/StackStatus.svelte
@@ -281,7 +281,7 @@
         <span class="stack-chip-label">Stacked: {data.position}/{data.size}</span>
         {#if downstackBlockerCount > 0}
           <span class="stack-chip-failure" aria-hidden="true">
-            <XIcon size={12} strokeWidth={2.8} />
+            <XIcon size={14} strokeWidth={2.8} />
             <span>{downstackBlockerCount}</span>
           </span>
         {/if}
@@ -362,8 +362,8 @@
 
   .stack-chip-failure {
     display: inline-flex;
-    align-items: center;
-    vertical-align: middle;
+    align-items: baseline;
+    vertical-align: baseline;
     gap: 1px;
     color: var(--accent-red);
     font-variant-numeric: tabular-nums;

--- a/frontend/src/lib/components/detail/StackStatus.svelte
+++ b/frontend/src/lib/components/detail/StackStatus.svelte
@@ -281,8 +281,7 @@
         <span class="stack-chip-label">Stacked: {data.position}/{data.size}</span>
         {#if downstackBlockerCount > 0}
           <span class="stack-chip-failure" aria-hidden="true">
-            <XIcon size={14} strokeWidth={2.8} />
-            <span>{downstackBlockerCount}</span>
+            <XIcon size={14} strokeWidth={2.8} /><span class="stack-chip-failure-count">{downstackBlockerCount}</span>
           </span>
         {/if}
         {#snippet trailing()}
@@ -362,9 +361,9 @@
 
   .stack-chip-failure {
     display: inline-flex;
-    align-items: baseline;
-    vertical-align: baseline;
-    gap: 1px;
+    align-items: center;
+    vertical-align: middle;
+    gap: 2px;
     color: var(--accent-red);
     font-variant-numeric: tabular-nums;
     font-weight: 700;
@@ -373,6 +372,11 @@
 
   .stack-chip-failure :global(svg) {
     display: block;
+  }
+
+  .stack-chip-failure-count {
+    font-size: 0.9em;
+    line-height: 1;
   }
 
   :global(.chip-chevron) {


### PR DESCRIPTION
Compact pull request metadata should scan as one line. The downstack warning count sat below the Stacked label, and its X glyph was smaller than the matching continuous integration (CI) failure glyph.\n\nThis aligns the warning with the text baseline, matches the CI glyph size, and adds real-browser geometry coverage so the two chips stay consistent.\n\n<sup>generated by a clanker</sup>