### PR TITLE
feat(activity): reflect live workspace activity across item views

### DIFF
--- a/context/testing.md
+++ b/context/testing.md
@@ -236,6 +236,8 @@ bridge on unmount so assertions do not read stale graph sessions.
 Playwright waits must observe the state consumed by the next assertion. Direct API reads after an optimistic
 mutation wait for its response; rendered assertions wait for rendered state, since route refinement can pair new
 controls with old content (`frontend/tests/e2e-full/utc-maintainer-flows.spec.ts:90`, `frontend/tests/e2e-full/repo-browser.spec.ts:480`).
+Tests that compress browser polling must patch the timer primitive used by the scheduler and await the response
+that carries the expected state (`frontend/tests/e2e-full/ci-dropdown.spec.ts:40`).
 
 Playwright suites with `route.fetch()` proxies must unregister routes with
 `page.unrouteAll({ behavior: "ignoreErrors" })` before page teardown; background refetches can otherwise fail outside the completed test (`frontend/tests/e2e-full/diff-view.spec.ts::mockReviewThreadsOnPreviewMarkdown`).

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -12,6 +12,12 @@ semantics.
 - Prevent narrow regressions that usually show up only after review or in e2e
   flows.
 
+## Browser Runtime Constraints
+
+- Do not require secure-context-only browser APIs: remote daemon access may use
+  plain HTTP, so local identity tokens must use runtime-independent identity
+  (`frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte:workspaceRefreshOwner`).
+
 ## Identity And Route State
 
 Interactive surfaces must agree on which item is selected.

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -130,10 +130,46 @@ embedder protocol for arbitrary host state.
 - List/detail reads return persisted plus last-known-good enrichment without
   foreground git or tmux probes; stale components reconcile through bounded
   background workers (`internal/server/workspaceapi/workspace_enrichment.go::toCachedWorkspaceResponse`).
-- `enrichment_status` is aggregate across reads and refresh/push/pull responses:
-  failed reconciliation retains last-known-good components while preserving
-  failure status/error
-  (`internal/server/workspaceapi/workspace_enrichment.go::refreshWorkspaceResponse`).
+- Activity and Issue/Pull Request list and detail responses share one cached
+  subject snapshot: every resolvable subject keeps a workspace reference, while
+  tmux activity remains optional and ephemeral (`internal/server/workspaceapi/subject_activity.go::Handler.WorkspaceSubjectSnapshot`).
+- Workspace enrichment is best-effort on Issue/PR detail: snapshot failures log
+  and omit optional workspace metadata rather than hiding a valid item; list and
+  Activity reads stay fail-fast because the snapshot affects ordering and identity (`internal/server/pullapi/routes.go::Handler.buildPullDetailResponse`, `internal/server/issueapi/routes.go::Handler.BuildDetail`).
+- Threaded and Mobile Activity merge that snapshot after provider-event filters,
+  so workspace recency can keep an event-less subject visible; Flat Activity
+  remains provider-event-only (`frontend/src/lib/views/MobileActivityView.svelte::groups`).
+- Activity normalizes search once and keeps workspace recency for subjects with
+  matching provider events across incremental polls; metadata search filters only
+  eventless rows (`internal/server/huma_routes.go::Server.workspaceActivityResponse`).
+- Activity event references key that snapshot by stable repo ID: issues use
+  own identity and PRs use resolved identity, so route reuse stays fail-closed
+  (`internal/server/helpers.go::workspaceRefForActivityItem`).
+- The shared subject snapshot holds the repository-reconciliation read barrier
+  across both its workspace-summary and subject-metadata reads, so a route move
+  cannot split one response across repository identities
+  (`internal/server/workspaceapi/subject_activity.go::Handler.WorkspaceSubjectSnapshot`).
+- Activity holds one reconciliation barrier across provider events and the
+  under-lock workspace-subject snapshot, keeping routes and stable IDs in one epoch
+  (`internal/server/huma_routes.go::Server.listActivity`).
+- Subject metadata and Issue/PR effective-activity ordering use JSON-backed
+  SQLite relations, so retained workspaces cannot exhaust bind variables
+  (`internal/db/workspace_subjects.go::DB.ListWorkspaceSubjectMetadata`, `internal/db/queries.go::workspaceActivityCTE`).
+- Association changes only activity identity: an issue keeps its own workspace
+  affordance after its work resolves to a PR, while that PR receives the tmux
+  recency override (`internal/server/workspaceapi/subject_activity.go::Handler.WorkspaceSubjectSnapshot`).
+- Aggregate enrichment is fresh only after divergence and tmux both complete;
+  partial results remain pending or stale
+  (`internal/server/workspaceapi/workspace_enrichment.go::workspaceResponseFromEnrichmentCacheEntry`).
+- Divergence and tmux freshness use only their own attempt and refresh times;
+  an unattempted component remains immediately due after unrelated component work
+  (`internal/server/workspaceapi/workspace_enrichment.go::cachedWorkspaceEnrichment`).
+- Failed enrichment retains last-known-good values and component-owned errors;
+  one component's success clears only its own error
+  (`internal/server/workspaceapi/workspace_enrichment.go::recordWorkspaceEnrichmentResult`).
+- Each workspace admits one background enrichment flight at a time; a full
+  refresh upgrade waits behind active tmux work, and only the matching unique
+  flight may release ownership (`internal/server/workspaceapi/workspace_enrichment.go::nextWorkspaceEnrichmentJob`).
 - Overlapping tmux probes wait for the active sample within the caller budget;
   fallback carries an error only when waiting or sample production fails
   (`internal/server/workspaceapi/routes_handlers.go::probeOneTmuxSession`).

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -151,8 +151,15 @@ components:
           type:
             - array
             - "null"
+        workspace_activity:
+          items:
+            $ref: "#/components/schemas/WorkspaceActivitySubjectResponse"
+          type:
+            - array
+            - "null"
       required:
         - items
+        - workspace_activity
         - capped
       type: object
     AddRepoInputBody:
@@ -2929,6 +2936,9 @@ components:
           type: string
         workspace:
           $ref: "#/components/schemas/WorkspaceRef"
+        workspace_activity_at:
+          format: date-time
+          type: string
       required:
         - repo
         - platform_host
@@ -4365,6 +4375,9 @@ components:
             - "null"
         workspace:
           $ref: "#/components/schemas/WorkspaceRef"
+        workspace_activity_at:
+          format: date-time
+          type: string
         worktree_links:
           items:
             $ref: "#/components/schemas/WorktreeLinkResponse"
@@ -7711,6 +7724,47 @@ components:
           type: string
       required:
         - status
+      type: object
+    WorkspaceActivitySubjectResponse:
+      additionalProperties: false
+      properties:
+        activity_at:
+          format: date-time
+          type: string
+        item_author:
+          type: string
+        item_number:
+          format: int64
+          type: integer
+        item_state:
+          type: string
+        item_title:
+          type: string
+        item_type:
+          type: string
+        item_url:
+          type: string
+        platform_host:
+          type: string
+        repo:
+          $ref: "#/components/schemas/RepoRefResponse"
+        repo_name:
+          type: string
+        repo_owner:
+          type: string
+        workspace:
+          $ref: "#/components/schemas/WorkspaceRef"
+      required:
+        - repo
+        - platform_host
+        - repo_owner
+        - repo_name
+        - item_type
+        - item_number
+        - item_title
+        - item_url
+        - item_state
+        - activity_at
       type: object
     WorkspaceDiffWatchResponse:
       additionalProperties: false

