### PR TITLE
fix: prevent hook tests from rewriting worktree configuration

### DIFF
--- a/context/testing.md
+++ b/context/testing.md
@@ -368,6 +368,9 @@ Disable Git auto-GC and auto-maintenance in synthetic repositories under
 Real-Git test packages use `gitsafe.RunIsolatedMain` in `TestMain`: one empty config per binary.
 Use `Runner` where code strips Git variables, and `MutableRunner` only for global config
 mutations (`internal/testutil/gitsafe/gitsafe.go::RunIsolatedMain`).
+Script tests that launch Git from repository hooks must strip Git's repository-local
+environment first; a nested `git init` can otherwise rewrite shared worktree config
+(`scripts/context-sync.test.mjs::isolatedGitEnv`).
 
 Real tmux and PTY tests can still run in parallel when each test owns its
 session names, temp dirs, sockets, and cleanup. If the bottleneck is external

--- a/scripts/context-sync.test.mjs
+++ b/scripts/context-sync.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile as execFileCallback } from "node:child_process";
-import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -9,12 +9,42 @@ import { test } from "node:test";
 
 const execFile = promisify(execFileCallback);
 const scriptPath = path.join(path.dirname(fileURLToPath(import.meta.url)), "context-sync");
+const gitRepositoryEnvVars = [
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_COMMON_DIR",
+  "GIT_CONFIG",
+  "GIT_CONFIG_COUNT",
+  "GIT_CONFIG_PARAMETERS",
+  "GIT_DIR",
+  "GIT_GRAFT_FILE",
+  "GIT_IMPLICIT_WORK_TREE",
+  "GIT_INDEX_FILE",
+  "GIT_NO_REPLACE_OBJECTS",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_PREFIX",
+  "GIT_REPLACE_REF_BASE",
+  "GIT_SHALLOW_FILE",
+  "GIT_WORK_TREE",
+];
 
-async function createContextRoot(t) {
+function isolatedGitEnv(env = process.env) {
+  const isolated = { ...env };
+  for (const name of gitRepositoryEnvVars) {
+    delete isolated[name];
+  }
+  for (const name of Object.keys(isolated)) {
+    if (/^GIT_CONFIG_(?:KEY|VALUE)_\d+$/.test(name)) {
+      delete isolated[name];
+    }
+  }
+  return isolated;
+}
+
+async function createContextRoot(t, env = process.env) {
   const root = await mkdtemp(path.join(os.tmpdir(), "kenn-forge-context-sync-test-"));
   t.after(() => rm(root, { recursive: true, force: true }));
 
-  await execFile("git", ["init", "--quiet", root]);
+  await execFile("git", ["init", "--quiet", root], { env: isolatedGitEnv(env) });
   await mkdir(path.join(root, "skills", "context-sync"), { recursive: true });
   await writeFile(path.join(root, "CLAUDE.md"), "# Agent instructions\n");
   await symlink("CLAUDE.md", path.join(root, "AGENTS.md"));
@@ -25,7 +55,10 @@ async function createContextRoot(t) {
 test("context sync accepts a valid routed context surface", async (t) => {
   const root = await createContextRoot(t);
 
-  const result = await execFile(scriptPath, ["--check"], { cwd: root });
+  const result = await execFile(scriptPath, ["--check"], {
+    cwd: root,
+    env: isolatedGitEnv(),
+  });
 
   assert.match(result.stdout, /structural check passed/);
 });
@@ -36,9 +69,35 @@ test("context sync rejects reintroduced Superpowers documents", async (t) => {
   await mkdir(specs, { recursive: true });
   await writeFile(path.join(specs, "completed-design.md"), "# Completed design\n");
 
-  await assert.rejects(execFile(scriptPath, ["--check"], { cwd: root }), (error) => {
-    assert.match(error.stderr, /docs\/superpowers must remain absent/);
-    assert.match(error.stderr, /structural check failed/);
-    return true;
+  await assert.rejects(
+    execFile(scriptPath, ["--check"], { cwd: root, env: isolatedGitEnv() }),
+    (error) => {
+      assert.match(error.stderr, /docs\/superpowers must remain absent/);
+      assert.match(error.stderr, /structural check failed/);
+      return true;
+    },
+  );
+});
+
+test("context sync fixtures ignore inherited hook repository bindings", async (t) => {
+  const hostRoot = await mkdtemp(path.join(os.tmpdir(), "kenn-forge-hook-host-test-"));
+  t.after(() => rm(hostRoot, { recursive: true, force: true }));
+  await execFile("git", ["init", "--quiet", hostRoot], { env: isolatedGitEnv() });
+
+  const hostConfigPath = path.join(hostRoot, ".git", "config");
+  const originalHostConfig = await readFile(hostConfigPath, "utf8");
+  const hookEnv = {
+    ...process.env,
+    GIT_DIR: path.join(hostRoot, ".git"),
+    GIT_WORK_TREE: hostRoot,
+  };
+
+  const root = await createContextRoot(t, hookEnv);
+  const result = await execFile(scriptPath, ["--check"], {
+    cwd: root,
+    env: isolatedGitEnv(hookEnv),
   });
+
+  assert.match(result.stdout, /structural check passed/);
+  assert.equal(await readFile(hostConfigPath, "utf8"), originalHostConfig);
 });


### PR DESCRIPTION
Repository hooks export bindings for the active Git repository. The context-sync fixture passed those bindings to a nested `git init`, which could rewrite shared worktree configuration and make one checkout appear polluted by another.

This isolates synthetic Git subprocesses from repository-local Git state. A regression binds the test to a disposable host repository and verifies that its config remains unchanged.

<details>
<summary>Validation</summary>

- Script regression suite passed: 45 Node tests and 22 Python tests.
- Non-mutating lint passed with zero issues.
- Commit and push hooks passed.

</details>