### PR TITLE
Clarify provider quota and app sync limits

### DIFF
--- a/docs/adr/0004-quota-meter-semantics.md
+++ b/docs/adr/0004-quota-meter-semantics.md
@@ -1,0 +1,67 @@
+# ADR 0004: Quota meter semantics
+
+Date: 2026-08-09
+
+## Status
+
+Accepted
+
+## Context
+
+The quota popover presents two different quantities. Provider REST and GitHub
+GraphQL numerators are capacity left, sourced from provider rate-limit
+responses. The local process-guard numerator is requests spent against the
+configured hourly ceiling. Giving those opposite quantities the same visual
+direction makes the numbers ambiguous.
+
+The local sync budget reserves `floor(limit / 10)` requests for essential
+repository discovery. Optional background work therefore stops at 2,700 spent
+requests for a 3,000-request ceiling, while essential discovery may use the
+final 300. The existing API does not expose that boundary, so the frontend
+cannot explain why background work stops before the hard ceiling.
+
+The provider resource values and host-level `sync_paused` flag can also come
+from different authorities: credential quota-registry snapshots override the
+REST and GraphQL values, while `sync_paused` remains tracker-derived. Using the
+flag for popover copy can contradict the provider values shown beside it.
+
+The status bar also imposes `white-space: nowrap`; without resetting that at
+the popover boundary, explanatory copy forces horizontal scrolling.
+
+## Decision
+
+Keep the existing compact popover, visual tokens, and provider-only status-bar
+trigger while giving the quota systems distinct geometry:
+
+- Provider capacity fills are anchored to the right and contract toward that
+  edge as capacity is consumed.
+- Local spend fills are anchored to the left and grow toward the hard ceiling.
+- The local meter marks the backend-provided `background_limit`; the segment
+  beyond it is visibly reserved for essential discovery.
+- Reaching that boundary is described as `background refresh paused`, not
+  `sync paused`.
+- Provider pressure is derived per REST or GraphQL resource from the displayed
+  values and `reserve_buffer`, not the host-level `sync_paused` flag.
+- `sync_throttle_factor` remains separate cadence information.
+
+Expose `background_limit` on `LocalSyncCeilingStatus` rather than duplicating
+the reserve calculation in Svelte. Keep the existing ceiling and provider
+fields intact.
+
+The compact visual UI does not add `remaining`, `used`, or `rem`. Popover
+tracks use meter semantics with explicit accessible names, raw values, limits,
+units, and policy descriptions for screen-reader users. Outlined tracks,
+opposing fill direction, alignment, and the threshold marker communicate
+meaning without relying on color alone.
+
+Reset inherited no-wrap behavior at the popover boundary. Include padding in
+its fixed width, let grid content shrink, and wrap identities and explanatory
+copy inside the content box. Horizontal clipping is only a final safeguard,
+not a substitute for correct layout.
+
+## Consequences
+
+Provider capacity and local spend remain separate across the backend, wire,
+and UI. A future reserve-policy change flows from the backend without a matching
+frontend constant. Tests cover the enforced API boundary, accessible meter
+values, opposing fill anchors, scoped pause copy, and real-browser overflow.

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -3643,6 +3643,9 @@ components:
     LocalSyncCeilingStatus:
       additionalProperties: false
       properties:
+        background_limit:
+          format: int64
+          type: integer
         limit:
           format: int64
           type: integer
@@ -3668,6 +3671,7 @@ components:
         - rate_principal
         - principal_label
         - limit
+        - background_limit
         - spent
         - remaining
         - reset_at

