### PR TITLE
Remove the bare 1 keyboard shortcut

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -268,6 +268,9 @@ Keyboard handlers must have one clear owner for each key press.
 - Modal frames outrank page-level shortcuts. When a modal, drawer, popover, or
   command surface is active, route and list navigation should run only through
   actions explicitly registered for that active surface.
+- Registry actions also back the command palette: remove only an accelerator by
+  setting `binding: null`; deleting the action removes the palette command too
+  (`frontend/src/lib/components/keyboard/Palette.svelte::visibleActions`).
 - If two surfaces can expose the same binding, document the precedence in the
   action registration rather than relying on registration order.
 - Shortcut labels and cheatsheet entries must match the actual key event

--- a/frontend/src/lib/stores/keyboard/actions.test.ts
+++ b/frontend/src/lib/stores/keyboard/actions.test.ts
@@ -115,6 +115,7 @@ describe("defaultActions", () => {
         "go.prev",
         "tab.toggle",
         "escape.list",
+        "nav.pulls.list",
         "sidebar.toggle",
         "palette.open",
         "repo.browser.open",
@@ -129,6 +130,16 @@ describe("defaultActions", () => {
       ]),
     );
     expect(ids).not.toContain("nav.pulls.board");
+  });
+
+  it("keeps the Pull requests list command palette-only", () => {
+    window.history.replaceState(null, "", "/issues");
+    const action = command("nav.pulls.list");
+
+    expect(action.binding).toBeNull();
+    action.handler(ctx("issues"));
+
+    expect(locationPath()).toBe("/pulls");
   });
 
   it("palette.open binds the terminal-safe shifted K chord and the existing palette chords", () => {

--- a/frontend/src/lib/stores/keyboard/actions.test.ts
+++ b/frontend/src/lib/stores/keyboard/actions.test.ts
@@ -115,7 +115,6 @@ describe("defaultActions", () => {
         "go.prev",
         "tab.toggle",
         "escape.list",
-        "nav.pulls.list",
         "sidebar.toggle",
         "palette.open",
         "repo.browser.open",
@@ -289,14 +288,6 @@ describe("defaultActions", () => {
         }),
       ),
     ).toBe(true);
-  });
-
-  it("does not enable pull request number navigation on Kata", () => {
-    const list = defaultActions.find((a) => a.id === "nav.pulls.list");
-
-    expect(list).toBeDefined();
-    expect(list!.when(ctx("kata"))).toBe(false);
-    expect(list!.when(ctx("pulls"))).toBe(true);
   });
 
   it("opens the repo browser from a selected pull request", () => {

--- a/frontend/src/lib/stores/keyboard/actions.ts
+++ b/frontend/src/lib/stores/keyboard/actions.ts
@@ -329,6 +329,24 @@ function repoBrowserPreview(ctx: Context): PreviewBlock {
   };
 }
 
+// Keep the Pull requests list command scoped to the pages where the former
+// number shortcut was available. The command remains palette-accessible but
+// no longer reserves a bare digit key.
+const onNumberNavPages = (ctx: Context): boolean => {
+  switch (ctx.page) {
+    case "settings":
+    case "design-system":
+    case "repos":
+    case "kata":
+    case "reviews":
+    case "workspaces":
+    case "activity":
+      return false;
+    default:
+      return true;
+  }
+};
+
 // Mirror App.svelte's navigateToSelectedPR helper (replaceUrl when a PR is
 // already selected in the URL, navigate otherwise).
 function navigateToSelectedPR(): void {
@@ -528,6 +546,15 @@ export const defaultActions: Action[] = [
         navigate("/pulls");
       }
     },
+  },
+  {
+    id: "nav.pulls.list",
+    label: "Pull requests (list)",
+    scope: "global",
+    binding: null,
+    priority: 0,
+    when: onNumberNavPages,
+    handler: () => navigate("/pulls"),
   },
   {
     id: "sidebar.toggle",

--- a/frontend/src/lib/stores/keyboard/actions.ts
+++ b/frontend/src/lib/stores/keyboard/actions.ts
@@ -329,24 +329,6 @@ function repoBrowserPreview(ctx: Context): PreviewBlock {
   };
 }
 
-// Mirrors App.svelte's pre-migration page exclusions for `1`/`2`/`f`/etc.:
-// settings, design-system, repos, reviews, workspaces, activity all returned
-// early before the global shortcut switch ran.
-const onNumberNavPages = (ctx: Context): boolean => {
-  switch (ctx.page) {
-    case "settings":
-    case "design-system":
-    case "repos":
-    case "kata":
-    case "reviews":
-    case "workspaces":
-    case "activity":
-      return false;
-    default:
-      return true;
-  }
-};
-
 // Mirror App.svelte's navigateToSelectedPR helper (replaceUrl when a PR is
 // already selected in the URL, navigate otherwise).
 function navigateToSelectedPR(): void {
@@ -546,15 +528,6 @@ export const defaultActions: Action[] = [
         navigate("/pulls");
       }
     },