--- a/frontend/src/lib/api/generated/schema.ts
+++ b/frontend/src/lib/api/generated/schema.ts
@@ -4399,6 +4399,7 @@ export interface components {
             readonly $schema?: string;
             capped: boolean;
             items: components["schemas"]["ActivityItemResponse"][] | null;
+            workspace_activity: components["schemas"]["WorkspaceActivitySubjectResponse"][] | null;
         };
         AddRepoInputBody: {
             /**
@@ -5697,6 +5698,8 @@ export interface components {
             repo_name: string;
             repo_owner: string;
             workspace?: components["schemas"]["WorkspaceRef"];
+            /** Format: date-time */
+            workspace_activity_at?: string;
         };
         Issues: {
             hide_bots: boolean;
@@ -6298,6 +6301,8 @@ export interface components {
             repo_owner: string;
             requested_reviewers?: string[] | null;
             workspace?: components["schemas"]["WorkspaceRef"];
+            /** Format: date-time */
+            workspace_activity_at?: string;
             worktree_links: components["schemas"]["WorktreeLinkResponse"][] | null;
         };
         MergeRequestSummary: {
@@ -7785,6 +7790,22 @@ export interface components {
             updated_at?: string;
             updated_reason?: string;
             updated_source?: string;
+        };
+        WorkspaceActivitySubjectResponse: {
+            /** Format: date-time */
+            activity_at: string;
+            item_author?: string;
+            /** Format: int64 */
+            item_number: number;
+            item_state: string;
+            item_title: string;
+            item_type: string;
+            item_url: string;
+            platform_host: string;
+            repo: components["schemas"]["RepoRefResponse"];
+            repo_name: string;
+            repo_owner: string;
+            workspace?: components["schemas"]["WorkspaceRef"];
         };
         WorkspaceDiffWatchResponse: {
             /**

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -24,6 +24,7 @@ export type LocalSyncCeilingStatus = components["schemas"]["LocalSyncCeilingStat
 export type RateLimitsResponse = components["schemas"]["RateLimitsResponse"];
 export type ActivityItem = components["schemas"]["ActivityItemResponse"];
 export type ActivityResponse = components["schemas"]["ActivityResponse"];
+export type WorkspaceActivitySubject = components["schemas"]["WorkspaceActivitySubjectResponse"];
 export type NotificationItem = components["schemas"]["NotificationResponse"];
 export type NotificationsResponse = components["schemas"]["NotificationsResponse"];
 export type NotificationSummary = components["schemas"]["NotificationSummaryResponse"];

--- a/frontend/src/lib/components/ActivityFeed.svelte
+++ b/frontend/src/lib/components/ActivityFeed.svelte
@@ -2,7 +2,7 @@
   import { EmptyState, SearchInput, Spinner, Toggle } from "@kenn-io/kit-ui";
   import { Effect } from "effect";
   import { onMount, onDestroy } from "svelte";
-  import type { ActivityItem } from "../api/types.js";
+  import type { ActivityItem, WorkspaceActivitySubject } from "../api/types.js";
   import type { AppExecution } from "../app/runtime.js";
   import { getAppRuntime } from "../app/runtime-context.js";
   import {
@@ -282,6 +282,16 @@
     }
     if (activity.getHideDefaultBranchActivity()) {
       result = result.filter((it) => !isDefaultBranchActivity(it));
+    }
+    return result;
+  });
+
+  const visibleWorkspaceActivity = $derived.by(() => {
+    let result: WorkspaceActivitySubject[] = activity.getWorkspaceActivity().filter((subject) =>
+      isActivityItemTypeEnabled(subject.item_type, activity.getEnabledItemTypes())
+    );
+    if (activity.getHideClosedMerged()) {
+      result = result.filter((subject) => subject.item_state !== "closed" && subject.item_state !== "merged");
     }
     return result;
   });
@@ -655,7 +665,7 @@
     </div>
     </ScrollBox>
   {:else if activity.getViewMode() === "threaded"}
-    {#if displayItems.length === 0 && activity.isActivityLoading()}
+    {#if displayItems.length === 0 && visibleWorkspaceActivity.length === 0 && activity.isActivityLoading()}
       <ScrollBox label="Activity feed">
       <div class="table-container">
         <div class="loading-placeholder">
@@ -667,6 +677,7 @@
     {:else}
       <ActivityThreaded
         items={displayItems}
+        workspaceActivity={visibleWorkspaceActivity}
         {onSelectItem}
         {onSelectBranchCommit}
         {compact}

--- a/frontend/src/lib/components/ActivityFeed.test.ts
+++ b/frontend/src/lib/components/ActivityFeed.test.ts
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
 import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
-import type { ActivityItem } from "../api/types.js";
+import type { ActivityItem, WorkspaceActivitySubject } from "../api/types.js";
 import { makeAppRuntime, type OwnedAppRuntime } from "../app/runtime.js";
 
 const runtimeCapture = vi.hoisted(() => ({ current: undefined as OwnedAppRuntime | undefined }));
@@ -18,6 +18,7 @@ import ActivityFeed from "./ActivityFeed.svelte";
 
 beforeEach(() => {
   runtimeCapture.current = makeAppRuntime();
+  workspaceActivity.value = [];
 });
 
 afterEach(async () => {
@@ -71,7 +72,26 @@ function branchActivityItem(id: string, overrides: Partial<ActivityItem> = {}): 
   });
 }
 
+function workspaceSubject(overrides: Partial<WorkspaceActivitySubject> = {}): WorkspaceActivitySubject {
+  return {
+    activity_at: "2026-08-09T12:00:00Z",
+    item_author: "alice",
+    item_number: 7,
+    item_state: "open",
+    item_title: "Workspace-only work",
+    item_type: "pr",
+    item_url: "https://github.com/acme/widgets/pull/7",
+    platform_host: "github.com",
+    repo: activityItem("repo-source").repo!,
+    repo_name: "widgets",
+    repo_owner: "acme",
+    workspace: { id: "ws-7", status: "ready" },
+    ...overrides,
+  };
+}
+
 const items = vi.hoisted(() => ({ value: [] as ActivityItem[] }));
+const workspaceActivity = vi.hoisted(() => ({ value: [] as WorkspaceActivitySubject[] }));
 const viewMode = vi.hoisted(() => ({
   value: "flat" as "flat" | "threaded",
 }));
@@ -109,6 +129,7 @@ vi.mock("../context.js", () => ({
       getHideDefaultBranchActivity: () => hideDefaultBranchActivity.value,
       getEnabledItemTypes: () => enabledItemTypes.value,
       getActivityItems: () => items.value,
+      getWorkspaceActivity: () => workspaceActivity.value,
       getActivityError: () => null,
       getViewMode: () => viewMode.value,
       getTimeRange: () => "7d",
@@ -205,6 +226,29 @@ describe("ActivityFeed compact mode", () => {
     expect(container.querySelector(".activity-table")).toBeNull();
     expect(container.querySelectorAll(".activity-compact-row")).toHaveLength(2);
     expect(screen.getByText("Add widget caching layer")).toBeTruthy();
+  });
+
+  it("shows workspace-only subjects only in threaded mode", () => {
+    items.value = [];
+    workspaceActivity.value = [workspaceSubject()];
+
+    const flat = render(ActivityFeed, { props: { compact: true } });
+    expect(flat.container.textContent).not.toContain("Workspace-only work");
+    cleanup();
+
+    viewMode.value = "threaded";
+    const threaded = render(ActivityFeed, { props: { compact: true } });
+    expect(threaded.container.textContent).toContain("Workspace-only work");
+  });
+
+  it("applies item-scope and closed filters to workspace summaries", () => {
+    viewMode.value = "threaded";
+    items.value = [];
+    workspaceActivity.value = [workspaceSubject({ item_state: "closed" })];
+    hideClosedMerged.value = true;
+
+    const { container } = render(ActivityFeed, { props: { compact: true } });
+    expect(container.textContent).not.toContain("Workspace-only work");
   });
 
   it("independently toggles PR and issue visibility", async () => {

--- a/frontend/src/lib/components/ActivityThreaded.svelte
+++ b/frontend/src/lib/components/ActivityThreaded.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { EmptyState } from "@kenn-io/kit-ui";
   import { ScrollBox } from "@kenn-io/kit-ui";
-  import type { ActivityItem } from "../api/types.js";
+  import type { ActivityItem, WorkspaceActivitySubject } from "../api/types.js";
   import { getStores } from "../context.js";
   import {
     collapseActivityRuns,
@@ -37,6 +37,7 @@
 
   interface Props {
     items: ActivityItem[];
+    workspaceActivity?: WorkspaceActivitySubject[];
     onSelectItem: ((item: ActivityItem) => void) | undefined;
     onSelectBranchCommit?: ((item: ActivityItem) => void) | undefined;
     compact?: boolean;
@@ -65,6 +66,7 @@
 
   let {
     items,
+    workspaceActivity = [],
     onSelectItem,
     onSelectBranchCommit,
     compact = false,
@@ -88,6 +90,8 @@
     latestTime: string;
     itemAuthor: string;
     workspace: ActivityItem["workspace"];
+    repo: ActivityItem["repo"];
+    workspaceActivityAt?: string;
     events: ActivityItem[];
     displayEvents: ReturnType<
       typeof collapseActivityRuns
@@ -124,7 +128,10 @@
 
   const repoLabelFormatter = $derived.by(() =>
     createRepoLabelFormatter(
-      items.map(activityRepoIdentity),
+      [
+        ...items.map(activityRepoIdentity),
+        ...workspaceActivity.map(workspaceRepoIdentity),
+      ],
       { showOrgNames: !grouping.getHideOrgName() },
     ),
   );
@@ -161,9 +168,9 @@
     }
 
     // Phase 2: build threaded entries from item groups and branch rows.
-    const threadedEntries: ThreadedEntry[] = [];
+    const itemGroups = new Map<string, ItemGroup>();
 
-    for (const [, events] of itemMap) {
+    for (const [itemKey, events] of itemMap) {
       events.sort((a, b) =>
         parseAPITimestamp(b.created_at).getTime() - parseAPITimestamp(a.created_at).getTime());
 
@@ -172,9 +179,7 @@
         throw new Error("activity group missing provider repo identity");
       }
       const branch = first.branch_name || "default branch";
-      threadedEntries.push({
-        kind: "item",
-        group: {
+      itemGroups.set(itemKey, {
           kind: "item",
           itemType: first.item_type,
           itemNumber: first.item_number,
@@ -190,13 +195,64 @@
           latestTime: first.created_at,
           itemAuthor: itemAuthor(first),
           workspace: first.workspace,
+          repo: first.repo,
           events,
           displayEvents: collapseActivityRuns(events, {
             rollUpCommits: activity.getRollUpCommits(),
           }),
-        },
       });
     }
+
+    for (const subject of workspaceActivity) {
+      const itemKey = activityItemKey({
+        provider: subject.repo.provider,
+        platformHost: subject.repo.platform_host,
+        owner: subject.repo.owner,
+        name: subject.repo.name,
+        repoPath: subject.repo.repo_path,
+        itemType: subject.item_type,
+        itemNumber: subject.item_number,
+      });
+      const existing = itemGroups.get(itemKey);
+      if (existing) {
+        if (parseAPITimestamp(subject.activity_at).getTime() > parseAPITimestamp(existing.latestTime).getTime()) {
+          existing.latestTime = subject.activity_at;
+        }
+        existing.itemTitle ||= subject.item_title;
+        existing.itemUrl ||= subject.item_url;
+        existing.itemState ||= subject.item_state;
+        existing.itemAuthor ||= subject.item_author ?? "";
+        existing.workspace ??= subject.workspace;
+        existing.workspaceActivityAt = subject.activity_at;
+        continue;
+      }
+      itemGroups.set(itemKey, {
+        kind: "item",
+        itemType: subject.item_type,
+        itemNumber: subject.item_number,
+        itemTitle: subject.item_title,
+        itemUrl: subject.item_url,
+        itemState: subject.item_state,
+        branchName: "",
+        provider: subject.repo.provider,
+        repoOwner: subject.repo.owner,
+        repoName: subject.repo.name,
+        repoPath: subject.repo.repo_path,
+        platformHost: subject.repo.platform_host,
+        latestTime: subject.activity_at,
+        itemAuthor: subject.item_author ?? "",
+        workspace: subject.workspace,
+        repo: subject.repo,
+        workspaceActivityAt: subject.activity_at,
+        events: [],
+        displayEvents: [],
+      });
+    }
+
+    const threadedEntries: ThreadedEntry[] = [...itemGroups.values()].map((group) => ({
+      kind: "item",
+      group,
+    }));
 
     for (const item of branchItems) {
       threadedEntries.push(branchEntryFromRow(item));
@@ -416,7 +472,31 @@
       // item_number 0) follows its provider URL instead of opening an
       // invalid #0 detail drawer, matching the expanded event rows.
       handleEventClick(group.events[0]!);
+      return;
     }
+    onSelectItem?.(subjectSelectionItem(group));
+  }
+
+  function subjectSelectionItem(group: ItemGroup): ActivityItem {
+    const id = `workspace:${itemKeyOf(group)}`;
+    return {
+      id,
+      cursor: id,
+      activity_type: "workspace",
+      author: group.itemAuthor,
+      body_preview: "",
+      created_at: group.latestTime,
+      item_number: group.itemNumber,
+      item_state: group.itemState,
+      item_title: group.itemTitle,
+      item_type: group.itemType,
+      item_url: group.itemUrl,
+      platform_host: group.platformHost,
+      repo_owner: group.repoOwner,
+      repo_name: group.repoName,
+      repo: group.repo,
+      ...(group.workspace ? { workspace: group.workspace } : {}),
+    };
   }
 
   function handleBranchRowClick(row: ActivityRow): void {
@@ -499,6 +579,16 @@
       owner: item.repo?.owner ?? item.repo_owner,
       name: item.repo?.name ?? item.repo_name,
       repoPath: item.repo?.repo_path,
+    };
+  }
+
+  function workspaceRepoIdentity(subject: WorkspaceActivitySubject): RepoLabelIdentity {
+    return {
+      provider: subject.repo.provider,
+      platformHost: subject.repo.platform_host,
+      owner: subject.repo.owner,
+      name: subject.repo.name,
+      repoPath: subject.repo.repo_path,
     };
   }
 
@@ -663,24 +753,28 @@
           class:selected={isSelectedItemGroup(itemGroup)}
           onclick={() => handleItemClick(itemGroup)}
         >
-          <button
-            class="thread-caret cell cell--caret"
-            type="button"
-            aria-label={activity.isThreadItemExpanded(key)
-              ? "Collapse item activity"
-              : "Expand item activity"}
-            aria-expanded={activity.isThreadItemExpanded(key)}
-            onclick={(e) => {
-              e.stopPropagation();
-              activity.toggleThreadItem(key);
-            }}
-          >
-            {#if activity.isThreadItemExpanded(key)}
-              <ChevronDownIcon size="14" strokeWidth="2" aria-hidden="true" />
-            {:else}
-              <ChevronRightIcon size="14" strokeWidth="2" aria-hidden="true" />
-            {/if}
-          </button>
+          {#if itemGroup.events.length > 0}
+            <button
+              class="thread-caret cell cell--caret"
+              type="button"
+              aria-label={activity.isThreadItemExpanded(key)
+                ? "Collapse item activity"
+                : "Expand item activity"}
+              aria-expanded={activity.isThreadItemExpanded(key)}
+              onclick={(e) => {
+                e.stopPropagation();
+                activity.toggleThreadItem(key);
+              }}
+            >
+              {#if activity.isThreadItemExpanded(key)}
+                <ChevronDownIcon size="14" strokeWidth="2" aria-hidden="true" />
+              {:else}
+                <ChevronRightIcon size="14" strokeWidth="2" aria-hidden="true" />
+              {/if}
+            </button>
+          {:else}
+            <span class="thread-caret-spacer cell cell--caret" aria-hidden="true"></span>
+          {/if}
           <span class="cell cell--type">
             <ItemKindChip
               kind={itemGroup.itemType === "pr" ? "pr" : "issue"}
@@ -711,7 +805,10 @@
             {/if}
             <span class="item-title">{itemGroup.itemTitle}</span>
           </span>
-          <span class="cell cell--time">{relativeTime(itemGroup.latestTime)}</span>
+          <span
+            class="cell cell--time"
+            title={itemGroup.workspaceActivityAt === itemGroup.latestTime ? "Recent workspace activity" : undefined}
+          >{relativeTime(itemGroup.latestTime)}</span>
           <span class="cell cell--link">
             {#if itemGroup.itemUrl}
               <button
@@ -727,7 +824,7 @@
           </span>
         </div>
 
-        {#if activity.isThreadItemExpanded(key)}
+        {#if itemGroup.events.length > 0 && activity.isThreadItemExpanded(key)}
           {#each itemGroup.displayEvents as row (row.id)}
             <!-- svelte-ignore a11y_click_events_have_key_events -->
             <!-- svelte-ignore a11y_no_static_element_interactions -->

--- a/frontend/src/lib/components/ActivityThreaded.test.ts
+++ b/frontend/src/lib/components/ActivityThreaded.test.ts
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render } from "@testing-library/svelte";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
-import type { ActivityItem } from "../api/types.js";
+import type { ActivityItem, WorkspaceActivitySubject } from "../api/types.js";
 import ActivityThreaded from "./ActivityThreaded.svelte";
 
 function activityItem(id: string, overrides: Partial<ActivityItem> = {}): ActivityItem {
@@ -50,6 +50,24 @@ function branchActivityItem(id: string, overrides: Partial<ActivityItem> = {}): 
   });
 }
 
+function workspaceSubject(overrides: Partial<WorkspaceActivitySubject> = {}): WorkspaceActivitySubject {
+  return {
+    activity_at: "2026-04-27T14:00:00Z",
+    item_author: "workspace-author",
+    item_number: 7,
+    item_state: "open",
+    item_title: "Keep the agent's work visible",
+    item_type: "pr",
+    item_url: "https://github.com/acme/widgets/pull/7",
+    platform_host: "github.com",
+    repo: activityItem("repo-source").repo!,
+    repo_name: "widgets",
+    repo_owner: "acme",
+    workspace: { id: "ws-pr-7", status: "ready" },
+    ...overrides,
+  };
+}
+
 const expanded = vi.hoisted(() => ({ value: true }));
 const groupByRepo = vi.hoisted(() => ({ value: false }));
 const hideOrgName = vi.hoisted(() => ({ value: false }));
@@ -87,6 +105,52 @@ describe("ActivityThreaded collapse", () => {
       props: { items: [activityItem("c1")], onSelectItem: undefined },
     });
     expect(container.querySelectorAll(".event-row").length).toBeGreaterThan(0);
+  });
+
+  it("renders a workspace-active subject with no provider events as an unexpandable group", async () => {
+    const onSelectItem = vi.fn();
+    const { container, getByLabelText } = render(ActivityThreaded, {
+      props: {
+        items: [],
+        workspaceActivity: [workspaceSubject()],
+        onSelectItem,
+      },
+    });
+
+    const row = container.querySelector(".item-row");
+    expect(row?.textContent).toContain("Keep the agent's work visible");
+    expect(row?.textContent).toContain("workspace-author");
+    expect(container.querySelector(".thread-caret")).toBeNull();
+    expect(container.querySelector(".event-row")).toBeNull();
+    expect(getByLabelText("Workspace attached (ready)")).toBeTruthy();
+
+    await fireEvent.click(row!);
+    expect(onSelectItem).toHaveBeenCalledWith(expect.objectContaining({ item_number: 7, item_type: "pr" }));
+  });
+
+  it("sorts existing threads by workspace activity without adding an event", () => {
+    const { container } = render(ActivityThreaded, {
+      props: {
+        items: [
+          activityItem("provider-newer", {
+            item_number: 2,
+            item_title: "Provider-only thread",
+            created_at: "2026-04-27T13:00:00Z",
+          }),
+          activityItem("workspace-older-event", {
+            item_number: 7,
+            item_title: "Workspace-active thread",
+            created_at: "2026-04-27T12:00:00Z",
+          }),
+        ],
+        workspaceActivity: [workspaceSubject()],
+        onSelectItem: undefined,
+      },
+    });
+
+    const rows = Array.from(container.querySelectorAll(".item-row:not(.branch-activity-row)"));
+    expect(rows[0]?.textContent).toContain("Workspace-active thread");
+    expect(container.querySelectorAll(".event-row")).toHaveLength(2);
   });
 
   it("hides events but keeps the item row when collapsed", () => {

--- a/frontend/src/lib/components/sidebar/IssueItem.svelte
+++ b/frontend/src/lib/components/sidebar/IssueItem.svelte
@@ -7,6 +7,7 @@
   import LabelRow from "../shared/LabelRow.svelte";
   import WorkspaceIndicator from "../shared/WorkspaceIndicator.svelte";
   import { repoIdentityKey } from "../../utils/repo-label.js";
+  import { effectiveActivity } from "../../utils/effective-activity.js";
 
   const { issues } = getStores();
 
@@ -51,7 +52,8 @@
     name: issue.repo.name,
     repoPath: issue.repo.repo_path,
   }));
-  const ago = $derived(formatRelativeTime(issue.LastActivityAt));
+  const activityTime = $derived(effectiveActivity(issue.LastActivityAt, issue.workspace_activity_at));
+  const ago = $derived(formatRelativeTime(activityTime.at));
 </script>
 
 <button class="issue-item" class:selected bind:this={el} onclick={onclick}>
@@ -93,7 +95,11 @@
       {#if issue.State !== "open"}
         <Chip size="xs" tone="merged" class="state-chip">Closed</Chip>
       {/if}
-      <span class="time">{ago}</span>
+      <span
+        class="time"
+        title={activityTime.fromWorkspace ? "Recent workspace activity" : undefined}
+        aria-label={activityTime.fromWorkspace ? `Recent workspace activity, ${ago}` : undefined}
+      >{ago}</span>
     </span>
   </div>
 </button>

--- a/frontend/src/lib/components/sidebar/IssueItem.test.ts
+++ b/frontend/src/lib/components/sidebar/IssueItem.test.ts
@@ -54,6 +54,14 @@ describe("IssueItem", () => {
     expect(screen.getByLabelText("Workspace attached (ready)")).toBeTruthy();
   });
 
+  it("labels a newer workspace timestamp as the row's effective activity", () => {
+    renderItem(mkIssue({ workspace_activity_at: "2026-05-02T12:00:00Z" }));
+
+    const time = document.querySelector('.time[title="Recent workspace activity"]');
+    expect(time).not.toBeNull();
+    expect(time?.getAttribute("aria-label")).toContain("Recent workspace activity");
+  });
+
   it("renders the repo name inside the meta row with no separate repo row", () => {
     render(IssueItem, {
       props: {

--- a/frontend/src/lib/components/sidebar/PullItem.svelte
+++ b/frontend/src/lib/components/sidebar/PullItem.svelte
@@ -16,6 +16,7 @@
   import LabelRow from "../shared/LabelRow.svelte";
   import WorkspaceIndicator from "../shared/WorkspaceIndicator.svelte";
   import { repoIdentityKey } from "../../utils/repo-label.js";
+  import { effectiveActivity } from "../../utils/effective-activity.js";
 
   const { pulls } = getStores();
   const hostState = getHostState();
@@ -61,7 +62,8 @@
     }
   });
 
-  const ago = $derived(formatRelativeTime(pr.LastActivityAt));
+  const activityTime = $derived(effectiveActivity(pr.LastActivityAt, pr.workspace_activity_at));
+  const ago = $derived(formatRelativeTime(activityTime.at));
   const hasWorktree = $derived(
     (pr.worktree_links?.length ?? 0) > 0,
   );
@@ -261,7 +263,11 @@
           </svg>
         {/if}
       </span>
-      <span class="time">{ago}</span>
+      <span
+        class="time"
+        title={activityTime.fromWorkspace ? "Recent workspace activity" : undefined}
+        aria-label={activityTime.fromWorkspace ? `Recent workspace activity, ${ago}` : undefined}
+      >{ago}</span>
     </span>
   </div>
 </button>

--- a/frontend/src/lib/components/sidebar/PullItem.test.ts
+++ b/frontend/src/lib/components/sidebar/PullItem.test.ts
@@ -60,6 +60,19 @@ describe("PullItem CI cluster", () => {
     vi.restoreAllMocks();
   });
 
+  it("labels a newer workspace timestamp as the row's effective activity", () => {
+    renderItem(
+      mkPR({
+        LastActivityAt: "2026-05-01T12:00:00Z",
+        workspace_activity_at: "2026-05-02T12:00:00Z",
+      }),
+    );
+
+    const time = document.querySelector('.time[title="Recent workspace activity"]');
+    expect(time).not.toBeNull();
+    expect(time?.getAttribute("aria-label")).toContain("Recent workspace activity");
+  });
+
   it("renders compact tokens for a mixed-state PR", () => {
     const checks = [
       {

--- a/frontend/src/lib/stores/activity.svelte.test.ts
+++ b/frontend/src/lib/stores/activity.svelte.test.ts
@@ -2,7 +2,7 @@ import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { GeneratedClient } from "../api/generated-api.js";
 import type { OwnedAppRuntime } from "../app/runtime.js";
-import type { ActivityItem, ActivitySettings } from "../api/types.js";
+import type { ActivityItem, ActivitySettings, WorkspaceActivitySubject } from "../api/types.js";
 import { makeTestAppRuntime } from "../testing/effect-layers.js";
 import {
   buildActivityItemTypeFilter,
@@ -49,6 +49,22 @@ function makeStore() {
   return createActivityStore({ client: fakeClient });
 }
 
+function workspaceActivity(itemNumber: number): WorkspaceActivitySubject {
+  return {
+    activity_at: `2026-08-09T12:00:0${itemNumber}Z`,
+    item_number: itemNumber,
+    item_state: "open",
+    item_title: `PR ${itemNumber}`,
+    item_type: "pr",
+    item_url: `https://github.com/acme/widgets/pull/${itemNumber}`,
+    platform_host: "github.com",
+    repo: { host: "github.com", owner: "acme", name: "widgets" },
+    repo_name: "widgets",
+    repo_owner: "acme",
+    workspace: { id: `workspace-${itemNumber}`, status: "ready" },
+  };
+}
+
 beforeEach(() => {
   runtime = undefined;
   window.history.replaceState(null, "", "/");
@@ -57,6 +73,21 @@ beforeEach(() => {
 afterEach(async () => {
   for (const item of getFlashes()) dismissFlash(item.id);
   if (runtime !== undefined) await Effect.runPromise(runtime.disposeEffect);
+});
+
+describe("activity store workspace activity", () => {
+  it("retains the complete workspace snapshot returned with an activity read", async () => {
+    const snapshot = [workspaceActivity(7)];
+    const client = {
+      GET: async () => ({ data: { items: [], capped: false, workspace_activity: snapshot }, error: null }),
+    } as unknown as GeneratedClient;
+    const store = createActivityStore({ client });
+
+    store.loadActivity();
+    await vi.waitFor(() => expect(store.isActivityLoading()).toBe(false));
+
+    expect(store.getWorkspaceActivity()).toEqual(snapshot);
+  });
 });
 
 describe("activity store collapse state", () => {

--- a/frontend/src/lib/stores/activity.svelte.ts
+++ b/frontend/src/lib/stores/activity.svelte.ts
@@ -9,6 +9,7 @@ import type {
   ActivityResponse,
   ActivitySettings,
   NotificationBulkResponse,
+  WorkspaceActivitySubject,
 } from "../api/types.js";
 import { ActivityWorkflow } from "./activity-workflow.js";
 import { showFlash } from "./flash.svelte.js";
@@ -129,6 +130,7 @@ export function createActivityStore(opts: ActivityStoreOptions) {
   // --- state ---
 
   let items = $state<ActivityItem[]>([]);
+  let workspaceActivity = $state.raw<WorkspaceActivitySubject[]>([]);
   let loading = $state(false);
   let storeError = $state<string | null>(null);
   let capped = $state(false);
@@ -157,6 +159,9 @@ export function createActivityStore(opts: ActivityStoreOptions) {
 
   function getActivityItems(): ActivityItem[] {
     return items;
+  }
+  function getWorkspaceActivity(): WorkspaceActivitySubject[] {
+    return workspaceActivity;
   }
   function isActivityLoading(): boolean {
     return loading;
@@ -346,6 +351,7 @@ export function createActivityStore(opts: ActivityStoreOptions) {
       const project = (result: OwnedActivityResponse) =>
         Effect.sync(() => {
           items = projectOwnedNotificationStates(result);
+          workspaceActivity = result.response.workspace_activity ?? [];
           capped = result.response.capped;
           loading = false;
         });
@@ -380,6 +386,7 @@ export function createActivityStore(opts: ActivityStoreOptions) {
       const project = (result: OwnedActivityResponse) =>
         Effect.sync(() => {
           items = projectOwnedNotificationStates(result);
+          workspaceActivity = result.response.workspace_activity ?? [];
           capped = result.response.capped;
           loading = false;
         });
@@ -406,8 +413,9 @@ export function createActivityStore(opts: ActivityStoreOptions) {
       const workflow = yield* ActivityWorkflow;
       yield* workflow.pollRead(activityRead(params), (result) => {
         const fresh = projectOwnedNotificationStates(result);
-        if (fresh.length === 0) return Effect.void;
         return Effect.sync(() => {
+          workspaceActivity = result.response.workspace_activity ?? [];
+          if (fresh.length === 0) return;
           const freshById = new Map(fresh.map((item) => [item.id, item]));
           items = items.map((item) => {
             const updated = freshById.get(item.id);
@@ -506,10 +514,12 @@ export function createActivityStore(opts: ActivityStoreOptions) {
           Effect.sync(() => {
             if (mode === "replace") {
               items = projectOwnedNotificationStates(result);
+              workspaceActivity = result.response.workspace_activity ?? [];
               capped = result.response.capped;
               loading = false;
               return;
             }
+            workspaceActivity = result.response.workspace_activity ?? [];
             const existingIds = new Set(items.map((item) => item.id));
             const newItems = projectOwnedNotificationStates(result, false).filter((item) => !existingIds.has(item.id));
             if (newItems.length > 0) {
@@ -653,6 +663,7 @@ export function createActivityStore(opts: ActivityStoreOptions) {
 
   return {
     getActivityItems,
+    getWorkspaceActivity,
     isActivityLoading,
     getActivityError,
     isActivityCapped,

--- a/frontend/src/lib/stores/workflow.svelte.test.ts
+++ b/frontend/src/lib/stores/workflow.svelte.test.ts
@@ -9,6 +9,7 @@ function pr(
   lastActivityAt: string,
   worktreeLinks: PullRequest["worktree_links"] = [],
   state: PullRequest["State"] = "open",
+  workspaceActivityAt?: string,
 ): PullRequest {
   return {
     ID: id,
@@ -16,6 +17,7 @@ function pr(
     State: state,
     KanbanStatus: kanbanStatus,
     LastActivityAt: lastActivityAt,
+    workspace_activity_at: workspaceActivityAt,
     worktree_links: worktreeLinks,
   } as PullRequest;
 }
@@ -66,5 +68,14 @@ describe("PR status grouping", () => {
       ["closed", "Closed"],
     ]);
     expect(groups.at(-1)?.items.map((item) => item.ID)).toEqual([3, 2]);
+  });
+
+  it("sorts a status group by effective provider and workspace activity", () => {
+    const groups = groupByWorkflow([
+      pr(1, "reviewing", "2026-01-03T00:00:00Z"),
+      pr(2, "reviewing", "2026-01-01T00:00:00Z", [], "open", "2026-01-04T00:00:00Z"),
+    ]);
+
+    expect(groups[0]?.items.map((item) => item.ID)).toEqual([2, 1]);
   });
 });

--- a/frontend/src/lib/stores/workflow.svelte.ts
+++ b/frontend/src/lib/stores/workflow.svelte.ts
@@ -1,4 +1,5 @@
 import type { KanbanStatus, PullRequest } from "../api/types.js";
+import { effectiveActivity } from "../utils/effective-activity.js";
 
 export type WorkflowGroup = KanbanStatus | "closed";
 
@@ -42,8 +43,8 @@ export function classifyPR(pr: PullRequest): WorkflowGroup {
  * Group PRs by workflow status.
  *
  * Returns groups in display order, omitting empty groups.
- * Items within each group are sorted by LastActivityAt
- * descending.
+ * Items within each group are sorted by effective provider/workspace
+ * activity descending.
  */
 export function groupByWorkflow(prs: PullRequest[]): WorkflowGroupEntry[] {
   const buckets = new Map<WorkflowGroup, PullRequest[]>();
@@ -60,7 +61,11 @@ export function groupByWorkflow(prs: PullRequest[]): WorkflowGroupEntry[] {
   for (const group of workflowGroupOrder) {
     const items = buckets.get(group)!;
     if (items.length === 0) continue;
-    items.sort((a, b) => new Date(b.LastActivityAt).getTime() - new Date(a.LastActivityAt).getTime());
+    items.sort(
+      (a, b) =>
+        Date.parse(effectiveActivity(b.LastActivityAt, b.workspace_activity_at).at) -
+        Date.parse(effectiveActivity(a.LastActivityAt, a.workspace_activity_at).at),
+    );
     result.push({
       group,
       label: workflowGroupLabels[group],

--- a/frontend/src/lib/utils/effective-activity.test.ts
+++ b/frontend/src/lib/utils/effective-activity.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { effectiveActivity } from "./effective-activity.js";
+
+describe("effectiveActivity", () => {
+  it("uses newer workspace activity without changing the provider timestamp", () => {
+    const providerAt = "2026-08-09T10:00:00Z";
+
+    expect(effectiveActivity(providerAt, "2026-08-09T11:00:00Z")).toEqual({
+      at: "2026-08-09T11:00:00Z",
+      fromWorkspace: true,
+    });
+    expect(providerAt).toBe("2026-08-09T10:00:00Z");
+  });
+
+  it("keeps provider activity when workspace activity is absent or older", () => {
+    expect(effectiveActivity("2026-08-09T10:00:00Z")).toEqual({
+      at: "2026-08-09T10:00:00Z",
+      fromWorkspace: false,
+    });
+    expect(effectiveActivity("2026-08-09T10:00:00Z", "2026-08-09T09:00:00Z")).toEqual({
+      at: "2026-08-09T10:00:00Z",
+      fromWorkspace: false,
+    });
+  });
+});

--- a/frontend/src/lib/utils/effective-activity.ts
+++ b/frontend/src/lib/utils/effective-activity.ts
@@ -1,0 +1,11 @@
+export interface EffectiveActivity {
+  at: string;
+  fromWorkspace: boolean;
+}
+
+export function effectiveActivity(providerAt: string, workspaceAt?: string): EffectiveActivity {
+  if (workspaceAt && Date.parse(workspaceAt) > Date.parse(providerAt)) {
+    return { at: workspaceAt, fromWorkspace: true };
+  }
+  return { at: providerAt, fromWorkspace: false };
+}

--- a/frontend/src/lib/views/MobileActivityView.svelte
+++ b/frontend/src/lib/views/MobileActivityView.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import { Effect } from "effect";
   import { onDestroy, onMount } from "svelte";
+  import { SvelteMap, SvelteSet } from "svelte/reactivity";
   import { getAppRuntime } from "../app/runtime-context.js";
   import type { AppExecution } from "../app/runtime.js";
-  import type { ActivityItem } from "../api/types.js";
+  import type { ActivityItem, WorkspaceActivitySubject } from "../api/types.js";
   import { getStores } from "../context.js";
   import {
     buildActivityFilterTypes,
@@ -61,6 +62,7 @@
     events: ActivityItem[];
     eventCount: number;
     latestTime: string;
+    workspaceActivityAt?: string;
   };
 
   const BOT_SUFFIXES = ["[bot]", "-bot", "bot"];
@@ -118,8 +120,22 @@
     return result;
   });
 
+  const visibleWorkspaceActivity = $derived.by(() => {
+    let result = activity.getWorkspaceActivity().filter((subject) =>
+      isActivityItemTypeEnabled(subject.item_type, activity.getEnabledItemTypes())
+    );
+
+    if (activity.getHideClosedMerged()) {
+      result = result.filter((subject) =>
+        subject.item_state !== "closed" && subject.item_state !== "merged"
+      );
+    }
+
+    return result;
+  });
+
   const groups = $derived.by(() => {
-    const map = new Map<string, ActivityItem[]>();
+    const map = new SvelteMap<string, ActivityItem[]>();
 
     for (const item of displayItems) {
       const key = isDefaultBranchActivity(item)
@@ -145,7 +161,7 @@
       else map.set(key, [item]);
     }
 
-    const result: ActivityGroup[] = [];
+    const groupsByKey = new SvelteMap<string, ActivityGroup>();
     for (const [key, events] of map) {
       events.sort(
         (a, b) =>
@@ -154,7 +170,7 @@
       );
       const representative = events[0];
       if (!representative) continue;
-      result.push({
+      groupsByKey.set(key, {
         key,
         representative,
         events,
@@ -162,6 +178,47 @@
         latestTime: representative.created_at,
       });
     }
+
+    for (const subject of visibleWorkspaceActivity) {
+      const key = activityItemKey({
+        provider: subject.repo.provider,
+        platformHost: subject.repo.platform_host,
+        owner: subject.repo.owner,
+        name: subject.repo.name,
+        repoPath: subject.repo.repo_path,
+        itemType: subject.item_type,
+        itemNumber: subject.item_number,
+      });
+      const existing = groupsByKey.get(key);
+      if (existing) {
+        if (
+          parseAPITimestamp(subject.activity_at).getTime()
+          > parseAPITimestamp(existing.latestTime).getTime()
+        ) {
+          existing.latestTime = subject.activity_at;
+        }
+        existing.workspaceActivityAt = subject.activity_at;
+        existing.representative = {
+          ...existing.representative,
+          item_title: existing.representative.item_title || subject.item_title,
+          item_url: existing.representative.item_url || subject.item_url,
+          item_state: existing.representative.item_state || subject.item_state,
+          item_author: existing.representative.item_author || subject.item_author || "",
+          ...(subject.workspace ? { workspace: subject.workspace } : {}),
+        };
+        continue;
+      }
+      groupsByKey.set(key, {
+        key,
+        representative: subjectSelectionItem(subject),
+        events: [],
+        eventCount: 0,
+        latestTime: subject.activity_at,
+        workspaceActivityAt: subject.activity_at,
+      });
+    }
+
+    const result = [...groupsByKey.values()];
 
     result.sort(
       (a, b) =>
@@ -175,7 +232,10 @@
 
   const repoLabelFormatter = $derived.by(() =>
     createRepoLabelFormatter(
-      displayItems.map(activityRepoIdentity),
+      [
+        ...displayItems.map(activityRepoIdentity),
+        ...visibleWorkspaceActivity.map(workspaceRepoIdentity),
+      ],
       { showOrgNames: !grouping.getHideOrgName() },
     ),
   );
@@ -192,7 +252,7 @@
   }
 
   function toggleItemType(itemType: ActivityItemType): void {
-    const next = new Set(activity.getEnabledItemTypes());
+    const next = new SvelteSet(activity.getEnabledItemTypes());
     if (next.has(itemType)) next.delete(itemType);
     else next.add(itemType);
     activity.setEnabledItemTypes(next);
@@ -261,6 +321,36 @@
       return;
     }
     onSelectItem?.(group.representative);
+  }
+
+  function subjectSelectionItem(subject: WorkspaceActivitySubject): ActivityItem {
+    const id = `workspace:${activityItemKey({
+      provider: subject.repo.provider,
+      platformHost: subject.repo.platform_host,
+      owner: subject.repo.owner,
+      name: subject.repo.name,
+      repoPath: subject.repo.repo_path,
+      itemType: subject.item_type,
+      itemNumber: subject.item_number,
+    })}`;
+    return {
+      id,
+      cursor: id,
+      activity_type: "workspace",
+      author: subject.item_author ?? "",
+      body_preview: "",
+      created_at: subject.activity_at,
+      item_number: subject.item_number,
+      item_state: subject.item_state,
+      item_title: subject.item_title,
+      item_type: subject.item_type,
+      item_url: subject.item_url,
+      platform_host: subject.repo.platform_host,
+      repo_owner: subject.repo.owner,
+      repo_name: subject.repo.name,
+      repo: subject.repo,
+      ...(subject.workspace ? { workspace: subject.workspace } : {}),
+    };
   }
 
   function handleEventClick(event: ActivityItem): void {
@@ -343,6 +433,16 @@
       owner: item.repo.owner,
       name: item.repo.name,
       repoPath: item.repo.repo_path,
+    };
+  }
+
+  function workspaceRepoIdentity(subject: WorkspaceActivitySubject): RepoLabelIdentity {
+    return {
+      provider: subject.repo.provider,
+      platformHost: subject.repo.platform_host,
+      owner: subject.repo.owner,
+      name: subject.repo.name,
+      repoPath: subject.repo.repo_path,
     };
   }
 
@@ -502,7 +602,11 @@
                       {/if}
                     {/if}
                   </span>
-                  <time>{relativeTime(group.latestTime)}</time>
+                  <time
+                    title={group.workspaceActivityAt === group.latestTime
+                      ? "Recent workspace activity"
+                      : undefined}
+                  >{relativeTime(group.latestTime)}</time>
                 </span>
 
                 <span class="mobile-activity-card__title">
@@ -514,41 +618,43 @@
                 </span>
               </button>
 
-              <Timeline
-                class="mobile-activity-events"
-                ariaLabel={`Recent activity for ${
-                  isDefaultBranchActivity(item) ? branchActivityTitle(item) : item.item_title
-                }`}
-              >
-                {#each latestEvents(group) as event (event.id)}
-                  <TimelineItem class="mobile-activity-event-item" tone={eventTone(event.activity_type)}>
-                    <div class="mobile-activity-event-slot">
-                      <button
-                        type="button"
-                        class="mobile-activity-event"
-                        onclick={() => handleEventClick(event)}
-                      >
-                        <span class="mobile-activity-event__body">
-                          <strong>{eventLabel(event)}</strong>
-                          <span>{eventDetail(event)}</span>
-                        </span>
-                        <time>{relativeTime(event.created_at)}</time>
-                      </button>
-                      {#if isUnreadNotification(event)}
+              {#if group.eventCount > 0}
+                <Timeline
+                  class="mobile-activity-events"
+                  ariaLabel={`Recent activity for ${
+                    isDefaultBranchActivity(item) ? branchActivityTitle(item) : item.item_title
+                  }`}
+                >
+                  {#each latestEvents(group) as event (event.id)}
+                    <TimelineItem class="mobile-activity-event-item" tone={eventTone(event.activity_type)}>
+                      <div class="mobile-activity-event-slot">
                         <button
                           type="button"
-                          class="mobile-activity-event-seen"
-                          aria-label="Mark notification seen"
-                          title="Mark seen"
-                          onclick={(domEvent) => handleMarkSeen(domEvent, event)}
+                          class="mobile-activity-event"
+                          onclick={() => handleEventClick(event)}
                         >
-                          <CheckIcon size="20" strokeWidth="2" aria-hidden="true" />
+                          <span class="mobile-activity-event__body">
+                            <strong>{eventLabel(event)}</strong>
+                            <span>{eventDetail(event)}</span>
+                          </span>
+                          <time>{relativeTime(event.created_at)}</time>
                         </button>
-                      {/if}
-                    </div>
-                  </TimelineItem>
-                {/each}
-              </Timeline>
+                        {#if isUnreadNotification(event)}
+                          <button
+                            type="button"
+                            class="mobile-activity-event-seen"
+                            aria-label="Mark notification seen"
+                            title="Mark seen"
+                            onclick={(domEvent) => handleMarkSeen(domEvent, event)}
+                          >
+                            <CheckIcon size="20" strokeWidth="2" aria-hidden="true" />
+                          </button>
+                        {/if}
+                      </div>
+                    </TimelineItem>
+                  {/each}
+                </Timeline>
+              {/if}
             </Card>
           </article>
         {/each}

--- a/frontend/src/lib/views/MobileActivityView.test.ts
+++ b/frontend/src/lib/views/MobileActivityView.test.ts
@@ -1,6 +1,6 @@
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
-import type { ActivityItem } from "../api/types.js";
+import type { ActivityItem, WorkspaceActivitySubject } from "../api/types.js";
 import MobileActivityView from "./MobileActivityViewRuntimeHarness.svelte";
 
 function branchActivityItem(id: string, overrides: Partial<ActivityItem> = {}): ActivityItem {
@@ -36,6 +36,7 @@ function branchActivityItem(id: string, overrides: Partial<ActivityItem> = {}): 
 }
 
 const items = vi.hoisted(() => ({ value: [] as ActivityItem[] }));
+const workspaceActivity = vi.hoisted(() => ({ value: [] as WorkspaceActivitySubject[] }));
 const onSelectItem = vi.hoisted(() => vi.fn());
 const hideClosedMerged = vi.hoisted(() => ({ value: false }));
 const hideOrgName = vi.hoisted(() => ({ value: false }));
@@ -69,6 +70,7 @@ vi.mock("../context.js", () => ({
       stopActivityPolling: vi.fn(),
       getActivitySearch: () => "",
       getActivityItems: () => items.value,
+      getWorkspaceActivity: () => workspaceActivity.value,
       getActivityError: () => null,
       getTimeRange: () => "7d",
       getEnabledItemTypes: () => enabledItemTypes.value,
@@ -107,6 +109,7 @@ vi.mock("../context.js", () => ({
 describe("MobileActivityView branch activity", () => {
   beforeEach(() => {
     items.value = [branchActivityItem("branch-commit")];
+    workspaceActivity.value = [];
     hideOrgName.value = false;
     hideClosedMerged.value = false;
     enabledItemTypes.value = new Set(["pr", "issue"]);
@@ -145,7 +148,8 @@ describe("MobileActivityView branch activity", () => {
     expect((issues as HTMLInputElement).checked).toBe(true);
 
     await fireEvent.click(prs);
-    expect(setEnabledItemTypes).toHaveBeenCalledWith(new Set(["issue"]));
+    expect(setEnabledItemTypes).toHaveBeenCalledOnce();
+    expect([...setEnabledItemTypes.mock.calls[0]![0]]).toEqual(["issue"]);
   });
 
   it("uses the shared repo path by default", () => {
@@ -256,6 +260,98 @@ describe("MobileActivityView branch activity", () => {
   });
 });
 
+function pullActivityItem(id: string, title: string, createdAt: string, number: number): ActivityItem {
+  return {
+    ...branchActivityItem(id),
+    activity_type: "comment",
+    body_preview: "Looks good",
+    branch_name: "",
+    commit_sha: "",
+    created_at: createdAt,
+    item_number: number,
+    item_state: "open",
+    item_title: title,
+    item_type: "pr",
+    item_url: `https://github.com/acme/widgets/pull/${number}`,
+    activity_url: "",
+  } as ActivityItem;
+}
+
+function workspaceSubject(
+  number: number,
+  title: string,
+  activityAt: string,
+  itemType: "pr" | "issue" = "pr",
+): WorkspaceActivitySubject {
+  return {
+    activity_at: activityAt,
+    item_author: "alice",
+    item_number: number,
+    item_state: "open",
+    item_title: title,
+    item_type: itemType,
+    item_url: `https://github.com/acme/widgets/${itemType === "pr" ? "pull" : "issues"}/${number}`,
+    platform_host: "github.com",
+    repo_owner: "acme",
+    repo_name: "widgets",
+    repo: {
+      provider: "github",
+      platform_host: "github.com",
+      owner: "acme",
+      name: "widgets",
+      repo_path: "acme/widgets",
+    },
+    workspace: { id: `workspace-${number}`, status: "ready" },
+  } as WorkspaceActivitySubject;
+}
+
+describe("MobileActivityView workspace activity", () => {
+  beforeEach(() => {
+    items.value = [];
+    workspaceActivity.value = [];
+    hideClosedMerged.value = false;
+    enabledItemTypes.value = new Set(["pr", "issue"]);
+    onSelectItem.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("orders an existing thread by its newer workspace activity", () => {
+    items.value = [
+      pullActivityItem("active", "Workspace-active pull", "2026-04-27T12:00:00Z", 1),
+      pullActivityItem("provider", "Provider-newer pull", "2026-04-27T13:00:00Z", 2),
+    ];
+    workspaceActivity.value = [workspaceSubject(1, "Workspace-active pull", "2026-04-27T14:00:00Z")];
+
+    const { container } = render(MobileActivityView, { props: { onSelectItem } });
+
+    const cards = Array.from(container.querySelectorAll(".mobile-activity-card__title"));
+    expect(cards.map((card) => card.textContent?.trim())).toEqual(["Workspace-active pull", "Provider-newer pull"]);
+  });
+
+  it("renders a workspace-only subject without inventing a timeline event", async () => {
+    workspaceActivity.value = [workspaceSubject(7, "Workspace-only pull", "2026-04-27T14:00:00Z")];
+
+    const { container } = render(MobileActivityView, { props: { onSelectItem } });
+
+    expect(screen.getByText("Workspace-only pull")).toBeTruthy();
+    expect(screen.getByText("0 events")).toBeTruthy();
+    expect(screen.getByLabelText("Workspace attached (ready)")).toBeTruthy();
+    expect(container.querySelector(".mobile-activity-events")).toBeNull();
+
+    await fireEvent.click(screen.getByRole("button", { name: /Workspace-only pull/ }));
+    expect(onSelectItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activity_type: "workspace",
+        item_number: 7,
+        item_type: "pr",
+      }),
+    );
+  });
+});
+
 function notificationItem(id: string, title: string, subjectState: string): ActivityItem {
   return {
     id,
@@ -287,6 +383,7 @@ function notificationItem(id: string, title: string, subjectState: string): Acti
 
 describe("MobileActivityView notifications", () => {
   beforeEach(() => {
+    workspaceActivity.value = [];
     hideClosedMerged.value = false;
     showNotifications.value = true;
     onSelectItem.mockClear();
@@ -342,6 +439,7 @@ describe("MobileActivityView notifications", () => {
 
 describe("MobileActivityView hide closed/merged", () => {
   beforeEach(() => {
+    workspaceActivity.value = [];
     hideClosedMerged.value = false;
     showNotifications.value = true;
     onSelectItem.mockClear();

--- a/frontend/tests/e2e-full/ci-dropdown.spec.ts
+++ b/frontend/tests/e2e-full/ci-dropdown.spec.ts
@@ -42,8 +42,11 @@ test.describe("CI dropdown", () => {
     try {
       await page.addInitScript(() => {
         const realSetInterval = window.setInterval;
+        const realSetTimeout = window.setTimeout;
         window.setInterval = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) =>
           realSetInterval(handler, timeout === 15_000 ? 100 : timeout, ...args)) as typeof window.setInterval;
+        window.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) =>
+          realSetTimeout(handler, timeout === 15_000 ? 100 : timeout, ...args)) as typeof window.setTimeout;
       });
 
       const seedResponse = await page.request.post(`${server.info.base_url}/__e2e/pr-ci-state/pending`);
@@ -79,11 +82,26 @@ test.describe("CI dropdown", () => {
       await expect(detail.locator(".ci-row .spin").first()).toBeVisible();
       await expect(detail.locator(".ci-row .spin svg").first()).toHaveAttribute("width", "14");
 
+      const successfulRefresh = page.waitForResponse(async (response) => {
+        const url = new URL(response.url());
+        if (
+          response.request().method() !== "POST" ||
+          url.pathname !== "/api/v1/pulls/github/acme/widgets/1/ci-refresh" ||
+          !response.ok()
+        ) {
+          return false;
+        }
+        const body = (await response.json()) as {
+          merge_request?: { CIStatus?: string };
+        };
+        return body.merge_request?.CIStatus === "success";
+      });
       const successResponse = await page.request.post(`${server.info.base_url}/__e2e/pr-ci-state/success`);
       expect(successResponse.ok()).toBe(true);
       await expect(successResponse.json()).resolves.toEqual({
         status: "success",
       });
+      await successfulRefresh;
 
       await expect(page.locator(".pull-detail").getByRole("button", { name: /CI: \d+ passed checks?/i })).toBeVisible();
 

--- a/frontend/tests/e2e-full/workspace-session-activity.spec.ts
+++ b/frontend/tests/e2e-full/workspace-session-activity.spec.ts
@@ -1,0 +1,304 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  devices,
+  expect,
+  request as playwrightRequest,
+  test,
+  type APIRequestContext,
+  type Page,
+} from "@playwright/test";
+
+import { startIsolatedWorkspaceE2EServer } from "./support/e2eServer";
+
+type WorkspaceResponse = {
+  id: string;
+  status: string;
+  error_message?: string | null;
+  tmux_activity_source?: string;
+};
+
+type ActivityResponse = {
+  workspace_activity: Array<{ item_number: number; item_type: string; activity_at: string }> | null;
+};
+
+type PullResponse = Array<{
+  Number: number;
+  LastActivityAt: string;
+  workspace?: { id: string; status: string };
+  workspace_activity_at?: string;
+}>;
+
+type IssueResponse = PullResponse;
+
+function hasCommand(command: string, args: string[] = ["--version"]): boolean {
+  try {
+    execFileSync(command, args, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForWorkspaceReady(api: APIRequestContext, workspaceID: string): Promise<void> {
+  await expect
+    .poll(async () => {
+      const response = await api.get(`/api/v1/workspaces/${workspaceID}`);
+      expect(response.ok(), await response.text()).toBe(true);
+      const workspace = (await response.json()) as WorkspaceResponse;
+      if (workspace.status === "error") throw new Error(workspace.error_message ?? "workspace creation failed");
+      return workspace.status;
+    })
+    .toBe("ready");
+}
+
+async function pull(api: APIRequestContext, number: number): Promise<PullResponse[number] | undefined> {
+  const response = await api.get("/api/v1/pulls?state=open");
+  expect(response.ok(), await response.text()).toBe(true);
+  return ((await response.json()) as PullResponse).find((item) => item.Number === number);
+}
+
+async function issue(api: APIRequestContext, number: number): Promise<IssueResponse[number] | undefined> {
+  const response = await api.get("/api/v1/issues?state=open");
+  expect(response.ok(), await response.text()).toBe(true);
+  return ((await response.json()) as IssueResponse).find((item) => item.Number === number);
+}
+
+async function listPulls(api: APIRequestContext): Promise<PullResponse> {
+  const response = await api.get("/api/v1/pulls?state=open");
+  expect(response.ok(), await response.text()).toBe(true);
+  return (await response.json()) as PullResponse;
+}
+
+async function listIssues(api: APIRequestContext): Promise<IssueResponse> {
+  const response = await api.get("/api/v1/issues?state=open");
+  expect(response.ok(), await response.text()).toBe(true);
+  return (await response.json()) as IssueResponse;
+}
+
+async function selectActivityViewItem(page: Page, label: string): Promise<void> {
+  const dropdown = page.locator(".activity-feed .kit-filter-dropdown__panel");
+  if (!(await dropdown.isVisible())) {
+    await page.locator(".activity-feed .kit-filter-dropdown__btn", { hasText: "View" }).click();
+    await expect(dropdown).toBeVisible();
+  }
+  await dropdown.locator(".kit-filter-dropdown__item", { hasText: label }).click();
+}
+
+test.describe("workspace session activity across item surfaces", () => {
+  test.describe.configure({ timeout: 120_000 });
+
+  test("first observation keeps refs idle, then output promotes Activity, Pulls, and Issues", async ({
+    browser,
+    page,
+  }) => {
+    test.skip(
+      !hasCommand("git") || !hasCommand("tmux", ["-V"]) || !hasCommand("sh", ["-c", ":"]),
+      "git, tmux, and sh are required for the real workspace activity flow",
+    );
+
+    const activitySignalDir = mkdtempSync(path.join(tmpdir(), "kenn-forge-activity-signal-"));
+    const changeSignal = path.join(activitySignalDir, "change");
+    const server = await startIsolatedWorkspaceE2EServer();
+    const api = await playwrightRequest.newContext({ baseURL: server.info.base_url });
+    try {
+      const settings = await api.put("/api/v1/settings", {
+        data: {
+          agents: [
+            {
+              key: "activity-e2e",
+              label: "Activity E2E",
+              command: [
+                "sh",
+                "-c",
+                'printf seed; : > "$1/seeded.$$"; while [ ! -f "$1/change" ]; do sleep 0.1; done; printf changed; sleep 60',
+                "activity-e2e",
+                activitySignalDir,
+              ],
+              enabled: true,
+            },
+          ],
+        },
+      });
+      expect(settings.ok(), await settings.text()).toBe(true);
+
+      const created = await api.post("/api/v1/workspaces", {
+        data: {
+          provider: "github",
+          platform_host: "github.com",
+          owner: "acme",
+          name: "widgets",
+          mr_number: 1,
+        },
+      });
+      expect(created.status(), await created.text()).toBe(202);
+      const workspace = (await created.json()) as WorkspaceResponse;
+      await waitForWorkspaceReady(api, workspace.id);
+
+      const issueCreated = await api.post("/api/v1/issues/github/acme/widgets/10/workspace", {
+        data: {},
+      });
+      expect(issueCreated.status(), await issueCreated.text()).toBe(202);
+      const issueWorkspace = (await issueCreated.json()) as WorkspaceResponse;
+      await waitForWorkspaceReady(api, issueWorkspace.id);
+
+      const launched = await api.post(`/api/v1/workspaces/${workspace.id}/runtime/sessions`, {
+        data: { target_key: "activity-e2e", display_region: "terminal" },
+      });
+      expect(launched.ok(), await launched.text()).toBe(true);
+
+      const issueLaunched = await api.post(`/api/v1/workspaces/${issueWorkspace.id}/runtime/sessions`, {
+        data: { target_key: "activity-e2e", display_region: "terminal" },
+      });
+      expect(issueLaunched.ok(), await issueLaunched.text()).toBe(true);
+
+      await expect
+        .poll(() => readdirSync(activitySignalDir).filter((entry) => entry.startsWith("seeded.")).length)
+        .toBe(2);
+      for (const workspaceID of [workspace.id, issueWorkspace.id]) {
+        await expect
+          .poll(async () => {
+            const response = await api.get(`/api/v1/workspaces/${workspaceID}`);
+            expect(response.ok(), await response.text()).toBe(true);
+            return ((await response.json()) as WorkspaceResponse).tmux_activity_source;
+          })
+          .toBe("none");
+      }
+
+      const seeded = await api.get("/api/v1/activity?since=2026-01-01T00:00:00Z");
+      expect(seeded.ok(), await seeded.text()).toBe(true);
+      expect(((await seeded.json()) as ActivityResponse).workspace_activity ?? []).toHaveLength(0);
+
+      await expect
+        .poll(async () => await pull(api, 1))
+        .toMatchObject({
+          workspace: { id: workspace.id, status: "ready" },
+        });
+      expect((await pull(api, 1))?.workspace_activity_at).toBeUndefined();
+
+      await expect
+        .poll(async () => await issue(api, 10))
+        .toMatchObject({
+          workspace: { id: issueWorkspace.id, status: "ready" },
+        });
+      expect((await issue(api, 10))?.workspace_activity_at).toBeUndefined();
+
+      writeFileSync(changeSignal, "change\n", "utf8");
+
+      await expect
+        .poll(
+          async () => {
+            const response = await api.get("/api/v1/activity?since=2026-01-01T00:00:00Z");
+            const activity = (await response.json()) as ActivityResponse;
+            const subjects = activity.workspace_activity ?? [];
+            return (
+              subjects.some((subject) => subject.item_type === "pr" && subject.item_number === 1) &&
+              subjects.some((subject) => subject.item_type === "issue" && subject.item_number === 10)
+            );
+          },
+          { timeout: 20_000 },
+        )
+        .toBe(true);
+
+      await expect
+        .poll(async () => {
+          const pulls = await listPulls(api);
+          return {
+            hasCompetingItems: pulls.length > 1,
+            firstNumber: pulls[0]?.Number,
+            workspaceID: pulls[0]?.workspace?.id,
+            hasNewerWorkspaceActivity:
+              pulls[0]?.workspace_activity_at !== undefined &&
+              Date.parse(pulls[0].workspace_activity_at) > Date.parse(pulls[0].LastActivityAt),
+          };
+        })
+        .toEqual({
+          hasCompetingItems: true,
+          firstNumber: 1,
+          workspaceID: workspace.id,
+          hasNewerWorkspaceActivity: true,
+        });
+
+      await expect
+        .poll(async () => {
+          const issues = await listIssues(api);
+          return {
+            hasCompetingItems: issues.length > 1,
+            firstNumber: issues[0]?.Number,
+            workspaceID: issues[0]?.workspace?.id,
+            hasNewerWorkspaceActivity:
+              issues[0]?.workspace_activity_at !== undefined &&
+              Date.parse(issues[0].workspace_activity_at) > Date.parse(issues[0].LastActivityAt),
+          };
+        })
+        .toEqual({
+          hasCompetingItems: true,
+          firstNumber: 10,
+          workspaceID: issueWorkspace.id,
+          hasNewerWorkspaceActivity: true,
+        });
+
+      await page.goto(`${server.info.base_url}/`);
+      await expect(page.locator(".activity-table .activity-row").first()).toBeVisible();
+      await selectActivityViewItem(page, "Threaded");
+      await selectActivityViewItem(page, "24h");
+      await selectActivityViewItem(page, "Notifications");
+      const pullActivityRow = page.locator(".threaded-view .item-row", { hasText: "Add widget caching layer" }).first();
+      await expect(pullActivityRow).toBeVisible();
+      await expect(pullActivityRow.locator('.cell--time[title="Recent workspace activity"]')).toBeVisible();
+      await expect(pullActivityRow.locator(".thread-caret")).toHaveCount(0);
+      const issueActivityRow = page
+        .locator(".threaded-view .item-row", { hasText: "Widget rendering broken on Safari" })
+        .first();
+      await expect(issueActivityRow).toBeVisible();
+      await expect(issueActivityRow.locator('.cell--time[title="Recent workspace activity"]')).toBeVisible();
+      await expect(issueActivityRow.locator(".thread-caret")).toHaveCount(0);
+
+      await page.goto(`${server.info.base_url}/pulls`);
+      const pullRow = page.locator(".pull-item", { hasText: "Add widget caching layer" }).first();
+      await expect(pullRow).toBeVisible();
+      await expect(page.locator(".pull-item").first()).toContainText("Add widget caching layer");
+      await expect(pullRow.locator('.time[title="Recent workspace activity"]')).toBeVisible();
+      await expect(pullRow.getByLabel("Workspace attached (ready)")).toBeVisible();
+
+      await page.goto(`${server.info.base_url}/issues`);
+      const issueRow = page.locator(".issue-item", { hasText: "Widget rendering broken on Safari" }).first();
+      await expect(issueRow).toBeVisible();
+      await expect(page.locator(".issue-item").first()).toContainText("Widget rendering broken on Safari");
+      await expect(issueRow.locator('.time[title="Recent workspace activity"]')).toBeVisible();
+      await expect(issueRow.getByLabel("Workspace attached (ready)")).toBeVisible();
+
+      const phoneContext = await browser.newContext({ ...devices["iPhone 13"] });
+      try {
+        const phonePage = await phoneContext.newPage();
+        await phonePage.goto(`${server.info.base_url}/m?range=24h&types=notification`);
+
+        await expect(phonePage.locator(".mobile-shell")).toBeVisible();
+        const mobileCards = phonePage.locator(".mobile-activity-card");
+        await expect(mobileCards.first()).toBeVisible();
+        const topTitles = await mobileCards
+          .locator(".mobile-activity-card__title")
+          .evaluateAll((titles) => titles.slice(0, 2).map((title) => title.textContent?.trim()));
+        expect(new Set(topTitles)).toEqual(new Set(["Add widget caching layer", "Widget rendering broken on Safari"]));
+
+        const mobileIssueCard = mobileCards.filter({ hasText: "Widget rendering broken on Safari" }).first();
+        await expect(mobileIssueCard).toContainText("0 events");
+        await expect(mobileIssueCard.locator('time[title="Recent workspace activity"]')).toBeVisible();
+        await expect(mobileIssueCard.getByLabel("Workspace attached (ready)")).toBeVisible();
+        await expect(mobileIssueCard.locator(".mobile-activity-events")).toHaveCount(0);
+        expect(await phonePage.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+
+        await mobileIssueCard.locator(".mobile-activity-card__button").click();
+        await expect(phonePage).toHaveURL(/\/focus\/issues\/github\/acme\/widgets\/10$/);
+      } finally {
+        await phoneContext.close();
+      }
+    } finally {
+      await api.dispose();
+      await server.stop();
+      rmSync(activitySignalDir, { force: true, recursive: true });
+    }
+  });
+});

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -1089,9 +1089,10 @@ type ActivityItemResponse struct {
 // ActivityResponse defines model for ActivityResponse.
 type ActivityResponse struct {
 	// Schema A URL to the JSON Schema for this object.
-	Schema *string                 `json:"$schema,omitempty"`
-	Capped bool                    `json:"capped"`
-	Items  *[]ActivityItemResponse `json:"items"`
+	Schema            *string                             `json:"$schema,omitempty"`
+	Capped            bool                                `json:"capped"`
+	Items             *[]ActivityItemResponse             `json:"items"`
+	WorkspaceActivity *[]WorkspaceActivitySubjectResponse `json:"workspace_activity"`
 }
 
 // AddRepoInputBody defines model for AddRepoInputBody.
@@ -2258,33 +2259,34 @@ type IssueEvent struct {
 // IssueResponse defines model for IssueResponse.
 type IssueResponse struct {
 	// Schema A URL to the JSON Schema for this object.
-	Schema             *string                     `json:"$schema,omitempty"`
-	Author             string                      `json:"Author"`
-	Body               string                      `json:"Body"`
-	ClosedAt           *time.Time                  `json:"ClosedAt"`
-	CommentCount       int64                       `json:"CommentCount"`
-	CreatedAt          time.Time                   `json:"CreatedAt"`
-	ID                 int64                       `json:"ID"`
-	LastActivityAt     time.Time                   `json:"LastActivityAt"`
-	Number             int64                       `json:"Number"`
-	PlatformExternalID string                      `json:"PlatformExternalID"`
-	PlatformID         int64                       `json:"PlatformID"`
-	RepoID             int64                       `json:"RepoID"`
-	Starred            bool                        `json:"Starred"`
-	State              string                      `json:"State"`
-	Title              string                      `json:"Title"`
-	URL                string                      `json:"URL"`
-	UpdatedAt          time.Time                   `json:"UpdatedAt"`
-	WorkflowStatus     IssueResponseWorkflowStatus `json:"WorkflowStatus"`
-	Assignees          *[]string                   `json:"assignees,omitempty"`
-	DetailFetchedAt    *string                     `json:"detail_fetched_at,omitempty"`
-	DetailLoaded       bool                        `json:"detail_loaded"`
-	Labels             *[]Label                    `json:"labels,omitempty"`
-	PlatformHost       string                      `json:"platform_host"`
-	Repo               RepoRefResponse             `json:"repo"`
-	RepoName           string                      `json:"repo_name"`
-	RepoOwner          string                      `json:"repo_owner"`
-	Workspace          *WorkspaceRef               `json:"workspace,omitempty"`
+	Schema              *string                     `json:"$schema,omitempty"`
+	Author              string                      `json:"Author"`
+	Body                string                      `json:"Body"`
+	ClosedAt            *time.Time                  `json:"ClosedAt"`
+	CommentCount        int64                       `json:"CommentCount"`
+	CreatedAt           time.Time                   `json:"CreatedAt"`
+	ID                  int64                       `json:"ID"`
+	LastActivityAt      time.Time                   `json:"LastActivityAt"`
+	Number              int64                       `json:"Number"`
+	PlatformExternalID  string                      `json:"PlatformExternalID"`
+	PlatformID          int64                       `json:"PlatformID"`
+	RepoID              int64                       `json:"RepoID"`
+	Starred             bool                        `json:"Starred"`
+	State               string                      `json:"State"`
+	Title               string                      `json:"Title"`
+	URL                 string                      `json:"URL"`
+	UpdatedAt           time.Time                   `json:"UpdatedAt"`
+	WorkflowStatus      IssueResponseWorkflowStatus `json:"WorkflowStatus"`
+	Assignees           *[]string                   `json:"assignees,omitempty"`
+	DetailFetchedAt     *string                     `json:"detail_fetched_at,omitempty"`
+	DetailLoaded        bool                        `json:"detail_loaded"`
+	Labels              *[]Label                    `json:"labels,omitempty"`
+	PlatformHost        string                      `json:"platform_host"`
+	Repo                RepoRefResponse             `json:"repo"`
+	RepoName            string                      `json:"repo_name"`
+	RepoOwner           string                      `json:"repo_owner"`
+	Workspace           *WorkspaceRef               `json:"workspace,omitempty"`
+	WorkspaceActivityAt *time.Time                  `json:"workspace_activity_at,omitempty"`
 }
 
 // IssueResponseWorkflowStatus defines model for IssueResponse.WorkflowStatus.
@@ -2773,51 +2775,52 @@ type MergeRequestEventResponse struct {
 
 // MergeRequestResponse defines model for MergeRequestResponse.
 type MergeRequestResponse struct {
-	Additions          int64                            `json:"Additions"`
-	Author             string                           `json:"Author"`
-	AuthorDisplayName  string                           `json:"AuthorDisplayName"`
-	BaseBranch         string                           `json:"BaseBranch"`
-	Body               string                           `json:"Body"`
-	CIChecksJSON       string                           `json:"CIChecksJSON"`
-	CIHadPending       bool                             `json:"CIHadPending"`
-	CIStatus           string                           `json:"CIStatus"`
-	ClosedAt           *time.Time                       `json:"ClosedAt"`
-	CommentCount       int64                            `json:"CommentCount"`
-	CreatedAt          time.Time                        `json:"CreatedAt"`
-	Deletions          int64                            `json:"Deletions"`
-	FilesChanged       *int64                           `json:"FilesChanged"`
-	HeadBranch         string                           `json:"HeadBranch"`
-	HeadRepoCloneURL   string                           `json:"HeadRepoCloneURL"`
-	ID                 int64                            `json:"ID"`
-	IsDraft            bool                             `json:"IsDraft"`
-	IsLocked           bool                             `json:"IsLocked"`
-	KanbanStatus       MergeRequestResponseKanbanStatus `json:"KanbanStatus"`
-	LastActivityAt     time.Time                        `json:"LastActivityAt"`
-	MergeCommitSHA     string                           `json:"MergeCommitSHA"`
-	MergeableState     string                           `json:"MergeableState"`
-	MergedAt           *time.Time                       `json:"MergedAt"`
-	Number             int64                            `json:"Number"`
-	PlatformExternalID string                           `json:"PlatformExternalID"`
-	PlatformID         int64                            `json:"PlatformID"`
-	RepoID             int64                            `json:"RepoID"`
-	ReviewDecision     string                           `json:"ReviewDecision"`
-	Starred            bool                             `json:"Starred"`
-	State              MergeRequestResponseState        `json:"State"`
-	Title              string                           `json:"Title"`
-	URL                string                           `json:"URL"`
-	UpdatedAt          time.Time                        `json:"UpdatedAt"`
-	Assignees          *[]string                        `json:"assignees,omitempty"`
-	DetailFetchedAt    *string                          `json:"detail_fetched_at,omitempty"`
-	DetailLoaded       bool                             `json:"detail_loaded"`
-	Labels             *[]Label                         `json:"labels,omitempty"`
-	PlatformHeadSha    *string                          `json:"platform_head_sha,omitempty"`
-	PlatformHost       string                           `json:"platform_host"`
-	Repo               RepoRefResponse                  `json:"repo"`
-	RepoName           string                           `json:"repo_name"`
-	RepoOwner          string                           `json:"repo_owner"`
-	RequestedReviewers *[]string                        `json:"requested_reviewers,omitempty"`
-	Workspace          *WorkspaceRef                    `json:"workspace,omitempty"`
-	WorktreeLinks      *[]WorktreeLinkResponse          `json:"worktree_links"`
+	Additions           int64                            `json:"Additions"`
+	Author              string                           `json:"Author"`
+	AuthorDisplayName   string                           `json:"AuthorDisplayName"`
+	BaseBranch          string                           `json:"BaseBranch"`
+	Body                string                           `json:"Body"`
+	CIChecksJSON        string                           `json:"CIChecksJSON"`
+	CIHadPending        bool                             `json:"CIHadPending"`
+	CIStatus            string                           `json:"CIStatus"`
+	ClosedAt            *time.Time                       `json:"ClosedAt"`
+	CommentCount        int64                            `json:"CommentCount"`
+	CreatedAt           time.Time                        `json:"CreatedAt"`
+	Deletions           int64                            `json:"Deletions"`
+	FilesChanged        *int64                           `json:"FilesChanged"`
+	HeadBranch          string                           `json:"HeadBranch"`
+	HeadRepoCloneURL    string                           `json:"HeadRepoCloneURL"`
+	ID                  int64                            `json:"ID"`
+	IsDraft             bool                             `json:"IsDraft"`
+	IsLocked            bool                             `json:"IsLocked"`
+	KanbanStatus        MergeRequestResponseKanbanStatus `json:"KanbanStatus"`
+	LastActivityAt      time.Time                        `json:"LastActivityAt"`
+	MergeCommitSHA      string                           `json:"MergeCommitSHA"`
+	MergeableState      string                           `json:"MergeableState"`
+	MergedAt            *time.Time                       `json:"MergedAt"`
+	Number              int64                            `json:"Number"`
+	PlatformExternalID  string                           `json:"PlatformExternalID"`
+	PlatformID          int64                            `json:"PlatformID"`
+	RepoID              int64                            `json:"RepoID"`
+	ReviewDecision      string                           `json:"ReviewDecision"`
+	Starred             bool                             `json:"Starred"`
+	State               MergeRequestResponseState        `json:"State"`
+	Title               string                           `json:"Title"`
+	URL                 string                           `json:"URL"`
+	UpdatedAt           time.Time                        `json:"UpdatedAt"`
+	Assignees           *[]string                        `json:"assignees,omitempty"`
+	DetailFetchedAt     *string                          `json:"detail_fetched_at,omitempty"`
+	DetailLoaded        bool                             `json:"detail_loaded"`
+	Labels              *[]Label                         `json:"labels,omitempty"`
+	PlatformHeadSha     *string                          `json:"platform_head_sha,omitempty"`
+	PlatformHost        string                           `json:"platform_host"`
+	Repo                RepoRefResponse                  `json:"repo"`
+	RepoName            string                           `json:"repo_name"`
+	RepoOwner           string                           `json:"repo_owner"`
+	RequestedReviewers  *[]string                        `json:"requested_reviewers,omitempty"`
+	Workspace           *WorkspaceRef                    `json:"workspace,omitempty"`
+	WorkspaceActivityAt *time.Time                       `json:"workspace_activity_at,omitempty"`
+	WorktreeLinks       *[]WorktreeLinkResponse          `json:"worktree_links"`
 }
 
 // MergeRequestResponseKanbanStatus defines model for MergeRequestResponse.KanbanStatus.
@@ -4162,6 +4165,22 @@ type WorkflowStateMetaResponse struct {
 
 // WorkflowStateMetaResponseStatus defines model for WorkflowStateMetaResponse.Status.
 type WorkflowStateMetaResponseStatus string
+
+// WorkspaceActivitySubjectResponse defines model for WorkspaceActivitySubjectResponse.
+type WorkspaceActivitySubjectResponse struct {
+	ActivityAt   time.Time       `json:"activity_at"`
+	ItemAuthor   *string         `json:"item_author,omitempty"`
+	ItemNumber   int64           `json:"item_number"`
+	ItemState    string          `json:"item_state"`
+	ItemTitle    string          `json:"item_title"`
+	ItemType     string          `json:"item_type"`
+	ItemUrl      string          `json:"item_url"`
+	PlatformHost string          `json:"platform_host"`
+	Repo         RepoRefResponse `json:"repo"`
+	RepoName     string          `json:"repo_name"`
+	RepoOwner    string          `json:"repo_owner"`
+	Workspace    *WorkspaceRef   `json:"workspace,omitempty"`
+}
 
 // WorkspaceDiffWatchResponse defines model for WorkspaceDiffWatchResponse.
 type WorkspaceDiffWatchResponse struct {

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -118,6 +118,65 @@ func appendLimitOffset(query string, args *[]any, limit, offset int) string {
 	return query
 }
 
+func workspaceActivityCTE(
+	alias string,
+	overrides []ItemActivityOverride,
+) (prefix, join, order string, args []any, err error) {
+	type key struct {
+		repoID int64
+		number int
+	}
+	deduped := make([]ItemActivityOverride, 0, len(overrides))
+	indexes := make(map[key]int, len(overrides))
+	for _, override := range overrides {
+		if override.RepoID == 0 || override.ItemNumber <= 0 || override.ActivityAt.IsZero() {
+			continue
+		}
+		k := key{repoID: override.RepoID, number: override.ItemNumber}
+		if i, ok := indexes[k]; ok {
+			if override.ActivityAt.After(deduped[i].ActivityAt) {
+				deduped[i] = override
+			}
+			continue
+		}
+		indexes[k] = len(deduped)
+		deduped = append(deduped, override)
+	}
+	if len(deduped) == 0 {
+		return "", "", alias + ".last_activity_at", nil, nil
+	}
+	type workspaceActivityJSONRow struct {
+		RepoID     int64  `json:"repo_id"`
+		ItemNumber int    `json:"item_number"`
+		ActivityAt string `json:"activity_at"`
+	}
+	rows := make([]workspaceActivityJSONRow, 0, len(deduped))
+	for _, override := range deduped {
+		rows = append(rows, workspaceActivityJSONRow{
+			RepoID: override.RepoID, ItemNumber: override.ItemNumber,
+			// modernc's default time.Time binding uses Time.String. Matching it
+			// keeps effective-activity comparisons identical to the former
+			// one-bind-per-field VALUES relation.
+			ActivityAt: override.ActivityAt.UTC().String(),
+		})
+	}
+	payload, err := json.Marshal(rows)
+	if err != nil {
+		return "", "", "", nil, fmt.Errorf("encode workspace activity overrides: %w", err)
+	}
+	prefix = `WITH workspace_activity(repo_id, item_number, activity_at) AS (
+		SELECT CAST(json_extract(value, '$.repo_id') AS INTEGER),
+		       CAST(json_extract(value, '$.item_number') AS INTEGER),
+		       json_extract(value, '$.activity_at')
+		FROM json_each(?)
+	)`
+	join = "LEFT JOIN workspace_activity wa ON wa.repo_id = " + alias +
+		".repo_id AND wa.item_number = " + alias + ".number"
+	order = "CASE WHEN wa.activity_at > " + alias + ".last_activity_at " +
+		"THEN wa.activity_at ELSE " + alias + ".last_activity_at END"
+	return prefix, join, order, []any{string(payload)}, nil
+}
+
 func sqlPlaceholders(count int) string {
 	parts := make([]string, count)
 	for i := range parts {
@@ -1951,7 +2010,12 @@ func (d *DB) ListMergeRequests(ctx context.Context, opts ListMergeRequestsOpts) 
 		where = "WHERE " + strings.Join(conds, " AND ")
 	}
 
-	query := fmt.Sprintf(`
+	activityCTE, activityJoin, activityOrder, activityArgs, err := workspaceActivityCTE("p", opts.WorkspaceActivity)
+	if err != nil {
+		return nil, fmt.Errorf("list merge requests: %w", err)
+	}
+	args = append(activityArgs, args...)
+	query := fmt.Sprintf(`%s
 		SELECT p.id, p.snapshot_revision, p.repo_id, p.platform_id, p.platform_external_id, p.number, p.url, p.title,
 		       p.author, p.author_display_name, p.state, p.is_draft, p.is_locked,
 		       p.body, p.head_branch, p.base_branch,
@@ -1974,7 +2038,8 @@ func (d *DB) ListMergeRequests(ctx context.Context, opts ListMergeRequestsOpts) 
 		LEFT JOIN forge_starred_items s
 		    ON s.item_type = 'pr' AND s.repo_id = p.repo_id AND s.number = p.number
 		%s
-		ORDER BY p.last_activity_at DESC, p.id DESC`, where)
+		%s
+		ORDER BY %s DESC, p.id DESC`, activityCTE, activityJoin, where, activityOrder)
 	query = appendLimitOffset(query, &args, opts.Limit, opts.Offset)
 
 	rows, err := d.ro.QueryContext(ctx, query, args...)
@@ -3199,7 +3264,12 @@ func (d *DB) ListIssues(
 		where = "WHERE " + strings.Join(conds, " AND ")
 	}
 
-	query := fmt.Sprintf(`
+	activityCTE, activityJoin, activityOrder, activityArgs, err := workspaceActivityCTE("i", opts.WorkspaceActivity)
+	if err != nil {
+		return nil, fmt.Errorf("list issues: %w", err)
+	}
+	args = append(activityArgs, args...)
+	query := fmt.Sprintf(`%s
 		SELECT i.id, i.snapshot_revision, i.repo_id, i.platform_id, i.platform_external_id, i.number, i.url, i.title,
 		       i.author, i.state, i.body, i.comment_count, i.labels_json, i.assignees_json,
 		       i.detail_fetched_at,
@@ -3213,7 +3283,8 @@ func (d *DB) ListIssues(
 		LEFT JOIN forge_item_workflow_state w
 		    ON w.repo_id = i.repo_id AND w.item_type = 'issue' AND w.item_number = i.number
 		%s
-		ORDER BY i.last_activity_at DESC, i.id DESC`, where)
+		%s
+		ORDER BY %s DESC, i.id DESC`, activityCTE, activityJoin, where, activityOrder)
 	query = appendLimitOffset(query, &args, opts.Limit, opts.Offset)
 
 	rows, err := d.ro.QueryContext(ctx, query, args...)
@@ -5217,6 +5288,7 @@ const workspaceSummaryColumns = `
 	w.git_head_ref, w.mr_head_repo, w.workspace_branch,
 	w.worktree_path, w.tmux_session, w.terminal_backend, w.status,
 	w.error_message, w.created_at, w.kata_metadata,
+	r.id,
 	CASE
 	    WHEN w.item_type = 'issue' THEN i.title
 	    ELSE m.title
@@ -5246,7 +5318,6 @@ const workspaceSummaryJoins = `
 	   AND rr.platform_host = w.platform_host
 	   AND rr.owner_key = w.repo_owner_key
 	   AND rr.name_key = w.repo_name_key
-	   AND rr.is_current = 1
 	   AND NOT EXISTS (
 	       SELECT 1
 	       FROM forge_repo_routes historical
@@ -5273,12 +5344,14 @@ func scanWorkspaceSummary(
 	var s WorkspaceSummary
 	var kataMetadataJSON string
 	var itemLastActivityAt sql.NullString
+	var repoID sql.NullInt64
 	err := scanner.Scan(
 		&s.ID, &s.Platform, &s.PlatformHost, &s.RepoOwner, &s.RepoName,
 		&s.ItemType, &s.ItemNumber, &s.ItemKey, &s.AssociatedPRNumber,
 		&s.GitHeadRef, &s.MRHeadRepo, &s.WorkspaceBranch,
 		&s.WorktreePath, &s.TmuxSession, &s.TerminalBackend, &s.Status,
 		&s.ErrorMessage, &s.CreatedAt, &kataMetadataJSON,
+		&repoID,
 		&s.SourceTitle, &s.SourceState, &s.SourceURL,
 		&s.MRIsDraft, &s.MRCIStatus,
 		&s.MRReviewDecision, &s.MRAdditions, &s.MRDeletions,
@@ -5288,6 +5361,9 @@ func scanWorkspaceSummary(
 	)
 	if err != nil {
 		return nil, err
+	}
+	if repoID.Valid {
+		s.RepoID = repoID.Int64
 	}
 	s.CreatedAt = s.CreatedAt.UTC()
 	s.MRTitle = s.SourceTitle

--- a/internal/db/queries_activity.go
+++ b/internal/db/queries_activity.go
@@ -128,7 +128,7 @@ func (d *DB) ListActivity(
 		}
 		notificationUnion = `
 			UNION ALL
-			SELECT 'notification', 'ntf', n.id,
+			SELECT 'notification', 'ntf', n.id, r.id,
 			       r.platform, r.platform_host, r.owner, r.name, r.repo_path_key,
 			       n.item_type, COALESCE(n.item_number, 0), n.subject_title,
 			       n.web_url, CASE WHEN n.unread = 1 THEN 'unread' ELSE 'read' END,
@@ -160,7 +160,7 @@ func (d *DB) ListActivity(
 	}
 
 	query := fmt.Sprintf(`
-		SELECT activity_type, source, source_id, platform, platform_host,
+		SELECT activity_type, source, source_id, repo_id, platform, platform_host,
 		       repo_owner, repo_name,
 		       item_type, item_number, item_title,
 		       item_url, item_state, author, item_author,
@@ -172,6 +172,7 @@ func (d *DB) ListActivity(
 		FROM (
 			SELECT 'new_pr' AS activity_type,
 			       'pr' AS source, p.id AS source_id,
+			       r.id AS repo_id,
 			       r.platform, r.platform_host, r.owner AS repo_owner, r.name AS repo_name,
 			       r.repo_path_key,
 			       'pr' AS item_type, p.number AS item_number,
@@ -188,7 +189,7 @@ func (d *DB) ListActivity(
 			FROM forge_merge_requests p
 			JOIN forge_repos r ON p.repo_id = r.id AND r.lifecycle_state = 'active'
 			UNION ALL
-			SELECT 'new_issue', 'issue', i.id,
+			SELECT 'new_issue', 'issue', i.id, r.id,
 			       r.platform, r.platform_host, r.owner, r.name, r.repo_path_key,
 			       'issue', i.number, i.title,
 			       i.url, i.state,
@@ -208,6 +209,7 @@ func (d *DB) ListActivity(
 			           ELSE e.event_type
 			       END,
 			       'pre', e.id,
+			       r.id,
 			       r.platform, r.platform_host, r.owner, r.name, r.repo_path_key,
 			       'pr', p.number, p.title,
 			       p.url, p.state,
@@ -225,7 +227,7 @@ func (d *DB) ListActivity(
 			WHERE e.event_type IN (
 				'issue_comment', 'review', 'commit', 'force_push')
 			UNION ALL
-			SELECT 'comment', 'ise', e.id,
+			SELECT 'comment', 'ise', e.id, r.id,
 			       r.platform, r.platform_host, r.owner, r.name, r.repo_path_key,
 			       'issue', i.number, i.title,
 			       i.url, i.state,
@@ -242,7 +244,7 @@ func (d *DB) ListActivity(
 			JOIN forge_repos r ON i.repo_id = r.id AND r.lifecycle_state = 'active'
 			WHERE e.event_type = 'issue_comment'
 			UNION ALL
-			SELECT 'default_branch_commit', 'bc', bc.id,
+			SELECT 'default_branch_commit', 'bc', bc.id, r.id,
 			       r.platform, r.platform_host, r.owner, r.name, r.repo_path_key,
 			       '', 0, '',
 			       '', '',
@@ -259,7 +261,7 @@ func (d *DB) ListActivity(
 			FROM forge_branch_commits bc
 			JOIN forge_repos r ON bc.repo_id = r.id AND r.lifecycle_state = 'active'
 			UNION ALL
-			SELECT 'default_branch_force_push', 'bfp', bfp.id,
+			SELECT 'default_branch_force_push', 'bfp', bfp.id, r.id,
 			       r.platform, r.platform_host, r.owner, r.name, r.repo_path_key,
 			       '', 0, '',
 			       '', '',
@@ -298,6 +300,7 @@ func (d *DB) ListActivity(
 		var committedAtStr sql.NullString
 		if err := rows.Scan(
 			&it.ActivityType, &it.Source, &it.SourceID,
+			&it.RepoID,
 			&it.Platform, &it.PlatformHost, &it.RepoOwner, &it.RepoName,
 			&it.ItemType, &it.ItemNumber, &it.ItemTitle,
 			&it.ItemURL, &it.ItemState, &it.Author, &it.ItemAuthor,

--- a/internal/db/queries_activity_test.go
+++ b/internal/db/queries_activity_test.go
@@ -75,9 +75,11 @@ func TestListActivity(t *testing.T) {
 		assert.Equal("pr", items[3].ItemType)
 		assert.Equal("new_issue", items[4].ActivityType)
 		assert.Equal("new_pr", items[5].ActivityType)
+		assert.Equal(repoB, items[5].RepoID)
 		assert.Equal("github.com", items[5].PlatformHost)
 		assert.Equal("bob", items[5].RepoOwner)
 		assert.Equal("new_pr", items[6].ActivityType)
+		assert.Equal(repoA, items[6].RepoID)
 		assert.Equal("alice", items[6].RepoOwner)
 	})
 

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -2056,6 +2056,62 @@ func TestListPullRequestsPaginationUsesStableTieBreaker(t *testing.T) {
 	assert.Equal(2, secondPage[0].Number)
 }
 
+func TestListMergeRequestsWorkspaceActivitySortsBeforePagination(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	repoID := insertTestRepo(t, d, "owner", "repo")
+	base := baseTime()
+	insertTestMR(t, d, repoID, 1, "provider newest", base.Add(2*time.Hour))
+	insertTestMR(t, d, repoID, 2, "workspace newest", base)
+
+	first, err := d.ListMergeRequests(t.Context(), ListMergeRequestsOpts{
+		Limit: 1,
+		WorkspaceActivity: []ItemActivityOverride{{
+			RepoID: repoID, ItemNumber: 2, ActivityAt: base.Add(3 * time.Hour),
+		}},
+	})
+	require.NoError(err)
+	require.Len(first, 1)
+	assert.Equal(2, first[0].Number)
+	assert.Equal(base, first[0].LastActivityAt)
+
+	second, err := d.ListMergeRequests(t.Context(), ListMergeRequestsOpts{
+		Limit: 1, Offset: 1,
+		WorkspaceActivity: []ItemActivityOverride{{
+			RepoID: repoID, ItemNumber: 2, ActivityAt: base.Add(3 * time.Hour),
+		}},
+	})
+	require.NoError(err)
+	require.Len(second, 1)
+	assert.Equal(1, second[0].Number)
+}
+
+func TestListMergeRequestsWorkspaceActivitySupportsLargeSubjectSets(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	repoID := insertTestRepo(t, d, "owner", "repo")
+	base := baseTime()
+	insertTestMR(t, d, repoID, 1, "provider newest", base.Add(2*time.Hour))
+	insertTestMR(t, d, repoID, 2, "workspace newest", base)
+
+	overrides := make([]ItemActivityOverride, 11_000)
+	for i := range overrides {
+		overrides[i] = ItemActivityOverride{
+			RepoID: repoID, ItemNumber: i + 1, ActivityAt: base.Add(time.Hour),
+		}
+	}
+	overrides[1].ActivityAt = base.Add(3 * time.Hour)
+
+	got, err := d.ListMergeRequests(t.Context(), ListMergeRequestsOpts{
+		Limit: 1, WorkspaceActivity: overrides,
+	})
+	require.NoError(err)
+	require.Len(got, 1)
+	assert.Equal(2, got[0].Number)
+}
+
 func TestListPullRequestsFilterByKanban(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -3290,6 +3346,52 @@ func TestListIssuesPaginationUsesStableTieBreaker(t *testing.T) {
 	require.NoError(err)
 	require.Len(secondPage, 1)
 	assert.Equal(2, secondPage[0].Number)
+}
+
+func TestListIssuesWorkspaceActivitySortsBeforePagination(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	repoID := insertTestRepo(t, d, "owner", "repo")
+	base := baseTime()
+	insertTestIssue(t, d, repoID, 1, "provider newest", base.Add(2*time.Hour))
+	insertTestIssue(t, d, repoID, 2, "workspace newest", base)
+
+	first, err := d.ListIssues(t.Context(), ListIssuesOpts{
+		Limit: 1,
+		WorkspaceActivity: []ItemActivityOverride{{
+			RepoID: repoID, ItemNumber: 2, ActivityAt: base.Add(3 * time.Hour),
+		}},
+	})
+	require.NoError(err)
+	require.Len(first, 1)
+	assert.Equal(2, first[0].Number)
+	assert.Equal(base, first[0].LastActivityAt)
+}
+
+func TestListIssuesWorkspaceActivitySupportsLargeSubjectSets(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	repoID := insertTestRepo(t, d, "owner", "repo")
+	base := baseTime()
+	insertTestIssue(t, d, repoID, 1, "provider newest", base.Add(2*time.Hour))
+	insertTestIssue(t, d, repoID, 2, "workspace newest", base)
+
+	overrides := make([]ItemActivityOverride, 11_000)
+	for i := range overrides {
+		overrides[i] = ItemActivityOverride{
+			RepoID: repoID, ItemNumber: i + 1, ActivityAt: base.Add(time.Hour),
+		}
+	}
+	overrides[1].ActivityAt = base.Add(3 * time.Hour)
+
+	got, err := d.ListIssues(t.Context(), ListIssuesOpts{
+		Limit: 1, WorkspaceActivity: overrides,
+	})
+	require.NoError(err)
+	require.Len(got, 1)
+	assert.Equal(2, got[0].Number)
 }
 
 func TestReplaceIssueLabels_RejectsWrongRepoID(t *testing.T) {

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -860,18 +860,44 @@ type WorkflowStateListRow struct {
 }
 
 type ListMergeRequestsOpts struct {
-	RepoID       int64
+	RepoID            int64
+	PlatformHost      string
+	RepoOwner         string
+	RepoName          string
+	RepoPath          string
+	RepoFilters       []RepoFilter
+	State             string
+	KanbanState       string
+	Starred           bool
+	Search            string
+	Limit             int
+	Offset            int
+	WorkspaceActivity []ItemActivityOverride
+}
+
+type ItemActivityOverride struct {
+	RepoID     int64
+	ItemNumber int
+	ActivityAt time.Time
+}
+
+type WorkspaceSubjectKey struct {
+	RepoID     int64  `json:"repo_id"`
+	ItemType   string `json:"item_type"`
+	ItemNumber int    `json:"item_number"`
+}
+
+type WorkspaceSubjectMetadata struct {
+	Key          WorkspaceSubjectKey
+	Platform     string
 	PlatformHost string
 	RepoOwner    string
 	RepoName     string
 	RepoPath     string
-	RepoFilters  []RepoFilter
+	Title        string
 	State        string
-	KanbanState  string
-	Starred      bool
-	Search       string
-	Limit        int
-	Offset       int
+	URL          string
+	Author       string
 }
 
 type RepoFilter struct {
@@ -934,17 +960,18 @@ type CommentAutocompleteReference struct {
 }
 
 type ListIssuesOpts struct {
-	PlatformHost string
-	RepoOwner    string
-	RepoName     string
-	RepoPath     string
-	RepoFilters  []RepoFilter
-	State        string
-	Starred      bool
-	Search       string
-	Assignee     string
-	Limit        int
-	Offset       int
+	PlatformHost      string
+	RepoOwner         string
+	RepoName          string
+	RepoPath          string
+	RepoFilters       []RepoFilter
+	State             string
+	Starred           bool
+	Search            string
+	Assignee          string
+	Limit             int
+	Offset            int
+	WorkspaceActivity []ItemActivityOverride
 }
 
 type StarredItem struct {
@@ -1067,6 +1094,7 @@ type ActivityItem struct {
 	ActivityType string // new_pr, new_issue, comment, review, commit, default_branch_*
 	Source       string // pr, issue, pre, ise, bc, bfp
 	SourceID     int64  // PK from the source table
+	RepoID       int64
 	Platform     string
 	PlatformHost string
 	RepoOwner    string
@@ -1251,6 +1279,7 @@ type Workspace struct {
 // WorkspaceSummary extends Workspace with joined source-item metadata.
 type WorkspaceSummary struct {
 	Workspace
+	RepoID           int64
 	SourceTitle      *string
 	SourceState      *string
 	SourceURL        *string

--- a/internal/db/workspace_subjects.go
+++ b/internal/db/workspace_subjects.go
@@ -1,0 +1,77 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+func (d *DB) ListWorkspaceSubjectMetadata(
+	ctx context.Context,
+	keys []WorkspaceSubjectKey,
+) (map[WorkspaceSubjectKey]WorkspaceSubjectMetadata, error) {
+	out := make(map[WorkspaceSubjectKey]WorkspaceSubjectMetadata)
+	if len(keys) == 0 {
+		return out, nil
+	}
+	unique := make([]WorkspaceSubjectKey, 0, len(keys))
+	seen := make(map[WorkspaceSubjectKey]struct{}, len(keys))
+	for _, key := range keys {
+		if key.RepoID == 0 || key.ItemNumber <= 0 {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		unique = append(unique, key)
+	}
+	if len(unique) == 0 {
+		return out, nil
+	}
+	requestedJSON, err := json.Marshal(unique)
+	if err != nil {
+		return nil, fmt.Errorf("encode workspace subject metadata request: %w", err)
+	}
+	query := `WITH requested(repo_id, item_type, item_number) AS (
+			SELECT CAST(json_extract(value, '$.repo_id') AS INTEGER),
+			       json_extract(value, '$.item_type'),
+			       CAST(json_extract(value, '$.item_number') AS INTEGER)
+			FROM json_each(?)
+		)
+		SELECT q.repo_id, q.item_type, q.item_number,
+		       r.platform, r.platform_host, r.owner, r.name, r.repo_path,
+		       p.title, p.state, p.url, p.author
+		FROM requested q
+		JOIN forge_repos r ON r.id = q.repo_id AND r.lifecycle_state = 'active'
+		JOIN forge_merge_requests p
+		  ON q.item_type = 'pull_request' AND p.repo_id = q.repo_id AND p.number = q.item_number
+		UNION ALL
+		SELECT q.repo_id, q.item_type, q.item_number,
+		       r.platform, r.platform_host, r.owner, r.name, r.repo_path,
+		       i.title, i.state, i.url, i.author
+		FROM requested q
+		JOIN forge_repos r ON r.id = q.repo_id AND r.lifecycle_state = 'active'
+		JOIN forge_issues i
+		  ON q.item_type = 'issue' AND i.repo_id = q.repo_id AND i.number = q.item_number`
+	rows, err := d.ro.QueryContext(ctx, query, string(requestedJSON))
+	if err != nil {
+		return nil, fmt.Errorf("list workspace subject metadata: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var item WorkspaceSubjectMetadata
+		if err := rows.Scan(
+			&item.Key.RepoID, &item.Key.ItemType, &item.Key.ItemNumber,
+			&item.Platform, &item.PlatformHost, &item.RepoOwner, &item.RepoName,
+			&item.RepoPath, &item.Title, &item.State, &item.URL, &item.Author,
+		); err != nil {
+			return nil, fmt.Errorf("scan workspace subject metadata: %w", err)
+		}
+		out[item.Key] = item
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list workspace subject metadata rows: %w", err)
+	}
+	return out, nil
+}

--- a/internal/db/workspace_subjects_test.go
+++ b/internal/db/workspace_subjects_test.go
@@ -1,0 +1,57 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListWorkspaceSubjectMetadataReturnsPullRequestAndIssue(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	repoID := insertTestRepo(t, d, "acme", "widget")
+	base := baseTime()
+	insertTestMR(t, d, repoID, 4, "live pull request", base)
+	insertTestIssue(t, d, repoID, 5, "live issue", base)
+
+	got, err := d.ListWorkspaceSubjectMetadata(t.Context(), []WorkspaceSubjectKey{
+		{RepoID: repoID, ItemType: WorkspaceItemTypePullRequest, ItemNumber: 4},
+		{RepoID: repoID, ItemType: WorkspaceItemTypeIssue, ItemNumber: 5},
+	})
+	require.NoError(err)
+	require.Len(got, 2)
+	assert.Equal("live pull request", got[WorkspaceSubjectKey{
+		RepoID: repoID, ItemType: WorkspaceItemTypePullRequest, ItemNumber: 4,
+	}].Title)
+	assert.Equal("live issue", got[WorkspaceSubjectKey{
+		RepoID: repoID, ItemType: WorkspaceItemTypeIssue, ItemNumber: 5,
+	}].Title)
+}
+
+func TestListWorkspaceSubjectMetadataSupportsLargeSubjectSets(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	repoID := insertTestRepo(t, d, "acme", "widget")
+	base := baseTime()
+	insertTestMR(t, d, repoID, 1, "live pull request", base)
+
+	// Three bind parameters per subject would exceed SQLite's default variable
+	// limit here. The request set must remain bounded independently of the
+	// number of retained workspaces.
+	keys := make([]WorkspaceSubjectKey, 11_000)
+	for i := range keys {
+		keys[i] = WorkspaceSubjectKey{
+			RepoID: repoID, ItemType: WorkspaceItemTypePullRequest, ItemNumber: i + 1,
+		}
+	}
+
+	got, err := d.ListWorkspaceSubjectMetadata(t.Context(), keys)
+	require.NoError(err, "metadata lookup failed for %d subjects", len(keys))
+	require.Len(got, 1)
+	assert.Equal("live pull request", got[WorkspaceSubjectKey{
+		RepoID: repoID, ItemType: WorkspaceItemTypePullRequest, ItemNumber: 1,
+	}].Title)
+}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -22800,6 +22800,97 @@ func TestAPIActivityReturnsUTCCreatedAt(t *testing.T) {
 	assert.Equal("comment", commentItem.ActivityType)
 }
 
+func TestAPIActivityFencesRepositoryReconciliationAcrossEventAndWorkspaceReads(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv, database := setupTestServer(t)
+	client := setupTestClient(t, srv)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	repo, err := database.GetRepoByIdentity(ctx, verifiedGitHubRepoIdentity("github.com", "acme", "widget"))
+	require.NoError(err)
+	require.NotNil(repo)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID: repo.ID, PlatformID: 701, Number: 701,
+		URL: "https://github.com/acme/widget/pull/701", Title: "Fenced activity",
+		Author: "alice", State: db.MergeRequestStateOpen,
+		CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+	require.NoError(database.InsertWorkspace(ctx, &db.Workspace{
+		ID: "ws-activity-fence", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget", ItemType: db.WorkspaceItemTypePullRequest,
+		ItemNumber: 701, WorktreePath: t.TempDir(), Status: "ready",
+	}))
+
+	afterItems := make(chan struct{})
+	continueRequest := make(chan struct{})
+	srv.activityAfterItemsForTest = func() {
+		close(afterItems)
+		<-continueRequest
+	}
+	responseDone := make(chan *generated.ListActivityResponse, 1)
+	errorDone := make(chan error, 1)
+	go func() {
+		response, requestErr := client.HTTP.ListActivityWithResponse(
+			context.Background(), &generated.ListActivityParams{},
+		)
+		responseDone <- response
+		errorDone <- requestErr
+	}()
+	<-afterItems
+
+	writeAttempted := make(chan struct{})
+	restoreHook := database.SetBeforeRepositoryReconciliationWriteLockForTest(func() {
+		close(writeAttempted)
+	})
+	t.Cleanup(restoreHook)
+	renameDone := make(chan error, 1)
+	go func() {
+		renamed := db.GitHubRepoIdentity("github.com", "acme", "gadget")
+		renamed.PlatformRepoID = repo.PlatformRepoID
+		_, _, renameErr := database.ReconcileRepositoryObservation(
+			context.Background(), renamed, now.Add(time.Minute),
+		)
+		renameDone <- renameErr
+	}()
+	<-writeAttempted
+
+	var renameErr error
+	renameCompletedEarly := false
+	select {
+	case renameErr = <-renameDone:
+		renameCompletedEarly = true
+		assert.Fail("repository reconciliation completed during activity snapshot")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(continueRequest)
+	response := <-responseDone
+	require.NoError(<-errorDone)
+	if !renameCompletedEarly {
+		renameErr = <-renameDone
+	}
+	require.NoError(renameErr)
+	require.NotNil(response)
+	require.Equal(http.StatusOK, response.StatusCode())
+	require.NotNil(response.JSON200)
+	require.NotNil(response.JSON200.Items)
+
+	var item *generated.ActivityItemResponse
+	for i := range *response.JSON200.Items {
+		candidate := &(*response.JSON200.Items)[i]
+		if candidate.ItemNumber == 701 {
+			item = candidate
+			break
+		}
+	}
+	require.NotNil(item)
+	assert.Equal("widget", item.RepoName)
+	require.NotNil(item.Workspace)
+	assert.Equal("ws-activity-fence", item.Workspace.Id)
+}
+
 func TestAPIActivityCommentCarriesPRAuthor(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -23380,6 +23471,64 @@ func TestAPIListActivity(t *testing.T) {
 	require.Len(*filtered.JSON200.Items, 1)
 	assert.Equal("comment", (*filtered.JSON200.Items)[0].ActivityType)
 	assert.Equal("reviewer", (*filtered.JSON200.Items)[0].Author)
+
+	whitespace := " \t "
+	unfiltered, err := client.HTTP.ListActivityWithResponse(
+		ctx, &generated.ListActivityParams{Since: &since, Search: &whitespace},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, unfiltered.StatusCode())
+	require.NotNil(unfiltered.JSON200)
+	require.NotNil(unfiltered.JSON200.Items)
+	assert.Len(*unfiltered.JSON200.Items, len(*resp.JSON200.Items))
+}
+
+func TestWorkspaceActivitySearchKeepsSubjectsWithMatchingProviderEvents(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	since := now.Add(-time.Hour)
+	repoID := int64(7)
+	matchedKey := db.WorkspaceSubjectKey{
+		RepoID: repoID, ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: 41,
+	}
+	eventlessKey := db.WorkspaceSubjectKey{
+		RepoID: repoID, ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: 42,
+	}
+	subject := func(key db.WorkspaceSubjectKey, title string) workspaceapi.SubjectActivity {
+		return workspaceapi.SubjectActivity{
+			Subject: db.WorkspaceSubjectMetadata{
+				Key: key, Platform: "github", PlatformHost: "github.com",
+				RepoOwner: "acme", RepoName: "widget", RepoPath: "acme/widget",
+				Title: title, Author: "alice", State: "open",
+			},
+			Workspace:  workspaceapi.WorkspaceRef{ID: "ws-" + strconv.Itoa(key.ItemNumber), Status: "ready"},
+			ActivityAt: &now,
+		}
+	}
+	snapshot := workspaceapi.WorkspaceSubjectSnapshot{
+		OwnReferences: map[db.WorkspaceSubjectKey]workspaceapi.WorkspaceRef{},
+		Subjects: map[db.WorkspaceSubjectKey]workspaceapi.SubjectActivity{
+			matchedKey:   subject(matchedKey, "Unrelated title"),
+			eventlessKey: subject(eventlessKey, "Another unrelated title"),
+		},
+	}
+	srv := &Server{repoResolver: httpapi.NewRepositoryResolver(httpapi.RepositoryResolverDeps{})}
+
+	got := srv.workspaceActivityResponse(
+		&listActivityInput{},
+		db.ListActivityOpts{Search: "reviewer", Since: &since},
+		snapshot,
+		[]db.ActivityItem{{
+			RepoID: repoID, ItemType: "pr", ItemNumber: matchedKey.ItemNumber,
+			Author: "reviewer", BodyPreview: "matches the search",
+		}},
+	)
+
+	require.Len(got, 1)
+	assert.Equal(matchedKey.ItemNumber, got[0].ItemNumber)
+	require.NotNil(got[0].Workspace)
+	assert.Equal("ws-41", got[0].Workspace.ID)
 }
 
 func TestAPIListActivityIncludesNotificationSyncedBeforeRepo(t *testing.T) {

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -213,8 +213,24 @@ type rateLimitsResponse struct {
 const activitySafetyCap = 5000
 
 type activityResponse struct {
-	Items  []activityItemResponse `json:"items"`
-	Capped bool                   `json:"capped"`
+	Items             []activityItemResponse             `json:"items"`
+	WorkspaceActivity []workspaceActivitySubjectResponse `json:"workspace_activity"`
+	Capped            bool                               `json:"capped"`
+}
+
+type workspaceActivitySubjectResponse struct {
+	Repo         httpapi.RepoRefResponse    `json:"repo"`
+	PlatformHost string                     `json:"platform_host"`
+	RepoOwner    string                     `json:"repo_owner"`
+	RepoName     string                     `json:"repo_name"`
+	ItemType     string                     `json:"item_type"`
+	ItemNumber   int                        `json:"item_number"`
+	ItemTitle    string                     `json:"item_title"`
+	ItemURL      string                     `json:"item_url"`
+	ItemState    string                     `json:"item_state"`
+	ItemAuthor   string                     `json:"item_author,omitempty"`
+	Workspace    *workspaceapi.WorkspaceRef `json:"workspace,omitempty"`
+	ActivityAt   string                     `json:"activity_at" format:"date-time"`
 }
 
 type activityItemResponse struct {

--- a/internal/server/apitest/workspace_subject_identity_test.go
+++ b/internal/server/apitest/workspace_subject_identity_test.go
@@ -1,0 +1,170 @@
+package apitest
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/apiclient/generated"
+	"go.kenn.io/forge/internal/db"
+)
+
+func TestWorkspaceReferencesUseStableRepositoryIdentityAcrossRenameAndRouteReuse(t *testing.T) {
+	require := require.New(t)
+	srv, database := setupTestServer(t)
+	client := setupTestClient(t, srv)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	oldIdentity := db.GitHubRepoIdentity("github.com", "acme", "widget")
+	oldIdentity.PlatformRepoID = "repo-old-widget"
+	oldRepo, accepted, err := database.ReconcileRepositoryObservation(ctx, oldIdentity, now)
+	require.NoError(err)
+	require.True(accepted)
+	seedWorkspaceIdentitySubjects(t, database, oldRepo.Repository.ID, "acme", "widget", "old", now)
+
+	renamedIdentity := db.GitHubRepoIdentity("github.com", "acme", "gadget")
+	renamedIdentity.PlatformRepoID = oldIdentity.PlatformRepoID
+	_, accepted, err = database.ReconcileRepositoryObservation(ctx, renamedIdentity, now.Add(time.Minute))
+	require.NoError(err)
+	require.True(accepted)
+
+	assertWorkspaceIdentitySurfaces(t, client.HTTP, "gadget", true)
+
+	replacementIdentity := db.GitHubRepoIdentity("github.com", "acme", "widget")
+	replacementIdentity.PlatformRepoID = "repo-replacement-widget"
+	replacement, accepted, err := database.ReconcileRepositoryObservation(
+		ctx, replacementIdentity, now.Add(2*time.Minute),
+	)
+	require.NoError(err)
+	require.True(accepted)
+	seedWorkspaceIdentitySubjects(
+		t, database, replacement.Repository.ID, "acme", "widget", "replacement", now.Add(2*time.Minute),
+	)
+
+	assertWorkspaceIdentitySurfaces(t, client.HTTP, "gadget", false)
+	assertWorkspaceIdentitySurfaces(t, client.HTTP, "widget", false)
+}
+
+func seedWorkspaceIdentitySubjects(
+	t *testing.T,
+	database *db.DB,
+	repoID int64,
+	owner string,
+	name string,
+	prefix string,
+	now time.Time,
+) {
+	t.Helper()
+	prID, err := database.UpsertMergeRequest(t.Context(), &db.MergeRequest{
+		RepoID: repoID, PlatformID: repoID*1000 + 61, Number: 61,
+		URL:   "https://github.com/" + owner + "/" + name + "/pull/61",
+		Title: prefix + " pull", Author: "alice", State: db.MergeRequestStateOpen,
+		CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(t, err)
+	require.NoError(t, database.EnsureKanbanState(t.Context(), prID))
+	_, err = database.UpsertIssue(t.Context(), &db.Issue{
+		RepoID: repoID, PlatformID: repoID*1000 + 62, Number: 62,
+		URL:   "https://github.com/" + owner + "/" + name + "/issues/62",
+		Title: prefix + " issue", Author: "bob", State: "open",
+		CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(t, err)
+
+	if prefix != "old" {
+		return
+	}
+	for _, workspace := range []*db.Workspace{
+		{
+			ID: "ws-stable-pr", Platform: "github", PlatformHost: "github.com",
+			RepoOwner: owner, RepoName: name, ItemType: db.WorkspaceItemTypePullRequest,
+			ItemNumber: 61, WorktreePath: t.TempDir(), Status: "ready",
+		},
+		{
+			ID: "ws-stable-issue", Platform: "github", PlatformHost: "github.com",
+			RepoOwner: owner, RepoName: name, ItemType: db.WorkspaceItemTypeIssue,
+			ItemNumber: 62, WorktreePath: t.TempDir(), Status: "ready",
+		},
+	} {
+		require.NoError(t, database.InsertWorkspace(t.Context(), workspace))
+	}
+}
+
+func assertWorkspaceIdentitySurfaces(
+	t *testing.T,
+	client *generated.ClientWithResponses,
+	repoName string,
+	wantWorkspace bool,
+) {
+	t.Helper()
+	require := require.New(t)
+	ctx := t.Context()
+
+	activityResponse, err := client.ListActivityWithResponse(ctx, &generated.ListActivityParams{})
+	require.NoError(err)
+	require.Equal(http.StatusOK, activityResponse.StatusCode())
+	require.NotNil(activityResponse.JSON200)
+	require.NotNil(activityResponse.JSON200.Items)
+	activityByType := make(map[string]generated.ActivityItemResponse)
+	for _, item := range *activityResponse.JSON200.Items {
+		if item.RepoName == repoName && (item.ItemNumber == 61 || item.ItemNumber == 62) {
+			activityByType[item.ItemType] = item
+		}
+	}
+	require.Contains(activityByType, "pr")
+	require.Contains(activityByType, "issue")
+	assertWorkspaceRef(t, activityByType["pr"].Workspace, "ws-stable-pr", wantWorkspace)
+	assertWorkspaceRef(t, activityByType["issue"].Workspace, "ws-stable-issue", wantWorkspace)
+
+	pullsResponse, err := client.ListPullsWithResponse(ctx, nil)
+	require.NoError(err)
+	require.Equal(http.StatusOK, pullsResponse.StatusCode())
+	require.NotNil(pullsResponse.JSON200)
+	var pull *generated.MergeRequestResponse
+	for i := range *pullsResponse.JSON200 {
+		candidate := &(*pullsResponse.JSON200)[i]
+		if candidate.RepoName == repoName && candidate.Number == 61 {
+			pull = candidate
+			break
+		}
+	}
+	require.NotNil(pull)
+	assertWorkspaceRef(t, pull.Workspace, "ws-stable-pr", wantWorkspace)
+	pullDetail, err := client.GetPullWithResponse(ctx, "gh", "acme", repoName, 61)
+	require.NoError(err)
+	require.Equal(http.StatusOK, pullDetail.StatusCode())
+	require.NotNil(pullDetail.JSON200)
+	assertWorkspaceRef(t, pullDetail.JSON200.Workspace, "ws-stable-pr", wantWorkspace)
+
+	issuesResponse, err := client.ListIssuesWithResponse(ctx, nil)
+	require.NoError(err)
+	require.Equal(http.StatusOK, issuesResponse.StatusCode())
+	require.NotNil(issuesResponse.JSON200)
+	var issue *generated.IssueResponse
+	for i := range *issuesResponse.JSON200 {
+		candidate := &(*issuesResponse.JSON200)[i]
+		if candidate.RepoName == repoName && candidate.Number == 62 {
+			issue = candidate
+			break
+		}
+	}
+	require.NotNil(issue)
+	assertWorkspaceRef(t, issue.Workspace, "ws-stable-issue", wantWorkspace)
+	issueDetail, err := client.GetIssueWithResponse(ctx, "gh", "acme", repoName, 62)
+	require.NoError(err)
+	require.Equal(http.StatusOK, issueDetail.StatusCode())
+	require.NotNil(issueDetail.JSON200)
+	assertWorkspaceRef(t, issueDetail.JSON200.Workspace, "ws-stable-issue", wantWorkspace)
+}
+
+func assertWorkspaceRef(t *testing.T, ref *generated.WorkspaceRef, wantID string, wantWorkspace bool) {
+	t.Helper()
+	if !wantWorkspace {
+		require.Nil(t, ref)
+		return
+	}
+	require.NotNil(t, ref)
+	require.Equal(t, wantID, ref.Id)
+}

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -1,8 +1,6 @@
 package server
 
 import (
-	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -22,47 +20,6 @@ type starredRequest struct {
 	PlatformHost string `json:"platform_host"`
 }
 
-func workspaceLookupKey(
-	provider, host, owner, name, itemType string,
-	number int,
-) string {
-	if provider == "" {
-		provider = string(platform.KindGitHub)
-	}
-	if host == "" {
-		if defaultHost, ok := platform.DefaultHost(platform.Kind(provider)); ok {
-			host = defaultHost
-		}
-	}
-	return strings.ToLower(provider) + "\x00" +
-		strings.ToLower(host) + "\x00" +
-		strings.ToLower(owner) + "\x00" +
-		strings.ToLower(name) + "\x00" +
-		itemType + "\x00" +
-		fmt.Sprint(number)
-}
-
-func (s *Server) buildWorkspaceRefLookup(
-	ctx context.Context,
-) (map[string]workspaceapi.WorkspaceRef, error) {
-	workspaces, err := s.db.ListWorkspaces(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("list workspaces: %w", err)
-	}
-	lookup := make(map[string]workspaceapi.WorkspaceRef, len(workspaces))
-	for _, ws := range workspaces {
-		key := workspaceLookupKey(
-			ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
-			ws.ItemType, ws.ItemNumber,
-		)
-		if _, exists := lookup[key]; exists {
-			continue
-		}
-		lookup[key] = workspaceapi.WorkspaceRef{ID: ws.ID, Status: ws.Status}
-	}
-	return lookup, nil
-}
-
 func workspaceItemTypeFromActivity(itemType string) string {
 	switch itemType {
 	case "pr":
@@ -75,17 +32,23 @@ func workspaceItemTypeFromActivity(itemType string) string {
 }
 
 func workspaceRefForActivityItem(
-	lookup map[string]workspaceapi.WorkspaceRef,
+	snapshot workspaceapi.WorkspaceSubjectSnapshot,
 	item db.ActivityItem,
 ) *workspaceapi.WorkspaceRef {
 	workspaceItemType := workspaceItemTypeFromActivity(item.ItemType)
 	if workspaceItemType == "" {
 		return nil
 	}
-	ref, ok := lookup[workspaceLookupKey(
-		item.Platform, item.PlatformHost, item.RepoOwner, item.RepoName,
-		workspaceItemType, item.ItemNumber,
-	)]
+	key := db.WorkspaceSubjectKey{
+		RepoID: item.RepoID, ItemType: workspaceItemType, ItemNumber: item.ItemNumber,
+	}
+	var ref workspaceapi.WorkspaceRef
+	var ok bool
+	if workspaceItemType == db.WorkspaceItemTypeIssue {
+		ref, ok = snapshot.OwnReferences[key]
+	} else if subject, exists := snapshot.Subjects[key]; exists {
+		ref, ok = subject.Workspace, true
+	}
 	if !ok {
 		return nil
 	}

--- a/internal/server/helpers_test.go
+++ b/internal/server/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/server/workspaceapi"
 )
 
 func TestParseRepoFiltersAcceptsProviderQualifiedRepoPath(t *testing.T) {
@@ -19,4 +20,44 @@ func TestParseRepoFiltersAcceptsProviderQualifiedRepoPath(t *testing.T) {
 func TestParseRepoFiltersRejectsUnqualifiedRepoPath(t *testing.T) {
 	assert.Empty(t, parseRepoFilters("gitea/acme/team/widgets"))
 	assert.Empty(t, parseRepoFilters("acme/widgets"))
+}
+
+func TestWorkspaceRefForActivityItemUsesStableRepositoryIdentity(t *testing.T) {
+	issueKey := db.WorkspaceSubjectKey{
+		RepoID: 41, ItemType: db.WorkspaceItemTypeIssue, ItemNumber: 7,
+	}
+	pullKey := db.WorkspaceSubjectKey{
+		RepoID: 41, ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: 8,
+	}
+	snapshot := workspaceapi.WorkspaceSubjectSnapshot{
+		OwnReferences: map[db.WorkspaceSubjectKey]workspaceapi.WorkspaceRef{
+			issueKey: {ID: "ws-issue", Status: "ready"},
+		},
+		Subjects: map[db.WorkspaceSubjectKey]workspaceapi.SubjectActivity{
+			pullKey: {Workspace: workspaceapi.WorkspaceRef{ID: "ws-associated", Status: "ready"}},
+		},
+	}
+
+	renamedIssue := db.ActivityItem{
+		RepoID: 41, RepoOwner: "acme", RepoName: "renamed",
+		ItemType: "issue", ItemNumber: 7,
+	}
+	assert.Equal(t,
+		&workspaceapi.WorkspaceRef{ID: "ws-issue", Status: "ready"},
+		workspaceRefForActivityItem(snapshot, renamedIssue),
+	)
+
+	associatedPull := db.ActivityItem{
+		RepoID: 41, RepoOwner: "acme", RepoName: "renamed",
+		ItemType: "pr", ItemNumber: 8,
+	}
+	assert.Equal(t,
+		&workspaceapi.WorkspaceRef{ID: "ws-associated", Status: "ready"},
+		workspaceRefForActivityItem(snapshot, associatedPull),
+	)
+
+	reusedRoute := renamedIssue
+	reusedRoute.RepoID = 42
+	assert.Nil(t, workspaceRefForActivityItem(snapshot, reusedRoute),
+		"a replacement repository at the same route must not inherit the old workspace")
 }

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -22,6 +23,7 @@ import (
 	"go.kenn.io/forge/internal/server/httpapi"
 	"go.kenn.io/forge/internal/server/issueapi"
 	"go.kenn.io/forge/internal/server/pullapi"
+	"go.kenn.io/forge/internal/server/workspaceapi"
 )
 
 type repoNumberInput struct {
@@ -1224,7 +1226,7 @@ func (s *Server) listActivity(ctx context.Context, input *listActivityInput) (*l
 		RepoFilters: parseRepoFilters(input.Repo),
 		Types:       input.Types,
 		ItemTypes:   input.ItemTypes,
-		Search:      input.Search,
+		Search:      strings.ToLower(strings.TrimSpace(input.Search)),
 		// Notifications are always on; this only drops notification rows in
 		// SQL when no config is loaded (the nil-config safety guard), so the
 		// safety-cap window is filled by real activity, not stale notifications.
@@ -1262,10 +1264,38 @@ func (s *Server) listActivity(ctx context.Context, input *listActivityInput) (*l
 		opts.NotificationRepoFilters = trackedRepos
 	}
 
+	releaseReconciliation, err := s.db.LockRepositoryReconciliationRead(ctx)
+	if err != nil {
+		slog.Error("lock activity repository snapshot failed", "err", err)
+		return nil, httpapi.Internal("list activity failed")
+	}
+	defer releaseReconciliation()
+
 	items, err := s.db.ListActivity(ctx, opts)
 	if err != nil {
 		slog.Error("list activity failed", "err", err)
 		return nil, httpapi.Internal("list activity failed")
+	}
+	var workspaceEventItems []db.ActivityItem
+	hasFullWorkspaceEventItems := opts.Search != "" && opts.AfterTime != nil
+	if hasFullWorkspaceEventItems {
+		workspaceOpts := opts
+		workspaceOpts.AfterTime = nil
+		workspaceOpts.AfterSource = ""
+		workspaceOpts.AfterSourceID = 0
+		workspaceEventItems, err = s.db.ListActivity(ctx, workspaceOpts)
+		if err != nil {
+			slog.Error("list activity search subjects failed", "err", err)
+			return nil, httpapi.Internal("list activity failed")
+		}
+	}
+	if s.activityAfterItemsForTest != nil {
+		s.activityAfterItemsForTest()
+	}
+	workspaceSnapshot, err := s.workspaceAPI.WorkspaceSubjectSnapshotUnderRepositoryReconciliationRead(ctx)
+	if err != nil {
+		slog.Error("list workspace activity failed", "err", err)
+		return nil, httpapi.Internal("list workspace activity failed")
 	}
 
 	if s.cfg != nil {
@@ -1273,29 +1303,22 @@ func (s *Server) listActivity(ctx context.Context, input *listActivityInput) (*l
 		for _, repo := range s.syncer.TrackedRepos() {
 			tracked[trackedRepoKey(repo)] = struct{}{}
 		}
-		filtered := make([]db.ActivityItem, 0, len(items))
-		for _, it := range items {
-			key := trackedRepoKey(ghclient.RepoRef{
-				Platform:     platform.Kind(it.Platform),
-				PlatformHost: it.PlatformHost,
-				Owner:        it.RepoOwner,
-				Name:         it.RepoName,
-			})
-			if _, ok := tracked[key]; ok {
-				filtered = append(filtered, it)
-			}
+		items = filterActivityItemsToTrackedRepositories(items, tracked)
+		if hasFullWorkspaceEventItems {
+			workspaceEventItems = filterActivityItemsToTrackedRepositories(workspaceEventItems, tracked)
 		}
-		items = filtered
 	}
 
 	capped := len(items) > activitySafetyCap
 	if capped {
 		items = items[:activitySafetyCap]
 	}
-
-	workspacesByItem, err := s.buildWorkspaceRefLookup(ctx)
-	if err != nil {
-		return nil, httpapi.Internal("load workspace refs failed")
+	if hasFullWorkspaceEventItems {
+		if len(workspaceEventItems) > activitySafetyCap {
+			workspaceEventItems = workspaceEventItems[:activitySafetyCap]
+		}
+	} else {
+		workspaceEventItems = items
 	}
 
 	out := make([]activityItemResponse, len(items))
@@ -1315,7 +1338,7 @@ func (s *Server) listActivity(ctx context.Context, input *listActivityInput) (*l
 			ItemTitle:    it.ItemTitle,
 			ItemURL:      it.ItemURL,
 			ItemState:    it.ItemState,
-			Workspace:    workspaceRefForActivityItem(workspacesByItem, it),
+			Workspace:    workspaceRefForActivityItem(workspaceSnapshot, it),
 			Author:       it.Author,
 			ItemAuthor:   it.ItemAuthor,
 			CreatedAt:    formatUTCRFC3339(it.CreatedAt),
@@ -1343,9 +1366,139 @@ func (s *Server) listActivity(ctx context.Context, input *listActivityInput) (*l
 		out[i] = item
 	}
 
+	workspaceActivity := s.workspaceActivityResponse(input, opts, workspaceSnapshot, workspaceEventItems)
 	return &listActivityOutput{
-		Body: activityResponse{Items: out, Capped: capped},
+		Body: activityResponse{Items: out, WorkspaceActivity: workspaceActivity, Capped: capped},
 	}, nil
+}
+
+func filterActivityItemsToTrackedRepositories(
+	items []db.ActivityItem,
+	tracked map[string]struct{},
+) []db.ActivityItem {
+	filtered := make([]db.ActivityItem, 0, len(items))
+	for _, item := range items {
+		key := trackedRepoKey(ghclient.RepoRef{
+			Platform:     platform.Kind(item.Platform),
+			PlatformHost: item.PlatformHost,
+			Owner:        item.RepoOwner,
+			Name:         item.RepoName,
+		})
+		if _, ok := tracked[key]; ok {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
+}
+
+func (s *Server) workspaceActivityResponse(
+	input *listActivityInput,
+	opts db.ListActivityOpts,
+	snapshot workspaceapi.WorkspaceSubjectSnapshot,
+	providerItems []db.ActivityItem,
+) []workspaceActivitySubjectResponse {
+	itemTypes := make(map[string]struct{}, len(input.ItemTypes))
+	for _, itemType := range input.ItemTypes {
+		itemTypes[strings.ToLower(strings.TrimSpace(itemType))] = struct{}{}
+	}
+	tracked := make(map[string]struct{})
+	if s.cfg != nil {
+		for _, repo := range s.syncer.TrackedRepos() {
+			tracked[trackedRepoKey(repo)] = struct{}{}
+		}
+	}
+	matchedSubjects := make(map[db.WorkspaceSubjectKey]struct{})
+	if opts.Search != "" {
+		for _, item := range providerItems {
+			itemType := workspaceItemTypeFromActivity(item.ItemType)
+			if itemType == "" {
+				continue
+			}
+			matchedSubjects[db.WorkspaceSubjectKey{
+				RepoID: item.RepoID, ItemType: itemType, ItemNumber: item.ItemNumber,
+			}] = struct{}{}
+		}
+	}
+	result := make([]workspaceActivitySubjectResponse, 0, len(snapshot.Subjects))
+	for key, activity := range snapshot.Subjects {
+		if activity.ActivityAt == nil || (opts.Since != nil && activity.ActivityAt.Before(*opts.Since)) {
+			continue
+		}
+		wireType := "issue"
+		if key.ItemType == db.WorkspaceItemTypePullRequest {
+			wireType = "pr"
+		}
+		if len(itemTypes) > 0 {
+			if _, ok := itemTypes[wireType]; !ok {
+				continue
+			}
+		}
+		subject := activity.Subject
+		if s.cfg != nil {
+			trackedKey := trackedRepoKey(ghclient.RepoRef{
+				Platform: platform.Kind(subject.Platform), PlatformHost: subject.PlatformHost,
+				Owner: subject.RepoOwner, Name: subject.RepoName,
+			})
+			if _, ok := tracked[trackedKey]; !ok {
+				continue
+			}
+		}
+		if !workspaceSubjectMatchesRepoFilters(subject, opts.RepoFilters) {
+			continue
+		}
+		if opts.Search != "" {
+			haystack := strings.ToLower(strings.Join([]string{
+				subject.Title, subject.Author, subject.RepoOwner + "/" + subject.RepoName,
+				subject.RepoPath, strconv.Itoa(key.ItemNumber),
+			}, " "))
+			if _, matchedProviderEvent := matchedSubjects[key]; !matchedProviderEvent && !strings.Contains(haystack, opts.Search) {
+				continue
+			}
+		}
+		ref := activity.Workspace
+		result = append(result, workspaceActivitySubjectResponse{
+			Repo: s.repoResolver.RefFromParts(
+				subject.Platform, subject.PlatformHost, subject.RepoOwner, subject.RepoName,
+			),
+			PlatformHost: subject.PlatformHost, RepoOwner: subject.RepoOwner, RepoName: subject.RepoName,
+			ItemType: wireType, ItemNumber: key.ItemNumber, ItemTitle: subject.Title,
+			ItemURL: subject.URL, ItemState: subject.State, ItemAuthor: subject.Author,
+			Workspace: &ref, ActivityAt: formatUTCRFC3339(*activity.ActivityAt),
+		})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].ActivityAt != result[j].ActivityAt {
+			return result[i].ActivityAt > result[j].ActivityAt
+		}
+		left := result[i].Repo.RepoPath + result[i].ItemType + strconv.Itoa(result[i].ItemNumber)
+		right := result[j].Repo.RepoPath + result[j].ItemType + strconv.Itoa(result[j].ItemNumber)
+		return left < right
+	})
+	return result
+}
+
+func workspaceSubjectMatchesRepoFilters(
+	subject db.WorkspaceSubjectMetadata,
+	filters []db.RepoFilter,
+) bool {
+	if len(filters) == 0 {
+		return true
+	}
+	for _, filter := range filters {
+		if !strings.EqualFold(filter.Platform, subject.Platform) ||
+			!strings.EqualFold(filter.PlatformHost, subject.PlatformHost) {
+			continue
+		}
+		if filter.RepoPath != "" && strings.EqualFold(filter.RepoPath, subject.RepoPath) {
+			return true
+		}
+		if filter.RepoOwner != "" && filter.RepoName != "" &&
+			strings.EqualFold(filter.RepoOwner, subject.RepoOwner) &&
+			strings.EqualFold(filter.RepoName, subject.RepoName) {
+			return true
+		}
+	}
+	return false
 }
 
 func branchActivityURL(it db.ActivityItem) string {

--- a/internal/server/issueapi/handler.go
+++ b/internal/server/issueapi/handler.go
@@ -11,7 +11,7 @@ import (
 	"go.kenn.io/forge/internal/db"
 	ghclient "go.kenn.io/forge/internal/github"
 	"go.kenn.io/forge/internal/server/httpapi"
-	"go.kenn.io/forge/internal/workspace"
+	"go.kenn.io/forge/internal/server/workspaceapi"
 )
 
 const (
@@ -24,11 +24,11 @@ const (
 )
 
 type Deps struct {
-	DB         *db.DB
-	Resolver   *httpapi.RepositoryResolver
-	Syncer     *ghclient.Syncer
-	Workspaces *workspace.Manager
-	Now        func() time.Time
+	DB                *db.DB
+	Resolver          *httpapi.RepositoryResolver
+	Syncer            *ghclient.Syncer
+	Now               func() time.Time
+	WorkspaceSubjects func(context.Context) (workspaceapi.WorkspaceSubjectSnapshot, error)
 
 	FilterRepos                       func([]db.Repo) []db.Repo
 	RepoOperations                    func(db.Repo) httpapi.RepoOperations
@@ -36,11 +36,11 @@ type Deps struct {
 }
 
 type Handler struct {
-	db         *db.DB
-	resolver   *httpapi.RepositoryResolver
-	syncer     *ghclient.Syncer
-	workspaces *workspace.Manager
-	now        func() time.Time
+	db                *db.DB
+	resolver          *httpapi.RepositoryResolver
+	syncer            *ghclient.Syncer
+	now               func() time.Time
+	workspaceSubjects func(context.Context) (workspaceapi.WorkspaceSubjectSnapshot, error)
 
 	filterRepos             func([]db.Repo) []db.Repo
 	repoOperations          func(db.Repo) httpapi.RepoOperations
@@ -56,8 +56,8 @@ func New(deps Deps) *Handler {
 		db:                      deps.DB,
 		resolver:                deps.Resolver,
 		syncer:                  deps.Syncer,
-		workspaces:              deps.Workspaces,
 		now:                     now,
+		workspaceSubjects:       deps.WorkspaceSubjects,
 		filterRepos:             deps.FilterRepos,
 		repoOperations:          deps.RepoOperations,
 		markClosedNotifications: deps.MarkClosedLinkedNotificationsDone,

--- a/internal/server/issueapi/handler_test.go
+++ b/internal/server/issueapi/handler_test.go
@@ -1,12 +1,20 @@
 package issueapi
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humago"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/server/httpapi"
+	"go.kenn.io/forge/internal/server/workspaceapi"
+	"go.kenn.io/forge/internal/testutil/dbtest"
 )
 
 func TestHandlerRegistersOnlyIssueRoutes(t *testing.T) {
@@ -72,4 +80,39 @@ func TestHandlerRegistersOnlyIssueRoutes(t *testing.T) {
 	} {
 		assert.NotContains(gotByID, operationID)
 	}
+}
+
+func TestIssueDetailTreatsWorkspaceSnapshotFailureAsBestEffort(t *testing.T) {
+	require := require.New(t)
+	database := dbtest.Open(t)
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	identity := db.GitHubRepoIdentity("github.com", "acme", "widget")
+	identity.PlatformRepoID = "repo-acme-widget"
+	repoID, err := database.UpsertRepo(t.Context(), identity)
+	require.NoError(err)
+	_, err = database.UpsertIssue(t.Context(), &db.Issue{
+		RepoID: repoID, PlatformID: 43, Number: 43, Title: "Available issue",
+		Author: "bob", State: "open",
+		CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+	repo, err := database.GetRepoByID(t.Context(), repoID)
+	require.NoError(err)
+	require.NotNil(repo)
+	issue, err := database.GetIssueByRepoIDAndNumber(t.Context(), repoID, 43)
+	require.NoError(err)
+	require.NotNil(issue)
+	handler := New(Deps{
+		DB:       database,
+		Resolver: httpapi.NewRepositoryResolver(httpapi.RepositoryResolverDeps{DB: database}),
+		WorkspaceSubjects: func(context.Context) (workspaceapi.WorkspaceSubjectSnapshot, error) {
+			return workspaceapi.WorkspaceSubjectSnapshot{}, errors.New("snapshot unavailable")
+		},
+	})
+
+	response, err := handler.BuildDetail(t.Context(), repo, issue)
+	require.NoError(err)
+	require.NotNil(response.Issue)
+	assert.Equal(t, 43, response.Issue.Number)
+	assert.Nil(t, response.Workspace)
 }

--- a/internal/server/issueapi/helpers.go
+++ b/internal/server/issueapi/helpers.go
@@ -9,8 +9,6 @@ import (
 
 	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/platform"
-	"go.kenn.io/forge/internal/server/httpapi"
-	"go.kenn.io/forge/internal/server/workspaceapi"
 )
 
 func (s *Handler) lookupRepoMap(ctx context.Context) (map[int64]db.Repo, error) {
@@ -26,44 +24,6 @@ func (s *Handler) lookupRepoMap(ctx context.Context) (map[int64]db.Repo, error) 
 		lookup[repo.ID] = repo
 	}
 	return lookup, nil
-}
-
-func workspaceLookupKey(provider, host, owner, name, itemType string, number int) string {
-	if provider == "" {
-		provider = string(platform.KindGitHub)
-	}
-	if host == "" {
-		host, _ = platform.DefaultHost(platform.Kind(provider))
-	}
-	return strings.ToLower(provider) + "\x00" + strings.ToLower(host) + "\x00" +
-		strings.ToLower(owner) + "\x00" + strings.ToLower(name) + "\x00" +
-		itemType + "\x00" + fmt.Sprint(number)
-}
-
-func (s *Handler) buildWorkspaceRefLookup(ctx context.Context) (map[string]workspaceapi.WorkspaceRef, error) {
-	workspaces, err := s.db.ListWorkspaces(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("list workspaces: %w", err)
-	}
-	lookup := make(map[string]workspaceapi.WorkspaceRef, len(workspaces))
-	for _, ws := range workspaces {
-		key := workspaceLookupKey(ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName, ws.ItemType, ws.ItemNumber)
-		if _, exists := lookup[key]; !exists {
-			lookup[key] = workspaceapi.WorkspaceRef{ID: ws.ID, Status: ws.Status}
-		}
-	}
-	return lookup, nil
-}
-
-func workspaceRefForIssue(lookup map[string]workspaceapi.WorkspaceRef, repo db.Repo, number int) *workspaceapi.WorkspaceRef {
-	ref, ok := lookup[workspaceLookupKey(
-		repo.Platform, httpapi.ProviderHost(repo), repo.Owner, repo.Name,
-		db.WorkspaceItemTypeIssue, number,
-	)]
-	if !ok {
-		return nil
-	}
-	return &ref
 }
 
 func parseRepoFilter(repo string) (provider, platformHost, repoPath string) {

--- a/internal/server/issueapi/routes.go
+++ b/internal/server/issueapi/routes.go
@@ -2,6 +2,7 @@ package issueapi
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -18,10 +19,30 @@ func (s *Handler) listIssues(ctx context.Context, input *listIssuesInput) (*list
 	if hasInvalidRepoFilter(input.Repo) {
 		return nil, httpapi.Validation("query.repo", "repo filter must be provider|platform_host/repo_path")
 	}
+	snapshot := workspaceapi.WorkspaceSubjectSnapshot{
+		OwnReferences: map[db.WorkspaceSubjectKey]workspaceapi.WorkspaceRef{},
+		Subjects:      map[db.WorkspaceSubjectKey]workspaceapi.SubjectActivity{},
+	}
+	var err error
+	if s.workspaceSubjects != nil {
+		snapshot, err = s.workspaceSubjects(ctx)
+		if err != nil {
+			return nil, httpapi.Internal("load workspace activity failed")
+		}
+	}
+	overrides := make([]db.ItemActivityOverride, 0, len(snapshot.Subjects))
+	for key, activity := range snapshot.Subjects {
+		if key.ItemType == db.WorkspaceItemTypeIssue && activity.ActivityAt != nil {
+			overrides = append(overrides, db.ItemActivityOverride{
+				RepoID: key.RepoID, ItemNumber: key.ItemNumber, ActivityAt: *activity.ActivityAt,
+			})
+		}
+	}
 	issues, err := s.db.ListIssues(ctx, db.ListIssuesOpts{
 		State: input.State, Search: input.Q, Starred: input.Starred,
 		Assignee: input.Assignee, Limit: input.Limit, Offset: input.Offset,
-		RepoFilters: parseRepoFilters(input.Repo),
+		RepoFilters:       parseRepoFilters(input.Repo),
+		WorkspaceActivity: overrides,
 	})
 	if err != nil {
 		return nil, httpapi.Internal("list issues failed")
@@ -30,21 +51,26 @@ func (s *Handler) listIssues(ctx context.Context, input *listIssuesInput) (*list
 	if err != nil {
 		return nil, httpapi.Internal("repo lookup failed")
 	}
-	workspaces, err := s.buildWorkspaceRefLookup(ctx)
-	if err != nil {
-		return nil, httpapi.Internal("load workspace refs failed")
-	}
 	out := make([]IssueResponse, 0, len(issues))
 	for _, issue := range issues {
 		repo, ok := repos[issue.RepoID]
 		if !ok {
 			continue
 		}
+		key := db.WorkspaceSubjectKey{RepoID: issue.RepoID, ItemType: db.WorkspaceItemTypeIssue, ItemNumber: issue.Number}
+		var workspaceRef *workspaceapi.WorkspaceRef
+		if ref, ok := snapshot.OwnReferences[key]; ok {
+			copy := ref
+			workspaceRef = &copy
+		}
 		response := IssueResponse{
 			Issue: issueResponseModel(issue), Repo: s.resolver.Ref(repo),
 			PlatformHost: repo.PlatformHost, RepoOwner: repo.Owner, RepoName: repo.Name,
-			Workspace:    workspaceRefForIssue(workspaces, repo, issue.Number),
+			Workspace:    workspaceRef,
 			DetailLoaded: issue.DetailFetchedAt != nil,
+		}
+		if activity, ok := snapshot.Subjects[key]; ok && activity.ActivityAt != nil {
+			response.WorkspaceActivityAt = formatUTCRFC3339(*activity.ActivityAt)
 		}
 		if issue.DetailFetchedAt != nil {
 			response.DetailFetchedAt = formatUTCRFC3339(*issue.DetailFetchedAt)
@@ -151,12 +177,20 @@ func (s *Handler) BuildDetail(ctx context.Context, repo *db.Repo, issue *db.Issu
 	if issue.DetailFetchedAt != nil {
 		response.DetailFetchedAt = formatUTCRFC3339(*issue.DetailFetchedAt)
 	}
-	if s.workspaces != nil {
-		workspace, workspaceErr := s.workspaces.GetByIssueForProvider(
-			ctx, repo.Platform, repo.PlatformHost, repo.Owner, repo.Name, issue.Number,
-		)
-		if workspaceErr == nil && workspace != nil {
-			response.Workspace = &workspaceapi.WorkspaceRef{ID: workspace.ID, Status: workspace.Status}
+	if s.workspaceSubjects != nil {
+		snapshot, snapshotErr := s.workspaceSubjects(ctx)
+		if snapshotErr != nil {
+			slog.Warn(
+				"load workspace activity for issue detail failed",
+				"issue_id", issue.ID, "err", snapshotErr,
+			)
+		} else {
+			key := db.WorkspaceSubjectKey{
+				RepoID: repo.ID, ItemType: db.WorkspaceItemTypeIssue, ItemNumber: issue.Number,
+			}
+			if workspaceRef, ok := snapshot.OwnReferences[key]; ok {
+				response.Workspace = &workspaceRef
+			}
 		}
 	}
 	return response, nil

--- a/internal/server/issueapi/types.go
+++ b/internal/server/issueapi/types.go
@@ -16,13 +16,14 @@ type WorkflowStateMetaResponse struct {
 
 type IssueResponse struct {
 	db.Issue
-	Repo            httpapi.RepoRefResponse    `json:"repo"`
-	PlatformHost    string                     `json:"platform_host"`
-	RepoOwner       string                     `json:"repo_owner"`
-	RepoName        string                     `json:"repo_name"`
-	Workspace       *workspaceapi.WorkspaceRef `json:"workspace,omitempty"`
-	DetailLoaded    bool                       `json:"detail_loaded"`
-	DetailFetchedAt string                     `json:"detail_fetched_at,omitempty"`
+	Repo                httpapi.RepoRefResponse    `json:"repo"`
+	PlatformHost        string                     `json:"platform_host"`
+	RepoOwner           string                     `json:"repo_owner"`
+	RepoName            string                     `json:"repo_name"`
+	Workspace           *workspaceapi.WorkspaceRef `json:"workspace,omitempty"`
+	WorkspaceActivityAt string                     `json:"workspace_activity_at,omitempty" format:"date-time"`
+	DetailLoaded        bool                       `json:"detail_loaded"`
+	DetailFetchedAt     string                     `json:"detail_fetched_at,omitempty"`
 }
 
 type IssueDetailResponse struct {

--- a/internal/server/pullapi/handler.go
+++ b/internal/server/pullapi/handler.go
@@ -13,7 +13,7 @@ import (
 	"go.kenn.io/forge/internal/gitclone"
 	ghclient "go.kenn.io/forge/internal/github"
 	"go.kenn.io/forge/internal/server/httpapi"
-	"go.kenn.io/forge/internal/workspace"
+	"go.kenn.io/forge/internal/server/workspaceapi"
 )
 
 type Event struct {
@@ -30,11 +30,11 @@ type Deps struct {
 	Resolver             *httpapi.RepositoryResolver
 	Syncer               *ghclient.Syncer
 	Clones               *gitclone.Manager
-	Workspaces           *workspace.Manager
 	Config               ConfigSnapshot
 	Now                  func() time.Time
 	DeferredMergeMaxWait time.Duration
 	DeleteWorkspace      func(context.Context, string) error
+	WorkspaceSubjects    func(context.Context) (workspaceapi.WorkspaceSubjectSnapshot, error)
 
 	FleetSelfKey                  func(string) string
 	FilterRepos                   func([]db.Repo) []db.Repo
@@ -50,13 +50,13 @@ type Deps struct {
 }
 
 type Handler struct {
-	db              *db.DB
-	resolver        *httpapi.RepositoryResolver
-	syncer          *ghclient.Syncer
-	clones          *gitclone.Manager
-	workspaces      *workspace.Manager
-	deleteWorkspace func(context.Context, string) error
-	now             func() time.Time
+	db                *db.DB
+	resolver          *httpapi.RepositoryResolver
+	syncer            *ghclient.Syncer
+	clones            *gitclone.Manager
+	deleteWorkspace   func(context.Context, string) error
+	now               func() time.Time
+	workspaceSubjects func(context.Context) (workspaceapi.WorkspaceSubjectSnapshot, error)
 
 	fleetSelfKey                  func(string) string
 	filterRepos                   func([]db.Repo) []db.Repo
@@ -100,9 +100,9 @@ func New(deps Deps) *Handler {
 		resolver:                      deps.Resolver,
 		syncer:                        deps.Syncer,
 		clones:                        deps.Clones,
-		workspaces:                    deps.Workspaces,
 		deleteWorkspace:               deps.DeleteWorkspace,
 		now:                           now,
+		workspaceSubjects:             deps.WorkspaceSubjects,
 		fleetSelfKey:                  deps.FleetSelfKey,
 		filterRepos:                   deps.FilterRepos,
 		repoOperations:                deps.RepoOperations,

--- a/internal/server/pullapi/handler_test.go
+++ b/internal/server/pullapi/handler_test.go
@@ -2,6 +2,7 @@ package pullapi
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"sync"
 	"testing"
@@ -11,6 +12,11 @@ import (
 	"github.com/danielgtaylor/huma/v2/adapters/humago"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/db"
+	ghclient "go.kenn.io/forge/internal/github"
+	"go.kenn.io/forge/internal/server/httpapi"
+	"go.kenn.io/forge/internal/server/workspaceapi"
+	"go.kenn.io/forge/internal/testutil/dbtest"
 )
 
 func TestHandlerRegistersPullRoutes(t *testing.T) {
@@ -97,6 +103,74 @@ func TestHandlerRegistersPullRoutes(t *testing.T) {
 	} {
 		assert.NotContains(gotByID, operationID)
 	}
+}
+
+func TestListPullsTreatsAssociatedWorkspaceSubjectAsHasWorkspace(t *testing.T) {
+	require := require.New(t)
+	database := dbtest.Open(t)
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	identity := db.GitHubRepoIdentity("github.com", "acme", "widget")
+	identity.PlatformRepoID = "repo-acme-widget"
+	repoID, err := database.UpsertRepo(t.Context(), identity)
+	require.NoError(err)
+	_, err = database.UpsertMergeRequest(t.Context(), &db.MergeRequest{
+		RepoID: repoID, PlatformID: 42, Number: 42, Title: "Associated work",
+		Author: "alice", State: db.MergeRequestStateOpen,
+		CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+	key := db.WorkspaceSubjectKey{RepoID: repoID, ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: 42}
+	handler := New(Deps{
+		DB:       database,
+		Resolver: httpapi.NewRepositoryResolver(httpapi.RepositoryResolverDeps{DB: database}),
+		WorkspaceSubjects: func(context.Context) (workspaceapi.WorkspaceSubjectSnapshot, error) {
+			return workspaceapi.WorkspaceSubjectSnapshot{
+				OwnReferences: map[db.WorkspaceSubjectKey]workspaceapi.WorkspaceRef{},
+				Subjects: map[db.WorkspaceSubjectKey]workspaceapi.SubjectActivity{
+					key: {Workspace: workspaceapi.WorkspaceRef{ID: "ws-adhoc", Status: "ready"}},
+				},
+			}, nil
+		},
+	})
+
+	result, err := handler.listPulls(t.Context(), &listPullsInput{State: "open"})
+	require.NoError(err)
+	require.Len(result.Body, 1)
+	require.NotNil(result.Body[0].Workspace)
+	assert.Equal(t, "ws-adhoc", result.Body[0].Workspace.ID)
+}
+
+func TestPullDetailTreatsWorkspaceSnapshotFailureAsBestEffort(t *testing.T) {
+	require := require.New(t)
+	database := dbtest.Open(t)
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	identity := db.GitHubRepoIdentity("github.com", "acme", "widget")
+	identity.PlatformRepoID = "repo-acme-widget"
+	repoID, err := database.UpsertRepo(t.Context(), identity)
+	require.NoError(err)
+	_, err = database.UpsertMergeRequest(t.Context(), &db.MergeRequest{
+		RepoID: repoID, PlatformID: 42, Number: 42, Title: "Available pull request",
+		Author: "alice", State: db.MergeRequestStateOpen,
+		CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(t.Context(), repoID, 42)
+	require.NoError(err)
+	require.NotNil(mr)
+	handler := New(Deps{
+		DB:       database,
+		Resolver: httpapi.NewRepositoryResolver(httpapi.RepositoryResolverDeps{DB: database}),
+		Syncer:   &ghclient.Syncer{},
+		WorkspaceSubjects: func(context.Context) (workspaceapi.WorkspaceSubjectSnapshot, error) {
+			return workspaceapi.WorkspaceSubjectSnapshot{}, errors.New("snapshot unavailable")
+		},
+	})
+
+	response, err := handler.BuildDetail(t.Context(), mr)
+	require.NoError(err)
+	require.NotNil(response.MergeRequest)
+	assert.Equal(t, 42, response.MergeRequest.Number)
+	assert.Nil(t, response.Workspace)
 }
 
 func TestHandlerStopClosesAdmissionAndShutdownWaitsForWorkers(t *testing.T) {

--- a/internal/server/pullapi/helpers.go
+++ b/internal/server/pullapi/helpers.go
@@ -8,7 +8,6 @@ import (
 
 	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/platform"
-	"go.kenn.io/forge/internal/server/workspaceapi"
 )
 
 type repoNumberPathRef struct {
@@ -25,63 +24,6 @@ func buildRepoLookup(repos []db.Repo) map[int64]db.Repo {
 		lookup[repo.ID] = repo
 	}
 	return lookup
-}
-
-func workspaceLookupKey(
-	provider, host, owner, name, itemType string,
-	number int,
-) string {
-	if provider == "" {
-		provider = string(platform.KindGitHub)
-	}
-	if host == "" {
-		if defaultHost, ok := platform.DefaultHost(platform.Kind(provider)); ok {
-			host = defaultHost
-		}
-	}
-	return strings.ToLower(provider) + "\x00" +
-		strings.ToLower(host) + "\x00" +
-		strings.ToLower(owner) + "\x00" +
-		strings.ToLower(name) + "\x00" +
-		itemType + "\x00" +
-		fmt.Sprint(number)
-}
-
-func (s *Handler) buildWorkspaceRefLookup(
-	ctx context.Context,
-) (map[string]workspaceapi.WorkspaceRef, error) {
-	workspaces, err := s.db.ListWorkspaces(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("list workspaces: %w", err)
-	}
-	lookup := make(map[string]workspaceapi.WorkspaceRef, len(workspaces))
-	for _, ws := range workspaces {
-		key := workspaceLookupKey(
-			ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
-			ws.ItemType, ws.ItemNumber,
-		)
-		if _, exists := lookup[key]; exists {
-			continue
-		}
-		lookup[key] = workspaceapi.WorkspaceRef{ID: ws.ID, Status: ws.Status}
-	}
-	return lookup, nil
-}
-
-func workspaceRefForRepoItem(
-	lookup map[string]workspaceapi.WorkspaceRef,
-	repo db.Repo,
-	itemType string,
-	number int,
-) *workspaceapi.WorkspaceRef {
-	ref, ok := lookup[workspaceLookupKey(
-		repo.Platform, repoProviderHost(repo), repo.Owner, repo.Name,
-		itemType, number,
-	)]
-	if !ok {
-		return nil
-	}
-	return &ref
 }
 
 func (s *Handler) lookupRepoMap(ctx context.Context) (map[int64]db.Repo, error) {

--- a/internal/server/pullapi/routes.go
+++ b/internal/server/pullapi/routes.go
@@ -367,14 +367,34 @@ func (s *Handler) listPulls(ctx context.Context, input *listPullsInput) (*listPu
 		return nil, httpapi.Validation("query.repo", "repo filter must be provider|platform_host/repo_path")
 	}
 
+	snapshot := workspaceapi.WorkspaceSubjectSnapshot{
+		OwnReferences: map[db.WorkspaceSubjectKey]workspaceapi.WorkspaceRef{},
+		Subjects:      map[db.WorkspaceSubjectKey]workspaceapi.SubjectActivity{},
+	}
+	var err error
+	if s.workspaceSubjects != nil {
+		snapshot, err = s.workspaceSubjects(ctx)
+		if err != nil {
+			return nil, httpapi.Internal("load workspace activity failed")
+		}
+	}
+	overrides := make([]db.ItemActivityOverride, 0, len(snapshot.Subjects))
+	for key, activity := range snapshot.Subjects {
+		if key.ItemType == db.WorkspaceItemTypePullRequest && activity.ActivityAt != nil {
+			overrides = append(overrides, db.ItemActivityOverride{
+				RepoID: key.RepoID, ItemNumber: key.ItemNumber, ActivityAt: *activity.ActivityAt,
+			})
+		}
+	}
 	opts := db.ListMergeRequestsOpts{
-		State:       input.State,
-		KanbanState: input.Kanban,
-		Starred:     input.Starred,
-		Search:      input.Q,
-		Limit:       input.Limit,
-		Offset:      input.Offset,
-		RepoFilters: parseRepoFilters(input.Repo),
+		State:             input.State,
+		KanbanState:       input.Kanban,
+		Starred:           input.Starred,
+		Search:            input.Q,
+		Limit:             input.Limit,
+		Offset:            input.Offset,
+		RepoFilters:       parseRepoFilters(input.Repo),
+		WorkspaceActivity: overrides,
 	}
 
 	mrs, err := s.db.ListMergeRequests(ctx, opts)
@@ -400,11 +420,6 @@ func (s *Handler) listPulls(ctx context.Context, input *listPullsInput) (*listPu
 		return nil, httpapi.Internal("load worktree links failed")
 	}
 	linksByMR := indexWorktreeLinksByMR(links, s.selfFleetKey(""))
-	workspacesByItem, err := s.buildWorkspaceRefLookup(ctx)
-	if err != nil {
-		return nil, httpapi.Internal("load workspace refs failed")
-	}
-
 	out := make([]MergeRequestResponse, 0, len(mrs))
 	for _, mr := range mrs {
 		rp, ok := repoByID[mr.RepoID]
@@ -420,6 +435,12 @@ func (s *Handler) listPulls(ctx context.Context, input *listPullsInput) (*listPu
 			responseMR.MergeableState = "dirty"
 		}
 		responseMR = mergeRequestResponseModel(responseMR)
+		key := db.WorkspaceSubjectKey{RepoID: mr.RepoID, ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: mr.Number}
+		var workspaceRef *workspaceapi.WorkspaceRef
+		if activity, ok := snapshot.Subjects[key]; ok {
+			copy := activity.Workspace
+			workspaceRef = &copy
+		}
 		resp := MergeRequestResponse{
 			MergeRequest:  responseMR,
 			Repo:          s.repoRefFromRepo(rp),
@@ -427,8 +448,11 @@ func (s *Handler) listPulls(ctx context.Context, input *listPullsInput) (*listPu
 			RepoName:      rp.Name,
 			PlatformHost:  rp.PlatformHost,
 			WorktreeLinks: wl,
-			Workspace:     workspaceRefForRepoItem(workspacesByItem, rp, db.WorkspaceItemTypePullRequest, mr.Number),
+			Workspace:     workspaceRef,
 			DetailLoaded:  mr.DetailFetchedAt != nil,
+		}
+		if activity, ok := snapshot.Subjects[key]; ok && activity.ActivityAt != nil {
+			resp.WorkspaceActivityAt = formatUTCRFC3339(*activity.ActivityAt)
 		}
 		if mr.DetailFetchedAt != nil {
 			resp.DetailFetchedAt = formatUTCRFC3339(*mr.DetailFetchedAt)
@@ -544,15 +568,20 @@ func (s *Handler) buildPullDetailResponse(
 	}
 	resp.Checks = checks
 
-	if s.workspaces != nil {
-		wsRef, wsErr := s.workspaces.GetByMRForProvider(
-			ctx, repo.Platform, repo.PlatformHost, repo.Owner, repo.Name,
-			mr.Number,
-		)
-		if wsErr == nil && wsRef != nil {
-			resp.Workspace = &workspaceapi.WorkspaceRef{
-				ID:     wsRef.ID,
-				Status: wsRef.Status,
+	if s.workspaceSubjects != nil {
+		snapshot, snapshotErr := s.workspaceSubjects(ctx)
+		if snapshotErr != nil {
+			slog.Warn(
+				"load workspace activity for pull detail failed",
+				"merge_request_id", mr.ID, "err", snapshotErr,
+			)
+		} else {
+			key := db.WorkspaceSubjectKey{
+				RepoID: mr.RepoID, ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: mr.Number,
+			}
+			if activity, ok := snapshot.Subjects[key]; ok {
+				workspaceRef := activity.Workspace
+				resp.Workspace = &workspaceRef
 			}
 		}
 	}

--- a/internal/server/pullapi/types.go
+++ b/internal/server/pullapi/types.go
@@ -17,14 +17,15 @@ type worktreeLinkResponse struct {
 
 type MergeRequestResponse struct {
 	db.MergeRequest
-	Repo            httpapi.RepoRefResponse    `json:"repo"`
-	RepoOwner       string                     `json:"repo_owner"`
-	RepoName        string                     `json:"repo_name"`
-	PlatformHost    string                     `json:"platform_host"`
-	WorktreeLinks   []worktreeLinkResponse     `json:"worktree_links"`
-	Workspace       *workspaceapi.WorkspaceRef `json:"workspace,omitempty"`
-	DetailLoaded    bool                       `json:"detail_loaded"`
-	DetailFetchedAt string                     `json:"detail_fetched_at,omitempty"`
+	Repo                httpapi.RepoRefResponse    `json:"repo"`
+	RepoOwner           string                     `json:"repo_owner"`
+	RepoName            string                     `json:"repo_name"`
+	PlatformHost        string                     `json:"platform_host"`
+	WorktreeLinks       []worktreeLinkResponse     `json:"worktree_links"`
+	Workspace           *workspaceapi.WorkspaceRef `json:"workspace,omitempty"`
+	WorkspaceActivityAt string                     `json:"workspace_activity_at,omitempty" format:"date-time"`
+	DetailLoaded        bool                       `json:"detail_loaded"`
+	DetailFetchedAt     string                     `json:"detail_fetched_at,omitempty"`
 }
 
 type mergeRequestEventResponse struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -211,8 +211,11 @@ type Server struct {
 	issueAPI               *issueapi.Handler
 	pullLifecycle          pullLifecycle
 	workspaceAPI           *workspaceapi.Handler
-	markdownImages         *markdownImageCache
-	roborevRepositories    *roborevRepositoryProbe
+	// activityAfterItemsForTest pauses Activity between its two identity reads
+	// so tests can prove the request-wide repository reconciliation fence.
+	activityAfterItemsForTest func()
+	markdownImages            *markdownImageCache
+	roborevRepositories       *roborevRepositoryProbe
 
 	// toolingStatus caches the assembled CLI tooling probe;
 	// toolingRun overrides the probe subprocess runner in tests.
@@ -996,7 +999,6 @@ func newServer(
 		Resolver:             repoResolver,
 		Syncer:               syncer,
 		Clones:               clones,
-		Workspaces:           s.workspaces,
 		Config:               pullConfigSnapshot(cfg),
 		Now:                  func() time.Time { return s.now() },
 		DeferredMergeMaxWait: deferredMergeMaxWait,
@@ -1004,7 +1006,8 @@ func newServer(
 			_, err := s.workspaceAPI.DeleteWorkspace(ctx, &workspaceapi.DeleteWorkspaceInput{ID: id})
 			return err
 		},
-		FleetSelfKey: s.fleetAPI.SelfKey,
+		WorkspaceSubjects: s.workspaceAPI.WorkspaceSubjectSnapshot,
+		FleetSelfKey:      s.fleetAPI.SelfKey,
 		FilterRepos: func(repos []db.Repo) []db.Repo {
 			if s.cfg == nil {
 				return repos
@@ -1020,11 +1023,11 @@ func newServer(
 		MarkClosedLinkedNotificationsDone: s.markClosedLinkedNotificationsDone,
 	})
 	s.issueAPI = issueapi.New(issueapi.Deps{
-		DB:         database,
-		Resolver:   repoResolver,
-		Syncer:     syncer,
-		Workspaces: s.workspaces,
-		Now:        func() time.Time { return s.now() },
+		DB:                database,
+		Resolver:          repoResolver,
+		Syncer:            syncer,
+		Now:               func() time.Time { return s.now() },
+		WorkspaceSubjects: s.workspaceAPI.WorkspaceSubjectSnapshot,
 		FilterRepos: func(repos []db.Repo) []db.Repo {
 			if s.cfg == nil {
 				return repos

--- a/internal/server/tmux_wrapper_test.go
+++ b/internal/server/tmux_wrapper_test.go
@@ -244,7 +244,7 @@ func setupWrapperServerWithScriptAndDBAndServer(
 	worktreeDir := filepath.Join(dir, "worktrees")
 
 	repos := []ghclient.RepoRef{
-		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+		{Platform: "github", Owner: "acme", Name: "widget", PlatformHost: "github.com"},
 	}
 	mock := &mockGH{}
 	syncer := ghclient.NewSyncer(
@@ -429,6 +429,95 @@ func TestWorkspaceResponseIncludesTmuxWorkingState(t *testing.T) {
 	require.NotNil(listed.Workspaces[0].TmuxPaneTitle)
 	assert.Equal("⠴ t3code-b5014b03", *listed.Workspaces[0].TmuxPaneTitle)
 	assert.True(listed.Workspaces[0].TmuxWorking)
+}
+
+func TestSearchedActivityIncrementalPollRetainsWorkspaceSubject(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	t.Setenv("TMUX_PANE_OUTPUT", "baseline output")
+	script, _ := writeTmuxRecorder(t)
+	client, _, database, _ := setupWrapperServerWithScriptAndDBAndServer(t, script)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	repo, err := database.GetRepoByIdentity(ctx, verifiedGitHubRepoIdentity("github.com", "acme", "widget"))
+	require.NoError(err)
+	require.NotNil(repo)
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, 1)
+	require.NoError(err)
+	require.NotNil(mr)
+	require.NoError(database.UpsertMREvents(ctx, []db.MREvent{{
+		MergeRequestID: mr.ID,
+		EventType:      "issue_comment",
+		Author:         "search-reviewer",
+		Body:           "matches only provider event fields",
+		CreatedAt:      now,
+		DedupeKey:      "searched-workspace-comment",
+	}}))
+
+	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			Provider: "github", PlatformHost: "github.com",
+			Owner: "acme", Name: "widget", MrNumber: 1,
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(createResp.JSON202)
+	workspaceID := createResp.JSON202.Id
+	waitForWorkspaceReady(t, ctx, client, workspaceID)
+
+	require.Eventually(func() bool {
+		activity := getRawWorkspaceActivity(t, client, ctx, workspaceID)
+		return activity.TmuxActivitySource == "none" && activity.TmuxLastOutputAt == nil
+	}, 3*time.Second, 50*time.Millisecond, "tmux baseline was not observed")
+	t.Setenv("TMUX_PANE_OUTPUT", "changed output")
+
+	search := "search-reviewer"
+	since := now.Add(-time.Hour).Format(time.RFC3339)
+	probe, err := client.HTTP.ListActivityWithResponse(
+		ctx, &generated.ListActivityParams{Search: &search, Since: &since},
+	)
+	require.NoError(err)
+	require.Equalf(http.StatusOK, probe.StatusCode(), "activity response: %s", probe.Body)
+	var initial *generated.ListActivityResponse
+	require.Eventually(func() bool {
+		response, requestErr := client.HTTP.ListActivityWithResponse(
+			ctx, &generated.ListActivityParams{Search: &search, Since: &since},
+		)
+		if requestErr != nil || response.JSON200 == nil || response.JSON200.WorkspaceActivity == nil {
+			return false
+		}
+		initial = response
+		return len(*response.JSON200.WorkspaceActivity) == 1
+	}, 8*time.Second, 100*time.Millisecond, "workspace activity did not observe changed tmux output")
+	require.NotNil(initial)
+	require.NotNil(initial.JSON200)
+	require.NotNil(initial.JSON200.Items)
+	require.Len(*initial.JSON200.Items, 1)
+	require.NotNil(initial.JSON200.WorkspaceActivity)
+	require.Len(*initial.JSON200.WorkspaceActivity, 1)
+	initialWorkspace := (*initial.JSON200.WorkspaceActivity)[0]
+	assert.EqualValues(1, initialWorkspace.ItemNumber)
+	require.NotNil(initialWorkspace.Workspace)
+	assert.Equal(workspaceID, initialWorkspace.Workspace.Id)
+
+	after := (*initial.JSON200.Items)[0].Cursor
+	incremental, err := client.HTTP.ListActivityWithResponse(
+		ctx, &generated.ListActivityParams{Search: &search, Since: &since, After: &after},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, incremental.StatusCode())
+	require.NotNil(incremental.JSON200)
+	require.NotNil(incremental.JSON200.Items)
+	assert.Empty(*incremental.JSON200.Items)
+	require.NotNil(incremental.JSON200.WorkspaceActivity)
+	require.Len(*incremental.JSON200.WorkspaceActivity, 1)
+	incrementalWorkspace := (*incremental.JSON200.WorkspaceActivity)[0]
+	assert.EqualValues(1, incrementalWorkspace.ItemNumber)
+	require.NotNil(incrementalWorkspace.Workspace)
+	assert.Equal(workspaceID, incrementalWorkspace.Workspace.Id)
 }
 
 func getRawWorkspaceActivity(

--- a/internal/server/workspaceapi/handler.go
+++ b/internal/server/workspaceapi/handler.go
@@ -129,6 +129,9 @@ type Handler struct {
 	workspaceEnrichmentMu          sync.Mutex
 	workspaceEnrichmentCache       map[string]workspaceEnrichmentCacheEntry
 	workspaceEnrichmentInFlight    map[string]uint64
+	workspaceEnrichmentFlightKinds map[string]workspaceEnrichmentKind
+	workspaceEnrichmentFlightIDs   map[string]uint64
+	workspaceEnrichmentNextFlight  uint64
 	workspaceEnrichmentGenerations map[string]uint64
 	workspaceEnrichmentPending     map[string]workspaceEnrichmentJob
 	workspaceEnrichmentWorkers     int
@@ -141,13 +144,16 @@ type Handler struct {
 	workspaceTmuxPrunedAt          time.Time
 	workspaceTmuxPrunePending      bool
 	workspaceTmuxPruneInFlight     bool
-	lifecycleMu                    sync.Mutex
-	lifecycleCtx                   context.Context
-	lifecycleCancel                context.CancelFunc
-	lifecycleWG                    sync.WaitGroup
-	lifecycleStarted               bool
-	lifecycleStopping              bool
-	lifecycleDone                  chan struct{}
+	// workspaceSubjectAfterSummariesForTest pauses a snapshot between its two
+	// repository-identity reads so tests can prove the reconciliation fence.
+	workspaceSubjectAfterSummariesForTest func()
+	lifecycleMu                           sync.Mutex
+	lifecycleCtx                          context.Context
+	lifecycleCancel                       context.CancelFunc
+	lifecycleWG                           sync.WaitGroup
+	lifecycleStarted                      bool
+	lifecycleStopping                     bool
+	lifecycleDone                         chan struct{}
 }
 
 // New creates the workspace and project handler.
@@ -179,6 +185,8 @@ func New(deps Deps) *Handler {
 		hub:                            &eventHubAdapter{broadcast: deps.Broadcast, subscribe: deps.Subscribe, generation: deps.Generation},
 		workspaceEnrichmentCache:       make(map[string]workspaceEnrichmentCacheEntry),
 		workspaceEnrichmentInFlight:    make(map[string]uint64),
+		workspaceEnrichmentFlightKinds: make(map[string]workspaceEnrichmentKind),
+		workspaceEnrichmentFlightIDs:   make(map[string]uint64),
 		workspaceEnrichmentGenerations: make(map[string]uint64),
 		workspaceEnrichmentPending:     make(map[string]workspaceEnrichmentJob),
 		workspaceEnrichmentSlots:       make(chan struct{}, tmuxProbeMaxConcurrency),

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -1738,6 +1738,8 @@ func (s *Handler) workspaceResponseWithEnrichment(
 		response:           resp,
 		divergenceComplete: divergenceErr == nil,
 		tmuxComplete:       sessionsErr == nil && activityErr == nil,
+		divergenceErr:      divergenceErr,
+		tmuxErr:            errors.Join(sessionsErr, activityErr),
 		err:                err,
 	}
 	if err != nil {
@@ -1752,6 +1754,29 @@ func (s *Handler) workspaceResponseWithEnrichment(
 	resp.EnrichmentRefreshedAt = &refreshedAt
 	result.response = resp
 	return result
+}
+
+func (s *Handler) workspaceResponseWithTmuxEnrichment(
+	ctx context.Context,
+	summary *db.WorkspaceSummary,
+) workspaceEnrichmentProbeResult {
+	resp := toWorkspaceResponse(summary)
+	resp.Repo = s.repoRefFromParts(
+		summary.Platform, summary.PlatformHost, summary.RepoOwner, summary.RepoName,
+	)
+	if s.workspaces == nil || summary.Status != "ready" {
+		return workspaceEnrichmentProbeResult{response: resp, kind: workspaceEnrichmentTmux}
+	}
+	sessions, sessionsErr := s.workspaceTmuxActivitySessions(ctx, summary)
+	activity, hasActivity, activityErr := s.probeWorkspaceTmuxActivity(ctx, summary, sessions)
+	if hasActivity {
+		applyTmuxActivity(&resp, activity)
+	}
+	err := errors.Join(sessionsErr, activityErr)
+	return workspaceEnrichmentProbeResult{
+		response: resp, tmuxComplete: err == nil, tmuxErr: err, err: err,
+		kind: workspaceEnrichmentTmux,
+	}
 }
 
 func (s *Handler) workspaceTmuxActivitySessions(

--- a/internal/server/workspaceapi/subject_activity.go
+++ b/internal/server/workspaceapi/subject_activity.go
@@ -1,0 +1,180 @@
+package workspaceapi
+
+import (
+	"context"
+	"time"
+
+	"go.kenn.io/forge/internal/db"
+)
+
+type SubjectActivity struct {
+	Subject    db.WorkspaceSubjectMetadata
+	Workspace  WorkspaceRef
+	ActivityAt *time.Time
+}
+
+type WorkspaceSubjectSnapshot struct {
+	OwnReferences map[db.WorkspaceSubjectKey]WorkspaceRef
+	Subjects      map[db.WorkspaceSubjectKey]SubjectActivity
+}
+
+type workspaceSubjectCandidate struct {
+	summary    db.WorkspaceSummary
+	activityAt *time.Time
+}
+
+func (s *Handler) WorkspaceSubjectSnapshot(
+	ctx context.Context,
+) (WorkspaceSubjectSnapshot, error) {
+	if s.db == nil {
+		return emptyWorkspaceSubjectSnapshot(), nil
+	}
+	releaseReconciliation, err := s.db.LockRepositoryReconciliationRead(ctx)
+	if err != nil {
+		return WorkspaceSubjectSnapshot{}, err
+	}
+	defer releaseReconciliation()
+	return s.WorkspaceSubjectSnapshotUnderRepositoryReconciliationRead(ctx)
+}
+
+// WorkspaceSubjectSnapshotUnderRepositoryReconciliationRead returns the same
+// snapshot as WorkspaceSubjectSnapshot for a caller that already holds the
+// repository-reconciliation read lock. Acquiring the lock again can deadlock
+// behind a queued reconciliation writer.
+func (s *Handler) WorkspaceSubjectSnapshotUnderRepositoryReconciliationRead(
+	ctx context.Context,
+) (WorkspaceSubjectSnapshot, error) {
+	snapshot := emptyWorkspaceSubjectSnapshot()
+	if s.db == nil {
+		return snapshot, nil
+	}
+	s.scheduleWorkspaceTmuxPrune()
+	summaries, err := s.db.ListWorkspaceSummaries(ctx)
+	if err != nil {
+		return WorkspaceSubjectSnapshot{}, err
+	}
+	if s.workspaceSubjectAfterSummariesForTest != nil {
+		s.workspaceSubjectAfterSummariesForTest()
+	}
+
+	keys := make([]db.WorkspaceSubjectKey, 0, len(summaries)*2)
+	resolved := make(map[db.WorkspaceSubjectKey]workspaceSubjectCandidate)
+	own := make(map[db.WorkspaceSubjectKey]db.WorkspaceSummary)
+	for i := range summaries {
+		summary := summaries[i]
+		if summary.RepoID == 0 {
+			continue
+		}
+		ownKey, hasOwn := ownWorkspaceSubjectKey(summary)
+		if hasOwn {
+			keys = append(keys, ownKey)
+			if current, ok := own[ownKey]; !ok || workspaceCandidatePreferred(summary, current, ownKey) {
+				own[ownKey] = summary
+			}
+		}
+		resolvedKey, ok := resolvedWorkspaceSubjectKey(summary)
+		if !ok {
+			continue
+		}
+		keys = append(keys, resolvedKey)
+		entry, refreshDue := s.cachedWorkspaceEnrichment(summary.ID, workspaceEnrichmentTmux)
+		if refreshDue && summary.Status == "ready" && !s.workspaceEnrichmentDisabled {
+			s.scheduleWorkspaceTmuxEnrichment(summary)
+		}
+		var activityAt *time.Time
+		if summary.Status == "ready" {
+			activityAt = cachedTmuxActivityAt(entry)
+		}
+		candidate := workspaceSubjectCandidate{summary: summary, activityAt: activityAt}
+		current, exists := resolved[resolvedKey]
+		if !exists {
+			resolved[resolvedKey] = candidate
+			continue
+		}
+		if activityAt != nil && (current.activityAt == nil || activityAt.After(*current.activityAt)) {
+			current.activityAt = activityAt
+		}
+		if workspaceCandidatePreferred(summary, current.summary, resolvedKey) {
+			current.summary = summary
+		}
+		resolved[resolvedKey] = current
+	}
+
+	metadata, err := s.db.ListWorkspaceSubjectMetadata(ctx, keys)
+	if err != nil {
+		return WorkspaceSubjectSnapshot{}, err
+	}
+	for key, summary := range own {
+		if _, ok := metadata[key]; !ok {
+			continue
+		}
+		snapshot.OwnReferences[key] = WorkspaceRef{ID: summary.ID, Status: summary.Status}
+	}
+	for key, candidate := range resolved {
+		subject, ok := metadata[key]
+		if !ok {
+			continue
+		}
+		snapshot.Subjects[key] = SubjectActivity{
+			Subject:    subject,
+			Workspace:  WorkspaceRef{ID: candidate.summary.ID, Status: candidate.summary.Status},
+			ActivityAt: candidate.activityAt,
+		}
+	}
+	return snapshot, nil
+}
+
+func emptyWorkspaceSubjectSnapshot() WorkspaceSubjectSnapshot {
+	return WorkspaceSubjectSnapshot{
+		OwnReferences: make(map[db.WorkspaceSubjectKey]WorkspaceRef),
+		Subjects:      make(map[db.WorkspaceSubjectKey]SubjectActivity),
+	}
+}
+
+func ownWorkspaceSubjectKey(summary db.WorkspaceSummary) (db.WorkspaceSubjectKey, bool) {
+	if summary.ItemNumber <= 0 ||
+		(summary.ItemType != db.WorkspaceItemTypePullRequest && summary.ItemType != db.WorkspaceItemTypeIssue) {
+		return db.WorkspaceSubjectKey{}, false
+	}
+	return db.WorkspaceSubjectKey{
+		RepoID: summary.RepoID, ItemType: summary.ItemType, ItemNumber: summary.ItemNumber,
+	}, true
+}
+
+func resolvedWorkspaceSubjectKey(summary db.WorkspaceSummary) (db.WorkspaceSubjectKey, bool) {
+	if summary.AssociatedPRNumber != nil && *summary.AssociatedPRNumber > 0 {
+		return db.WorkspaceSubjectKey{
+			RepoID: summary.RepoID, ItemType: db.WorkspaceItemTypePullRequest,
+			ItemNumber: *summary.AssociatedPRNumber,
+		}, true
+	}
+	return ownWorkspaceSubjectKey(summary)
+}
+
+func cachedTmuxActivityAt(entry *workspaceEnrichmentCacheEntry) *time.Time {
+	if entry == nil || !entry.hasTmux || entry.response.TmuxLastOutputAt == nil {
+		return nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, *entry.response.TmuxLastOutputAt)
+	if err != nil {
+		return nil
+	}
+	parsed = parsed.UTC()
+	return &parsed
+}
+
+func workspaceCandidatePreferred(
+	candidate db.WorkspaceSummary,
+	current db.WorkspaceSummary,
+	key db.WorkspaceSubjectKey,
+) bool {
+	candidateDirect := candidate.ItemType == key.ItemType && candidate.ItemNumber == key.ItemNumber
+	currentDirect := current.ItemType == key.ItemType && current.ItemNumber == key.ItemNumber
+	if candidateDirect != currentDirect {
+		return candidateDirect
+	}
+	if !candidate.CreatedAt.Equal(current.CreatedAt) {
+		return candidate.CreatedAt.After(current.CreatedAt)
+	}
+	return candidate.ID > current.ID
+}

--- a/internal/server/workspaceapi/subject_activity_test.go
+++ b/internal/server/workspaceapi/subject_activity_test.go
@@ -1,0 +1,273 @@
+package workspaceapi
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/db"
+)
+
+func TestWorkspaceSubjectSnapshotFencesRepositoryReconciliationAcrossReads(t *testing.T) {
+	require := require.New(t)
+	h := newEnrichmentTestHandler(t, "")
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	identity := db.GitHubRepoIdentity("github.com", "acme", "widget")
+	identity.PlatformRepoID = "repo-acme-widget"
+	repository, accepted, err := h.db.ReconcileRepositoryObservation(t.Context(), identity, now)
+	require.NoError(err)
+	require.True(accepted)
+	require.NoError(h.db.InsertWorkspace(t.Context(), &db.Workspace{
+		ID: "ws-fenced", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget", ItemType: db.WorkspaceItemTypePullRequest,
+		ItemNumber: 51, WorktreePath: t.TempDir(), Status: "ready",
+	}))
+	_, err = h.db.UpsertMergeRequest(t.Context(), &db.MergeRequest{
+		RepoID: repository.Repository.ID, PlatformID: 51, Number: 51,
+		URL: "https://github.com/acme/widget/pull/51", Title: "Fenced work",
+		Author: "alice", State: "open", CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+
+	afterSummaries := make(chan struct{})
+	continueSnapshot := make(chan struct{})
+	h.workspaceSubjectAfterSummariesForTest = func() {
+		close(afterSummaries)
+		<-continueSnapshot
+	}
+	snapshotDone := make(chan error, 1)
+	go func() {
+		_, snapshotErr := h.WorkspaceSubjectSnapshot(context.Background())
+		snapshotDone <- snapshotErr
+	}()
+	<-afterSummaries
+
+	writeAttempted := make(chan struct{})
+	restoreHook := h.db.SetBeforeRepositoryReconciliationWriteLockForTest(func() {
+		close(writeAttempted)
+	})
+	t.Cleanup(restoreHook)
+	renameDone := make(chan error, 1)
+	go func() {
+		renamed := db.GitHubRepoIdentity("github.com", "acme", "gadget")
+		renamed.PlatformRepoID = identity.PlatformRepoID
+		_, _, renameErr := h.db.ReconcileRepositoryObservation(context.Background(), renamed, now.Add(time.Minute))
+		renameDone <- renameErr
+	}()
+	<-writeAttempted
+
+	select {
+	case err := <-renameDone:
+		require.Failf("repository reconciliation completed during snapshot", "error: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(continueSnapshot)
+	require.NoError(<-snapshotDone)
+	require.NoError(<-renameDone)
+}
+
+func TestWorkspaceSubjectSnapshotKeepsReferenceAndCachedActivity(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	h := newEnrichmentTestHandler(t, "")
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	h.now = func() time.Time { return now }
+	identity := db.GitHubRepoIdentity("github.com", "acme", "widget")
+	identity.PlatformRepoID = "repo-acme-widget"
+	repoID, err := h.db.UpsertRepo(t.Context(), identity)
+	require.NoError(err)
+	_, err = h.db.UpsertMergeRequest(t.Context(), &db.MergeRequest{
+		RepoID: repoID, PlatformID: 41, Number: 41,
+		URL: "https://github.com/acme/widget/pull/41", Title: "Live work",
+		Author: "alice", State: "open", CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+	require.NoError(h.db.InsertWorkspace(t.Context(), &db.Workspace{
+		ID: "ws-41", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget", ItemType: db.WorkspaceItemTypePullRequest,
+		ItemNumber: 41, GitHeadRef: "feature", WorkspaceBranch: "feature",
+		WorktreePath: t.TempDir(), TmuxSession: "ws-41", Status: "ready",
+	}))
+	activityAt := now.Add(time.Minute).Format(time.RFC3339)
+	h.workspaceEnrichmentCache["ws-41"] = workspaceEnrichmentCacheEntry{
+		response: workspaceResponse{TmuxLastOutputAt: &activityAt},
+		hasTmux:  true, tmuxRefreshedAt: now, tmuxAttemptAt: now,
+	}
+
+	snapshot, err := h.WorkspaceSubjectSnapshot(t.Context())
+	require.NoError(err)
+	key := db.WorkspaceSubjectKey{RepoID: repoID, ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: 41}
+	assert.Equal(WorkspaceRef{ID: "ws-41", Status: "ready"}, snapshot.OwnReferences[key])
+	require.Contains(snapshot.Subjects, key)
+	require.NotNil(snapshot.Subjects[key].ActivityAt)
+	assert.Equal(now.Add(time.Minute), *snapshot.Subjects[key].ActivityAt)
+	assert.Equal("Live work", snapshot.Subjects[key].Subject.Title)
+}
+
+func TestWorkspaceSubjectSnapshotResolvesAdHocAssociationAsPullReference(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	h := newEnrichmentTestHandler(t, "")
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	h.now = func() time.Time { return now }
+	identity := db.GitHubRepoIdentity("github.com", "acme", "widget")
+	identity.PlatformRepoID = "repo-acme-widget"
+	repoID, err := h.db.UpsertRepo(t.Context(), identity)
+	require.NoError(err)
+	_, err = h.db.UpsertMergeRequest(t.Context(), &db.MergeRequest{
+		RepoID: repoID, PlatformID: 42, Number: 42,
+		URL: "https://github.com/acme/widget/pull/42", Title: "Associated work",
+		Author: "alice", State: "open", CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+	associatedPR := 42
+	require.NoError(h.db.InsertWorkspace(t.Context(), &db.Workspace{
+		ID: "ws-adhoc", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget", ItemType: db.WorkspaceItemTypeAdHoc,
+		ItemKey: "adhoc:associated-work", AssociatedPRNumber: &associatedPR,
+		GitHeadRef: "feature", WorkspaceBranch: "feature",
+		WorktreePath: t.TempDir(), TmuxSession: "ws-adhoc", Status: "ready",
+	}))
+
+	snapshot, err := h.WorkspaceSubjectSnapshot(t.Context())
+	require.NoError(err)
+	key := db.WorkspaceSubjectKey{RepoID: repoID, ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: 42}
+	assert.Empty(snapshot.OwnReferences, "ad-hoc identity must not masquerade as a direct PR workspace")
+	require.Contains(snapshot.Subjects, key)
+	assert.Equal(WorkspaceRef{ID: "ws-adhoc", Status: "ready"}, snapshot.Subjects[key].Workspace)
+}
+
+func TestWorkspaceSubjectSnapshotUsesStableRepositoryIdentityAfterRename(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	h := newEnrichmentTestHandler(t, "")
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	h.now = func() time.Time { return now }
+	identity := db.GitHubRepoIdentity("github.com", "acme", "widget")
+	identity.PlatformRepoID = "repo-acme-widget"
+	repository, accepted, err := h.db.ReconcileRepositoryObservation(
+		t.Context(), identity, now,
+	)
+	require.NoError(err)
+	require.True(accepted)
+	repoID := repository.Repository.ID
+	_, err = h.db.UpsertMergeRequest(t.Context(), &db.MergeRequest{
+		RepoID: repoID, PlatformID: 43, Number: 43,
+		URL: "https://github.com/acme/gadget/pull/43", Title: "Renamed work",
+		Author: "alice", State: "open", CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+	require.NoError(h.db.InsertWorkspace(t.Context(), &db.Workspace{
+		ID: "ws-renamed", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget", ItemType: db.WorkspaceItemTypePullRequest,
+		ItemNumber: 43, GitHeadRef: "feature", WorkspaceBranch: "feature",
+		WorktreePath: t.TempDir(), TmuxSession: "ws-renamed", Status: "ready",
+	}))
+	renamedIdentity := db.GitHubRepoIdentity("github.com", "acme", "gadget")
+	renamedIdentity.PlatformRepoID = identity.PlatformRepoID
+	_, accepted, err = h.db.ReconcileRepositoryObservation(
+		t.Context(), renamedIdentity, now.Add(time.Minute),
+	)
+	require.NoError(err)
+	require.True(accepted)
+
+	snapshot, err := h.WorkspaceSubjectSnapshot(t.Context())
+	require.NoError(err)
+	key := db.WorkspaceSubjectKey{RepoID: repoID, ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: 43}
+	require.Contains(snapshot.Subjects, key)
+	assert.Equal("gadget", snapshot.Subjects[key].Subject.RepoName)
+	assert.Equal(WorkspaceRef{ID: "ws-renamed", Status: "ready"}, snapshot.Subjects[key].Workspace)
+}
+
+func TestWorkspaceSubjectSnapshotRejectsAmbiguousReusedRoute(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	h := newEnrichmentTestHandler(t, "")
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	h.now = func() time.Time { return now }
+	oldIdentity := db.GitHubRepoIdentity("github.com", "acme", "widget")
+	oldIdentity.PlatformRepoID = "repo-old-widget"
+	oldRepo, accepted, err := h.db.ReconcileRepositoryObservation(t.Context(), oldIdentity, now)
+	require.NoError(err)
+	require.True(accepted)
+	_, err = h.db.UpsertMergeRequest(t.Context(), &db.MergeRequest{
+		RepoID: oldRepo.Repository.ID, PlatformID: 45, Number: 45,
+		URL: "https://github.com/acme/widget/pull/45", Title: "Old routed work",
+		Author: "alice", State: "open", CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+	require.NoError(h.db.InsertWorkspace(t.Context(), &db.Workspace{
+		ID: "ws-old-route", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget", ItemType: db.WorkspaceItemTypePullRequest,
+		ItemNumber: 45, GitHeadRef: "feature", WorkspaceBranch: "feature",
+		WorktreePath: t.TempDir(), TmuxSession: "ws-old-route", Status: "ready",
+	}))
+
+	renamedIdentity := db.GitHubRepoIdentity("github.com", "acme", "gadget")
+	renamedIdentity.PlatformRepoID = oldIdentity.PlatformRepoID
+	_, accepted, err = h.db.ReconcileRepositoryObservation(t.Context(), renamedIdentity, now.Add(time.Minute))
+	require.NoError(err)
+	require.True(accepted)
+	replacementIdentity := db.GitHubRepoIdentity("github.com", "acme", "widget")
+	replacementIdentity.PlatformRepoID = "repo-replacement-widget"
+	replacement, accepted, err := h.db.ReconcileRepositoryObservation(
+		t.Context(), replacementIdentity, now.Add(2*time.Minute),
+	)
+	require.NoError(err)
+	require.True(accepted)
+	_, err = h.db.UpsertMergeRequest(t.Context(), &db.MergeRequest{
+		RepoID: replacement.Repository.ID, PlatformID: 145, Number: 45,
+		URL: "https://github.com/acme/widget/pull/45", Title: "Replacement work",
+		Author: "bob", State: "open", CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+
+	snapshot, err := h.WorkspaceSubjectSnapshot(t.Context())
+	require.NoError(err)
+	assert.Empty(snapshot.OwnReferences,
+		"ambiguous historical routes must not bind the workspace to the replacement repository")
+	assert.Empty(snapshot.Subjects)
+}
+
+func TestWorkspaceSubjectSnapshotKeepsNonReadyReferenceWithoutCachedActivity(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	h := newEnrichmentTestHandler(t, "")
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	h.now = func() time.Time { return now }
+	identity := db.GitHubRepoIdentity("github.com", "acme", "widget")
+	identity.PlatformRepoID = "repo-acme-widget"
+	repoID, err := h.db.UpsertRepo(t.Context(), identity)
+	require.NoError(err)
+	_, err = h.db.UpsertMergeRequest(t.Context(), &db.MergeRequest{
+		RepoID: repoID, PlatformID: 44, Number: 44,
+		URL: "https://github.com/acme/widget/pull/44", Title: "Stopped work",
+		Author: "alice", State: "open", CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+	require.NoError(h.db.InsertWorkspace(t.Context(), &db.Workspace{
+		ID: "ws-stopped", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget", ItemType: db.WorkspaceItemTypePullRequest,
+		ItemNumber: 44, GitHeadRef: "feature", WorkspaceBranch: "feature",
+		WorktreePath: t.TempDir(), TmuxSession: "ws-stopped", Status: "ready",
+	}))
+	activityAt := now.Add(time.Minute).Format(time.RFC3339)
+	h.workspaceEnrichmentCache["ws-stopped"] = workspaceEnrichmentCacheEntry{
+		response: workspaceResponse{TmuxLastOutputAt: &activityAt},
+		hasTmux:  true, tmuxRefreshedAt: now, tmuxAttemptAt: now,
+	}
+	errorMessage := "tmux session no longer exists"
+	require.NoError(h.db.UpdateWorkspaceStatus(
+		t.Context(), "ws-stopped", "error", &errorMessage,
+	))
+
+	snapshot, err := h.WorkspaceSubjectSnapshot(t.Context())
+	require.NoError(err)
+	key := db.WorkspaceSubjectKey{RepoID: repoID, ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: 44}
+	assert.Equal(WorkspaceRef{ID: "ws-stopped", Status: "error"}, snapshot.OwnReferences[key])
+	require.Contains(snapshot.Subjects, key)
+	assert.Equal(WorkspaceRef{ID: "ws-stopped", Status: "error"}, snapshot.Subjects[key].Workspace)
+	assert.Nil(snapshot.Subjects[key].ActivityAt)
+}

--- a/internal/server/workspaceapi/workspace_enrichment.go
+++ b/internal/server/workspaceapi/workspace_enrichment.go
@@ -3,6 +3,7 @@ package workspaceapi
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"time"
 
 	"go.kenn.io/forge/internal/db"
@@ -32,19 +33,34 @@ type workspaceEnrichmentCacheEntry struct {
 	divergenceRefreshedAt time.Time
 	tmuxRefreshedAt       time.Time
 	lastAttemptAt         time.Time
-	lastError             string
+	divergenceError       string
+	tmuxError             string
+	divergenceAttemptAt   time.Time
+	tmuxAttemptAt         time.Time
 }
+
+type workspaceEnrichmentKind uint8
+
+const (
+	workspaceEnrichmentFull workspaceEnrichmentKind = iota
+	workspaceEnrichmentTmux
+)
 
 type workspaceEnrichmentJob struct {
 	summary    db.WorkspaceSummary
 	generation uint64
+	kind       workspaceEnrichmentKind
+	flightID   uint64
 }
 
 type workspaceEnrichmentProbeResult struct {
 	response           workspaceResponse
 	divergenceComplete bool
 	tmuxComplete       bool
+	divergenceErr      error
+	tmuxErr            error
 	err                error
+	kind               workspaceEnrichmentKind
 }
 
 func (s *Handler) toCachedWorkspaceResponse(
@@ -62,7 +78,7 @@ func (s *Handler) toCachedWorkspaceResponse(
 		return
 	}
 
-	entry, refreshDue := s.cachedWorkspaceEnrichment(summary.ID)
+	entry, refreshDue := s.cachedWorkspaceEnrichment(summary.ID, workspaceEnrichmentFull)
 	resp = s.workspaceResponseFromEnrichmentCacheEntry(summary, entry)
 	if refreshDue {
 		s.scheduleWorkspaceEnrichment(*summary)
@@ -86,19 +102,30 @@ func (s *Handler) workspaceResponseFromEnrichmentCacheEntry(
 	applyWorkspaceEnrichmentCacheEntry(&resp, *entry)
 	hasResponse := entry.hasDivergence || entry.hasTmux
 	switch {
-	case entry.lastError != "":
+	case entry.errorMessage() != "":
 		resp.EnrichmentStatus = workspaceEnrichmentFailed
-		errMessage := entry.lastError
+		errMessage := entry.errorMessage()
 		resp.EnrichmentError = &errMessage
 	case hasResponse:
 		refreshedAt, _ := entry.oldestRefreshedAt()
-		if s.now().Sub(refreshedAt) < workspaceEnrichmentTTL {
-			resp.EnrichmentStatus = workspaceEnrichmentFresh
-		} else {
+		if s.now().Sub(refreshedAt) >= workspaceEnrichmentTTL {
 			resp.EnrichmentStatus = workspaceEnrichmentStale
+		} else if entry.hasDivergence && entry.hasTmux {
+			resp.EnrichmentStatus = workspaceEnrichmentFresh
 		}
 	}
 	return resp
+}
+
+func (entry workspaceEnrichmentCacheEntry) errorMessage() string {
+	messages := make([]string, 0, 2)
+	if entry.divergenceError != "" {
+		messages = append(messages, entry.divergenceError)
+	}
+	if entry.tmuxError != "" {
+		messages = append(messages, entry.tmuxError)
+	}
+	return strings.Join(messages, "\n")
 }
 
 func (entry workspaceEnrichmentCacheEntry) oldestRefreshedAt() (time.Time, bool) {
@@ -141,6 +168,7 @@ func applyWorkspaceEnrichmentCacheEntry(
 
 func (s *Handler) cachedWorkspaceEnrichment(
 	workspaceID string,
+	kind workspaceEnrichmentKind,
 ) (*workspaceEnrichmentCacheEntry, bool) {
 	s.workspaceEnrichmentMu.Lock()
 	defer s.workspaceEnrichmentMu.Unlock()
@@ -150,15 +178,20 @@ func (s *Handler) cachedWorkspaceEnrichment(
 		return nil, true
 	}
 	copy := entry
-	latestAttempt := entry.lastAttemptAt
-	if entry.divergenceRefreshedAt.After(latestAttempt) {
-		latestAttempt = entry.divergenceRefreshedAt
+	componentDue := func(attemptedAt, refreshedAt time.Time) bool {
+		latest := attemptedAt
+		if refreshedAt.After(latest) {
+			latest = refreshedAt
+		}
+		return latest.IsZero() || s.now().Sub(latest) >= workspaceEnrichmentTTL
 	}
-	if entry.tmuxRefreshedAt.After(latestAttempt) {
-		latestAttempt = entry.tmuxRefreshedAt
+	tmuxDue := componentDue(entry.tmuxAttemptAt, entry.tmuxRefreshedAt)
+	if kind == workspaceEnrichmentTmux {
+		return &copy, tmuxDue
 	}
-	return &copy, latestAttempt.IsZero() ||
-		s.now().Sub(latestAttempt) >= workspaceEnrichmentTTL
+	return &copy, tmuxDue || componentDue(
+		entry.divergenceAttemptAt, entry.divergenceRefreshedAt,
+	)
 }
 
 func (s *Handler) refreshWorkspaceResponse(
@@ -195,6 +228,17 @@ func (s *Handler) workspaceResponseAfterEnrichmentAttempt(
 }
 
 func (s *Handler) scheduleWorkspaceEnrichment(summary db.WorkspaceSummary) {
+	s.scheduleWorkspaceEnrichmentKind(summary, workspaceEnrichmentFull)
+}
+
+func (s *Handler) scheduleWorkspaceTmuxEnrichment(summary db.WorkspaceSummary) {
+	s.scheduleWorkspaceEnrichmentKind(summary, workspaceEnrichmentTmux)
+}
+
+func (s *Handler) scheduleWorkspaceEnrichmentKind(
+	summary db.WorkspaceSummary,
+	kind workspaceEnrichmentKind,
+) {
 	s.workspaceEnrichmentMu.Lock()
 	defer s.workspaceEnrichmentMu.Unlock()
 	if s.workspaceEnrichmentGenerations == nil {
@@ -206,11 +250,17 @@ func (s *Handler) scheduleWorkspaceEnrichment(summary db.WorkspaceSummary) {
 	generation := s.workspaceEnrichmentGenerations[summary.ID]
 	if inFlight, ok := s.workspaceEnrichmentInFlight[summary.ID]; ok &&
 		inFlight == generation {
-		return
+		if s.workspaceEnrichmentFlightKinds[summary.ID] == workspaceEnrichmentFull ||
+			kind == workspaceEnrichmentTmux {
+			return
+		}
 	}
 	if pending, ok := s.workspaceEnrichmentPending[summary.ID]; ok &&
 		pending.generation == generation {
 		pending.summary = summary
+		if kind == workspaceEnrichmentFull {
+			pending.kind = workspaceEnrichmentFull
+		}
 		s.workspaceEnrichmentPending[summary.ID] = pending
 		return
 	}
@@ -220,6 +270,7 @@ func (s *Handler) scheduleWorkspaceEnrichment(summary db.WorkspaceSummary) {
 	s.workspaceEnrichmentPending[summary.ID] = workspaceEnrichmentJob{
 		summary:    summary,
 		generation: generation,
+		kind:       kind,
 	}
 	s.startWorkspaceEnrichmentWorkersLocked()
 }
@@ -275,11 +326,25 @@ func (s *Handler) nextWorkspaceEnrichmentJob() (
 		return workspaceEnrichmentJob{}, true, true
 	}
 	for workspaceID, job := range s.workspaceEnrichmentPending {
-		delete(s.workspaceEnrichmentPending, workspaceID)
 		if s.workspaceEnrichmentGenerations[workspaceID] != job.generation {
+			delete(s.workspaceEnrichmentPending, workspaceID)
 			continue
 		}
+		if _, active := s.workspaceEnrichmentInFlight[workspaceID]; active {
+			continue
+		}
+		delete(s.workspaceEnrichmentPending, workspaceID)
+		s.workspaceEnrichmentNextFlight++
+		job.flightID = s.workspaceEnrichmentNextFlight
 		s.workspaceEnrichmentInFlight[workspaceID] = job.generation
+		if s.workspaceEnrichmentFlightKinds == nil {
+			s.workspaceEnrichmentFlightKinds = make(map[string]workspaceEnrichmentKind)
+		}
+		s.workspaceEnrichmentFlightKinds[workspaceID] = job.kind
+		if s.workspaceEnrichmentFlightIDs == nil {
+			s.workspaceEnrichmentFlightIDs = make(map[string]uint64)
+		}
+		s.workspaceEnrichmentFlightIDs[workspaceID] = job.flightID
 		return job, false, true
 	}
 	s.workspaceEnrichmentWorkers--
@@ -290,12 +355,18 @@ func (s *Handler) runWorkspaceEnrichmentJob(
 	ctx context.Context,
 	job workspaceEnrichmentJob,
 ) {
-	defer s.finishWorkspaceEnrichment(job.summary.ID, job.generation)
+	defer s.finishWorkspaceEnrichment(job.summary.ID, job.generation, job.flightID)
 	probeCtx, cancel := context.WithTimeout(
 		ctx, workspaceEnrichmentRefreshTimeout,
 	)
 	defer cancel()
-	result := s.workspaceResponseWithEnrichment(probeCtx, &job.summary)
+	var result workspaceEnrichmentProbeResult
+	if job.kind == workspaceEnrichmentTmux {
+		result = s.workspaceResponseWithTmuxEnrichment(probeCtx, &job.summary)
+	} else {
+		result = s.workspaceResponseWithEnrichment(probeCtx, &job.summary)
+	}
+	result.kind = job.kind
 	if _, recorded, changed := s.recordWorkspaceEnrichmentResult(
 		job.summary.ID, job.generation, result,
 	); recorded && changed {
@@ -354,15 +425,25 @@ func (s *Handler) recordWorkspaceEnrichmentResult(
 		entry.hasDivergence = true
 		entry.divergenceRefreshedAt = now
 	}
+	if result.kind == workspaceEnrichmentFull {
+		entry.divergenceAttemptAt = now
+		if result.divergenceErr != nil {
+			entry.divergenceError = result.divergenceErr.Error()
+		} else if result.divergenceComplete {
+			entry.divergenceError = ""
+		}
+	}
 	if result.tmuxComplete {
 		applyCachedWorkspaceTmux(&entry.response, result.response)
 		entry.hasTmux = true
 		entry.tmuxRefreshedAt = now
 	}
+	entry.tmuxAttemptAt = now
 	entry.lastAttemptAt = now
-	entry.lastError = ""
-	if result.err != nil {
-		entry.lastError = result.err.Error()
+	if result.tmuxErr != nil {
+		entry.tmuxError = result.tmuxErr.Error()
+	} else if result.tmuxComplete {
+		entry.tmuxError = ""
 	}
 	s.workspaceEnrichmentCache[workspaceID] = entry
 	return entry, true, workspaceEnrichmentBroadcastWorthy(prior, entry)
@@ -380,7 +461,8 @@ func workspaceEnrichmentBroadcastWorthy(prior, next workspaceEnrichmentCacheEntr
 	if prior.hasDivergence != next.hasDivergence || prior.hasTmux != next.hasTmux {
 		return true
 	}
-	if prior.lastError != next.lastError {
+	if prior.divergenceError != next.divergenceError ||
+		prior.tmuxError != next.tmuxError {
 		return true
 	}
 	return next.hasDivergence &&
@@ -398,10 +480,14 @@ func intPointerEqual(a, b *int) bool {
 func (s *Handler) finishWorkspaceEnrichment(
 	workspaceID string,
 	generation uint64,
+	flightID uint64,
 ) {
 	s.workspaceEnrichmentMu.Lock()
-	if s.workspaceEnrichmentInFlight[workspaceID] == generation {
+	if s.workspaceEnrichmentInFlight[workspaceID] == generation &&
+		s.workspaceEnrichmentFlightIDs[workspaceID] == flightID {
 		delete(s.workspaceEnrichmentInFlight, workspaceID)
+		delete(s.workspaceEnrichmentFlightKinds, workspaceID)
+		delete(s.workspaceEnrichmentFlightIDs, workspaceID)
 	}
 	s.workspaceEnrichmentMu.Unlock()
 }

--- a/internal/server/workspaceapi/workspace_enrichment_test.go
+++ b/internal/server/workspaceapi/workspace_enrichment_test.go
@@ -256,7 +256,7 @@ func TestWorkspaceEnrichmentSupersededResponseUsesCurrentCacheState(t *testing.T
 	require.NotNil(response.CommitsAhead)
 	assert.Equal(currentAhead, *response.CommitsAhead)
 	assert.False(response.TmuxWorking)
-	assert.Equal(workspaceEnrichmentFresh, response.EnrichmentStatus)
+	assert.Equal(workspaceEnrichmentPending, response.EnrichmentStatus)
 	assert.Nil(response.EnrichmentError)
 }
 
@@ -350,7 +350,7 @@ func TestCachedWorkspaceEnrichmentReportsStaleAndFailedState(t *testing.T) {
 	srv.workspaceEnrichmentMu.Lock()
 	entry := srv.workspaceEnrichmentCache[summary.ID]
 	entry.lastAttemptAt = now
-	entry.lastError = "tmux activity probe failed"
+	entry.tmuxError = "tmux activity probe failed"
 	srv.workspaceEnrichmentCache[summary.ID] = entry
 	srv.workspaceEnrichmentMu.Unlock()
 
@@ -358,6 +358,170 @@ func TestCachedWorkspaceEnrichmentReportsStaleAndFailedState(t *testing.T) {
 	assert.Equal("failed", failed.EnrichmentStatus)
 	require.NotNil(failed.EnrichmentError)
 	assert.Equal("tmux activity probe failed", *failed.EnrichmentError)
+}
+
+func TestCachedWorkspaceEnrichmentTracksComponentStaleness(t *testing.T) {
+	assert := assert.New(t)
+	srv := newEnrichmentTestHandler(t, "")
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	srv.now = func() time.Time { return now }
+	srv.workspaceEnrichmentCache["ws"] = workspaceEnrichmentCacheEntry{
+		hasDivergence:         true,
+		hasTmux:               true,
+		divergenceRefreshedAt: now.Add(-workspaceEnrichmentTTL - time.Second),
+		tmuxRefreshedAt:       now,
+		divergenceAttemptAt:   now.Add(-workspaceEnrichmentTTL - time.Second),
+		tmuxAttemptAt:         now,
+	}
+
+	_, fullDue := srv.cachedWorkspaceEnrichment("ws", workspaceEnrichmentFull)
+	_, tmuxDue := srv.cachedWorkspaceEnrichment("ws", workspaceEnrichmentTmux)
+	assert.True(fullDue)
+	assert.False(tmuxDue)
+
+	entry := srv.workspaceEnrichmentCache["ws"]
+	entry.divergenceRefreshedAt = now
+	entry.divergenceAttemptAt = now
+	entry.tmuxRefreshedAt = now.Add(-workspaceEnrichmentTTL - time.Second)
+	entry.tmuxAttemptAt = entry.tmuxRefreshedAt
+	srv.workspaceEnrichmentCache["ws"] = entry
+	_, fullDue = srv.cachedWorkspaceEnrichment("ws", workspaceEnrichmentFull)
+	_, tmuxDue = srv.cachedWorkspaceEnrichment("ws", workspaceEnrichmentTmux)
+	assert.True(fullDue)
+	assert.True(tmuxDue)
+}
+
+func TestCachedWorkspaceEnrichmentDoesNotTreatTmuxAttemptAsDivergenceAttempt(t *testing.T) {
+	assert := assert.New(t)
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	srv := newEnrichmentTestHandler(t, "")
+	srv.now = func() time.Time { return now }
+	srv.workspaceEnrichmentCache["ws"] = workspaceEnrichmentCacheEntry{
+		hasTmux:         true,
+		tmuxRefreshedAt: now,
+		tmuxAttemptAt:   now,
+		lastAttemptAt:   now,
+	}
+
+	_, fullDue := srv.cachedWorkspaceEnrichment("ws", workspaceEnrichmentFull)
+	_, tmuxDue := srv.cachedWorkspaceEnrichment("ws", workspaceEnrichmentTmux)
+
+	assert.True(fullDue)
+	assert.False(tmuxDue)
+}
+
+func TestCachedWorkspaceEnrichmentKeepsFreshTmuxOnlyResultPending(t *testing.T) {
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	srv := &Handler{now: func() time.Time { return now }}
+	summary := db.WorkspaceSummary{Workspace: db.Workspace{
+		ID: "ws-tmux-only", Status: "ready",
+	}}
+	entry := workspaceEnrichmentCacheEntry{
+		hasTmux: true, tmuxRefreshedAt: now, tmuxAttemptAt: now,
+	}
+
+	response := srv.workspaceResponseFromEnrichmentCacheEntry(&summary, &entry)
+
+	assert.Equal(t, workspaceEnrichmentPending, response.EnrichmentStatus)
+	assert.Nil(t, response.CommitsAhead)
+	assert.Nil(t, response.CommitsBehind)
+}
+
+func TestWorkspaceEnrichmentTmuxSuccessPreservesDivergenceFailure(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	srv := &Handler{
+		now:                            func() time.Time { return now },
+		workspaceEnrichmentCache:       make(map[string]workspaceEnrichmentCacheEntry),
+		workspaceEnrichmentGenerations: map[string]uint64{"ws-component-errors": 1},
+	}
+	summary := db.WorkspaceSummary{Workspace: db.Workspace{
+		ID: "ws-component-errors", Status: "ready",
+	}}
+
+	_, recorded, _ := srv.recordWorkspaceEnrichmentResult(
+		summary.ID,
+		1,
+		workspaceEnrichmentProbeResult{
+			divergenceErr: errors.New("git divergence probe failed"),
+			tmuxErr:       errors.New("tmux activity probe failed"),
+			err: errors.Join(
+				errors.New("git divergence probe failed"),
+				errors.New("tmux activity probe failed"),
+			),
+			kind: workspaceEnrichmentFull,
+		},
+	)
+	require.True(recorded)
+	failed := srv.workspaceResponseFromEnrichmentCacheEntry(
+		&summary, new(srv.workspaceEnrichmentCache[summary.ID]),
+	)
+	require.NotNil(failed.EnrichmentError)
+	assert.Contains(*failed.EnrichmentError, "git divergence probe failed")
+	assert.Contains(*failed.EnrichmentError, "tmux activity probe failed")
+
+	now = now.Add(time.Second)
+	_, recorded, _ = srv.recordWorkspaceEnrichmentResult(
+		summary.ID,
+		1,
+		workspaceEnrichmentProbeResult{
+			tmuxComplete: true,
+			kind:         workspaceEnrichmentTmux,
+		},
+	)
+	require.True(recorded)
+	stillFailed := srv.workspaceResponseFromEnrichmentCacheEntry(
+		&summary, new(srv.workspaceEnrichmentCache[summary.ID]),
+	)
+	require.NotNil(stillFailed.EnrichmentError)
+	assert.Contains(*stillFailed.EnrichmentError, "git divergence probe failed")
+	assert.NotContains(*stillFailed.EnrichmentError, "tmux activity probe failed")
+}
+
+func TestNextWorkspaceEnrichmentJobLeavesUpgradeQueuedDuringActiveFlight(t *testing.T) {
+	assert := assert.New(t)
+	srv := &Handler{
+		workspaceEnrichmentInFlight: map[string]uint64{"ws-upgrade": 3},
+		workspaceEnrichmentFlightKinds: map[string]workspaceEnrichmentKind{
+			"ws-upgrade": workspaceEnrichmentTmux,
+		},
+		workspaceEnrichmentGenerations: map[string]uint64{"ws-upgrade": 3},
+		workspaceEnrichmentPending: map[string]workspaceEnrichmentJob{
+			"ws-upgrade": {
+				summary:    db.WorkspaceSummary{Workspace: db.Workspace{ID: "ws-upgrade", Status: "ready"}},
+				generation: 3,
+				kind:       workspaceEnrichmentFull,
+			},
+		},
+		workspaceEnrichmentWorkers: 2,
+	}
+
+	_, prune, ok := srv.nextWorkspaceEnrichmentJob()
+
+	assert.False(ok)
+	assert.False(prune)
+	assert.Contains(srv.workspaceEnrichmentPending, "ws-upgrade")
+	assert.Equal(uint64(3), srv.workspaceEnrichmentInFlight["ws-upgrade"])
+	assert.Equal(workspaceEnrichmentTmux, srv.workspaceEnrichmentFlightKinds["ws-upgrade"])
+}
+
+func TestFinishWorkspaceEnrichmentRequiresMatchingFlightID(t *testing.T) {
+	assert := assert.New(t)
+	srv := &Handler{
+		workspaceEnrichmentInFlight:    map[string]uint64{"ws-flight": 4},
+		workspaceEnrichmentFlightKinds: map[string]workspaceEnrichmentKind{"ws-flight": workspaceEnrichmentFull},
+		workspaceEnrichmentFlightIDs:   map[string]uint64{"ws-flight": 12},
+	}
+
+	srv.finishWorkspaceEnrichment("ws-flight", 4, 11)
+	assert.Contains(srv.workspaceEnrichmentInFlight, "ws-flight")
+	assert.Equal(uint64(12), srv.workspaceEnrichmentFlightIDs["ws-flight"])
+
+	srv.finishWorkspaceEnrichment("ws-flight", 4, 12)
+	assert.NotContains(srv.workspaceEnrichmentInFlight, "ws-flight")
+	assert.NotContains(srv.workspaceEnrichmentFlightKinds, "ws-flight")
+	assert.NotContains(srv.workspaceEnrichmentFlightIDs, "ws-flight")
 }
 
 func TestWorkspaceEnrichmentRefreshFailurePreservesLastKnownGood(t *testing.T) {
@@ -427,7 +591,7 @@ func TestWorkspaceEnrichmentRefreshFailurePreservesLastKnownGood(t *testing.T) {
 	assert.Equal(now, got.divergenceRefreshedAt)
 	assert.Equal(lastGood.tmuxRefreshedAt, got.tmuxRefreshedAt)
 	assert.Equal(now, got.lastAttemptAt)
-	assert.Contains(got.lastError, "tmux display-message:")
+	assert.Contains(got.tmuxError, "tmux display-message:")
 
 	missingSummary := db.WorkspaceSummary{Workspace: db.Workspace{
 		ID:           "ws-partial-refresh",
@@ -519,8 +683,14 @@ func TestWorkspaceEnrichmentBroadcastsOnlyDurableChanges(t *testing.T) {
 	}))
 
 	// A new failure notifies once; the same repeated failure stays silent.
-	assert.True(record(workspaceEnrichmentProbeResult{err: errors.New("boom")}))
-	assert.False(record(workspaceEnrichmentProbeResult{err: errors.New("boom")}))
+	assert.True(record(workspaceEnrichmentProbeResult{
+		divergenceErr: errors.New("boom"),
+		kind:          workspaceEnrichmentFull,
+	}))
+	assert.False(record(workspaceEnrichmentProbeResult{
+		divergenceErr: errors.New("boom"),
+		kind:          workspaceEnrichmentFull,
+	}))
 
 	// Recovery notifies.
 	assert.True(record(workspaceEnrichmentProbeResult{
@@ -528,6 +698,55 @@ func TestWorkspaceEnrichmentBroadcastsOnlyDurableChanges(t *testing.T) {
 		divergenceComplete: true,
 		tmuxComplete:       true,
 	}))
+
+	// Tmux-only failures and recovery notify just like divergence failures;
+	// only routine activity-field movement stays silent.
+	assert.True(record(workspaceEnrichmentProbeResult{
+		tmuxErr: errors.New("tmux boom"),
+		kind:    workspaceEnrichmentTmux,
+	}))
+	assert.False(record(workspaceEnrichmentProbeResult{
+		tmuxErr: errors.New("tmux boom"),
+		kind:    workspaceEnrichmentTmux,
+	}))
+	assert.True(record(workspaceEnrichmentProbeResult{
+		tmuxComplete: true,
+		kind:         workspaceEnrichmentTmux,
+	}))
+}
+
+func TestTmuxOnlyEnrichmentBroadcastsFirstCompletion(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv := newEnrichmentTestHandler(t, "")
+	srv.workspaceEnrichmentDisabled = false
+	var events []Event
+	srv.hub.broadcast = func(event Event) uint64 {
+		events = append(events, event)
+		return uint64(len(events))
+	}
+	require.NoError(srv.db.InsertWorkspace(t.Context(), &db.Workspace{
+		ID: "ws-tmux-broadcast", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget", ItemType: db.WorkspaceItemTypeAdHoc,
+		ItemKey: "adhoc:tmux-broadcast", WorktreePath: t.TempDir(), Status: "ready",
+	}))
+	summary, err := srv.db.GetWorkspaceSummary(t.Context(), "ws-tmux-broadcast")
+	require.NoError(err)
+	require.NotNil(summary)
+	srv.workspaceEnrichmentGenerations[summary.ID] = 0
+	job := workspaceEnrichmentJob{
+		summary:    *summary,
+		generation: srv.workspaceEnrichmentGeneration("ws-tmux-broadcast"),
+		kind:       workspaceEnrichmentTmux,
+	}
+
+	srv.runWorkspaceEnrichmentJob(t.Context(), job)
+
+	require.Len(events, 1)
+	assert.Equal(Event{
+		Type: "workspace_status",
+		Data: map[string]string{"id": "ws-tmux-broadcast"},
+	}, events[0])
 }
 
 func TestWorkspaceEnrichmentUsesBoundedWorkersPastBackgroundCapacity(t *testing.T) {


### PR DESCRIPTION
Provider events can stay quiet while an agent actively works in a linked workspace. That made the relevant pull request or issue remain buried in Activity, Issues, and Pull Requests even though its tmux session was producing output.

This change treats the latest observed workspace output as an ephemeral recency signal across all three views. It keeps provider history unchanged, preserves stable pagination by sorting item lists in SQLite, and uses one subject snapshot so repository renames, associated pull requests, and direct issue workspace links follow the same identity rules. Threaded Activity can now show a workspace-active subject without inventing a provider event.

The repository-wide short lane encountered host-timing failures in unrelated PTY, server-startup, repository-browser, and command build tests while other repositories were compiling. Each reported failure passed in an isolated rerun; the affected packages and the full internal server package passed in the broad run.

<details>
<summary>Validation</summary>

- Generated API contracts reproduce without drift.
- Affected Go packages and the full internal server package pass.
- Frontend type, Svelte, and Effect diagnostics report zero errors.
- Changed frontend unit tests pass (125 tests); every unrelated full-suite timeout file passes in focused reruns (388 tests total across both batches).
- The affected full-stack Playwright suite passes (32 tests), including real tmux first-observation and event-less Activity behavior.
- Non-mutating Go lint reports zero issues.
- Context structure and public-history private-data scans pass.

</details>
