### PR TITLE
fix: support Windows clipboard in remote HTTP terminals

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -263,9 +263,13 @@ Keyboard handlers must have one clear owner for each key press.
 - xterm must advertise the Kitty keyboard protocol so terminal applications can
   negotiate detailed key reports instead of misreading legacy cursor input
   (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::start`).
-- Browser paste shortcuts remain browser-owned inside xterm; Forge consumes each
-  non-empty paste event once at the terminal container
+- Browser paste shortcuts remain browser-owned inside xterm (Ctrl+V on Windows
+  and Linux, Cmd+V on macOS); macOS Ctrl+V remains terminal input. Forge
+  consumes each non-empty paste event once at the terminal container
   (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::isBrowserPasteShortcut`).
+- Forge-owned paste matches xterm: LF and CRLF become one carriage return
+  before sanitizing and framing; a standalone carriage return stays unchanged
+  (`frontend/src/lib/components/terminal/bracketedPaste.ts::sanitizeTerminalPasteText`).
 - Plain-HTTP remote terminals keep copy usable through a gesture-authorized copy-event fallback
   (`frontend/src/lib/components/terminal/terminalClipboardWriter.ts::writeTextThroughCopyEvent`).
 - On insecure origins right-button mouse events stay out of tmux so the browser context menu remains usable

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -270,8 +270,9 @@ Keyboard handlers must have one clear owner for each key press.
 - Forge-owned paste matches xterm: LF and CRLF become one carriage return
   before sanitizing and framing; a standalone carriage return stays unchanged
   (`frontend/src/lib/components/terminal/bracketedPaste.ts::sanitizeTerminalPasteText`).
-- Plain-HTTP remote terminals keep copy usable through a gesture-authorized copy-event fallback
-  (`frontend/src/lib/components/terminal/terminalClipboardWriter.ts::writeTextThroughCopyEvent`).
+- Plain-HTTP remote terminals keep copy usable through a gesture-authorized copy-event fallback, but
+  revocation must be rechecked between async clipboard stages so a rejected stale write cannot reach
+  copy-event or server fallback (`frontend/src/lib/components/terminal/terminalClipboardWriter.ts`).
 - On insecure origins right-button mouse events stay out of tmux so the browser context menu remains usable
   (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::handleInsecureTerminalRightMouse`).
 - Modal frames outrank page-level shortcuts. When a modal, drawer, popover, or

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -263,6 +263,13 @@ Keyboard handlers must have one clear owner for each key press.
 - xterm must advertise the Kitty keyboard protocol so terminal applications can
   negotiate detailed key reports instead of misreading legacy cursor input
   (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::start`).
+- Browser paste shortcuts remain browser-owned inside xterm; Forge consumes each
+  non-empty paste event once at the terminal container
+  (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::isBrowserPasteShortcut`).
+- Plain-HTTP remote terminals keep copy usable through a gesture-authorized copy-event fallback
+  (`frontend/src/lib/components/terminal/terminalClipboardWriter.ts::writeTextThroughCopyEvent`).
+- On insecure origins right-button mouse events stay out of tmux so the browser context menu remains usable
+  (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::handleInsecureTerminalRightMouse`).
 - Modal frames outrank page-level shortcuts. When a modal, drawer, popover, or
   command surface is active, route and list navigation should run only through
   actions explicitly registered for that active surface.

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -166,6 +166,10 @@ stale tabs.
   (`frontend/src/lib/components/terminal/workspace-runtime-workflow.ts::storeAndPresentMutation`).
 - Workspace terminals use xterm.js exclusively; there is no renderer setting
   or alternate renderer path (`frontend/src/lib/components/terminal/TerminalPane.svelte`).