--- a/frontend/src/lib/api/generated/schema.ts
+++ b/frontend/src/lib/api/generated/schema.ts
@@ -6205,6 +6205,8 @@ export interface components {
         };
         LocalSyncCeilingStatus: {
             /** Format: int64 */
+            background_limit: number;
+            /** Format: int64 */
             limit: number;
             platform_host: string;
             principal_label: string;

--- a/frontend/src/lib/components/layout/BudgetBars.svelte
+++ b/frontend/src/lib/components/layout/BudgetBars.svelte
@@ -10,14 +10,16 @@
 
   let { providerPools, onclick, expanded = false }: Props = $props();
 
-  function anyPaused(): boolean {
-    return Object.values(providerPools).some(
-      (pool) =>
-        pool.sync_paused ||
-        [pool.rest, pool.graphql].some(
-          (resource) => resource.known && resource.remaining <= pool.reserve_buffer,
-        ),
-    );
+  function resourceAtReserve(resource: "rest" | "graphql"): boolean {
+    return Object.values(providerPools).some((pool) => {
+      const status = pool[resource];
+      return (
+        status.known &&
+        status.limit > 0 &&
+        status.remaining >= 0 &&
+        status.remaining <= pool.reserve_buffer
+      );
+    });
   }
 
   function restEntries() {
@@ -36,14 +38,15 @@
     return worstCaseRatio(gqlEntries());
   }
 
-  function barColor(ratio: number): string {
-    if (anyPaused()) return "var(--budget-red)";
+  function barColor(ratio: number, atReserve: boolean): string {
+    if (atReserve) return "var(--budget-red)";
     return budgetColor(ratio);
   }
 
   const rr = $derived(restRatio());
   const gr = $derived(gqlRatio());
-  const paused = $derived(anyPaused());
+  const restAtReserve = $derived(resourceAtReserve("rest"));
+  const gqlAtReserve = $derived(resourceAtReserve("graphql"));
 </script>
 
 <button
@@ -52,19 +55,20 @@
   {onclick}
   aria-haspopup="dialog"
   aria-expanded={expanded}
+  aria-label="Show provider quota details"
 >
 
   <span class="budget-bar-group">
     <span
       class="budget-label"
-      style:color={rr >= 0 ? barColor(rr) : paused ? "var(--budget-red)" : "var(--text-muted)"}
+      style:color={rr >= 0 ? barColor(rr, restAtReserve) : "var(--text-muted)"}
     >{rr >= 0 ? "REST" : "--"}</span>
     <span class="budget-track">
       {#if rr >= 0}
         <span
           class="budget-fill"
-          style:width="{Math.max(rr * 100, 2)}%"
-          style:background={barColor(rr)}
+          style:width="{Math.max(rr * 100, 0)}%"
+          style:background={barColor(rr, restAtReserve)}
         ></span>
       {/if}
     </span>
@@ -73,14 +77,14 @@
   <span class="budget-bar-group">
     <span
       class="budget-label"
-      style:color={gr >= 0 ? barColor(gr) : paused ? "var(--budget-red)" : "var(--text-muted)"}
+      style:color={gr >= 0 ? barColor(gr, gqlAtReserve) : "var(--text-muted)"}
     >{gr >= 0 ? "GQL" : "--"}</span>
     <span class="budget-track">
       {#if gr >= 0}
         <span
           class="budget-fill"
-          style:width="{Math.max(gr * 100, 2)}%"
-          style:background={barColor(gr)}
+          style:width="{Math.max(gr * 100, 0)}%"
+          style:background={barColor(gr, gqlAtReserve)}
         ></span>
       {/if}
     </span>
@@ -132,7 +136,7 @@
   .budget-fill {
     display: block;
     height: 100%;
+    margin-left: auto;
     border-radius: 2px;
-    transition: width 0.5s ease;
   }
 </style>

--- a/frontend/src/lib/components/layout/BudgetPopover.svelte
+++ b/frontend/src/lib/components/layout/BudgetPopover.svelte
@@ -36,6 +36,10 @@
     return Object.entries(providerPools);
   }
 
+  function githubUserHandle(label: string): string {
+    return label.startsWith("GitHub user ") ? label.slice("GitHub user ".length) : "";
+  }
+
   function ratio(remaining: number, limit: number): number {
     if (limit <= 0) return -1;
     return remaining / limit;
@@ -68,7 +72,6 @@
   }
 
   function poolHealthColor(pool: RateLimitHostStatus): string {
-    if (pool.sync_paused) return "var(--budget-red)";
     const known = poolResources(pool).filter(resourceFresh);
     if (known.length === 0) return "var(--text-muted)";
     if (known.some((resource) => resource.remaining <= pool.reserve_buffer)) {
@@ -83,6 +86,12 @@
     );
   }
 
+  function resourcesAtReserve(pool: RateLimitHostStatus): string[] {
+    return resourceRows(pool)
+      .filter(({ resource }) => resourceFresh(resource) && resource.remaining <= pool.reserve_buffer)
+      .map(({ label }) => label);
+  }
+
   function resourceRows(pool: RateLimitHostStatus) {
     return [
       { label: "REST", resource: pool.rest, unit: "req" },
@@ -95,6 +104,23 @@
   function ceilingEntries() {
     return Object.entries(localCeilings).filter(([, ceiling]) => ceiling.limit > 0);
   }
+
+  function ceilingRatio(value: number, limit: number): number {
+    if (limit <= 0) return 0;
+    return Math.min(Math.max(value / limit, 0), 1);
+  }
+
+  function backgroundRefreshPaused(ceiling: LocalSyncCeilingStatus): boolean {
+    return ceiling.background_limit > 0 && ceiling.spent >= ceiling.background_limit;
+  }
+
+  function ceilingValueText(ceiling: LocalSyncCeilingStatus): string {
+    const usage = `${ceiling.spent} requests used of ${ceiling.limit}`;
+    if (ceiling.spent >= ceiling.limit) {
+      return `${usage}; app sync paused; discovery reserve exhausted`;
+    }
+    return `${usage}; background refresh pauses at ${ceiling.background_limit}; ${Math.max(ceiling.limit - ceiling.spent, 0)} requests available for essential discovery`;
+  }
 </script>
 
 <div
@@ -106,6 +132,7 @@
   <div class="popover-header">Provider quota</div>
 
   {#each poolEntries() as [poolKey, pool], i (poolKey)}
+    {@const userHandle = githubUserHandle(pool.principal_label)}
     {#if i > 0}
       <div class="popover-divider"></div>
     {/if}
@@ -118,8 +145,12 @@
           style:background={poolHealthColor(pool)}
         ></span>
         <span class="host-identity">
-          <span>{pool.platform_host || poolKey}</span>
-          <span class="principal-label">{pool.principal_label}</span>
+          <span>{pool.platform_host || poolKey}:</span>
+          {#if userHandle}
+            <span class="principal-label principal-label--user">@{userHandle}</span>
+          {:else}
+            <span class="principal-label">{pool.principal_label}</span>
+          {/if}
         </span>
       </div>
 
@@ -129,10 +160,18 @@
           {#if resourceFresh(resource) && ratio(resource.remaining, resource.limit) >= 0}
             {@const resourceRatio = ratio(resource.remaining, resource.limit)}
             <span class="row-bar-cell">
-              <span class="bar-track">
+              <span
+                class="bar-track bar-track--provider"
+                role="meter"
+                aria-label={`${label} capacity remaining`}
+                aria-valuemin="0"
+                aria-valuemax={resource.limit}
+                aria-valuenow={resource.remaining}
+                aria-valuetext={`${resource.remaining} ${unit === "pts" ? "points" : "requests"} remaining of ${resource.limit}`}
+              >
                 <span
-                  class="bar-fill"
-                  style:width="{Math.max(resourceRatio * 100, 2)}%"
+                  class="bar-fill bar-fill--provider"
+                  style:width="{Math.max(resourceRatio * 100, 0)}%"
                   style:background={resourceColor(resource, pool.reserve_buffer)}
                 ></span>
               </span>
@@ -148,11 +187,9 @@
         </div>
       {/each}
       {#if poolAtReserve(pool)}
-        <div class="reserve-indicator">provider reserve reached</div>
+        <div class="reserve-indicator">{resourcesAtReserve(pool).join(" + ")} provider reserve reached</div>
       {/if}
-      {#if pool.sync_paused}
-        <div class="throttle-indicator throttle-paused">sync paused</div>
-      {:else if pool.sync_throttle_factor > 1}
+      {#if pool.sync_throttle_factor > 1}
         <div class="throttle-indicator">sync {pool.sync_throttle_factor}x slower</div>
       {/if}
     </div>
@@ -160,20 +197,59 @@
 
   {#if ceilingEntries().length > 0}
     <div class="popover-section-divider"></div>
-    <div class="popover-header local-ceiling-header">Local sync ceiling</div>
+    <div class="popover-header local-ceiling-header">App sync limit</div>
     {#each ceilingEntries() as [key, ceiling] (key)}
       <div class="ceiling-section">
-        <div class="credential-name">{ceiling.platform_host || key} · {ceiling.principal_label}</div>
+        {#if ceilingEntries().length > 1}
+          {@const userHandle = githubUserHandle(ceiling.principal_label)}
+          <div class="ceiling-identity">
+            <span>{ceiling.platform_host || key}:</span>
+            {#if userHandle}
+              <span class="principal-label principal-label--user">@{userHandle}</span>
+            {:else}
+              <span class="principal-label">{ceiling.principal_label}</span>
+            {/if}
+          </div>
+        {/if}
         <div class="budget-row budget-row--ceiling">
           <span class="row-label">Process guard</span>
-          <span class="row-bar-cell"></span>
+          <span class="row-bar-cell">
+            <span
+              class="bar-track bar-track--local"
+              role="meter"
+              aria-label={`Local requests used for ${ceiling.platform_host || key}, ${ceiling.principal_label}`}
+              aria-valuemin="0"
+              aria-valuemax={ceiling.limit}
+              aria-valuenow={Math.min(Math.max(ceiling.spent, 0), ceiling.limit)}
+              aria-valuetext={ceilingValueText(ceiling)}
+            >
+              <span
+                class="bar-fill bar-fill--local"
+                style:width="{ceilingRatio(ceiling.spent, ceiling.limit) * 100}%"
+                style:background={syncBudgetColor(ceiling.spent, ceiling.limit)}
+              ></span>
+              <span
+                class="background-limit-marker"
+                style:left="{ceilingRatio(ceiling.background_limit, ceiling.limit) * 100}%"
+                aria-hidden="true"
+              ></span>
+            </span>
+          </span>
           <span class="row-value">
             <span
               class="budget-spent"
               style:color={syncBudgetColor(ceiling.spent, ceiling.limit)}
             >{formatCompact(ceiling.spent)}</span> / {formatCompact(ceiling.limit)} <span class="row-unit">requests</span>
           </span>
-          <span class="row-note">Emergency ceiling for background sync; provider quota above is authoritative.</span>
+          <span class="row-note">
+            {#if ceiling.spent >= ceiling.limit}
+              app sync paused · discovery reserve exhausted{#if resetText(ceiling.reset_at)} · {resetText(ceiling.reset_at)}{/if}
+            {:else if backgroundRefreshPaused(ceiling)}
+              background refresh paused · {formatCompact(Math.max(ceiling.limit - ceiling.spent, 0))} discovery requests before app sync pauses{#if resetText(ceiling.reset_at)} · {resetText(ceiling.reset_at)}{/if}
+            {:else}
+              Local guard for background refresh; provider quota above is separate.
+            {/if}
+          </span>
         </div>
       </div>
     {/each}
@@ -186,11 +262,15 @@
     right: 0;
     bottom: calc(100% + 4px);
     width: 320px;
+    max-width: calc(100vw - var(--space-4));
     max-height: 400px;
     overflow-y: auto;
+    overflow-x: clip;
+    box-sizing: border-box;
     padding: 12px 16px;
     z-index: var(--z-popover, 1000);
     font-size: var(--font-size-xs);
+    white-space: normal;
   }
   .popover-header {
     font-size: var(--font-size-2xs);
@@ -210,6 +290,21 @@
     display: flex;
     align-items: center;
     gap: 6px;
+    min-width: 0;
+  }
+  .host-identity {
+    display: flex;
+    min-width: 0;
+    align-items: baseline;
+    gap: var(--space-1);
+    flex-wrap: wrap;
+  }
+  .host-identity > span {
+    overflow-wrap: anywhere;
+  }
+  .principal-label--user {
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
   }
   .health-dot {
     width: 8px;
@@ -220,22 +315,11 @@
   .budget-row {
     /* label | bar | value (with inline reset) */
     display: grid;
-    grid-template-columns: 78px 42px 1fr;
+    grid-template-columns: 78px 42px minmax(0, 1fr);
     align-items: center;
     column-gap: 8px;
     margin-bottom: 6px;
   }
-  .budget-row--ceiling {
-    align-items: start;
-  }
-
-  .credential-name {
-    color: var(--text-secondary);
-    font-size: var(--font-size-2xs);
-    font-weight: 600;
-    margin: 7px 0 5px;
-  }
-
   .popover-section-divider {
     border-top: 1px solid var(--border-default);
     margin: 12px 0 10px;
@@ -244,6 +328,23 @@
   .local-ceiling-header {
     margin-bottom: 6px;
   }
+  .ceiling-section + .ceiling-section {
+    margin-top: 8px;
+  }
+  .ceiling-identity {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-1);
+    min-width: 0;
+    margin-bottom: 4px;
+    color: var(--text-secondary);
+    font-size: var(--font-size-2xs);
+    font-weight: 600;
+    flex-wrap: wrap;
+  }
+  .ceiling-identity > span {
+    overflow-wrap: anywhere;
+  }
   .row-label {
     color: var(--text-muted);
     font-size: var(--font-size-2xs);
@@ -251,20 +352,36 @@
   .row-bar-cell {
     display: flex;
     align-items: center;
+    min-width: 0;
   }
   .bar-track {
+    position: relative;
     width: 100%;
     height: 5px;
     background: var(--budget-bar-bg);
+    outline: 1px solid var(--border-muted);
+    outline-offset: -1px;
     border-radius: 3px;
     overflow: hidden;
   }
   .bar-fill {
+    display: block;
     height: 100%;
     border-radius: 3px;
-    transition: width 0.5s ease;
+  }
+  .bar-fill--provider {
+    margin-left: auto;
+  }
+  .background-limit-marker {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: var(--text-primary);
+    opacity: 0.8;
   }
   .row-value {
+    min-width: 0;
     color: var(--text-primary);
     font-size: var(--font-size-2xs);
     font-variant-numeric: tabular-nums;
@@ -279,12 +396,14 @@
   }
   .row-note {
     display: block;
-    grid-column: 3;
+    grid-column: 2 / -1;
+    min-width: 0;
     margin-top: 1px;
     color: var(--text-muted);
     font-size: 0.9em;
     line-height: 1.2;
     white-space: normal;
+    overflow-wrap: anywhere;
   }
   .row-unknown {
     color: var(--text-muted);

--- a/frontend/src/lib/components/layout/StatusBar.budget.browser.svelte.ts
+++ b/frontend/src/lib/components/layout/StatusBar.budget.browser.svelte.ts
@@ -47,7 +47,19 @@ function syncStatus(status: Record<string, unknown>): MockRouteOverride {
   };
 }
 
-function credentialAwareRateLimits(): MockRouteOverride {
+function credentialAwareRateLimits(
+  localCeilings: Record<string, unknown> = {
+    "github.com": {
+      provider: "github",
+      platform_host: "github.com",
+      rate_principal: "host",
+      principal_label: "Host credential",
+      limit: 50000,
+      spent: 42,
+      remaining: 49958,
+    },
+  },
+): MockRouteOverride {
   return (req) => {
     if (req.method !== "GET" || req.url.pathname !== "/api/v1/rate-limits") return null;
     const reset = new Date(Date.now() + 30 * 60_000).toISOString();
@@ -76,17 +88,7 @@ function credentialAwareRateLimits(): MockRouteOverride {
           graphql: { remaining: -1, limit: -1, reset_at: "", known: false, requests: 0 },
         },
       },
-      local_ceilings: {
-        "github.com": {
-          provider: "github",
-          platform_host: "github.com",
-          rate_principal: "host",
-          principal_label: "Host credential",
-          limit: 50000,
-          spent: 42,
-          remaining: 49958,
-        },
-      },
+      local_ceilings: localCeilings,
     });
   };
 }
@@ -206,11 +208,144 @@ describe("budget display", () => {
     const popover = await openPopover(bars);
     expect(popover.textContent).toContain("Provider quota");
     expect(popover.textContent).toContain("GitHub App installation 42");
-    expect(popover.textContent).toContain("GitHub user maintainer");
-    expect(popover.textContent).toContain("Local sync ceiling");
+    expect(popover.textContent).toContain("@maintainer");
+    expect(popover.textContent).toContain("App sync limit");
     expect(popover.textContent).toContain("42 / 50k requests");
     expect(popover.textContent).not.toContain("Eager refresh");
     expect(popover.textContent).not.toContain("budgeted req/hr");
+    expect(popover.querySelector(".ceiling-identity")).toBeNull();
+  });
+
+  it("labels each app sync limit when multiple credentials have local ceilings", async () => {
+    const reset = new Date(Date.now() + 30 * 60_000).toISOString();
+    const bars = await mountStatusBar([
+      credentialAwareRateLimits({
+        "github:github.com:installation:42": {
+          provider: "github",
+          platform_host: "github.com",
+          rate_principal: "installation:42",
+          principal_label: "GitHub App installation 42",
+          limit: 1500,
+          background_limit: 1200,
+          spent: 400,
+          remaining: 1100,
+          reset_at: reset,
+        },
+        "github:github.com:user:7": {
+          provider: "github",
+          platform_host: "github.com",
+          rate_principal: "user:7",
+          principal_label: "GitHub user maintainer",
+          limit: 500,
+          background_limit: 400,
+          spent: 400,
+          remaining: 100,
+          reset_at: reset,
+        },
+      }),
+    ]);
+
+    const popover = await openPopover(bars);
+    const identities = Array.from(popover.querySelectorAll<HTMLElement>(".ceiling-identity")).map((identity) =>
+      identity.textContent?.replace(/\s+/g, " ").trim(),
+    );
+    expect(identities).toEqual(["github.com: GitHub App installation 42", "github.com: @maintainer"]);
+    expect(popover.scrollWidth).toBeLessThanOrEqual(popover.clientWidth);
+  });
+
+  it("distinguishes provider capacity from a paused local background boundary", async () => {
+    const reset = new Date(Date.now() + 30 * 60_000).toISOString();
+    const bars = await mountStatusBar([
+      rateLimits(
+        {
+          "github.com": {
+            provider: "github",
+            rate_principal: "user:7",
+            principal_label: "GitHub user maintainer",
+            reserve_buffer: 200,
+            sync_throttle_factor: 1,
+            sync_paused: true,
+            rest: {
+              remaining: 3800,
+              limit: 5000,
+              reset_at: reset,
+              known: true,
+              requests: 1200,
+            },
+            graphql: {
+              remaining: 4800,
+              limit: 5000,
+              reset_at: reset,
+              known: true,
+              requests: 200,
+            },
+          },
+        },
+        {
+          "github:github.com:user:7": {
+            provider: "github",
+            platform_host: "github.com",
+            rate_principal: "user:7",
+            principal_label: "GitHub user maintainer",
+            limit: 3000,
+            background_limit: 2700,
+            spent: 2800,
+            remaining: 200,
+            reset_at: reset,
+          },
+        },
+      ),
+    ]);
+
+    const popover = await openPopover(bars);
+    expect(popover.textContent).not.toContain("sync paused");
+    expect(popover.textContent).toContain("background refresh paused");
+    expect(popover.textContent).toContain("200 discovery requests before app sync pauses");
+    expect(popover.textContent).not.toMatch(/\b(?:remaining|used|rem)\b/i);
+    expect(popover.textContent).not.toContain("GitHub user maintainer");
+    const identities = popover.querySelectorAll<HTMLElement>(".host-identity");
+    expect(identities).toHaveLength(1);
+    expect(identities[0]?.textContent?.replace(/\s+/g, " ").trim()).toBe("github.com: @maintainer");
+    const principal = popover.querySelector<HTMLElement>(".principal-label--user");
+    expect(principal?.textContent).toBe("@maintainer");
+    expect(getComputedStyle(principal!).fontFamily).toBe(
+      getComputedStyle(document.documentElement).getPropertyValue("--font-mono").trim(),
+    );
+    const secondaryTextProbe = document.createElement("span");
+    secondaryTextProbe.style.color = "var(--text-secondary)";
+    document.body.append(secondaryTextProbe);
+    expect(getComputedStyle(principal!).color).toBe(getComputedStyle(secondaryTextProbe).color);
+    secondaryTextProbe.remove();
+    expect(healthDot(popover, "github.com").style.background).toBe("var(--budget-green)");
+
+    const providerMeters = popover.querySelectorAll<HTMLElement>('.bar-track--provider[role="meter"]');
+    expect(providerMeters).toHaveLength(2);
+    expect(providerMeters[0]?.getAttribute("aria-label")).toContain("REST capacity remaining");
+    expect(providerMeters[0]?.getAttribute("aria-valuenow")).toBe("3800");
+    expect(providerMeters[0]?.getAttribute("aria-valuemax")).toBe("5000");
+    for (const meter of providerMeters) {
+      const fill = meter.querySelector<HTMLElement>(".bar-fill");
+      expect(fill).not.toBeNull();
+      expect(Math.abs(fill!.getBoundingClientRect().right - meter.getBoundingClientRect().right)).toBeLessThan(1);
+    }
+
+    const localMeter = popover.querySelector<HTMLElement>('.bar-track--local[role="meter"]');
+    expect(localMeter).not.toBeNull();
+    expect(localMeter?.getAttribute("aria-label")).toContain("Local requests used");
+    expect(localMeter?.getAttribute("aria-valuenow")).toBe("2800");
+    expect(localMeter?.getAttribute("aria-valuemax")).toBe("3000");
+    const localFill = localMeter!.querySelector<HTMLElement>(".bar-fill");
+    expect(localFill).not.toBeNull();
+    expect(Math.abs(localFill!.getBoundingClientRect().left - localMeter!.getBoundingClientRect().left)).toBeLessThan(
+      1,
+    );
+    const threshold = localMeter!.querySelector<HTMLElement>(".background-limit-marker");
+    expect(threshold).not.toBeNull();
+    const expectedThreshold =
+      localMeter!.getBoundingClientRect().left + localMeter!.getBoundingClientRect().width * 0.9;
+    expect(Math.abs(threshold!.getBoundingClientRect().left - expectedThreshold)).toBeLessThan(1);
+
+    expect(popover.scrollWidth).toBeLessThanOrEqual(popover.clientWidth);
   });
 
   it("budget bars keep eager refresh budget out of the compact status", async () => {
@@ -229,9 +364,9 @@ describe("budget display", () => {
     expect(units).toContain("req");
     expect(units).toContain("pts");
     expect(popover.textContent).toContain("Provider quota");
-    expect(popover.textContent).toContain("Local sync ceiling");
+    expect(popover.textContent).toContain("App sync limit");
     expect(popover.textContent).toContain("42 / 50k requests");
-    expect(popover.textContent).toContain("provider quota above is authoritative");
+    expect(popover.textContent).toContain("provider quota above is separate");
     expect(popover.querySelector(".budget-spent")?.textContent).toBe("42");
 
     const ceilingNote = popover.querySelector<HTMLElement>(".budget-row--ceiling .row-note");
@@ -240,12 +375,17 @@ describe("budget display", () => {
     expect(ceilingNote!.getBoundingClientRect().height).toBeGreaterThan(noteLineHeight * 1.5);
 
     const ceilingLabel = popover.querySelector<HTMLElement>(".budget-row--ceiling .row-label");
+    const ceilingMeter = popover.querySelector<HTMLElement>(".budget-row--ceiling .bar-track");
     const ceilingValue = popover.querySelector<HTMLElement>(".budget-row--ceiling .row-value");
     expect(ceilingLabel).not.toBeNull();
+    expect(ceilingMeter).not.toBeNull();
     expect(ceilingValue).not.toBeNull();
     expect(
       Math.abs(ceilingLabel!.getBoundingClientRect().top - ceilingValue!.getBoundingClientRect().top),
     ).toBeLessThan(2);
+    const meterRect = ceilingMeter!.getBoundingClientRect();
+    const valueRect = ceilingValue!.getBoundingClientRect();
+    expect(Math.abs(meterRect.top + meterRect.height / 2 - (valueRect.top + valueRect.height / 2))).toBeLessThan(1);
 
     // The bar runs with overflow="visible" so the popover's absolute
     // bottom-anchored panel can open fully above the 24px bar rather than
@@ -268,6 +408,7 @@ describe("budget display", () => {
             provider: "github",
             platform_host: "github.com",
             limit: 500,
+            background_limit: 450,
             spent: 500,
             remaining: 0,
           },
@@ -283,7 +424,10 @@ describe("budget display", () => {
     const spent = popover.querySelector<HTMLElement>(".budget-spent");
     expect(spent?.textContent).toBe("500");
     expect(spent?.style.color).toBe("var(--budget-red)");
-    expect(popover.textContent).toContain("Local sync ceiling");
+    expect(popover.textContent).toContain("App sync limit");
+    expect(popover.textContent).toContain("app sync paused");
+    expect(popover.textContent).toContain("discovery reserve exhausted");
+    expect(popover.textContent).not.toContain("background refresh paused");
   });
 
   it("identifies a local ceiling failure while provider quota remains healthy", async () => {
@@ -514,7 +658,7 @@ describe("budget display", () => {
 
     const popover = await openPopover(bars);
     expect(popover.textContent).toContain("Provider quota");
-    expect(popover.textContent).not.toContain("Local sync ceiling");
+    expect(popover.textContent).not.toContain("App sync limit");
   });
 
   it("stale host excluded from compact bars, fresh host drives ratio", async () => {
@@ -530,7 +674,9 @@ describe("budget display", () => {
     expect(bars.textContent).toContain("REST");
     expect(bars.textContent).toContain("GQL");
     // Bar fill should be present (driven by fresh host, not stale)
-    expect(bars.querySelector(".budget-fill")).not.toBeNull();
+    const restFill = bars.querySelector<HTMLElement>(".budget-fill");
+    expect(restFill).not.toBeNull();
+    expect(restFill?.style.background).toBe("var(--budget-green)");
 
     // Popover: stale host health dot should be muted
     const popover = await openPopover(bars);

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -2556,14 +2556,15 @@ type ListWorktreesOutputBody struct {
 
 // LocalSyncCeilingStatus defines model for LocalSyncCeilingStatus.
 type LocalSyncCeilingStatus struct {
-	Limit          int64  `json:"limit"`
-	PlatformHost   string `json:"platform_host"`
-	PrincipalLabel string `json:"principal_label"`
-	Provider       string `json:"provider"`
-	RatePrincipal  string `json:"rate_principal"`
-	Remaining      int64  `json:"remaining"`
-	ResetAt        string `json:"reset_at"`
-	Spent          int64  `json:"spent"`
+	BackgroundLimit int64  `json:"background_limit"`
+	Limit           int64  `json:"limit"`
+	PlatformHost    string `json:"platform_host"`
+	PrincipalLabel  string `json:"principal_label"`
+	Provider        string `json:"provider"`
+	RatePrincipal   string `json:"rate_principal"`
+	Remaining       int64  `json:"remaining"`
+	ResetAt         string `json:"reset_at"`
+	Spent           int64  `json:"spent"`
 }
 
 // MergePRBody defines model for MergePRBody.

--- a/internal/github/budget.go
+++ b/internal/github/budget.go
@@ -222,6 +222,16 @@ func (b *SyncBudget) Limit() int {
 	return b.limit
 }
 
+// BackgroundLimit returns the maximum total spend optional background work
+// may consume in the current local window. Capacity above this boundary stays
+// available to essential discovery.
+func (b *SyncBudget) BackgroundLimit() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.rollLocked()
+	return b.optionalLimitLocked()
+}
+
 // ResetAt returns the end of the budget's current local hourly window.
 func (b *SyncBudget) ResetAt() time.Time {
 	b.mu.Lock()

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -22063,8 +22063,11 @@ func TestAPIRateLimitsSeparatesCredentialPoolsFromLocalCeilings(t *testing.T) {
 		userIdentity, ghclient.QuotaResourceREST,
 		ghclient.Rate{Limit: 5000, Remaining: 4900, Reset: reset},
 	)
-	budget := ghclient.NewSyncBudget(50000)
-	budget.Spend(42)
+	budget := ghclient.NewSyncBudgetWithEssentialReserve(3001)
+	_, ok := budget.TrySpend(2701)
+	require.True(ok)
+	_, ok = budget.TrySpend(1)
+	require.False(ok, "optional work must stop at the background boundary")
 	expectedCeilingResetAt := budget.ResetAt().UTC().Format(time.RFC3339)
 	syncer := ghclient.NewSyncer(
 		map[string]ghclient.Client{"github.com": &mockGH{}},
@@ -22096,10 +22099,75 @@ func TestAPIRateLimitsSeparatesCredentialPoolsFromLocalCeilings(t *testing.T) {
 	assert.False(user.GraphQL.Known)
 	ceiling, ok := body.LocalCeilings["github.com"]
 	require.True(ok)
-	assert.Equal(50000, ceiling.Limit)
-	assert.Equal(42, ceiling.Spent)
-	assert.Equal(49958, ceiling.Remaining)
+	assert.Equal(3001, ceiling.Limit)
+	assert.Equal(2701, ceiling.BackgroundLimit)
+	assert.Equal(2701, ceiling.Spent)
+	assert.Equal(300, ceiling.Remaining)
 	assert.Equal(expectedCeilingResetAt, ceiling.ResetAt)
+}
+
+func TestAPIRateLimitsMarksExpiredProviderQuotaUnknown(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	identity := ghclient.IdentityKey{Host: "github.com", Principal: "user:7"}
+	registry := ghclient.NewQuotaRegistry()
+	registry.UpdateSnapshot(identity, ghclient.QuotaResourceREST, ghclient.Rate{
+		Limit: 5000, Remaining: 4800, Reset: time.Now().UTC().Add(-time.Second),
+	})
+	availability := registry.CheckReserve(
+		identity, []ghclient.QuotaResource{ghclient.QuotaResourceREST}, 1,
+		ghclient.RateReserveBuffer,
+	)
+	require.False(availability.Known)
+
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": &mockGH{}}, database, nil, nil,
+		time.Minute, nil, nil,
+	)
+	syncer.SetQuotaRegistry(registry)
+	t.Cleanup(syncer.Stop)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/rate-limits", nil)
+	New(database, syncer, nil, "/", nil, ServerOptions{}).ServeHTTP(recorder, request)
+	require.Equal(http.StatusOK, recorder.Code)
+
+	var response rateLimitsResponse
+	require.NoError(json.NewDecoder(recorder.Body).Decode(&response))
+	status, ok := response.ProviderPools["github:github.com:user:7"]
+	require.True(ok)
+	assert.False(status.REST.Known)
+	assert.Equal(4800, status.REST.Remaining)
+}
+
+func TestAPIRateLimitsRollsExpiredTrackerBeforeResponse(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	tracker := ghclient.NewRateTracker(database, "github.com", "host", "rest")
+	tracker.UpdateFromRate(ghclient.Rate{
+		Limit: 5000, Remaining: 3000, Reset: time.Now().UTC().Add(time.Hour),
+	})
+	tracker.SetResetAtForTesting(time.Now().UTC().Add(-time.Second))
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": &mockGH{}}, database, nil, nil,
+		time.Minute, map[string]*ghclient.RateTracker{"github.com": tracker}, nil,
+	)
+	t.Cleanup(syncer.Stop)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/rate-limits", nil)
+	New(database, syncer, nil, "/", nil, ServerOptions{}).ServeHTTP(recorder, request)
+	require.Equal(http.StatusOK, recorder.Code)
+
+	var response rateLimitsResponse
+	require.NoError(json.NewDecoder(recorder.Body).Decode(&response))
+	status, ok := response.ProviderPools["github.com"]
+	require.True(ok)
+	assert.False(status.REST.Known)
+	assert.Equal(-1, status.REST.Remaining)
+	assert.Empty(status.REST.ResetAt)
 }
 
 func TestAPISyncPRIncrementsRequestCount(t *testing.T) {

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -195,14 +195,15 @@ type rateLimitHostStatus struct {
 // principal. It is independent of provider quota: the ceiling can be reached
 // while GitHub still reports capacity, and it resets on its own clock.
 type localSyncCeilingStatus struct {
-	Provider       string `json:"provider"`
-	PlatformHost   string `json:"platform_host"`
-	RatePrincipal  string `json:"rate_principal"`
-	PrincipalLabel string `json:"principal_label"`
-	Limit          int    `json:"limit"`
-	Spent          int    `json:"spent"`
-	Remaining      int    `json:"remaining"`
-	ResetAt        string `json:"reset_at"`
+	Provider        string `json:"provider"`
+	PlatformHost    string `json:"platform_host"`
+	RatePrincipal   string `json:"rate_principal"`
+	PrincipalLabel  string `json:"principal_label"`
+	Limit           int    `json:"limit"`
+	BackgroundLimit int    `json:"background_limit"`
+	Spent           int    `json:"spent"`
+	Remaining       int    `json:"remaining"`
+	ResetAt         string `json:"reset_at"`
 }
 
 type rateLimitsResponse struct {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -896,9 +896,11 @@ func (s *Server) getRateLimits(
 		if rt == nil {
 			return rateLimitResourceStatus{Remaining: -1, Limit: -1}
 		}
+		requests := rt.RequestsThisHour()
+		remaining := rt.Remaining()
 		resource := rateLimitResourceStatus{
-			Remaining: rt.Remaining(), Limit: rt.RateLimit(),
-			Known: rt.Known(), Requests: rt.RequestsThisHour(),
+			Remaining: remaining, Limit: rt.RateLimit(),
+			Known: rt.Known() && remaining >= 0, Requests: requests,
 		}
 		if resetAt := rt.ResetAt(); resetAt != nil {
 			resource.ResetAt = formatUTCRFC3339(*resetAt)
@@ -925,6 +927,7 @@ func (s *Server) getRateLimits(
 	// per resource, including pools no local tracker observed yet, so it
 	// overrides the tracker-derived view wherever it holds a pool.
 	if quotaRegistry != nil {
+		now := time.Now().UTC()
 		for _, pool := range quotaRegistry.Snapshot() {
 			key := rateLimitStatusKeyFor(
 				string(platform.KindGitHub), pool.Identity.Host, pool.Identity.Principal,
@@ -943,7 +946,7 @@ func (s *Server) getRateLimits(
 			}
 			resource := rateLimitResourceStatus{
 				Remaining: pool.Remaining, Limit: pool.Limit,
-				Known: pool.Known, Requests: pool.Requests,
+				Known: pool.Known && pool.ResetAt.After(now), Requests: pool.Requests,
 			}
 			if !pool.ResetAt.IsZero() {
 				resource.ResetAt = formatUTCRFC3339(pool.ResetAt)
@@ -977,12 +980,13 @@ func (s *Server) getRateLimits(
 		}
 		ceilings[statusKey] = localSyncCeilingStatus{
 			Provider: providerName, PlatformHost: host,
-			RatePrincipal:  principal,
-			PrincipalLabel: labelFor(key, providerName, principal),
-			Limit:          budget.Limit(),
-			Spent:          budget.Spent(),
-			Remaining:      budget.Remaining(),
-			ResetAt:        formatUTCRFC3339(budget.ResetAt()),
+			RatePrincipal:   principal,
+			PrincipalLabel:  labelFor(key, providerName, principal),
+			Limit:           budget.Limit(),
+			BackgroundLimit: budget.BackgroundLimit(),
+			Spent:           budget.Spent(),
+			Remaining:       budget.Remaining(),
+			ResetAt:         formatUTCRFC3339(budget.ResetAt()),
 		}
 	}
 	return &rateLimitsOutput{


### PR DESCRIPTION
- Show provider quota as capacity left and the app sync limit as spend, with opposite meter direction and accessible descriptions.
- Separate provider throttling from the app's background-refresh boundary and preserve the discovery reserve.
- Treat expired registry and tracker quota windows as unknown at the API boundary so stale capacity cannot drive the UI.
- Show live discovery capacity after background refresh pauses, then identify the hard app-sync ceiling when that reserve is exhausted.
- Collapse credential identity to `host: @user`, keep the single-limit view compact, and label each app limit when multiple credentials exist.
- Fix compact-popover wrapping and meter/value alignment without introducing horizontal scrolling.
- Keep the existing notification route-reuse check inside the rolling activity window instead of pinning it to an expired calendar date.

### Screenshot

![Provider quota popover showing remaining provider quota and the app sync limit](https://github.com/user-attachments/assets/531db8b7-362c-432e-9e78-e5f6a7ca8f0f)