-  },
-  {
-    id: "nav.pulls.list",
-    label: "Pull requests (list)",
-    scope: "global",
-    binding: { key: "1" },
-    priority: 0,
-    when: onNumberNavPages,
-    handler: () => navigate("/pulls"),
   },
   {
     id: "sidebar.toggle",

--- a/frontend/src/lib/stores/keyboard/dispatch.svelte.test.ts
+++ b/frontend/src/lib/stores/keyboard/dispatch.svelte.test.ts
@@ -93,6 +93,15 @@ describe("dispatchKeydown — global registry", () => {
     expect(e.preventDefault).toHaveBeenCalled();
     expect(isSidebarCollapsed()).toBe(false);
   });
+
+  it("leaves the bare 1 key unhandled", () => {
+    registerScopedActions("defaults", defaultActions);
+    const e = event({ key: "1" });
+
+    dispatchKeydown(e, () => ctx);
+
+    expect(e.preventDefault).not.toHaveBeenCalled();
+  });
 });
 
 describe("dispatchKeydown — modal stack", () => {

--- a/frontend/src/lib/utils/markdownImages.test.ts
+++ b/frontend/src/lib/utils/markdownImages.test.ts
@@ -130,7 +130,7 @@ describe("expandMarkdownImages", () => {
       expect(getTopFrame()?.frameId).toBe("markdown-image-lightbox");
       expect(getStackDepth()).toBe(1);
 
-      closeButton?.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "1" }));
+      closeButton?.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "j" }));
       expect(windowShortcut).not.toHaveBeenCalled();
 
       const escape = new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "Escape" });

--- a/frontend/tests/e2e-full/comment-editor.spec.ts
+++ b/frontend/tests/e2e-full/comment-editor.spec.ts
@@ -91,7 +91,7 @@ test.describe("comment editor autocomplete", () => {
     await editor.evaluate((node) => {
       node.dispatchEvent(
         new KeyboardEvent("keydown", {
-          key: "1",
+          key: "f",
           bubbles: true,
           cancelable: true,
         }),

--- a/frontend/tests/e2e-full/navigation.spec.ts
+++ b/frontend/tests/e2e-full/navigation.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 
+import { runPaletteCommand } from "./support/paletteCommands";
 import { openSettingsPanel } from "./support/settingsPanel";
 
 // The activity-selection-restore flows, the legacy /mail fallthrough, and the
@@ -50,6 +51,18 @@ test.describe("view navigation", () => {
     await expect.poll(() => new URL(page.url()).pathname).toBe("/kata");
     await expect(page.getByRole("heading", { name: "Kata" })).toBeVisible();
     await expect(page.getByRole("button", { name: /^Select repository:/ })).not.toBeAttached();
+  });
+
+  test("keeps the pull request list command palette-only", async ({ page }) => {
+    await page.goto("/issues");
+    await page.locator(".issue-item").first().waitFor({ state: "visible", timeout: 10_000 });
+
+    await page.keyboard.press("1");
+    await expect.poll(() => new URL(page.url()).pathname).toBe("/issues");
+
+    await runPaletteCommand(page, "Pull requests (list)");
+    await expect.poll(() => new URL(page.url()).pathname).toBe("/pulls");
+    await page.locator(".pull-item").first().waitFor({ state: "visible", timeout: 10_000 });
   });
 
   test("Docs route loads its mode shell directly", async ({ page }) => {

--- a/frontend/tests/e2e-full/navigation.spec.ts
+++ b/frontend/tests/e2e-full/navigation.spec.ts
@@ -44,19 +44,12 @@ test.describe("view navigation", () => {
     await page.locator(".activity-feed").waitFor({ state: "visible", timeout: 5_000 });
   });
 
-  test("Kata shell does not expose repo selector or respond to PR number shortcuts", async ({ page }) => {
+  test("Kata shell does not expose the repository selector", async ({ page }) => {
     await page.goto("/kata");
 
     await expect.poll(() => new URL(page.url()).pathname).toBe("/kata");
     await expect(page.getByRole("heading", { name: "Kata" })).toBeVisible();
     await expect(page.getByRole("button", { name: /^Select repository:/ })).not.toBeAttached();
-
-    await page.locator("main.app-main").click();
-    await page.keyboard.press("1");
-    await expect.poll(() => new URL(page.url()).pathname).toBe("/kata");
-
-    await page.keyboard.press("2");
-    await expect.poll(() => new URL(page.url()).pathname).toBe("/kata");
   });
 
   test("Docs route loads its mode shell directly", async ({ page }) => {

--- a/frontend/tests/e2e/keyboard-modal-isolation.spec.ts
+++ b/frontend/tests/e2e/keyboard-modal-isolation.spec.ts
@@ -126,8 +126,6 @@ for (const m of MODAL_OPENERS) {
     // selection count would change.
     await page.keyboard.press("j");
     await page.keyboard.press("k");
-    await page.keyboard.press("1");
-    await page.keyboard.press("2");
 
     const afterSelected = await page.locator(".pr-list-row.selected").count();
     expect(afterSelected).toBe(beforeSelected);


### PR DESCRIPTION
Pressing `1` outside an editor redirected most views to the Pull Requests list. This single-key navigation was easy to trigger accidentally and could abandon the current workflow.

This removes only the digit binding. Bare `1` now remains available to the active page, while **Pull requests (list)** remains available in the command palette. The rest of the shortcut set and keyboard ownership rules stay unchanged.

<details>
<summary>Validation</summary>

- Frontend unit suite: 3,891 passed, 2 skipped.
- Real-browser palette suite: 4 passed.
- Affected Playwright specs passed in Chromium and Firefox.
- Non-mutating lint and push hooks passed.
- Gitleaks scanned both commits and every introduced blob.

</details>

<sup>generated by a clanker</sup>