+- Own every non-empty browser text paste at the terminal container boundary,
+  sanitize and send it once, and do not delegate single-line paste to xterm;
+  this event path must remain usable on insecure HTTP origins without the async
+  Clipboard API (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::handleTerminalPaste`).
 - Treat terminal processes as native-terminal-equivalent, but accept bounded, write-only OSC 52 writes only after one
   recent one-shot trusted DOM gesture; terminal data callbacks are not input provenance, and browser denial falls back
   through CSRF-protected loopback (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::handleTerminalKeyDown`).

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -20,6 +20,7 @@ const {
   webLinksAddonCtor,
   xtermFitAddons,
   xtermInstances,
+  xtermCustomKeyEventHandlers,
   xtermOnDataHandlers,
   xtermOscHandlers,
   xtermTerminalCtor,
@@ -55,6 +56,7 @@ const {
     rows: number;
     write: ReturnType<typeof vi.fn>;
   }>,
+  xtermCustomKeyEventHandlers: [] as Array<(event: KeyboardEvent) => boolean>,
   xtermOnDataHandlers: [] as Array<(data: string) => void>,
   xtermOscHandlers: new Map<number, (data: string) => boolean | Promise<boolean>>(),
   xtermTerminalCtor: vi.fn(),
@@ -76,6 +78,7 @@ let initialTerminalDimensions = { cols: 80, rows: 24 };
 let fitDimensions: { cols: number; rows: number } | undefined = { cols: 80, rows: 24 };
 const originalDocumentFonts = Object.getOwnPropertyDescriptor(document, "fonts");
 const originalNavigatorClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+const originalIsSecureContext = Object.getOwnPropertyDescriptor(window, "isSecureContext");
 
 function deferred<T>(): {
   promise: Promise<T>;
@@ -203,6 +206,9 @@ vi.mock("@xterm/xterm", () => ({
       },
       options: { ...options },
       clearTextureAtlas: vi.fn(),
+      attachCustomKeyEventHandler: vi.fn((handler: (event: KeyboardEvent) => boolean) => {
+        xtermCustomKeyEventHandlers.push(handler);
+      }),
       dispose: vi.fn(),
       focus: vi.fn(),
       loadAddon: vi.fn(),
@@ -314,6 +320,7 @@ describe("TerminalPane", () => {
     webLinksAddonCtor.mockReset();
     xtermFitAddons.length = 0;
     xtermInstances.length = 0;
+    xtermCustomKeyEventHandlers.length = 0;
     xtermTerminalCtor.mockReset();
     xtermOpen.mockReset();
     xtermOnDataHandlers.length = 0;
@@ -360,12 +367,52 @@ describe("TerminalPane", () => {
     } else {
       Reflect.deleteProperty(navigator, "clipboard");
     }
+    if (originalIsSecureContext) {
+      Object.defineProperty(window, "isSecureContext", originalIsSecureContext);
+    } else {
+      Reflect.deleteProperty(window, "isSecureContext");
+    }
   });
 
   it("uses xterm.js", async () => {
     render(TerminalPane, { props: { workspaceId: "ws-123" } });
 
     await waitFor(() => expect(xtermTerminalCtor).toHaveBeenCalled());
+  });
+
+  it("leaves browser paste shortcuts to Chrome instead of sending control characters", async () => {
+    render(TerminalPane, { props: { workspaceId: "ws-123" } });
+    await waitFor(() => expect(xtermCustomKeyEventHandlers).toHaveLength(1));
+    const handler = xtermCustomKeyEventHandlers[0]!;
+
+    expect(handler(new KeyboardEvent("keydown", { key: "v", ctrlKey: true }))).toBe(false);
+    expect(handler(new KeyboardEvent("keydown", { key: "V", ctrlKey: true, shiftKey: true }))).toBe(false);
+    expect(handler(new KeyboardEvent("keydown", { key: "c", ctrlKey: true }))).toBe(true);
+  });
+
+  it("keeps insecure-origin right clicks out of tmux without blocking Chrome's context menu", async () => {
+    Object.defineProperty(window, "isSecureContext", { configurable: true, value: false });
+    const { container } = render(TerminalPane, { props: { workspaceId: "ws-123" } });
+    await waitFor(() => expect(xtermTerminalCtor).toHaveBeenCalled());
+    const terminalContainer = container.querySelector<HTMLElement>(".terminal-container")!;
+    const xtermChild = document.createElement("div");
+    terminalContainer.append(xtermChild);
+    const mouseDown = vi.fn();
+    const mouseUp = vi.fn();
+    xtermChild.addEventListener("mousedown", mouseDown);
+    xtermChild.addEventListener("mouseup", mouseUp);
+
+    const downAllowed = xtermChild.dispatchEvent(
+      new MouseEvent("mousedown", { bubbles: true, cancelable: true, button: 2 }),
+    );
+    const upAllowed = xtermChild.dispatchEvent(
+      new MouseEvent("mouseup", { bubbles: true, cancelable: true, button: 2 }),
+    );
+
+    expect(mouseDown).not.toHaveBeenCalled();
+    expect(mouseUp).not.toHaveBeenCalled();
+    expect(downAllowed).toBe(true);
+    expect(upAllowed).toBe(true);
   });
 
   it("uses the same safe opener for detected URLs and OSC 8 links", async () => {
@@ -1393,7 +1440,7 @@ describe("TerminalPane", () => {
     );
   });
 
-  it("leaves single-line browser paste for xterm.js default handling", async () => {
+  it("sends single-line browser paste through the terminal session once", async () => {
     const { container } = render(TerminalPane, {
       props: { workspaceId: "ws-123" },
     });
@@ -1412,15 +1459,22 @@ describe("TerminalPane", () => {
     }) as ClipboardEvent;
     Object.defineProperty(event, "clipboardData", {
       value: {
-        getData: vi.fn((type: string) => (type === "text/plain" ? "single line" : "")),
+        getData: vi.fn((type: string) => (type === "text/plain" ? "single\x1b[201~ line" : "")),
       },
     });
 
     const defaultAllowed = terminalContainer!.dispatchEvent(event);
 
-    expect(defaultAllowed).toBe(true);
-    expect(laterPasteListener).toHaveBeenCalledTimes(1);
-    expect(mockSockets[0]!.sent).toHaveLength(0);
+    expect(defaultAllowed).toBe(false);
+    expect(laterPasteListener).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(mockSockets[0]!.sent.map((_, index) => sentText(mockSockets[0]!, index))).toContain("single[201~ line"),
+    );
+    expect(
+      mockSockets[0]!.sent
+        .map((_, index) => sentText(mockSockets[0]!, index))
+        .filter((text) => text === "single[201~ line"),
+    ).toHaveLength(1);
   });
 });
 

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -380,14 +380,28 @@ describe("TerminalPane", () => {
     await waitFor(() => expect(xtermTerminalCtor).toHaveBeenCalled());
   });
 
-  it("leaves browser paste shortcuts to Chrome instead of sending control characters", async () => {
+  it("leaves Ctrl+V browser-owned on Windows and Linux", async () => {
+    vi.spyOn(navigator, "platform", "get").mockReturnValue("Win32");
     render(TerminalPane, { props: { workspaceId: "ws-123" } });
     await waitFor(() => expect(xtermCustomKeyEventHandlers).toHaveLength(1));
     const handler = xtermCustomKeyEventHandlers[0]!;
 
     expect(handler(new KeyboardEvent("keydown", { key: "v", ctrlKey: true }))).toBe(false);
     expect(handler(new KeyboardEvent("keydown", { key: "V", ctrlKey: true, shiftKey: true }))).toBe(false);
+    expect(handler(new KeyboardEvent("keydown", { key: "v", metaKey: true }))).toBe(true);
     expect(handler(new KeyboardEvent("keydown", { key: "c", ctrlKey: true }))).toBe(true);
+  });
+
+  it("leaves Cmd+V browser-owned on macOS without consuming Ctrl+V", async () => {
+    vi.spyOn(navigator, "platform", "get").mockReturnValue("MacIntel");
+    render(TerminalPane, { props: { workspaceId: "ws-123" } });
+    await waitFor(() => expect(xtermCustomKeyEventHandlers).toHaveLength(1));
+    const handler = xtermCustomKeyEventHandlers[0]!;
+
+    expect(handler(new KeyboardEvent("keydown", { key: "v", metaKey: true }))).toBe(false);
+    expect(handler(new KeyboardEvent("keydown", { key: "V", metaKey: true, shiftKey: true }))).toBe(false);
+    expect(handler(new KeyboardEvent("keydown", { key: "v", ctrlKey: true }))).toBe(true);
+    expect(handler(new KeyboardEvent("keydown", { key: "V", ctrlKey: true, shiftKey: true }))).toBe(true);
   });
 
   it("keeps insecure-origin right clicks out of tmux without blocking Chrome's context menu", async () => {
@@ -1394,7 +1408,7 @@ describe("TerminalPane", () => {
     }) as ClipboardEvent;
     Object.defineProperty(event, "clipboardData", {
       value: {
-        getData: vi.fn((type: string) => (type === "text/plain" ? "first\x1b[201~\nsecond\nthird" : "")),
+        getData: vi.fn((type: string) => (type === "text/plain" ? "first\x1b[201~\r\nsecond\r\nthird" : "")),
       },
     });
 
@@ -1404,7 +1418,7 @@ describe("TerminalPane", () => {
     expect(laterPasteListener).not.toHaveBeenCalled();
     await waitFor(() =>
       expect(mockSockets[0]!.sent.map((_, index) => sentText(mockSockets[0]!, index))).toContain(
-        "\x1b[200~first[201~\nsecond\nthird\x1b[201~",
+        "\x1b[200~first[201~\rsecond\rthird\x1b[201~",
       ),
     );
   });
@@ -1426,7 +1440,7 @@ describe("TerminalPane", () => {
     }) as ClipboardEvent;
     Object.defineProperty(event, "clipboardData", {
       value: {
-        getData: vi.fn((type: string) => (type === "text/plain" ? "first\nsecond\nthird" : "")),
+        getData: vi.fn((type: string) => (type === "text/plain" ? "first\r\nsecond\r\nthird" : "")),
       },
     });
 
@@ -1435,7 +1449,7 @@ describe("TerminalPane", () => {
     expect(defaultAllowed).toBe(false);
     await waitFor(() =>
       expect(mockSockets[0]!.sent.map((_, index) => sentText(mockSockets[0]!, index))).toContain(
-        "first\nsecond\nthird",
+        "first\rsecond\rthird",
       ),
     );
   });

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -74,6 +74,7 @@ vi.mock("@xterm/xterm", () => ({
       buffer: { active: { baseY: 0, type: "normal" as const } },
       cols: 80,
       rows: 24,
+      attachCustomKeyEventHandler: vi.fn(),
       clearTextureAtlas: vi.fn(),
       dispose: mocks.mockDispose,
       focus: vi.fn(),

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalViewEmbed.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalViewEmbed.test.ts
@@ -66,6 +66,7 @@ vi.mock("@xterm/xterm", () => ({
     return {
       cols: 80,
       rows: 24,
+      attachCustomKeyEventHandler: vi.fn(),
       open: vi.fn(),
       focus: vi.fn(),
       loadAddon: vi.fn(),

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -15,10 +15,7 @@
   import { workspaceTmuxWebSocketPath } from "../../api/workspace-runtime.js";
   import { createWorkspaceSwitchPaneTimer } from "../../instrumentation/workspaceSwitchTiming.js";
   import { traceHeadersForRequest } from "../../instrumentation/traceContext.js";
-  import {
-    createTerminalPastePayload,
-    isMultilinePaste,
-  } from "./bracketedPaste.js";
+  import { createTerminalPastePayload } from "./bracketedPaste.js";
   import { embeddedWebSocketUrl } from "./embeddedWebSocket.js";
   import { parseOsc52ClipboardWrite } from "./osc52Clipboard.js";
   import {
@@ -307,6 +304,15 @@
   function handleTerminalKeyDown(event: KeyboardEvent): void {
     if (disposed || disabled || event.isComposing || !event.isTrusted) return;
     clipboardWriter?.authorizeKeyboardGesture();
+  }
+
+  function isBrowserPasteShortcut(event: KeyboardEvent): boolean {
+    return !event.altKey && (event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "v";
+  }
+
+  function handleInsecureTerminalRightMouse(event: MouseEvent): void {
+    if (window.isSecureContext || event.button !== 2) return;
+    event.stopPropagation();
   }
 
   function handleTerminalWheel(event: WheelEvent): void {
@@ -655,7 +661,7 @@
       event.clipboardData?.getData("text/plain") ||
       event.clipboardData?.getData("text") ||
       "";
-    if (!isMultilinePaste(pastedText)) return;
+    if (pastedText === "") return;
 
     event.preventDefault();
     event.stopImmediatePropagation();
@@ -924,6 +930,7 @@
         registerTerminalTextureAtlasParticipant(terminal);
 
       term.open(containerEl);
+      term.attachCustomKeyEventHandler((event) => !isBrowserPasteShortcut(event));
       term.parser.registerOscHandler(52, handleOsc52Clipboard);
       switchTimer.record("terminal-constructed");
       containerEl.addEventListener("paste", handleTerminalPaste, true);
@@ -1076,6 +1083,8 @@
   onpointerdowncapture={handleTerminalPointerDown}
   onlostpointercapture={handleTerminalLostPointerCapture}
   onkeydowncapture={handleTerminalKeyDown}
+  onmousedowncapture={handleInsecureTerminalRightMouse}
+  onmouseupcapture={handleInsecureTerminalRightMouse}
   onwheel={handleTerminalWheel}
   onfocusout={handleTerminalFocusOut}
 >

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -307,7 +307,8 @@
   }
 
   function isBrowserPasteShortcut(event: KeyboardEvent): boolean {
-    return !event.altKey && (event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "v";
+    const pasteModifierPressed = terminalLinkUsesMetaKey ? event.metaKey : event.ctrlKey;
+    return !event.altKey && pasteModifierPressed && event.key.toLowerCase() === "v";
   }
 
   function handleInsecureTerminalRightMouse(event: MouseEvent): void {

--- a/frontend/src/lib/components/terminal/bracketedPaste.test.ts
+++ b/frontend/src/lib/components/terminal/bracketedPaste.test.ts
@@ -14,21 +14,21 @@ describe("bracketed paste payloads", () => {
     expect(isMultilinePaste("one\rtwo")).toBe(true);
   });
 
-  it("wraps pasted text without normalizing literal newlines", () => {
-    expect(createBracketedPastePayload("one\r\ntwo\nthree")).toBe("\x1b[200~one\r\ntwo\nthree\x1b[201~");
+  it("normalizes Windows and Unix line endings like xterm", () => {
+    expect(createBracketedPastePayload("one\r\ntwo\nthree\rfour")).toBe("\x1b[200~one\rtwo\rthree\rfour\x1b[201~");
   });
 
-  it("strips terminal control bytes while preserving tabs and newlines", () => {
+  it("strips terminal control bytes while preserving tabs and normalized line endings", () => {
     expect(sanitizeTerminalPasteText("one\t\n\x1b[201~\nmalicious-command\r\n\x9b200~\x07two")).toBe(
-      "one\t\n[201~\nmalicious-command\r\n200~two",
+      "one\t\r[201~\rmalicious-command\r200~two",
     );
   });
 
   it("sanitizes pasted text before building bracketed paste payloads", () => {
-    expect(createBracketedPastePayload("one\x1b[201~\ntwo")).toBe("\x1b[200~one[201~\ntwo\x1b[201~");
+    expect(createBracketedPastePayload("one\x1b[201~\ntwo")).toBe("\x1b[200~one[201~\rtwo\x1b[201~");
   });
 
   it("builds raw sanitized payloads when bracketed paste mode is disabled", () => {
-    expect(createTerminalPastePayload("one\x1b[201~\ntwo", false)).toBe("one[201~\ntwo");
+    expect(createTerminalPastePayload("one\x1b[201~\ntwo", false)).toBe("one[201~\rtwo");
   });
 });

--- a/frontend/src/lib/components/terminal/bracketedPaste.ts
+++ b/frontend/src/lib/components/terminal/bracketedPaste.ts
@@ -17,7 +17,7 @@ export function createTerminalPastePayload(text: string, bracketedPasteMode: boo
 
 export function sanitizeTerminalPasteText(text: string): string {
   let sanitizedText = "";
-  for (const character of text) {
+  for (const character of text.replace(/\r?\n/g, "\r")) {
     const codePoint = character.codePointAt(0);
     if (codePoint === undefined || isUnsafeTerminalControlByte(codePoint)) {
       continue;

--- a/frontend/src/lib/components/terminal/terminalClipboardWriter.test.ts
+++ b/frontend/src/lib/components/terminal/terminalClipboardWriter.test.ts
@@ -38,14 +38,17 @@ function deferred<T>(): {
 function createPort(): {
   port: TerminalClipboardPort;
   deferredWrites: Array<Promise<string>>;
+  writeCopyEventText: ReturnType<typeof vi.fn>;
   writeLocalText: ReturnType<typeof vi.fn>;
   writeText: ReturnType<typeof vi.fn>;
 } {
   const deferredWrites: Array<Promise<string>> = [];
+  const writeCopyEventText = vi.fn(() => false);
   const writeLocalText = vi.fn(async () => undefined);
   const writeText = vi.fn(async () => undefined);
   return {
     deferredWrites,
+    writeCopyEventText,
     writeLocalText,
     writeText,
     port: {
@@ -53,6 +56,7 @@ function createPort(): {
         deferredWrites.push(text);
         return text.then(() => undefined);
       },
+      writeCopyEventText,
       writeLocalText,
       writeText,
     },
@@ -83,8 +87,10 @@ describe("browser terminal clipboard port", () => {
       return true;
     });
     Object.defineProperty(document, "execCommand", { configurable: true, value: execCommand });
+    const writer = await makeTestWriter(createBrowserTerminalClipboardPort());
 
-    await expect(createBrowserTerminalClipboardPort().writeText("remote selection")).resolves.toBeUndefined();
+    writer.authorizeKeyboardGesture();
+    await expect(writer.write("remote selection")).resolves.toBe("written");
 
     expect(execCommand).toHaveBeenCalledTimes(1);
     expect(setData).toHaveBeenCalledWith("text/plain", "remote selection");
@@ -231,6 +237,7 @@ describe("terminal clipboard writer", () => {
         deferredWrites.push(text);
         return deferredWrites.length === 1 ? firstWrite.promise : text.then(() => undefined);
       },
+      writeCopyEventText: vi.fn(() => false),
       writeLocalText: vi.fn(async () => undefined),
       writeText: vi.fn(async () => undefined),
     });
@@ -311,6 +318,7 @@ describe("terminal clipboard writer", () => {
         void text.catch(() => undefined);
         return pending.promise;
       },
+      writeCopyEventText: vi.fn(() => false),
       writeLocalText: vi.fn(async () => undefined),
       writeText,
     };
@@ -334,6 +342,7 @@ describe("terminal clipboard writer", () => {
         deferredWrites.push(text);
         return deferredWrite.promise;
       },
+      writeCopyEventText: vi.fn(() => false),
       writeLocalText,
       writeText,
     });
@@ -357,6 +366,7 @@ describe("terminal clipboard writer", () => {
       beginDeferredWrite() {
         throw new DOMException("unsupported", "NotSupportedError");
       },
+      writeCopyEventText: vi.fn(() => false),
       writeLocalText,
       writeText,
     });
@@ -371,12 +381,44 @@ describe("terminal clipboard writer", () => {
     expect(writeLocalText).not.toHaveBeenCalled();
   });
 
+  it("does not invoke the copy-event fallback after focus loss during a Clipboard API write", async () => {
+    const directWrite = deferred<void>();
+    const writeText = vi.fn(() => directWrite.promise);
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        write: vi.fn(async () => {
+          throw new DOMException("denied", "NotAllowedError");
+        }),
+        writeText,
+      },
+    });
+    vi.stubGlobal(
+      "ClipboardItem",
+      class {
+        constructor(_items: Record<string, Promise<Blob>>) {}
+      },
+    );
+    const execCommand = vi.fn(() => false);
+    Object.defineProperty(document, "execCommand", { configurable: true, value: execCommand });
+    const writer = await makeTestWriter(createBrowserTerminalClipboardPort());
+
+    writer.authorizeKeyboardGesture();
+    const copied = writer.write("stale terminal write");
+    await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith("stale terminal write"));
+    writer.cancelAuthorization();
+    directWrite.reject(new DOMException("denied", "NotAllowedError"));
+
+    await expect(copied).resolves.toBe("unauthorized");
+    expect(execCommand).not.toHaveBeenCalled();
+  });
+
   it("falls back to writeText when deferred clipboard setup is unavailable", async () => {
     const writeText = vi.fn(async () => undefined);
     const writer = await makeTestWriter({
       beginDeferredWrite() {
         throw new DOMException("unsupported", "NotSupportedError");
       },
+      writeCopyEventText: vi.fn(() => false),
       writeLocalText: vi.fn(async () => undefined),
       writeText,
     });
@@ -394,6 +436,7 @@ describe("terminal clipboard writer", () => {
       beginDeferredWrite() {
         throw new DOMException("unsupported", "NotSupportedError");
       },
+      writeCopyEventText: vi.fn(() => false),
       writeLocalText,
       writeText: vi.fn(async () => {
         throw new DOMException("denied", "NotAllowedError");
@@ -413,6 +456,7 @@ describe("terminal clipboard writer", () => {
         void text.catch(() => undefined);
         return deferredWrite.promise;
       },
+      writeCopyEventText: vi.fn(() => false),
       writeLocalText: vi.fn(async () => {
         throw new Error("local clipboard unavailable");
       }),

--- a/frontend/src/lib/components/terminal/terminalClipboardWriter.test.ts
+++ b/frontend/src/lib/components/terminal/terminalClipboardWriter.test.ts
@@ -10,6 +10,7 @@ import {
 } from "./terminalClipboardWriter";
 
 const writerScopes: Scope.CloseableScope[] = [];
+const originalExecCommand = Object.getOwnPropertyDescriptor(document, "execCommand");
 
 async function makeTestWriter(
   port: TerminalClipboardPort,
@@ -62,9 +63,33 @@ afterEach(async () => {
   await Promise.all(writerScopes.splice(0).map((scope) => Effect.runPromise(Scope.close(scope, Exit.void))));
   vi.useRealTimers();
   vi.unstubAllGlobals();
+  if (originalExecCommand) {
+    Object.defineProperty(document, "execCommand", originalExecCommand);
+  } else {
+    Reflect.deleteProperty(document, "execCommand");
+  }
 });
 
 describe("browser terminal clipboard port", () => {
+  it("writes through a copy event when the Clipboard API is unavailable", async () => {
+    vi.stubGlobal("navigator", {});
+    const setData = vi.fn();
+    const execCommand = vi.fn((command: string) => {
+      expect(command).toBe("copy");
+      const event = new Event("copy", { bubbles: true, cancelable: true }) as ClipboardEvent;
+      Object.defineProperty(event, "clipboardData", { value: { setData } });
+      const defaultAllowed = document.dispatchEvent(event);
+      expect(defaultAllowed).toBe(false);
+      return true;
+    });
+    Object.defineProperty(document, "execCommand", { configurable: true, value: execCommand });
+
+    await expect(createBrowserTerminalClipboardPort().writeText("remote selection")).resolves.toBeUndefined();
+
+    expect(execCommand).toHaveBeenCalledTimes(1);
+    expect(setData).toHaveBeenCalledWith("text/plain", "remote selection");
+  });
+
   it("handles an expired deferred payload without leaking an unhandled rejection", async () => {
     const payload = deferred<string>();
     const write = vi.fn(async () => undefined);

--- a/frontend/src/lib/components/terminal/terminalClipboardWriter.ts
+++ b/frontend/src/lib/components/terminal/terminalClipboardWriter.ts
@@ -38,6 +38,27 @@ interface PendingClipboardWrite {
   source: "keyboard" | "pointer-confirmed" | "pointer-prepared";
 }
 
+function writeTextThroughCopyEvent(text: string): boolean {
+  if (typeof document.execCommand !== "function") return false;
+
+  let handled = false;
+  const handleCopy = (event: ClipboardEvent): void => {
+    if (!event.clipboardData) return;
+    // kit-ui-check-ignore: gesture-authorized OSC 52 fallback for insecure HTTP origins.
+    event.clipboardData.setData("text/plain", text);
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    handled = true;
+  };
+  document.addEventListener("copy", handleCopy, true);
+  try {
+    // kit-ui-check-ignore: gesture-authorized OSC 52 fallback for insecure HTTP origins.
+    return document.execCommand("copy") && handled;
+  } finally {
+    document.removeEventListener("copy", handleCopy, true);
+  }
+}
+
 export function createBrowserTerminalClipboardPort(): TerminalClipboardPort {
   return {
     beginDeferredWrite(text) {
@@ -54,12 +75,18 @@ export function createBrowserTerminalClipboardPort(): TerminalClipboardPort {
     writeLocalText(text) {
       return writeTerminalClipboardThroughServer(text);
     },
-    writeText(text) {
-      if (!navigator.clipboard?.writeText) {
-        return Promise.reject(new DOMException("Clipboard writes are unavailable", "NotSupportedError"));
+    async writeText(text) {
+      if (navigator.clipboard?.writeText) {
+        try {
+          // kit-ui-check-ignore: gesture-authorized OSC 52 browser clipboard write.
+          await navigator.clipboard.writeText(text);
+          return;
+        } catch {
+          // A trusted copy event remains available on insecure HTTP origins.
+        }
       }
-      // kit-ui-check-ignore: OSC 52 is Clipboard API-only; do not fall back to legacy DOM copy.
-      return navigator.clipboard.writeText(text);
+      if (writeTextThroughCopyEvent(text)) return;
+      throw new DOMException("Clipboard writes are unavailable", "NotSupportedError");
     },
   };
 }

--- a/frontend/src/lib/components/terminal/terminalClipboardWriter.ts
+++ b/frontend/src/lib/components/terminal/terminalClipboardWriter.ts
@@ -9,6 +9,7 @@ const POINTER_RELEASE_GRACE_MS = 1_000;
 
 export interface TerminalClipboardPort {
   beginDeferredWrite(text: Promise<string>): Promise<void>;
+  writeCopyEventText(text: string): boolean;
   writeLocalText(text: string): Promise<void>;
   writeText(text: string): Promise<void>;
 }
@@ -75,18 +76,15 @@ export function createBrowserTerminalClipboardPort(): TerminalClipboardPort {
     writeLocalText(text) {
       return writeTerminalClipboardThroughServer(text);
     },
-    async writeText(text) {
-      if (navigator.clipboard?.writeText) {
-        try {
-          // kit-ui-check-ignore: gesture-authorized OSC 52 browser clipboard write.
-          await navigator.clipboard.writeText(text);
-          return;
-        } catch {
-          // A trusted copy event remains available on insecure HTTP origins.
-        }
+    writeCopyEventText(text) {
+      return writeTextThroughCopyEvent(text);
+    },
+    writeText(text) {
+      if (!navigator.clipboard?.writeText) {
+        return Promise.reject(new DOMException("Clipboard writes are unavailable", "NotSupportedError"));
       }
-      if (writeTextThroughCopyEvent(text)) return;
-      throw new DOMException("Clipboard writes are unavailable", "NotSupportedError");
+      // kit-ui-check-ignore: gesture-authorized OSC 52 browser clipboard write.
+      return navigator.clipboard.writeText(text);
     },
   };
 }
@@ -300,6 +298,14 @@ export function makeTerminalClipboardWriter(
             const directWritten = yield* writeDirect(text);
             if (disposed || writeGeneration !== revocationGeneration) return "unauthorized";
             if (directWritten) return "written";
+            let copyEventWritten = false;
+            try {
+              copyEventWritten = port.writeCopyEventText(text);
+            } catch {
+              // Continue to the local fallback when the browser rejects legacy copy.
+            }
+            if (disposed || writeGeneration !== revocationGeneration) return "unauthorized";
+            if (copyEventWritten) return "written";
             const localWritten = yield* writeLocal(text);
             if (disposed || writeGeneration !== revocationGeneration) return "unauthorized";
             return localWritten ? "written" : "blocked";

--- a/frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts
+++ b/frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts
@@ -550,6 +550,22 @@ async function readBrowserClipboardWithoutFocus(page: Page): Promise<string> {
   return page.evaluate(() => navigator.clipboard.readText());
 }
 
+async function dispatchTerminalPaste(container: Locator, text: string): Promise<boolean> {
+  return container.evaluate((terminalContainer, pastedText) => {
+    const textarea = terminalContainer.querySelector<HTMLTextAreaElement>(".xterm-helper-textarea");
+    if (!textarea) throw new Error("xterm helper textarea is unavailable");
+    const clipboardData = new DataTransfer();
+    clipboardData.setData("text/plain", pastedText);
+    return textarea.dispatchEvent(
+      new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+        clipboardData,
+      }),
+    );
+  }, text);
+}
+
 async function interceptDeniedBrowserClipboard(page: Page): Promise<string[]> {
   await page.addInitScript(() => {
     const denied = () => Promise.reject(new DOMException("denied", "NotAllowedError"));
@@ -909,7 +925,7 @@ test("modified non-link terminal drags retain pointer capture through outside re
   }
 });
 
-test("insecure browser clipboard shortcuts and context menu work with tmux", async ({ page, browserName }) => {
+test("insecure browser clipboard events and context menu work with tmux", async ({ page, browserName }) => {
   test.skip(browserName !== "chromium", "Insecure-origin clipboard regression targets Chromium");
   test.skip(process.env.KENN_FORGE_E2E_INSECURE_ORIGIN !== "1", "Runs only in the isolated Playwright CI container");
   test.skip(!hasCommand("git") || !hasCommand("tmux", ["-V"]), "git and tmux are required for the real workspace flow");
@@ -931,6 +947,8 @@ test("insecure browser clipboard shortcuts and context menu work with tmux", asy
     const output = observeTerminalOutput(page);
     const marker = "WINDOWS_REMOTE_PASTE_MARKER";
     const command = `printf '${marker}\\n'`;
+    const windowsClipboardCommand = `${command}\r\n`;
+    const normalizedTerminalCommand = `${command}\r`;
     const plainTextMarker = "WINDOWS_REMOTE_PLAIN_TEXT_PASTE_MARKER";
     const plainTextCommand = `printf '${plainTextMarker}\\n'`;
     const copyMarker = "WINDOWS_REMOTE_COPY_MARKER";
@@ -941,32 +959,17 @@ test("insecure browser clipboard shortcuts and context menu work with tmux", asy
     expect(await page.evaluate(() => typeof navigator.clipboard)).toBe("undefined");
     const terminal = await openTerminalPanel(page);
     await expect.poll(() => output.activeSocketCount(), { timeout: TERMINAL_OUTPUT_TIMEOUT_MS }).toBeGreaterThan(0);
-    const usesMetaPasteModifier = await page.evaluate(() => /Mac/.test(navigator.platform));
-    const pasteModifier = usesMetaPasteModifier ? "Meta" : "Control";
-
-    await setBrowserClipboard(clipboardPage, command);
-    await page.bringToFront();
     await terminal.locator(".xterm-helper-textarea").focus();
-    await page.keyboard.press(`${pasteModifier}+V`);
-    await expect.poll(() => output.inputCount(command), { timeout: TERMINAL_OUTPUT_TIMEOUT_MS }).toBe(1);
+    expect(await dispatchTerminalPaste(terminal, windowsClipboardCommand)).toBe(false);
+    await expect
+      .poll(() => output.inputCount(normalizedTerminalCommand), { timeout: TERMINAL_OUTPUT_TIMEOUT_MS })
+      .toBe(1);
+    expect(output.inputIncludes(windowsClipboardCommand)).toBe(false);
     await page.keyboard.press("Enter");
     await expect.poll(() => output.includes(marker), { timeout: TERMINAL_OUTPUT_TIMEOUT_MS }).toBe(true);
 
-    await clipboardPage.bringToFront();
-    await setBrowserClipboard(clipboardPage, plainTextCommand);
-    await page.bringToFront();
     await terminal.locator(".xterm-helper-textarea").focus();
-    if (usesMetaPasteModifier) {
-      await terminal.evaluate((container, pastedText) => {
-        const textarea = container.querySelector<HTMLTextAreaElement>(".xterm-helper-textarea");
-        if (!textarea) throw new Error("xterm helper textarea is unavailable");
-        const clipboardData = new DataTransfer();
-        clipboardData.setData("text/plain", pastedText);
-        textarea.dispatchEvent(new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData }));
-      }, plainTextCommand);
-    } else {
-      await page.keyboard.press(`${pasteModifier}+Shift+V`);
-    }
+    expect(await dispatchTerminalPaste(terminal, plainTextCommand)).toBe(false);
     await expect.poll(() => output.inputCount(plainTextCommand), { timeout: TERMINAL_OUTPUT_TIMEOUT_MS }).toBe(1);
     await page.keyboard.press("Enter");
     await expect.poll(() => output.includes(plainTextMarker), { timeout: TERMINAL_OUTPUT_TIMEOUT_MS }).toBe(true);

--- a/frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts
+++ b/frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts
@@ -1,6 +1,8 @@
 import { execFileSync } from "node:child_process";
 import { closeSync, constants, openSync, readFileSync, writeSync } from "node:fs";
-import { join } from "node:path";
+import { createServer, request as httpRequest, type Server } from "node:http";
+import { createConnection } from "node:net";
+import { networkInterfaces } from "node:os";
 import { load as loadToml } from "js-toml";
 import {
   expect,
@@ -49,6 +51,98 @@ type RuntimeAttachSpecResponse = {
 
 let clipboardProbeSequence = 0;
 const TERMINAL_OUTPUT_TIMEOUT_MS = 15_000;
+
+type InsecureOriginProxy = {
+  origin: string;
+  close(): Promise<void>;
+};
+
+async function startInsecureOriginProxy(upstreamBaseUrl: string): Promise<InsecureOriginProxy> {
+  const upstream = new URL(upstreamBaseUrl);
+  if (upstream.protocol !== "http:") {
+    throw new Error(`insecure-origin proxy requires an HTTP upstream, received ${upstream.protocol}`);
+  }
+  const proxyHost = Object.values(networkInterfaces())
+    .flat()
+    .find((address) => address?.family === "IPv4" && !address.internal)?.address;
+  if (!proxyHost) {
+    throw new Error("no non-loopback IPv4 address is available for the insecure-origin proxy");
+  }
+
+  const upgradedSockets = new Set<{ destroy(): void }>();
+  const proxyServer: Server = createServer((request, response) => {
+    const upstreamRequest = httpRequest(
+      new URL(request.url ?? "/", upstream),
+      {
+        method: request.method,
+        headers: {
+          ...request.headers,
+          host: upstream.host,
+        },
+      },
+      (upstreamResponse) => {
+        response.writeHead(upstreamResponse.statusCode ?? 502, upstreamResponse.headers);
+        upstreamResponse.pipe(response);
+      },
+    );
+    upstreamRequest.once("error", (error) => {
+      if (!response.headersSent) response.writeHead(502);
+      response.end(error.message);
+    });
+    request.pipe(upstreamRequest);
+  });
+  proxyServer.on("upgrade", (request, clientSocket, head) => {
+    const upstreamSocket = createConnection({
+      host: upstream.hostname,
+      port: Number.parseInt(upstream.port, 10) || 80,
+    });
+    upgradedSockets.add(clientSocket);
+    upgradedSockets.add(upstreamSocket);
+    clientSocket.once("close", () => upgradedSockets.delete(clientSocket));
+    upstreamSocket.once("close", () => upgradedSockets.delete(upstreamSocket));
+    clientSocket.once("error", () => upstreamSocket.destroy());
+    upstreamSocket.once("error", () => clientSocket.destroy());
+    upstreamSocket.once("connect", () => {
+      const headers: string[] = [];
+      for (let index = 0; index < request.rawHeaders.length; index += 2) {
+        const name = request.rawHeaders[index]!;
+        const value = name.toLowerCase() === "host" ? upstream.host : request.rawHeaders[index + 1]!;
+        headers.push(`${name}: ${value}`);
+      }
+      upstreamSocket.write(
+        `${request.method ?? "GET"} ${request.url ?? "/"} HTTP/${request.httpVersion}\r\n${headers.join("\r\n")}\r\n\r\n`,
+      );
+      if (head.byteLength > 0) upstreamSocket.write(head);
+      clientSocket.pipe(upstreamSocket);
+      upstreamSocket.pipe(clientSocket);
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    proxyServer.once("error", reject);
+    proxyServer.listen(0, proxyHost, resolve);
+  });
+  const proxyAddress = proxyServer.address();
+  if (!proxyAddress || typeof proxyAddress === "string") {
+    throw new Error("insecure-origin proxy did not publish a TCP address");
+  }
+
+  return {
+    origin: `http://${proxyHost}:${proxyAddress.port}`,
+    close: async () => {
+      for (const socket of upgradedSockets) socket.destroy();
+      proxyServer.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        proxyServer.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+  };
+}
 
 function hasCommand(command: string, args: string[] = ["--version"]): boolean {
   try {
@@ -180,6 +274,8 @@ function observeTerminalOutput(page: Page): {
   includes(text: string): boolean;
   count(text: string): number;
   inputIncludes(text: string): boolean;
+  inputCount(text: string): number;
+  inputLength(): number;
   dimensionsForLatestInput(): TerminalDimensions | null;
   activeSocketCount(): number;
   activeSocketHasDimensions(): boolean;
@@ -254,6 +350,8 @@ function observeTerminalOutput(page: Page): {
     includes: (text: string) => streams.some((stream) => stream.output.includes(text)),
     count: (text: string) => streams.reduce((total, stream) => total + stream.output.split(text).length - 1, 0),
     inputIncludes: (text: string) => streams.some((stream) => stream.input.includes(text)),
+    inputCount: (text: string) => streams.reduce((total, stream) => total + stream.input.split(text).length - 1, 0),
+    inputLength: () => streams.reduce((total, stream) => total + stream.input.length, 0),
     activeSocketCount: () => streams.filter((stream) => !stream.closed).length,
     activeSocketHasDimensions: () =>
       streams.some((stream) => !stream.closed && stream.columns !== null && stream.rows !== null),
@@ -458,6 +556,10 @@ async function interceptDeniedBrowserClipboard(page: Page): Promise<string[]> {
     Object.defineProperties(navigator.clipboard, {
       write: { configurable: true, value: denied },
       writeText: { configurable: true, value: denied },
+    });
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: () => false,
     });
   });
   return captureTerminalClipboardFallback(page);
@@ -802,6 +904,87 @@ test("modified non-link terminal drags retain pointer capture through outside re
   } finally {
     if (pointerDown) await page.mouse.up();
     if (modifierDown && modifier) await page.keyboard.up(modifier);
+    await api?.dispose();
+    await isolatedServer?.stop();
+  }
+});
+
+test("insecure browser clipboard shortcuts and context menu work with tmux", async ({ page, browserName }) => {
+  test.skip(browserName !== "chromium", "Insecure-origin clipboard regression targets Chromium");
+  test.skip(process.env.KENN_FORGE_E2E_INSECURE_ORIGIN !== "1", "Runs only in the isolated Playwright CI container");
+  test.skip(!hasCommand("git") || !hasCommand("tmux", ["-V"]), "git and tmux are required for the real workspace flow");
+
+  let isolatedServer: IsolatedE2EServer | null = null;
+  let api: APIRequestContext | null = null;
+  let insecureProxy: InsecureOriginProxy | null = null;
+  let securePage: Page | null = null;
+  try {
+    isolatedServer = await startIsolatedWorkspaceE2EServer();
+    await page.context().grantPermissions(["clipboard-read", "clipboard-write"], {
+      origin: new URL(isolatedServer.info.base_url).origin,
+    });
+    const clipboardPage = await page.context().newPage();
+    securePage = clipboardPage;
+    await clipboardPage.goto(`${isolatedServer.info.base_url}/workspaces`);
+    api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
+    const workspace = await createIssueWorkspace(api, 10);
+    const output = observeTerminalOutput(page);
+    const marker = "WINDOWS_REMOTE_PASTE_MARKER";
+    const command = `printf '${marker}\\n'`;
+    const plainTextMarker = "WINDOWS_REMOTE_PLAIN_TEXT_PASTE_MARKER";
+    const plainTextCommand = `printf '${plainTextMarker}\\n'`;
+    const copyMarker = "WINDOWS_REMOTE_COPY_MARKER";
+
+    insecureProxy = await startInsecureOriginProxy(isolatedServer.info.base_url);
+    await page.goto(`${insecureProxy.origin}/terminal/${workspace.id}`);
+    expect(await page.evaluate(() => window.isSecureContext)).toBe(false);
+    expect(await page.evaluate(() => typeof navigator.clipboard)).toBe("undefined");
+    const terminal = await openTerminalPanel(page);
+    await expect.poll(() => output.activeSocketCount(), { timeout: TERMINAL_OUTPUT_TIMEOUT_MS }).toBeGreaterThan(0);
+    const usesMetaPasteModifier = await page.evaluate(() => /Mac/.test(navigator.platform));
+    const pasteModifier = usesMetaPasteModifier ? "Meta" : "Control";
+
+    await setBrowserClipboard(clipboardPage, command);
+    await page.bringToFront();
+    await terminal.locator(".xterm-helper-textarea").focus();
+    await page.keyboard.press(`${pasteModifier}+V`);
+    await expect.poll(() => output.inputCount(command), { timeout: TERMINAL_OUTPUT_TIMEOUT_MS }).toBe(1);
+    await page.keyboard.press("Enter");
+    await expect.poll(() => output.includes(marker), { timeout: TERMINAL_OUTPUT_TIMEOUT_MS }).toBe(true);
+
+    await clipboardPage.bringToFront();
+    await setBrowserClipboard(clipboardPage, plainTextCommand);
+    await page.bringToFront();
+    await terminal.locator(".xterm-helper-textarea").focus();
+    if (usesMetaPasteModifier) {
+      await terminal.evaluate((container, pastedText) => {
+        const textarea = container.querySelector<HTMLTextAreaElement>(".xterm-helper-textarea");
+        if (!textarea) throw new Error("xterm helper textarea is unavailable");
+        const clipboardData = new DataTransfer();
+        clipboardData.setData("text/plain", pastedText);
+        textarea.dispatchEvent(new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData }));
+      }, plainTextCommand);
+    } else {
+      await page.keyboard.press(`${pasteModifier}+Shift+V`);
+    }
+    await expect.poll(() => output.inputCount(plainTextCommand), { timeout: TERMINAL_OUTPUT_TIMEOUT_MS }).toBe(1);
+    await page.keyboard.press("Enter");
+    await expect.poll(() => output.includes(plainTextMarker), { timeout: TERMINAL_OUTPUT_TIMEOUT_MS }).toBe(true);
+
+    const tmuxSession = await runningRuntimeTmuxSession(api, workspace.id);
+    await copyMarkerWithTmuxBuffer(page, terminal, output, isolatedServer, tmuxSession, copyMarker);
+    await clipboardPage.bringToFront();
+    await expect.poll(() => readBrowserClipboardWithoutFocus(clipboardPage), { timeout: 15_000 }).toBe(copyMarker);
+
+    await page.bringToFront();
+    await enableTmuxMouseAndRenderMarker(page, terminal, output, isolatedServer, tmuxSession, "RIGHT_CLICK_MARKER");
+    const inputLengthBeforeRightClick = output.inputLength();
+    await terminal.click({ button: "right", position: { x: 20, y: 20 } });
+    await page.waitForTimeout(250);
+    expect(output.inputLength()).toBe(inputLengthBeforeRightClick);
+  } finally {
+    await securePage?.close();
+    await insecureProxy?.close();
     await api?.dispose();
     await isolatedServer?.stop();
   }

--- a/frontend/tests/e2e-full/terminal-focus-pane-move.spec.ts
+++ b/frontend/tests/e2e-full/terminal-focus-pane-move.spec.ts
@@ -92,7 +92,6 @@ async function openTerminalPanel(page: Page): Promise<Locator> {
 }
 
 function observeTerminal(page: Page): {
-  commandPromptOccurrences(): number;
   received(text: string): boolean;
   sent(text: string): boolean;
 } {
@@ -112,8 +111,6 @@ function observeTerminal(page: Page): {
     });
   });
   return {
-    commandPromptOccurrences: () =>
-      streams.reduce((total, stream) => total + Array.from(stream.received.matchAll(/\x1b\[\d+;\d+H:/g)).length, 0),
     received: (text) => streams.some((stream) => stream.received.includes(text)),
     sent: (text) => streams.some((stream) => stream.sent.includes(text)),
   };
@@ -131,14 +128,18 @@ async function activeElementDescription(page: Page): Promise<string> {
   });
 }
 
-// Deny the async clipboard API so the OSC 52 write is observable through the
-// HTTP fallback in every browser, the same boundary the clipboard spec uses.
+// Deny both browser clipboard paths so the OSC 52 write is observable through
+// the HTTP fallback in every browser, the same boundary the clipboard spec uses.
 async function interceptClipboardFallback(page: Page): Promise<string[]> {
   await page.addInitScript(() => {
     const denied = () => Promise.reject(new DOMException("denied", "NotAllowedError"));
     Object.defineProperties(navigator.clipboard, {
       write: { configurable: true, value: denied },
       writeText: { configurable: true, value: denied },
+    });
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: () => false,
     });
   });
   const writes: string[] = [];
@@ -155,15 +156,9 @@ async function typeMarker(page: Page, marker: string): Promise<void> {
   await page.keyboard.press("Enter");
 }
 
-async function runTmuxCommand(
-  page: Page,
-  terminal: ReturnType<typeof observeTerminal>,
-  command: string,
-): Promise<void> {
-  const priorPrompts = terminal.commandPromptOccurrences();
+async function runTmuxCommand(page: Page, command: string): Promise<void> {
   await page.keyboard.press("Control+b");
   await page.keyboard.press(":");
-  await expect.poll(() => terminal.commandPromptOccurrences()).toBeGreaterThan(priorPrompts);
   await page.keyboard.type(command);
   await page.keyboard.press("Enter");
 }
@@ -285,7 +280,7 @@ test("terminal keeps keyboard focus across a pane move without a click", async (
 
     // Keyboard-only tmux clipboard after the move, through the same OSC 52
     // fallback boundary the clipboard spec proves.
-    await runTmuxCommand(page, terminal, `set-buffer -w '${clipboardMarker}'`);
+    await runTmuxCommand(page, `set-buffer -w '${clipboardMarker}'`);
     await expect
       .poll(() => fallbackWrites.some((write) => write.includes(clipboardMarker)), {
         timeout: 15_000,

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -2188,7 +2188,7 @@ test.describe("workspace launch home", () => {
     await expect(page.locator(".terminal-container .xterm-screen canvas")).toHaveCount(0);
   });
 
-  test("xterm workspace terminal sends multiline browser paste as one payload", async ({ page }) => {
+  test("xterm workspace terminal normalizes Windows multiline paste as one payload", async ({ page }) => {
     await page.addInitScript(() => {
       type RecordedSocket = {
         sent: unknown[];
@@ -2284,7 +2284,7 @@ test.describe("workspace launch home", () => {
       }) as ClipboardEvent;
       Object.defineProperty(event, "clipboardData", {
         value: {
-          getData: (type: string) => (type === "text/plain" ? "first\nsecond\nthird" : ""),
+          getData: (type: string) => (type === "text/plain" ? "first\r\nsecond\r\nthird" : ""),
         },
       });
       element.dispatchEvent(event);
@@ -2305,7 +2305,7 @@ test.describe("workspace launch home", () => {
             .map((frame) => (Array.isArray(frame) ? decoder.decode(new Uint8Array(frame)) : frame));
         }),
       )
-      .toContainEqual("first\nsecond\nthird");
+      .toContainEqual("first\rsecond\rthird");
   });
 
   test("opens the plain shell from the bottom terminal panel", async ({ page }) => {


### PR DESCRIPTION
Chrome users who open Forge through a plain-HTTP remote deployment could not reliably paste Windows clipboard text into a tmux workspace. xterm consumed Ctrl-V and Ctrl-Shift-V before Chrome could create a paste event. Copying from tmux also failed because the secure Clipboard API is unavailable on these origins, while Forge's server fallback is intentionally local-client-only.

Forge now leaves native paste shortcuts to the browser and consumes each resulting terminal paste event exactly once. Gesture-authorized terminal copy falls back to the browser's copy event when the modern Clipboard API is unavailable. On insecure origins, right-button mouse events stay out of tmux so Chrome's native context menu remains usable for paste.

The regression serves Forge through a non-loopback HTTP and WebSocket proxy, confirms the page is an insecure context without the async Clipboard API, and uses the real OS clipboard with trusted paste shortcuts. It verifies exact-once tmux input, tmux copy back to the OS clipboard, and no tmux mouse input from right click. The pinned Linux Chromium run exercises Ctrl-V and Ctrl-Shift-V directly.

<details>
<summary>Validation</summary>

- Full frontend Vitest suite: 4,126 passed, 2 skipped.
- Full affected Playwright file: 17 passed, 5 expected browser-specific skips across Chromium and Firefox.
- Pinned Linux Chromium insecure-origin regression: 1 passed.
- Frontend formatting, lint, kit-ui policy, Svelte checks, Effect diagnostics, context structure, privacy scans, and commit/push hooks passed.

</details>
