### PR TITLE
Retain recent terminals for faster workspace switches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,9 @@ only routes to them.
 ## Git Workflow
 
 - **Commit every turn** — always commit your work at the end of each turn, no exceptions
+- Superpowers design specs and implementation plans are temporary working artifacts; never commit
+  or retain them. Before committing, distill current contracts into the matching `context/` topic
+  docs and delete the artifacts. Do not convert a transient spec into an ADR to preserve it.
 - **Capture context before committing** — before every agent-created Git commit, invoke
   the repository-local `context-sync` skill with `--commit`. Apply clear scoped context
   changes before invoking the normal external commit skill. Block only when an unclear

--- a/context/config-persistence.md
+++ b/context/config-persistence.md
@@ -5,3 +5,4 @@ back to TOML.
 
 - `configFile` in `internal/config/config.go` is the hand-maintained subset of `Config` that `Save` writes to disk. A `Config` field absent from `configFile` (or from the `Save` initializer) loads from TOML fine but is silently dropped on the next save or restart.
 - Every new persisted config field or section must be wired in three places — `Config`, `configFile`, and the `Save` initializer — and covered by a save/load round-trip test with a non-default value (see `TestPullRequestsConfigRoundTrip` in `internal/config/config_test.go`).
+- When zero is meaningful, represent the saved value as optional so TOML `omitempty` cannot turn explicit zero into an unset default; the round-trip test must cover zero (`internal/config/config.go::Terminal`).

--- a/context/docs-authoring.md
+++ b/context/docs-authoring.md
@@ -12,9 +12,9 @@ screenshots, or the Zensical site.
 - Promote rationale to an ADR only when it explains a constraint that still
   binds current code and is not derivable from it; reports retain reproducible
   outcomes.
-- Do not retain completed plans or design specs, superseded proposals, review
-  notes, prototype comparisons, or rollout narratives after extracting current
-  contracts.
+- Superpowers plans and design specs are temporary working artifacts, not repository
+  documentation. Before committing, distill current contracts into the matching
+  `context/` topic docs, delete the artifacts, and do not convert them into ADRs.
 - Verify candidate documentation against implementation and tests before
   promoting it into living documentation.
 

--- a/context/testing.md
+++ b/context/testing.md
@@ -260,6 +260,9 @@ WebSocket dimensions; resize frames can lag an inline pane's rendered size
 When a real-tmux browser test moves one session between terminal hosts, close
 the old WebSocket before mounting the next host and reassert mouse mode; concurrent
 clients change tmux sizing and mode delivery (`frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts:524`).
+Reconnect tests must close and observe the WebSocket before enabling Playwright offline mode;
+offline emulation can stall the close event and turn the assertion into a browser-network race
+(`frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts:2231`).
 Terminal-emulator protocol negotiation tests must use the PTY-owner e2e option;
 tmux consumes application mode sequences and changes the boundary under test
 (`frontend/tests/e2e-full/00-terminal-kitty-keyboard.spec.ts::kittyCursorProbeCommand`).

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -213,6 +213,10 @@ Persisted controls must state their scope clearly.
   mutation generation; value equality alone is ABA-prone, while stale full-object
   saves can erase unrelated preferences
   (`frontend/src/lib/stores/terminal-settings-persistence.ts::saveTerminalSettings`).
+- Server-backed settings with irreversible local effects must publish only after
+  persistence succeeds, not during preview or optimistic save; lowering terminal
+  retention destroys cache entries that rollback cannot reconstruct
+  (`frontend/src/lib/stores/terminal-settings-persistence.ts::isDeferredSetting`).
 - A settings form that snapshots its baseline must either merge sibling mutations
   or keep the form and those controls mutually gated while either save settles
   (`frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte::terminalZoomSaving`).
@@ -354,14 +358,15 @@ Keyboard handlers must have one clear owner for each key press.
 - Session terminals are one live subtree PER SESSION KEY, owned by the app-level
   pool: every container — workflow tabs, the terminal dock, a promoted detail
   pane — renders a `SessionTerminalSlot` and none renders a `TerminalPane` of its
-  own, or one tmux session gets two sockets. A container mounts a session into
-  the pool only while it actually renders it, since a parked terminal keeps its
-  websocket (`frontend/src/lib/stores/session-host.svelte.ts`).
+  own, or one tmux session gets two sockets. A live view's desired set claims its
+  sessions even behind hidden tabs; only sessions released by every view enter
+  the bounded retention cache (`frontend/src/lib/stores/session-host.svelte.ts::isSessionClaimed`).
 - xterm WebGL texture atlases are shared across matching live panes; every explicit
   atlas clear must refresh sibling renderers, or cached glyph coordinates display
   repurposed characters (`frontend/src/lib/components/terminal/sharedTerminalTextureAtlas.ts::clearSharedTerminalTextureAtlas`).
 - A pooled terminal constructs immediately, even in parking, so every mounted
-  session keeps its websocket; it opts out of renderer autofocus. After
+  session keeps its websocket; retained sessions disable WebGL until reclaimed,
+  and the pool opts out of renderer autofocus. After
   attachment the pool honors queued focus requests — explicit ones always, soft
   navigation-driven ones (a detail surface switched items) only when current
   focus is not sacred — and restores focus-event-tracked keyboard ownership: a

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -202,6 +202,13 @@ stale tabs.
   unintended navigation when the user is targeting a nested control.
 - Persisted "last active tab" state must be scoped per workspace.
 
+## Released Terminal Retention
+
+- A live view's desired set claims its sessions even when a tab is hidden; only unclaimed sessions enter the bounded, release-ordered LRU, and a zero limit disables retention (`frontend/src/lib/stores/session-host.svelte.ts::noteSessionReleased`).
+- While a workspace switch awaits destination runtime reconciliation, cache trimming must protect that destination prefix; otherwise releasing the previous workspace can evict the pending cache hit at capacity (`frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte::releaseOwnedSessions`).
+- Retention keeps the parsed xterm subtree and connected socket but relinquishes interaction, resize, and WebGL resources; reclaim reparents the same subtree without reconnect or replay (`frontend/src/lib/components/terminal/PooledSessionTerminal.svelte`, `frontend/src/lib/components/terminal/XtermTerminalPane.svelte::syncRendererState`).
+- Released sessions are browser presentation cache, never runtime authority: disconnect, exit, deletion, or stale generation causes app-level final discard rather than background reconnect (`frontend/src/lib/stores/session-host.svelte.ts::noteSessionExited`, `frontend/src/lib/stores/session-host.svelte.ts::discardSessionsWithPrefix`).
+
 ## Shell Command Override
 
 When tmux is unavailable, the plain shell session is launched through ptyowner

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -7430,6 +7430,9 @@ components:
         line_height:
           format: double
           type: number
+        retained_sessions:
+          format: int64
+          type: integer
         scrollback:
           format: int64
           type: integer
@@ -7442,6 +7445,7 @@ components:
         - cursor_blink
         - font_ligatures
         - hide_tmux_status
+        - retained_sessions
       type: object
     TerminalClipboardInputBody:
       additionalProperties: false

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -94,6 +94,7 @@ vi.mock("./lib/context.js", async (importOriginal) => ({
   getStores: () => ({
     settings: {
       getLaunchTargets: () => [],
+      getTerminalSettings: () => ({ retained_sessions: 10 }),
     },
   }),
 }));

--- a/frontend/src/lib/api/generated/schema.ts
+++ b/frontend/src/lib/api/generated/schema.ts
@@ -7661,6 +7661,8 @@ export interface components {
             /** Format: double */
             line_height: number;
             /** Format: int64 */
+            retained_sessions: number;
+            /** Format: int64 */
             scrollback: number;
         };
         TerminalClipboardInputBody: {

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -78,6 +78,7 @@ export const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
   cursor_blink: true,
   font_ligatures: false,
   hide_tmux_status: false,
+  retained_sessions: 10,
 };
 
 export const DEFAULT_MODE_VISIBILITY: ModeVisibility = {

--- a/frontend/src/lib/components/settings/TerminalSettings.svelte
+++ b/frontend/src/lib/components/settings/TerminalSettings.svelte
@@ -80,6 +80,9 @@
   let hideTmuxStatusDraft = $state(
     DEFAULT_TERMINAL_SETTINGS.hide_tmux_status,
   );
+  let retainedSessionsDraft = $state<number | null>(
+    DEFAULT_TERMINAL_SETTINGS.retained_sessions,
+  );
   let fontDialogOpen = $state(false);
   let localFonts = $state<FontData[] | null>(null);
   let fontLoadError = $state<string | null>(null);
@@ -154,6 +157,8 @@
       cursor_blink: cursorBlinkDraft,
       font_ligatures: fontLigaturesDraft,
       hide_tmux_status: hideTmuxStatusDraft,
+      retained_sessions:
+        retainedSessionsDraft ?? DEFAULT_TERMINAL_SETTINGS.retained_sessions,
     };
   }
 
@@ -170,7 +175,8 @@
       pendingTerminal.letter_spacing !== currentTerminal.letter_spacing ||
       pendingTerminal.cursor_blink !== currentTerminal.cursor_blink ||
       pendingTerminal.font_ligatures !== currentTerminal.font_ligatures ||
-      pendingTerminal.hide_tmux_status !== currentTerminal.hide_tmux_status
+      pendingTerminal.hide_tmux_status !== currentTerminal.hide_tmux_status ||
+      pendingTerminal.retained_sessions !== currentTerminal.retained_sessions
   );
   const isDefaultDraft = $derived(
     pendingTerminal.font_family === DEFAULT_TERMINAL_SETTINGS.font_family &&
@@ -184,7 +190,9 @@
       pendingTerminal.font_ligatures ===
         DEFAULT_TERMINAL_SETTINGS.font_ligatures &&
       pendingTerminal.hide_tmux_status ===
-        DEFAULT_TERMINAL_SETTINGS.hide_tmux_status
+        DEFAULT_TERMINAL_SETTINGS.hide_tmux_status &&
+      pendingTerminal.retained_sessions ===
+        DEFAULT_TERMINAL_SETTINGS.retained_sessions
   );
   const canSave = $derived(!saving && isDirty);
   const localMonospaceFonts = $derived.by(() => {
@@ -212,6 +220,7 @@
     cursorBlinkDraft = value.cursor_blink;
     fontLigaturesDraft = value.font_ligatures;
     hideTmuxStatusDraft = value.hide_tmux_status;
+    retainedSessionsDraft = value.retained_sessions;
   }
 
   $effect(() => {
@@ -412,6 +421,24 @@
       />
     </label>
 
+    <label class="control-field" for="terminal-retained-sessions">
+      <span class="setting-label">Retained terminal sessions</span>
+      <input
+        id="terminal-retained-sessions"
+        class="number-input"
+        type="number"
+        min="0"
+        max="20"
+        step="1"
+        bind:value={retainedSessionsDraft}
+        disabled={saving}
+      />
+      <span class="field-help">
+        Keep recently viewed terminal sessions ready for faster workspace
+        switching. Higher values use more memory. Use 0 to disable retention.
+      </span>
+    </label>
+
   </div>
 
   <Checkbox
@@ -546,6 +573,12 @@
     font-size: var(--font-size-sm);
     color: var(--text-secondary);
     font-weight: 600;
+  }
+
+  .field-help {
+    color: var(--text-tertiary);
+    font-size: var(--font-size-xs);
+    line-height: 1.35;
   }
 
   .font-row {

--- a/frontend/src/lib/components/settings/TerminalSettings.test.ts
+++ b/frontend/src/lib/components/settings/TerminalSettings.test.ts
@@ -15,6 +15,7 @@ const { mockGetTerminalSettings, mockSetTerminalSettings, mockTerminalStore, moc
       cursor_blink: true,
       font_ligatures: false,
       hide_tmux_status: false,
+      retained_sessions: 10,
     };
     const store = { terminal: { ...defaultTerminal } };
     return {
@@ -143,6 +144,38 @@ describe("TerminalSettings", () => {
     vi.stubGlobal("fetch", fetch);
   });
 
+  it("persists zero retained sessions without falling back to the default", async () => {
+    const updated = {
+      ...mockTerminalStore.defaultTerminal,
+      retained_sessions: 0,
+    };
+    mockUpdateSettings.mockResolvedValue({ terminal: updated });
+    const onUpdate = vi.fn();
+
+    render(TerminalSettings, {
+      props: {
+        terminal: { ...mockTerminalStore.defaultTerminal },
+        onUpdate,
+      },
+    });
+
+    const retentionInput = screen.getByLabelText(/^Retained terminal sessions/) as HTMLInputElement;
+    expect(retentionInput.min).toBe("0");
+    expect(retentionInput.max).toBe("20");
+    await fireEvent.input(retentionInput, {
+      target: { value: "0" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockUpdateSettings).toHaveBeenCalledWith({ terminal: updated });
+      expect(onUpdate).toHaveBeenCalledWith(updated);
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Reset" }));
+    expect(retentionInput.value).toBe("10");
+  });
+
   it("enables save after editing and persists the font family", async () => {
     mockUpdateSettings.mockResolvedValue({
       terminal: {
@@ -154,6 +187,7 @@ describe("TerminalSettings", () => {
         cursor_blink: true,
         font_ligatures: false,
         hide_tmux_status: false,
+        retained_sessions: 10,
       },
     });
     const onUpdate = vi.fn();
@@ -169,6 +203,7 @@ describe("TerminalSettings", () => {
           cursor_blink: true,
           font_ligatures: false,
           hide_tmux_status: false,
+          retained_sessions: 10,
         },
         onUpdate,
       },
@@ -198,6 +233,7 @@ describe("TerminalSettings", () => {
           cursor_blink: true,
           font_ligatures: false,
           hide_tmux_status: false,
+          retained_sessions: 10,
         },
       });
     });
@@ -211,6 +247,7 @@ describe("TerminalSettings", () => {
         cursor_blink: true,
         font_ligatures: false,
         hide_tmux_status: false,
+        retained_sessions: 10,
       });
     });
     expect(mockSetTerminalSettings).toHaveBeenCalledWith({
@@ -222,6 +259,7 @@ describe("TerminalSettings", () => {
       cursor_blink: true,
       font_ligatures: false,
       hide_tmux_status: false,
+      retained_sessions: 10,
     });
   });
 
@@ -236,6 +274,7 @@ describe("TerminalSettings", () => {
         cursor_blink: false,
         font_ligatures: false,
         hide_tmux_status: false,
+        retained_sessions: 10,
       },
     });
     const onUpdate = vi.fn();
@@ -251,6 +290,7 @@ describe("TerminalSettings", () => {
           cursor_blink: true,
           font_ligatures: false,
           hide_tmux_status: false,
+          retained_sessions: 10,
         },
         onUpdate,
       },
@@ -282,6 +322,7 @@ describe("TerminalSettings", () => {
           cursor_blink: false,
           font_ligatures: false,
           hide_tmux_status: false,
+          retained_sessions: 10,
         },
       });
     });
@@ -298,6 +339,7 @@ describe("TerminalSettings", () => {
         cursor_blink: true,
         font_ligatures: true,
         hide_tmux_status: false,
+        retained_sessions: 10,
       },
     });
     const onUpdate = vi.fn();
@@ -313,6 +355,7 @@ describe("TerminalSettings", () => {
           cursor_blink: true,
           font_ligatures: false,
           hide_tmux_status: false,
+          retained_sessions: 10,
         },
         onUpdate,
       },
@@ -332,6 +375,7 @@ describe("TerminalSettings", () => {
           cursor_blink: true,
           font_ligatures: true,
           hide_tmux_status: false,
+          retained_sessions: 10,
         },
       });
     });
@@ -348,6 +392,7 @@ describe("TerminalSettings", () => {
         cursor_blink: true,
         font_ligatures: false,
         hide_tmux_status: true,
+        retained_sessions: 10,
       },
     });
 
@@ -362,6 +407,7 @@ describe("TerminalSettings", () => {
           cursor_blink: true,
           font_ligatures: false,
           hide_tmux_status: false,
+          retained_sessions: 10,
         },
         onUpdate: vi.fn(),
       },
@@ -381,6 +427,7 @@ describe("TerminalSettings", () => {
           cursor_blink: true,
           font_ligatures: false,
           hide_tmux_status: true,
+          retained_sessions: 10,
         },
       });
     });
@@ -403,6 +450,7 @@ describe("TerminalSettings", () => {
             cursor_blink: true,
             font_ligatures: false,
             hide_tmux_status: false,
+            retained_sessions: 10,
           },
           onUpdate,
         },
@@ -433,6 +481,7 @@ describe("TerminalSettings", () => {
         cursor_blink: true,
         font_ligatures: false,
         hide_tmux_status: false,
+        retained_sessions: 10,
       },
     });
 
@@ -447,6 +496,7 @@ describe("TerminalSettings", () => {
           cursor_blink: true,
           font_ligatures: false,
           hide_tmux_status: false,
+          retained_sessions: 10,
         },
         onUpdate: vi.fn(),
       },
@@ -477,6 +527,7 @@ describe("TerminalSettings", () => {
           cursor_blink: true,
           font_ligatures: false,
           hide_tmux_status: false,
+          retained_sessions: 10,
         },
       });
     });
@@ -494,6 +545,7 @@ describe("TerminalSettings", () => {
           cursor_blink: true,
           font_ligatures: false,
           hide_tmux_status: false,
+          retained_sessions: 10,
         },
         livePreview: true,
         onUpdate: vi.fn(),
@@ -513,6 +565,7 @@ describe("TerminalSettings", () => {
       cursor_blink: true,
       font_ligatures: false,
       hide_tmux_status: false,
+      retained_sessions: 10,
     });
 
     unmount();
@@ -526,6 +579,7 @@ describe("TerminalSettings", () => {
       cursor_blink: true,
       font_ligatures: false,
       hide_tmux_status: false,
+      retained_sessions: 10,
     });
   });
 
@@ -540,6 +594,7 @@ describe("TerminalSettings", () => {
         cursor_blink: true,
         font_ligatures: false,
         hide_tmux_status: false,
+        retained_sessions: 10,
       },
     });
     const { unmount } = render(TerminalSettings, {
@@ -553,6 +608,7 @@ describe("TerminalSettings", () => {
           cursor_blink: true,
           font_ligatures: false,
           hide_tmux_status: false,
+          retained_sessions: 10,
         },
         livePreview: true,
         onUpdate: vi.fn(),
@@ -580,6 +636,7 @@ describe("TerminalSettings", () => {
       cursor_blink: true,
       font_ligatures: false,
       hide_tmux_status: false,
+      retained_sessions: 10,
     });
   });
 
@@ -595,6 +652,7 @@ describe("TerminalSettings", () => {
           cursor_blink: true,
           font_ligatures: false,
           hide_tmux_status: false,
+          retained_sessions: 10,
         },
         livePreview: true,
         onUpdate: vi.fn(),
@@ -615,6 +673,7 @@ describe("TerminalSettings", () => {
       cursor_blink: true,
       font_ligatures: false,
       hide_tmux_status: false,
+      retained_sessions: 10,
     });
   });
 
@@ -630,6 +689,7 @@ describe("TerminalSettings", () => {
           cursor_blink: true,
           font_ligatures: false,
           hide_tmux_status: false,
+          retained_sessions: 10,
         },
         onUpdate: vi.fn(),
       },
@@ -653,6 +713,7 @@ describe("TerminalSettings", () => {
           cursor_blink: true,
           font_ligatures: false,
           hide_tmux_status: false,
+          retained_sessions: 10,
         },
         onUpdate: vi.fn(),
       },

--- a/frontend/src/lib/components/terminal/PooledSessionTerminal.svelte
+++ b/frontend/src/lib/components/terminal/PooledSessionTerminal.svelte
@@ -5,6 +5,7 @@
   import { nextAnimationFrame } from "../../browser/animation-frame.js";
   import TerminalPane from "./TerminalPane.svelte";
   import { focusIsSacred } from "./terminal-focus.ts";
+  import { createWorkspaceSwitchPaneTimer } from "../../instrumentation/workspaceSwitchTiming.js";
   import {
     consumeSessionFocus,
     pendingSessionFocus,
@@ -16,10 +17,12 @@
     parking: HTMLElement | null;
     slotEl: HTMLElement | null;
     active: boolean;
+    retained: boolean;
     onExit: (code: number) => void;
+    onConnectionChange: (connected: boolean) => void;
   }
 
-  let { session, parking, slotEl, active, onExit }: Props = $props();
+  let { session, parking, slotEl, active, retained, onExit, onConnectionChange }: Props = $props();
   const appRuntime = getAppRuntime();
 
   let wrapper = $state<HTMLElement | null>(null);
@@ -28,6 +31,10 @@
   // has laid it out. Activating a terminal earlier makes the fit addon measure
   // the parking node and resize the real tmux pane to one row.
   let attached = $state(false);
+  // Set when this component has actually entered the released cache. A normal
+  // pane transfer also reparents the wrapper, but must not be reported as a
+  // retained-session hit by workspace-switch profiling.
+  let wasRetained = false;
 
   // The wrapper owns the keyboard when the last focus event landed inside it.
   // Focus events are the only reliable signal: a real pane move tears down the
@@ -62,6 +69,7 @@
     attached = false;
     park.appendChild(node);
     if (!destination || destination === park) {
+      if (retained) wasRetained = true;
       // Parked with nowhere to go: the pane closed — unless this park is the
       // transient first half of a cross-flush transfer whose destination
       // registers a moment later (a promotion can do this). Settle on the
@@ -85,6 +93,9 @@
       );
       return execution.interrupt;
     }
+    const retainedPaintTimer = wasRetained && !retained
+      ? createWorkspaceSwitchPaneTimer()
+      : null;
     const execution = untrack(() =>
       appRuntime.runCommand(
         Effect.promise(() => tick()).pipe(
@@ -93,6 +104,18 @@
           Effect.andThen(Effect.sync(() => {
             attached = true;
           })),
+          Effect.andThen(
+            retainedPaintTimer
+              ? nextAnimationFrame.pipe(
+                  Effect.andThen(
+                    Effect.sync(() => {
+                      retainedPaintTimer.record("retained-first-paint", { cacheHit: true });
+                      wasRetained = false;
+                    }),
+                  ),
+                )
+              : Effect.void,
+          ),
         ),
         {
           operation: "attach pooled terminal session",
@@ -185,10 +208,12 @@
     reconnectOnExit={false}
     disabled={session.disabled ?? false}
     active={active && attached}
+    renderingEnabled={!retained}
     autoFocus={false}
     cursorWheelInput={session.cursorWheelInput ?? false}
     initialStatus={session.status}
     onExit={(code) => onExit(code)}
+    onConnectionChange={(connected) => onConnectionChange(connected)}
   />
 </div>
 

--- a/frontend/src/lib/components/terminal/SessionTerminalPool.browser.svelte.ts
+++ b/frontend/src/lib/components/terminal/SessionTerminalPool.browser.svelte.ts
@@ -4,12 +4,16 @@ import { DEFAULT_TERMINAL_SETTINGS } from "../../api/types.js";
 
 import {
   consumeSessionFocus,
+  isSessionMounted,
+  noteSessionConnection,
   noteSessionMounted,
-  noteSessionUnmounted,
+  noteSessionDiscarded,
+  noteSessionReleased,
   registerSessionSlot,
   requestSessionFocus,
   resetSessionHostForTest,
   sessionHostKey,
+  setRetainedSessionLimit,
   setSessionSlotVisible,
 } from "../../stores/session-host.svelte.ts";
 import SessionTerminalPool from "./SessionTerminalPoolRuntimeHarness.svelte";
@@ -496,11 +500,28 @@ describe("SessionTerminalPool", () => {
     await waitForReparent();
     expect(wrapperFor(agent)).not.toBeNull();
 
-    noteSessionUnmounted(agent);
+    noteSessionDiscarded(agent);
     flushSync();
 
     // Svelte cannot remove a node this component reparented out of its own
     // fragment, so the pool has to; otherwise a dead terminal stays on screen.
+    expect(wrapperFor(agent)).toBeNull();
+    expect(slotA.childElementCount).toBe(0);
+  });
+
+  it("removes a released terminal when the retention limit evicts it", async () => {
+    mountSession(agent);
+    noteSessionConnection(agent, true);
+    mountPool();
+    showIn(agent, slotA);
+    await waitForReparent();
+    expect(wrapperFor(agent)).not.toBeNull();
+
+    noteSessionReleased(agent);
+    setRetainedSessionLimit(0);
+    flushSync();
+
+    expect(isSessionMounted(agent)).toBe(false);
     expect(wrapperFor(agent)).toBeNull();
     expect(slotA.childElementCount).toBe(0);
   });

--- a/frontend/src/lib/components/terminal/SessionTerminalPool.svelte
+++ b/frontend/src/lib/components/terminal/SessionTerminalPool.svelte
@@ -1,14 +1,20 @@
 <script lang="ts">
+  import { getStores } from "../../context.js";
   import {
     getSessionSlotElement,
+    isSessionClaimed,
     isSessionSlotVisible,
     mountedSessions,
+    noteSessionConnection,
     noteSessionExited,
     registerSessionParking,
+    setRetainedSessionLimit,
     type MountedSession,
     type SessionHostKey,
   } from "../../stores/session-host.svelte.ts";
   import PooledSessionTerminal from "./PooledSessionTerminal.svelte";
+
+  const { settings: settingsStore } = getStores();
 
   // Every workspace's live session terminals, rendered once here and reparented
   // into whichever slot shows them. This has to sit OUTSIDE the reparented
@@ -21,6 +27,10 @@
   $effect(() => {
     registerSessionParking(parkingNode);
     return () => registerSessionParking(null);
+  });
+
+  $effect(() => {
+    setRetainedSessionLimit(settingsStore.getTerminalSettings().retained_sessions ?? 10);
   });
 
   function slotFor(hostKey: SessionHostKey): HTMLElement | null {
@@ -36,6 +46,10 @@
   function handleExit(session: MountedSession, code: number): void {
     noteSessionExited(session.hostKey, code);
   }
+
+  function handleConnectionChange(session: MountedSession, connected: boolean): void {
+    noteSessionConnection(session.hostKey, connected);
+  }
 </script>
 
 <div class="session-pool-parking" bind:this={parkingNode} aria-hidden="true"></div>
@@ -46,7 +60,9 @@
     parking={parkingNode}
     slotEl={slotFor(session.hostKey)}
     active={activeFor(session.hostKey)}
+    retained={!isSessionClaimed(session.hostKey)}
     onExit={(code) => handleExit(session, code)}
+    onConnectionChange={(connected) => handleConnectionChange(session, connected)}
   />
 {/each}
 

--- a/frontend/src/lib/components/terminal/TerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/TerminalPane.svelte
@@ -6,10 +6,12 @@
     websocketPath?: string | undefined;
     reconnectOnExit?: boolean | undefined;
     active?: boolean | undefined;
+    renderingEnabled?: boolean | undefined;
     autoFocus?: boolean | undefined;
     cursorWheelInput?: boolean;
     disabled?: boolean;
     onExit?: ((code: number) => void) | undefined;
+    onConnectionChange?: ((connected: boolean) => void) | undefined;
     // When the session is already exited at mount time, skip the
     // WebSocket connect — the server's attach endpoint returns 404
     // for non-running sessions, which would loop scheduleReconnect.
@@ -21,10 +23,12 @@
     websocketPath = undefined,
     reconnectOnExit = undefined,
     active = undefined,
+    renderingEnabled = undefined,
     autoFocus = undefined,
     cursorWheelInput = false,
     disabled = false,
     onExit = undefined,
+    onConnectionChange = undefined,
     initialStatus = undefined,
   }: TerminalPaneProps = $props();
 
@@ -41,9 +45,11 @@
   {websocketPath}
   {reconnectOnExit}
   {active}
+  {renderingEnabled}
   {autoFocus}
   {cursorWheelInput}
   {disabled}
   {onExit}
+  {onConnectionChange}
   {initialStatus}
 />

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -16,6 +16,7 @@ const {
   mouseDragObserveTerminalData,
   mouseDragReset,
   resizeObserverCallbacks,
+  webglAddons,
   webLinksAddonCtor,
   xtermFitAddons,
   xtermInstances,
@@ -37,6 +38,7 @@ const {
   mouseDragObserveTerminalData: vi.fn(),
   mouseDragReset: vi.fn(),
   resizeObserverCallbacks: [] as ResizeObserverCallback[],
+  webglAddons: [] as Array<{ dispose: ReturnType<typeof vi.fn>; onContextLoss: ReturnType<typeof vi.fn> }>,
   webLinksAddonCtor: vi.fn(),
   xtermFitAddons: [] as Array<{ fit: ReturnType<typeof vi.fn>; proposeDimensions: ReturnType<typeof vi.fn> }>,
   xtermInstances: [] as Array<{
@@ -261,10 +263,12 @@ vi.mock("@xterm/addon-web-links", () => ({
 vi.mock("@xterm/addon-webgl", () => ({
   WebglAddon: vi.fn().mockImplementation(function (options) {
     mockWebglCtor(options);
-    return {
+    const addon = {
       dispose: vi.fn(),
       onContextLoss: vi.fn(),
     };
+    webglAddons.push(addon);
+    return addon;
   }),
 }));
 
@@ -306,6 +310,7 @@ describe("TerminalPane", () => {
     mouseDragObserveTerminalData.mockReset();
     mouseDragReset.mockReset();
     resizeObserverCallbacks.length = 0;
+    webglAddons.length = 0;
     webLinksAddonCtor.mockReset();
     xtermFitAddons.length = 0;
     xtermInstances.length = 0;
@@ -533,6 +538,43 @@ describe("TerminalPane", () => {
       }),
     );
     expect(mockWebglCtor).toHaveBeenCalledWith({ customGlyphs: true });
+  });
+
+  it("releases WebGL while retained and recreates it when claimed", async () => {
+    const { rerender, unmount } = render(TerminalPane, {
+      props: { workspaceId: "ws-123", renderingEnabled: true },
+    });
+    await waitFor(() => expect(webglAddons).toHaveLength(1));
+    await waitFor(() => expect(mockSockets).toHaveLength(1));
+    const terminal = xtermInstances[0]!;
+    const initialWebgl = webglAddons[0]!;
+    const closeSocket = vi.spyOn(mockSockets[0]!, "close");
+
+    await rerender({ workspaceId: "ws-123", renderingEnabled: false });
+
+    expect(initialWebgl.dispose).toHaveBeenCalledTimes(1);
+    expect(terminal.dispose).not.toHaveBeenCalled();
+
+    await rerender({ workspaceId: "ws-123", renderingEnabled: true });
+    await waitFor(() => expect(webglAddons).toHaveLength(2));
+    expect(xtermInstances).toHaveLength(1);
+
+    const replacementWebgl = webglAddons[1]!;
+    unmount();
+
+    expect(replacementWebgl.dispose).toHaveBeenCalledTimes(1);
+    expect(terminal.dispose).toHaveBeenCalledTimes(1);
+    expect(closeSocket).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports socket connection changes", async () => {
+    const onConnectionChange = vi.fn();
+    render(TerminalPane, { props: { workspaceId: "ws-123", onConnectionChange } });
+    await waitFor(() => expect(onConnectionChange).toHaveBeenCalledWith(true));
+
+    mockSockets[0]!.onclose();
+
+    await waitFor(() => expect(onConnectionChange).toHaveBeenCalledWith(false));
   });
 
   it("uses configured terminal metrics for xterm.js", async () => {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -33,9 +33,10 @@
   } from "../../api/workspace-runtime.js";
   import {
     mountedSessions,
+    noteSessionDiscarded,
     noteSessionMounted,
+    noteSessionReleased,
     isSessionSlotVisible,
-    noteSessionUnmounted,
     onSessionExited,
     requestSessionFocus,
     sessionHostKey,
@@ -1500,17 +1501,15 @@
     );
   }
 
-  // Prefixes this view has ever mounted terminals under, so moving to another
-  // workspace can take the previous one's down. Nothing else would: the pool
-  // outlives this view, and every parked terminal holds a live websocket, so
-  // browsing ten workspaces would otherwise leave ten attachments open.
+  // Prefixes this view has claimed terminals under. Moving to another workspace
+  // releases the previous claims into the app-level bounded retention cache.
   const ownedSessionPrefixes = new Set<string>();
 
   function releaseOwnedSessions(except?: string): void {
     for (const prefix of ownedSessionPrefixes) {
       if (prefix === except) continue;
       for (const session of mountedSessions()) {
-        if (session.hostKey.startsWith(prefix)) noteSessionUnmounted(session.hostKey);
+        if (session.hostKey.startsWith(prefix)) noteSessionReleased(session.hostKey, except);
       }
       ownedSessionPrefixes.delete(prefix);
     }
@@ -1530,7 +1529,7 @@
   //
   // Reconciled from state rather than pushed from each mount/unmount call site:
   // a session changes region without either side calling anything, and a missed
-  // noteSessionUnmounted would leave a socket attached to nothing.
+  // a missed release would leave a claimed socket attached to nothing.
   $effect(() => {
     const prefix = sessionHostPrefix(workspaceId, workspaceHostKey);
     const desired = new Map<SessionHostKey, MountedSession>();
@@ -1558,6 +1557,13 @@
         disabled: actionsBlocked,
       });
     }
+    // An empty list is authoritative only after this workspace's runtime
+    // snapshot is live. During a route switch `runtimeSessions` is deliberately
+    // empty while the fetch is pending; treating that transient state as a
+    // tombstone would discard the retained terminal just before it is reused.
+    const liveGenerationKeys = runtimeLive
+      ? new Set(runtimeSessions.map(sessionHostKeyFor))
+      : null;
     untrack(() => {
       releaseOwnedSessions(prefix);
       if (desired.size > 0) ownedSessionPrefixes.add(prefix);
@@ -1567,13 +1573,17 @@
       for (const session of mountedSessions()) {
         if (!session.hostKey.startsWith(prefix)) continue;
         if (desired.has(session.hostKey)) continue;
-        noteSessionUnmounted(session.hostKey);
+        if (liveGenerationKeys === null || liveGenerationKeys.has(session.hostKey)) {
+          noteSessionReleased(session.hostKey, liveGenerationKeys === null ? prefix : undefined);
+        } else {
+          noteSessionDiscarded(session.hostKey);
+        }
       }
     });
   });
 
-  // The pool is app-level, so a destroyed view leaves its terminals running
-  // forever unless it hands them back.
+  // A destroyed view releases its claims; the app-level pool applies the
+  // configured retention limit and owns final disposal.
   $effect(() => () => untrack(() => releaseOwnedSessions()));
 
   // Pooled terminals report an exit by key; only this view can map that back to

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -134,6 +134,8 @@ vi.mock("../../context.js", async (importOriginal) => {
           letter_spacing: 0,
           cursor_blink: true,
           font_ligatures: false,
+          hide_tmux_status: false,
+          retained_sessions: 10,
         }),
         setTerminalSettings: mocks.mockSetTerminalSettings,
         getModeVisibility: () => ({
@@ -248,7 +250,12 @@ vi.mock("../detail/PullDetail.svelte", async () => ({
 // renders portal slots and no terminal would ever appear.
 import WorkspaceTerminalView from "./WorkspaceTerminalViewTestHarness.svelte";
 import WorkspacePaneControls from "./WorkspacePaneControls.svelte";
-import { mountedSessions, resetSessionHostForTest, sessionHostPrefix } from "../../stores/session-host.svelte.ts";
+import {
+  isSessionClaimed,
+  mountedSessions,
+  resetSessionHostForTest,
+  sessionHostPrefix,
+} from "../../stores/session-host.svelte.ts";
 import {
   activeHostedSession,
   getInlineWorkspaceController,
@@ -1629,35 +1636,57 @@ describe("WorkspaceTerminalView", () => {
     expect(document.querySelector(".terminal-panel.open")).toBeNull();
   });
 
-  it("hands back the previous workspace's pooled terminals when the selection moves on", async () => {
-    // The pool outlives this view, so nothing else would take them down. Every
-    // parked terminal holds a live websocket; browsing ten workspaces must not
-    // leave ten attachments open.
+  it("releases the previous workspace's pooled terminals for bounded retention", async () => {
     const { rerender } = render(WorkspaceTerminalView, {
       props: { workspaceId: "ws-1" },
     });
 
     await screen.findByRole("tab", { name: /Helper/ });
     await waitFor(() => expect(mountedSessions()).toHaveLength(1));
+    await waitFor(() => expect(sockets).toHaveLength(1));
+    sockets[0]!.onopen();
+    await waitFor(() => expect(sockets[0]!.send).toHaveBeenCalled());
     const firstPrefix = sessionHostPrefix("ws-1", undefined);
     expect(mountedSessions()[0]?.hostKey.startsWith(firstPrefix)).toBe(true);
+    const firstHostKey = mountedSessions()[0]!.hostKey;
+    const firstWrapper = document.querySelector(`[data-session-host="${firstHostKey}"]`);
+    const firstSocket = sockets[0];
 
     await rerender({ workspaceId: "ws-2" });
 
     await waitFor(() => {
-      expect(mountedSessions().some((session) => session.hostKey.startsWith(firstPrefix))).toBe(false);
+      const retained = mountedSessions().find((session) => session.hostKey.startsWith(firstPrefix));
+      expect(retained).toBeDefined();
+      expect(isSessionClaimed(retained!.hostKey)).toBe(false);
+      expect(document.querySelector(`[data-session-host="${firstHostKey}"]`)).toBe(firstWrapper);
+      expect(sockets.filter((socket) => socket.url.includes("/workspaces/ws-1/"))).toEqual([firstSocket]);
+    });
+
+    await rerender({ workspaceId: "ws-1" });
+
+    await waitFor(() => {
+      expect(isSessionClaimed(firstHostKey)).toBe(true);
+      expect(sockets.filter((socket) => socket.url.includes("/workspaces/ws-1/"))).toEqual([firstSocket]);
+      expect(document.querySelector(`[data-session-host="${firstHostKey}"]`)).toBe(firstWrapper);
     });
   });
 
-  it("hands back its pooled terminals when the view itself goes away", async () => {
-    render(WorkspaceTerminalView, { props: { workspaceId: "ws-1" } });
+  it("releases its pooled terminals when the view itself goes away", async () => {
+    const { rerender } = render(WorkspaceTerminalView, { props: { workspaceId: "ws-1" } });
 
     await screen.findByRole("tab", { name: /Helper/ });
     await waitFor(() => expect(mountedSessions()).toHaveLength(1));
+    await waitFor(() => expect(sockets).toHaveLength(1));
+    sockets[0]!.onopen();
+    await waitFor(() => expect(sockets[0]!.send).toHaveBeenCalled());
+    const hostKey = mountedSessions()[0]!.hostKey;
 
-    cleanup();
+    await rerender({ workspaceId: "ws-1", showView: false });
 
-    expect(mountedSessions()).toHaveLength(0);
+    await waitFor(() => {
+      expect(mountedSessions()).toHaveLength(1);
+      expect(isSessionClaimed(hostKey)).toBe(false);
+    });
   });
 
   it("shows a relaunched agent with the same key and a new generation", async () => {
@@ -2150,7 +2179,7 @@ describe("WorkspaceTerminalView", () => {
     expect(socket.close).not.toHaveBeenCalled();
   });
 
-  it("hands a docked terminal back when the terminal panel closes", async () => {
+  it("releases a connected docked terminal when the terminal panel closes", async () => {
     localStorage.setItem("kenn-forge-workspace-active-tab:ws-1", "home");
     mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithTwoTerminalSessions());
 
@@ -2166,12 +2195,15 @@ describe("WorkspaceTerminalView", () => {
       }),
     );
     await waitFor(() => expect(sockets).toHaveLength(1));
+    sockets[0]!.onopen();
+    await waitFor(() => expect(sockets[0]!.send).toHaveBeenCalled());
+    const hostKey = mountedSessions()[0]!.hostKey;
 
     await fireEvent.click(screen.getAllByRole("button", { name: "Close terminal panel" })[0]!);
 
-    // A closed panel renders nothing, and a pooled terminal nothing renders
-    // would otherwise sit parked with its socket open forever.
-    await waitFor(() => expect(sockets[0]!.close).toHaveBeenCalled());
+    await waitFor(() => expect(isSessionClaimed(hostKey)).toBe(false));
+    expect(mountedSessions().some((session) => session.hostKey === hostKey)).toBe(true);
+    expect(sockets[0]!.close).not.toHaveBeenCalled();
   });
 
   it("shows a workspace sidebar collapse button", async () => {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalViewTestHarness.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalViewTestHarness.svelte
@@ -11,9 +11,9 @@
   // In the app that pool is mounted by WorkspaceHost, so a test that mounts the
   // view alone would have slots and no terminals.
   type ViewProps = ComponentProps<typeof WorkspaceTerminalView>;
-  type Props = ViewProps & { runtime?: AppRuntime };
+  type Props = ViewProps & { runtime?: AppRuntime; showView?: boolean };
 
-  let { runtime, ...props }: Props = $props();
+  let { runtime, showView = true, ...props }: Props = $props();
   const initialRuntime = untrack(() => runtime);
   if (initialRuntime) {
     setAppRuntime(initialRuntime);
@@ -26,5 +26,7 @@
 </script>
 
 <SessionTerminalPool />
-<WorkspaceTerminalView {...props} />
+{#if showView}
+  <WorkspaceTerminalView {...props} />
+{/if}
 {@render externalDock?.()}

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -52,10 +52,12 @@
     websocketPath?: string | undefined;
     reconnectOnExit?: boolean | undefined;
     active?: boolean | undefined;
+    renderingEnabled?: boolean | undefined;
     autoFocus?: boolean | undefined;
     cursorWheelInput?: boolean;
     disabled?: boolean;
     onExit?: ((code: number) => void) | undefined;
+    onConnectionChange?: ((connected: boolean) => void) | undefined;
     // When the session is not attachable at mount time, skip the
     // WebSocket connect — the server's attach endpoint returns 404
     // for non-running sessions, which would loop scheduleReconnect.
@@ -67,10 +69,12 @@
     websocketPath,
     reconnectOnExit = true,
     active = true,
+    renderingEnabled = true,
     autoFocus = true,
     cursorWheelInput = false,
     disabled = false,
     onExit,
+    onConnectionChange,
     initialStatus,
   }: TerminalPaneProps = $props();
   const runtime = getAppRuntime();
@@ -86,6 +90,7 @@
   let fitAddon: FitAddon | null = null;
   let ligaturesAddon: LigaturesAddon | null = null;
   let webglAddon: WebglAddon | null = null;
+  let rendererParked = false;
   let terminalSession: TerminalSessionController | null = null;
   let connectionGeneration = 0;
   let unregisterTextureAtlasParticipant: (() => void) | null = null;
@@ -529,6 +534,7 @@
     if (!terminal) return;
     webglAddon?.dispose();
     webglAddon = null;
+    if (rendererParked) return;
     if (isFirefox()) {
       scheduleTerminalResize();
       return;
@@ -546,6 +552,20 @@
     } catch {
       // WebGL unavailable; canvas renderer used as fallback.
     }
+  }
+
+  function syncRendererState(): void {
+    if (!terminal) return;
+    const shouldPark = !renderingEnabled;
+    if (rendererParked === shouldPark) return;
+    rendererParked = shouldPark;
+    if (shouldPark) {
+      webglAddon?.dispose();
+      webglAddon = null;
+      return;
+    }
+    recreateWebglAddon();
+    scheduleTerminalRefresh();
   }
 
   function syncLigaturesAddon(): void {
@@ -721,6 +741,7 @@
       },
       onOpen: () => {
         connectionGeneration += 1;
+        onConnectionChange?.(true);
         switchTimer.record("socket-open");
         sendResizeActive(resizeAuthorityRegionSize() !== null);
         const size = resizeAuthorityRegionSize();
@@ -730,6 +751,7 @@
       },
       onMessage: handleTerminalMessage,
       onDisconnected: () => {
+        onConnectionChange?.(false);
         cancelPendingTerminalSequence();
         clipboardWriter?.cancelAuthorization();
         mouseDragAutoscroll?.reset();
@@ -795,6 +817,8 @@
     fitAddon?.fit();
     if (active) scheduleTerminalRefresh();
   });
+
+  $effect(syncRendererState);
 
   $effect(() => {
     if (!terminal) return;
@@ -918,6 +942,7 @@
         ligaturesAddon = new LigaturesAddon();
         term.loadAddon(ligaturesAddon);
       }
+      rendererParked = !renderingEnabled;
       recreateWebglAddon();
 
       appliedTerminalFontFamily = terminalFontFamily;

--- a/frontend/src/lib/components/terminal/terminalSettingsPersistence.test.ts
+++ b/frontend/src/lib/components/terminal/terminalSettingsPersistence.test.ts
@@ -10,6 +10,15 @@ import {
   restoreTerminalSettingsPreview,
   saveTerminalSettings as saveTerminalSettingsEffect,
 } from "../../stores/terminal-settings-persistence.js";
+import {
+  isSessionMounted,
+  noteSessionConnection,
+  noteSessionMounted,
+  noteSessionReleased,
+  resetSessionHostForTest,
+  sessionHostKey,
+  setRetainedSessionLimit,
+} from "../../stores/session-host.svelte.ts";
 
 let runtime: OwnedAppRuntime;
 let persistSettings: (settings: TerminalSettings) => Promise<TerminalSettings>;
@@ -82,6 +91,7 @@ function saveTerminalSettings(options: {
 
 beforeEach(() => {
   runtime = makeAppRuntime();
+  resetSessionHostForTest();
   persistSettings = (settings) => Promise.resolve(settings);
   persistedTerminal = { ...DEFAULT_TERMINAL_SETTINGS };
   const fetch: typeof globalThis.fetch = async (input, init) => {
@@ -131,7 +141,128 @@ function createStore() {
   };
 }
 
+function createRetentionAwareStore() {
+  const store = createStore();
+  return {
+    getTerminalSettings: store.getTerminalSettings,
+    setTerminalSettings: (settings: TerminalSettings) => {
+      store.setTerminalSettings(settings);
+      setRetainedSessionLimit(settings.retained_sessions);
+    },
+  };
+}
+
+function releaseConnectedSession(): string {
+  const hostKey = sessionHostKey("ws-retained", undefined, "agent", "2026-08-10T00:00:00Z");
+  noteSessionMounted({ hostKey, websocketPath: "/ws/agent", status: "running" });
+  noteSessionConnection(hostKey, true);
+  noteSessionReleased(hostKey);
+  return hostKey;
+}
+
 describe("terminal settings persistence", () => {
+  it("does not evict released sessions when a lower retention preview is cancelled", () => {
+    const store = createRetentionAwareStore();
+    const baseline = store.getTerminalSettings();
+    const hostKey = releaseConnectedSession();
+
+    previewTerminalSettings(store, baseline, {
+      ...baseline,
+      font_size: 20,
+      retained_sessions: 0,
+    });
+
+    expect(store.getTerminalSettings().font_size).toBe(20);
+    expect(store.getTerminalSettings().retained_sessions).toBe(10);
+    expect(isSessionMounted(hostKey)).toBe(true);
+
+    restoreTerminalSettingsPreview(store);
+
+    expect(store.getTerminalSettings()).toEqual(baseline);
+    expect(isSessionMounted(hostKey)).toBe(true);
+  });
+
+  it("does not evict released sessions when saving a lower retention limit fails", async () => {
+    const failedSave = deferred<TerminalSettings>();
+    const store = createRetentionAwareStore();
+    const baseline = store.getTerminalSettings();
+    const hostKey = releaseConnectedSession();
+    const persist = vi.fn(() => failedSave.promise);
+
+    const save = saveTerminalSettings({
+      baseline,
+      changes: { retained_sessions: 0 },
+      persist,
+      store,
+    });
+    await vi.waitFor(() => expect(persist).toHaveBeenCalledTimes(1));
+
+    expect(store.getTerminalSettings().retained_sessions).toBe(10);
+    expect(isSessionMounted(hostKey)).toBe(true);
+
+    failedSave.reject(new Error("settings unavailable"));
+    await expect(save).rejects.toMatchObject({ _tag: "TransientTransportError" });
+
+    expect(store.getTerminalSettings().retained_sessions).toBe(10);
+    expect(isSessionMounted(hostKey)).toBe(true);
+  });
+
+  it("persists zero as an explicit retained-session limit", async () => {
+    const store = createStore();
+    const persist = vi.fn(async (settings: TerminalSettings) => settings);
+    const baseline = store.getTerminalSettings();
+
+    await saveTerminalSettings({
+      baseline,
+      changes: { retained_sessions: 0 },
+      persist,
+      store,
+    });
+
+    expect(persist).toHaveBeenCalledWith({
+      ...DEFAULT_TERMINAL_SETTINGS,
+      retained_sessions: 0,
+    });
+    expect(store.getTerminalSettings().retained_sessions).toBe(0);
+  });
+
+  it("publishes an earlier confirmed retention limit when a newer save fails", async () => {
+    const firstSave = deferred<TerminalSettings>();
+    const secondSave = deferred<TerminalSettings>();
+    const store = createRetentionAwareStore();
+    const persist = vi
+      .fn<(settings: TerminalSettings) => Promise<TerminalSettings>>()
+      .mockImplementationOnce(() => firstSave.promise)
+      .mockImplementationOnce(() => secondSave.promise);
+
+    const firstRetention = saveTerminalSettings({
+      baseline: store.getTerminalSettings(),
+      changes: { retained_sessions: 8 },
+      persist,
+      store,
+    });
+    const secondRetention = saveTerminalSettings({
+      baseline: store.getTerminalSettings(),
+      changes: { retained_sessions: 6 },
+      persist,
+      store,
+    });
+
+    await vi.waitFor(() => expect(persist).toHaveBeenCalledTimes(1));
+    firstSave.resolve({
+      ...DEFAULT_TERMINAL_SETTINGS,
+      retained_sessions: 8,
+    });
+    await firstRetention;
+    await vi.waitFor(() => expect(persist).toHaveBeenCalledTimes(2));
+
+    expect(store.getTerminalSettings().retained_sessions).toBe(10);
+    secondSave.reject(new Error("settings unavailable"));
+    await expect(secondRetention).rejects.toMatchObject({ _tag: "TransientTransportError" });
+
+    expect(store.getTerminalSettings().retained_sessions).toBe(8);
+  });
+
   it("serializes options and zoom saves without dropping either change", async () => {
     const firstSave = deferred<TerminalSettings>();
     const store = createStore();

--- a/frontend/src/lib/instrumentation/workspaceSwitchTiming.test.ts
+++ b/frontend/src/lib/instrumentation/workspaceSwitchTiming.test.ts
@@ -189,6 +189,17 @@ describe("workspace switch timing", () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  test("a retained terminal's first paint ends the interaction trace", async () => {
+    vi.useFakeTimers();
+    beginWorkspaceSwitch("ws-1", undefined);
+
+    expect(createWorkspaceSwitchPaneTimer().record("retained-first-paint", { cacheHit: true })).toBe(true);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(currentInteractionTraceId()).toBeNull();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   test("the recording-window fallback ends an unfinished interaction trace", () => {
     vi.useFakeTimers();
     beginWorkspaceSwitch("ws-1", undefined);

--- a/frontend/src/lib/instrumentation/workspaceSwitchTiming.ts
+++ b/frontend/src/lib/instrumentation/workspaceSwitchTiming.ts
@@ -28,6 +28,7 @@ export const WORKSPACE_SWITCH_PHASES = [
   "socket-open",
   "first-bytes",
   "first-paint",
+  "retained-first-paint",
 ] as const;
 
 export type WorkspaceSwitchPhase = (typeof WORKSPACE_SWITCH_PHASES)[number];
@@ -129,7 +130,7 @@ function recordPhase(sw: WorkspaceSwitch, phase: WorkspaceSwitchPhase, detail?: 
     traceId: sw.traceId,
     ...detail,
   });
-  if (phase === "first-paint") endSwitchTrace(sw);
+  if (phase === "first-paint" || phase === "retained-first-paint") endSwitchTrace(sw);
   return true;
 }
 

--- a/frontend/src/lib/stores/session-host.svelte.ts
+++ b/frontend/src/lib/stores/session-host.svelte.ts
@@ -55,6 +55,10 @@ let parkingEl: HTMLElement | null = null;
 const slotEls = $state<Record<SessionHostKey, HTMLElement | null>>({});
 const slotVisible = $state<Record<SessionHostKey, boolean>>({});
 let mounted = $state<readonly MountedSession[]>([]);
+const claimed = $state<Record<SessionHostKey, boolean>>({});
+const connected = new Map<SessionHostKey, boolean>();
+let releasedKeys: SessionHostKey[] = [];
+let retainedSessionLimit = 10;
 
 export function registerSessionSlot(key: SessionHostKey, el: HTMLElement | null): void {
   // A targeted property write, not `slotEls = { ...slotEls, [key]: el }`. This
@@ -154,7 +158,23 @@ export function isSessionMounted(key: SessionHostKey): boolean {
   return mounted.some((session) => session.hostKey === key);
 }
 
+export function isSessionClaimed(key: SessionHostKey): boolean {
+  return claimed[key] === true;
+}
+
+function removeReleasedKey(key: SessionHostKey): void {
+  releasedKeys = releasedKeys.filter((candidate) => candidate !== key);
+}
+
+function clearSessionFocusForKey(key: SessionHostKey): void {
+  if (pendingFocusKey !== key) return;
+  pendingFocusKey = null;
+  pendingFocusSoft = false;
+}
+
 export function noteSessionMounted(session: MountedSession): void {
+  claimed[session.hostKey] = true;
+  removeReleasedKey(session.hostKey);
   const existing = mounted.find((candidate) => candidate.hostKey === session.hostKey);
   if (existing) {
     if (
@@ -172,18 +192,68 @@ export function noteSessionMounted(session: MountedSession): void {
   mounted = [...mounted, session];
 }
 
-export function noteSessionUnmounted(key: SessionHostKey): void {
+export function noteSessionDiscarded(key: SessionHostKey): void {
   if (!isSessionMounted(key)) return;
-  // A focus request this session never got to consume dies with it. Left armed, it
-  // waits for a subtree under the same key to mount - a revisit, or the pane being
-  // reopened for its own reasons - and steals focus for a Focus Terminal the user
-  // pressed long before, somewhere else.
-  if (pendingFocusKey === key) {
-    pendingFocusKey = null;
-    pendingFocusSoft = false;
-  }
+  // A focus request this session never got to consume dies with it. Left armed,
+  // it waits for a subtree under the same key to mount and steals focus later.
+  clearSessionFocusForKey(key);
+  delete claimed[key];
+  connected.delete(key);
+  removeReleasedKey(key);
   mounted = mounted.filter((session) => session.hostKey !== key);
   registerSessionSlot(key, null);
+}
+
+function trimReleasedSessions(protectedPrefix?: string): void {
+  while (releasedKeys.length > retainedSessionLimit) {
+    const oldest = releasedKeys.find((key) => protectedPrefix === undefined || !key.startsWith(protectedPrefix));
+    if (oldest === undefined) return;
+    noteSessionDiscarded(oldest);
+  }
+}
+
+/**
+ * Release a claimed session into the bounded cache.
+ *
+ * During a workspace switch, the destination runtime snapshot arrives after
+ * the previous workspace is released. Protecting that destination's prefix
+ * lets cache trimming evict another released session instead of destroying the
+ * terminal that the pending snapshot is about to reclaim.
+ */
+export function noteSessionReleased(key: SessionHostKey, protectedPrefix?: string): void {
+  if (!isSessionMounted(key)) return;
+  claimed[key] = false;
+  clearSessionFocusForKey(key);
+  removeReleasedKey(key);
+  // A released component can stop its reconnect loop only by leaving the keyed
+  // pool. Check current state as well as future disconnect notifications.
+  if (connected.get(key) !== true) {
+    noteSessionDiscarded(key);
+    return;
+  }
+  releasedKeys = [...releasedKeys, key];
+  trimReleasedSessions(protectedPrefix);
+}
+
+export function noteSessionConnection(key: SessionHostKey, isConnected: boolean): void {
+  if (!isSessionMounted(key)) {
+    connected.delete(key);
+    return;
+  }
+  connected.set(key, isConnected);
+  if (!isConnected && !isSessionClaimed(key)) noteSessionDiscarded(key);
+}
+
+export function setRetainedSessionLimit(limit: number): void {
+  retainedSessionLimit = Math.max(0, Math.min(20, Math.trunc(limit)));
+  trimReleasedSessions();
+}
+
+export function discardSessionsWithPrefix(prefix: string): void {
+  const sessions = mounted.slice();
+  for (const session of sessions) {
+    if (session.hostKey.startsWith(prefix)) noteSessionDiscarded(session.hostKey);
+  }
 }
 
 const exitListeners = new Set<(key: SessionHostKey, code: number) => void>();
@@ -201,7 +271,12 @@ export function onSessionExited(cb: (key: SessionHostKey, code: number) => void)
 }
 
 export function noteSessionExited(key: SessionHostKey, code: number): void {
-  for (const listener of [...exitListeners]) listener(key, code);
+  // Final disposal is app-level authority: a released session can exit while
+  // no workspace view exists to hear the event. Remove it before notifying any
+  // current view so listeners never observe a dead cache entry.
+  noteSessionDiscarded(key);
+  const listeners = Array.from(exitListeners);
+  for (const listener of listeners) listener(key, code);
 }
 
 // A Focus Terminal aimed at a promoted session whose terminal is not on screen
@@ -253,6 +328,10 @@ export function resetSessionHostForTest(): void {
   parkingEl = null;
   for (const key of Object.keys(slotEls)) delete slotEls[key];
   for (const key of Object.keys(slotVisible)) delete slotVisible[key];
+  for (const key of Object.keys(claimed)) delete claimed[key];
+  connected.clear();
+  releasedKeys = [];
+  retainedSessionLimit = 10;
   mounted = [];
   pendingFocusKey = null;
   pendingFocusSoft = false;

--- a/frontend/src/lib/stores/session-host.test.ts
+++ b/frontend/src/lib/stores/session-host.test.ts
@@ -1,21 +1,39 @@
 import { beforeEach, describe, expect, it } from "vite-plus/test";
 import {
   consumeSessionFocus,
+  discardSessionsWithPrefix,
   getSessionSlotElement,
+  isSessionClaimed,
   isSessionMounted,
   isSessionSlotVisible,
   mountedSessions,
+  noteSessionConnection,
+  noteSessionDiscarded,
+  noteSessionExited,
   noteSessionMounted,
-  noteSessionUnmounted,
+  noteSessionReleased,
+  onSessionExited,
   registerSessionSlot,
   requestSessionFocus,
   releaseSessionSlot,
   resetSessionHostForTest,
   sessionHostKey,
+  sessionHostPrefix,
+  setRetainedSessionLimit,
   setSessionSlotVisible,
 } from "./session-host.svelte.ts";
 
 const agentOnA = sessionHostKey("ws-1", undefined, "agent", "2026-01-01T00:00:00Z");
+
+function mountedSession(workspaceId: string, sessionKey: string) {
+  const hostKey = sessionHostKey(workspaceId, undefined, sessionKey, "2026-01-01T00:00:00Z");
+  return { hostKey, websocketPath: `/ws/${sessionKey}`, status: "running" };
+}
+
+function mountConnected(session: ReturnType<typeof mountedSession>): void {
+  noteSessionMounted(session);
+  noteSessionConnection(session.hostKey, true);
+}
 
 describe("session host registry", () => {
   beforeEach(() => resetSessionHostForTest());
@@ -40,7 +58,7 @@ describe("session host registry", () => {
     noteSessionMounted({ hostKey: agentOnA, websocketPath: "/ws/agent", status: "running" });
     requestSessionFocus(agentOnA);
 
-    noteSessionUnmounted(agentOnA);
+    noteSessionDiscarded(agentOnA);
 
     // Nothing consumed it, so it would sit armed until something mounted under this
     // key again - a revisit, or the pane reopening for its own reasons - and take the
@@ -151,7 +169,7 @@ describe("session host registry", () => {
     expect(mountedSessions()[0]?.status).toBe("running");
     expect(isSessionMounted(agentOnA)).toBe(true);
 
-    noteSessionUnmounted(agentOnA);
+    noteSessionDiscarded(agentOnA);
     expect(mountedSessions()).toHaveLength(0);
     expect(isSessionMounted(agentOnA)).toBe(false);
   });
@@ -159,9 +177,151 @@ describe("session host registry", () => {
   it("drops the slot of an unmounted session", () => {
     noteSessionMounted({ hostKey: agentOnA, websocketPath: "/ws/agent", status: "running" });
     registerSessionSlot(agentOnA, document.createElement("div"));
-    noteSessionUnmounted(agentOnA);
+    noteSessionDiscarded(agentOnA);
     // The terminal is gone, so a stale slot would have the pool reparenting a
     // subtree that no longer exists.
     expect(getSessionSlotElement(agentOnA)).toBeNull();
+  });
+
+  it("evicts released sessions in release order", () => {
+    const first = mountedSession("ws-1", "first");
+    const second = mountedSession("ws-2", "second");
+    const third = mountedSession("ws-3", "third");
+    setRetainedSessionLimit(2);
+
+    for (const session of [first, second, third]) {
+      mountConnected(session);
+      noteSessionReleased(session.hostKey);
+    }
+
+    expect(mountedSessions().map(({ hostKey }) => hostKey)).toEqual([second.hostKey, third.hostKey]);
+    expect(isSessionClaimed(second.hostKey)).toBe(false);
+    expect(isSessionClaimed(third.hostKey)).toBe(false);
+  });
+
+  it("protects a pending destination from eviction while releasing the previous workspace", () => {
+    const destination = mountedSession("ws-1", "agent");
+    const previous = mountedSession("ws-2", "agent");
+    setRetainedSessionLimit(1);
+    mountConnected(destination);
+    noteSessionReleased(destination.hostKey);
+    mountConnected(previous);
+
+    noteSessionReleased(previous.hostKey, sessionHostPrefix("ws-1", undefined));
+
+    expect(mountedSessions().map(({ hostKey }) => hostKey)).toEqual([destination.hostKey]);
+    expect(isSessionClaimed(destination.hostKey)).toBe(false);
+  });
+
+  it("moves a reclaimed session to the newest release position", () => {
+    const first = mountedSession("ws-1", "first");
+    const second = mountedSession("ws-2", "second");
+    const third = mountedSession("ws-3", "third");
+    setRetainedSessionLimit(2);
+    mountConnected(first);
+    noteSessionReleased(first.hostKey);
+    mountConnected(second);
+    noteSessionReleased(second.hostKey);
+
+    noteSessionMounted(first);
+    noteSessionReleased(first.hostKey);
+    mountConnected(third);
+    noteSessionReleased(third.hostKey);
+
+    expect(mountedSessions().map(({ hostKey }) => hostKey)).toEqual([first.hostKey, third.hostKey]);
+  });
+
+  it("does not count claimed sessions toward the released limit", () => {
+    const claimed = mountedSession("ws-1", "claimed");
+    const released = mountedSession("ws-2", "released");
+    setRetainedSessionLimit(1);
+    mountConnected(claimed);
+    mountConnected(released);
+
+    noteSessionReleased(released.hostKey);
+
+    expect(mountedSessions().map(({ hostKey }) => hostKey)).toEqual([claimed.hostKey, released.hostKey]);
+    expect(isSessionClaimed(claimed.hostKey)).toBe(true);
+  });
+
+  it("applies a lower limit immediately and zero disables retention", () => {
+    const first = mountedSession("ws-1", "first");
+    const second = mountedSession("ws-2", "second");
+    mountConnected(first);
+    noteSessionReleased(first.hostKey);
+    mountConnected(second);
+    noteSessionReleased(second.hostKey);
+
+    setRetainedSessionLimit(1);
+    expect(mountedSessions().map(({ hostKey }) => hostKey)).toEqual([second.hostKey]);
+    setRetainedSessionLimit(0);
+    expect(mountedSessions()).toEqual([]);
+  });
+
+  it("discards immediately when released while disconnected", () => {
+    const session = mountedSession("ws-1", "agent");
+    noteSessionMounted(session);
+
+    noteSessionReleased(session.hostKey);
+
+    expect(isSessionMounted(session.hostKey)).toBe(false);
+  });
+
+  it("discards a released session on disconnect but keeps a claimed one", () => {
+    const claimed = mountedSession("ws-1", "claimed");
+    const released = mountedSession("ws-2", "released");
+    mountConnected(claimed);
+    mountConnected(released);
+    noteSessionReleased(released.hostKey);
+
+    noteSessionConnection(claimed.hostKey, false);
+    noteSessionConnection(released.hostKey, false);
+
+    expect(isSessionMounted(claimed.hostKey)).toBe(true);
+    expect(isSessionMounted(released.hostKey)).toBe(false);
+  });
+
+  it("discards a session before routing its exit", () => {
+    const session = mountedSession("ws-1", "agent");
+    mountConnected(session);
+    let mountedWhenRouted = true;
+    const stopListening = onSessionExited((hostKey) => {
+      if (hostKey === session.hostKey) mountedWhenRouted = isSessionMounted(hostKey);
+    });
+
+    noteSessionExited(session.hostKey, 0);
+    stopListening();
+
+    expect(mountedWhenRouted).toBe(false);
+    expect(isSessionMounted(session.hostKey)).toBe(false);
+  });
+
+  it("purges every generation for one workspace and host prefix", () => {
+    const local = mountedSession("ws-1", "agent");
+    const localSecondGeneration = {
+      ...local,
+      hostKey: sessionHostKey("ws-1", undefined, "agent", "2026-02-02T00:00:00Z"),
+    };
+    const fleet = {
+      ...local,
+      hostKey: sessionHostKey("ws-1", "build", "agent", "2026-01-01T00:00:00Z"),
+    };
+    for (const session of [local, localSecondGeneration, fleet]) mountConnected(session);
+    noteSessionReleased(localSecondGeneration.hostKey);
+
+    discardSessionsWithPrefix(sessionHostPrefix("ws-1", undefined));
+
+    expect(mountedSessions().map(({ hostKey }) => hostKey)).toEqual([fleet.hostKey]);
+  });
+
+  it("clears deferred focus on final discard", () => {
+    const session = mountedSession("ws-1", "agent");
+    noteSessionMounted(session);
+    requestSessionFocus(session.hostKey);
+
+    noteSessionDiscarded(session.hostKey);
+    noteSessionMounted(session);
+
+    expect(consumeSessionFocus(session.hostKey)).toBe(false);
   });
 });

--- a/frontend/src/lib/stores/settings.svelte.ts
+++ b/frontend/src/lib/stores/settings.svelte.ts
@@ -109,6 +109,10 @@ export function createSettingsStore() {
     return terminalSettings.font_ligatures;
   }
 
+  function getTerminalRetainedSessions(): number {
+    return terminalSettings.retained_sessions;
+  }
+
   function hasConfiguredRepos(): boolean {
     return repos.length > 0;
   }
@@ -137,6 +141,7 @@ export function createSettingsStore() {
     getTerminalLetterSpacing,
     getTerminalCursorBlink,
     getTerminalFontLigatures,
+    getTerminalRetainedSessions,
     hasConfiguredRepos,
     isSettingsLoaded,
   };

--- a/frontend/src/lib/stores/terminal-settings-persistence.ts
+++ b/frontend/src/lib/stores/terminal-settings-persistence.ts
@@ -48,10 +48,25 @@ const TERMINAL_SETTINGS_KEYS = [
   "cursor_blink",
   "font_ligatures",
   "hide_tmux_status",
+  "retained_sessions",
 ] satisfies ReadonlyArray<keyof TerminalSettings>;
 
 function changedKeys(settings: Partial<Record<keyof TerminalSettings, unknown>>): Array<keyof TerminalSettings> {
   return TERMINAL_SETTINGS_KEYS.filter((key) => key in settings);
+}
+
+function isDeferredSetting(key: keyof TerminalSettings): boolean {
+  return key === "retained_sessions";
+}
+
+function immediateSettings(settings: Partial<TerminalSettings>): Partial<TerminalSettings> {
+  const immediate: Partial<TerminalSettings> = {};
+  for (const key of changedKeys(settings)) {
+    if (!isDeferredSetting(key)) {
+      Object.assign(immediate, { [key]: settings[key] });
+    }
+  }
+  return immediate;
 }
 
 function previewOwnsField(queue: SaveQueue, preview: TerminalSettingsPreview, key: keyof TerminalSettings): boolean {
@@ -71,6 +86,25 @@ function reconcileSettings(
   for (const key of changedKeys(expected)) {
     if (ownsField(key) && Object.is(current[key], expected[key])) {
       Object.assign(updates, { [key]: replacement[key] });
+    }
+  }
+  if (changedKeys(updates).length > 0) {
+    store.setTerminalSettings({ ...current, ...updates });
+  }
+}
+
+function reconcileSavedSettings(
+  store: TerminalSettingsStore,
+  expected: Partial<TerminalSettings>,
+  saved: TerminalSettings,
+  ownsField: (key: keyof TerminalSettings) => boolean,
+): void {
+  const current = store.getTerminalSettings();
+  const updates: Partial<TerminalSettings> = {};
+
+  for (const key of changedKeys(expected)) {
+    if (ownsField(key) && (isDeferredSetting(key) || Object.is(current[key], expected[key]))) {
+      Object.assign(updates, { [key]: saved[key] });
     }
   }
   if (changedKeys(updates).length > 0) {
@@ -177,7 +211,7 @@ export function previewTerminalSettings(
       Object.assign(authoritativeBaseline, { [key]: current[key] });
     }
   }
-  const changes = terminalSettingsChanges(authoritativeBaseline, next);
+  const changes = immediateSettings(terminalSettingsChanges(authoritativeBaseline, next));
   queue.previewGeneration += 1;
   const previewGeneration = queue.previewGeneration;
   const previousPreview = previews.get(store);
@@ -303,10 +337,13 @@ export const saveTerminalSettings = Effect.fn("TerminalSettings.save")(function*
       delete activeQueue.fieldPreviewGenerations[key];
     }
     activeQueue.pending += 1;
-    store.setTerminalSettings({
-      ...store.getTerminalSettings(),
-      ...changes,
-    });
+    const optimisticChanges = immediateSettings(changes);
+    if (changedKeys(optimisticChanges).length > 0) {
+      store.setTerminalSettings({
+        ...store.getTerminalSettings(),
+        ...optimisticChanges,
+      });
+    }
     return { activeQueue, mutationGeneration };
   });
   const save = workflow
@@ -325,14 +362,14 @@ export const saveTerminalSettings = Effect.fn("TerminalSettings.save")(function*
           }
           state.activeQueue.confirmed = confirmed;
           confirmPreviewChanges(store, changes);
-          reconcileSettings(
+          reconcileSavedSettings(
             store,
             changes,
             saved,
             (key) => state.activeQueue.fieldOptimisticGenerations[key] === state.mutationGeneration,
           );
         } else {
-          reconcileSettings(
+          reconcileSavedSettings(
             store,
             changes,
             state.activeQueue.confirmed,

--- a/frontend/src/lib/stores/workspace-host.svelte.ts
+++ b/frontend/src/lib/stores/workspace-host.svelte.ts
@@ -21,7 +21,13 @@ import {
 } from "./workspace-create-pending.svelte.js";
 import { getStackDepth } from "./keyboard/modal-stack.svelte.js";
 import { getPaneLayoutStore, resetPaneLayoutStoresForTest } from "./paneLayout.svelte.js";
-import { clearSessionFocusRequest, getSessionSlotElement, requestSessionFocus } from "./session-host.svelte.ts";
+import {
+  clearSessionFocusRequest,
+  discardSessionsWithPrefix,
+  getSessionSlotElement,
+  requestSessionFocus,
+  sessionHostPrefix,
+} from "./session-host.svelte.ts";
 import { forgetWorkspaceRoute, getRoute, navigate, replaceUrl } from "./router.svelte.ts";
 
 export type HostedWorkspaceKey = { workspaceId: string; hostKey: string | undefined };
@@ -439,6 +445,7 @@ export function rememberTerminalRouteKey(key: HostedWorkspaceKey): void {
 }
 
 export function notifyWorkspaceDeleted(workspaceId: string, hostKey?: string, identity?: WorkspaceItemIdentity): void {
+  discardSessionsWithPrefix(sessionHostPrefix(workspaceId, hostKey));
   // Inline claims only ever hold local workspaces (hostKey undefined);
   // fleet deletions can't match one.
   if (hostKey === undefined) {

--- a/frontend/src/lib/stores/workspace-host.test.ts
+++ b/frontend/src/lib/stores/workspace-host.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, it, beforeEach, vi } from "vite-plus/test";
 import { getPaneLayoutStore, promoteSessionBesideWorkspace } from "./paneLayout.svelte.js";
 import { pushModalFrame } from "./keyboard/modal-stack.svelte.js";
-import { consumeSessionFocus, registerSessionSlot, resetSessionHostForTest } from "./session-host.svelte.ts";
+import {
+  consumeSessionFocus,
+  mountedSessions,
+  noteSessionConnection,
+  noteSessionMounted,
+  noteSessionReleased,
+  registerSessionSlot,
+  resetSessionHostForTest,
+  sessionHostKey,
+} from "./session-host.svelte.ts";
 import {
   createdWorkspaceRef,
   markWorkspaceIdDeleted,
@@ -505,6 +514,20 @@ describe("workspace host store", () => {
     expect(desiredSlot()).toBe("prs"); // same id on a fleet host is a different workspace
     expect(prs.effectiveWorkspaceRef(identityA, refA)).toEqual(refA); // no tombstone
     expect(getLastWorkspaceRoute()).toBe("/workspaces"); // fleet route forgotten
+  });
+
+  it("purges pooled sessions only for the deleted workspace and host", () => {
+    const localKey = sessionHostKey("ws-a", undefined, "agent", "local-generation");
+    const fleetKey = sessionHostKey("ws-a", "build-host", "agent", "fleet-generation");
+    for (const hostKey of [localKey, fleetKey]) {
+      noteSessionMounted({ hostKey, websocketPath: `/terminal/${hostKey}`, status: "running" });
+      noteSessionConnection(hostKey, true);
+    }
+    noteSessionReleased(localKey);
+
+    notifyWorkspaceDeleted("ws-a");
+
+    expect(mountedSessions().map((session) => session.hostKey)).toEqual([fleetKey]);
   });
 
   it("dock collapse means claimed-but-hidden", () => {

--- a/frontend/src/test/mockApiFetch.ts
+++ b/frontend/src/test/mockApiFetch.ts
@@ -312,6 +312,7 @@ export const mockSettings = {
     cursor_blink: true,
     font_ligatures: false,
     hide_tmux_status: false,
+    retained_sessions: 10,
   },
   agents: [],
   notifications: {

--- a/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
+++ b/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
@@ -6,10 +6,10 @@
 // hosted WorkspaceHost/WorkspaceTerminalView instance reparents between the
 // Workspaces tab slot and a per-surface WorkspaceDockPanel slot without
 // tearing down the terminal underneath it. A `data-continuity` tag applied
-// via evaluate is the proof a reparent preserves the exact DOM node — a
-// destroy+recreate (the reconnecting switch a differing remembered key
-// takes) cannot carry the tag forward. After every reparent a command is
-// typed into the terminal that creates a marker file in the workspace's
+// via evaluate is the proof a reparent or released-session reclaim preserves
+// the exact DOM node. Tests that require destroy+recreate disable retention
+// and verify the tag is absent after reconnect. After every reparent a command
+// is typed into the terminal that creates a marker file in the workspace's
 // worktree, and the test asserts the file appears on disk: keystrokes must
 // travel the WebSocket to the real tmux shell and execute. This is durable
 // evidence the session is live — unlike a screenshot-hash diff, which
@@ -31,6 +31,7 @@ import {
 } from "@playwright/test";
 import { startIsolatedWorkspaceE2EServer, type IsolatedE2EServer } from "./support/e2eServer";
 import { runPaletteCommand } from "./support/paletteCommands";
+import { openSettingsPanel } from "./support/settingsPanel";
 
 type WorkspaceStatusResponse = {
   id: string;
@@ -515,6 +516,47 @@ async function expectPersistedTerminalFontSize(api: APIRequestContext, fontSize:
       return settings.terminal.font_size;
     })
     .toBe(fontSize);
+}
+
+async function setRetainedSessions(api: APIRequestContext, limit: number): Promise<void> {
+  const currentResponse = await api.get("/api/v1/settings");
+  expect(currentResponse.ok()).toBe(true);
+  const current = (await currentResponse.json()) as { terminal: Record<string, unknown> };
+  const updateResponse = await api.put("/api/v1/settings", {
+    data: {
+      terminal: {
+        ...current.terminal,
+        retained_sessions: limit,
+      },
+    },
+  });
+  expect(updateResponse.ok(), await updateResponse.text()).toBe(true);
+}
+
+async function trackSessionWebSockets(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const log: Array<{ id: number; url: string; closed: boolean }> = [];
+    (window as unknown as { __wsLog: typeof log }).__wsLog = log;
+    const Native = window.WebSocket;
+    class TrackedWebSocket extends Native {
+      constructor(url: string | URL, protocols?: string | string[]) {
+        super(url, protocols);
+        const entry = { id: log.length + 1, url: String(url), closed: false };
+        log.push(entry);
+        this.addEventListener("close", () => {
+          entry.closed = true;
+        });
+      }
+    }
+    window.WebSocket = TrackedWebSocket as unknown as typeof WebSocket;
+  });
+}
+
+function sessionWebSockets(page: Page, workspaceId: string) {
+  return page.evaluate((needle) => {
+    const log = (window as unknown as { __wsLog?: Array<{ id: number; url: string; closed: boolean }> }).__wsLog ?? [];
+    return log.filter((entry) => entry.url.includes(needle));
+  }, `/workspaces/${workspaceId}/runtime/sessions/`);
 }
 
 test.describe("inline workspace pane continuity", () => {
@@ -1611,7 +1653,7 @@ test.describe("inline workspace pane continuity", () => {
     }
   });
 
-  test("a different remembered key takes the reconnecting switch path", async ({ page }) => {
+  test("a different remembered key parks the released terminal while switching", async ({ page }) => {
     test.skip(
       !hasCommand("git") || !hasCommand("tmux", ["-V"]),
       "git and tmux are required for the real workspace flow",
@@ -1642,20 +1684,26 @@ test.describe("inline workspace pane continuity", () => {
       });
       await expect(page.locator('[data-continuity="witness-a"]')).toBeVisible();
 
-      // Flip to the Workspaces tab: route memory points at B, not A, so WTV
-      // must take its normal reconnecting switch instead of a reparent.
+      // Flip to the Workspaces tab: route memory points at B, not A. The
+      // released A terminal remains parked for reuse while B owns the visible
+      // workspace slot.
       await selectTopBarTab(page, "Workspaces");
       await expect(page).toHaveURL(new RegExp(`/terminal/${workspaceB.id}$`));
 
-      await expect(page.locator('[data-continuity="witness-a"]')).toHaveCount(0);
+      const parkedA = page.locator('.session-pool-parking [data-continuity="witness-a"]');
+      await expect(parkedA).toHaveCount(1);
+      await expect(parkedA).not.toBeVisible();
       await expect(page.locator(".workspace-list-sidebar .ws-row.selected")).toContainText(DARK_MODE_ISSUE_TITLE);
+      const workspaceBContainer = await openTerminalPanel(page);
+      await expect(workspaceBContainer).toBeVisible();
+      await expect(workspaceBContainer).not.toHaveAttribute("data-continuity", "witness-a");
     } finally {
       await api?.dispose();
       await isolatedServer?.stop();
     }
   });
 
-  test("tmux wheel scrolling survives local workspace renderer replacement", async ({ page }) => {
+  test("tmux wheel scrolling survives retained workspace terminal reuse", async ({ page }) => {
     test.skip(
       !hasCommand("git") || !hasCommand("tmux", ["-V"]),
       "git and tmux are required for the real workspace flow",
@@ -1705,7 +1753,7 @@ test.describe("inline workspace pane continuity", () => {
       await expect(page).toHaveURL(new RegExp(`/terminal/${workspaceA.id}$`));
       const returnedA = page.locator(".terminal-panel.open .terminal-container").first();
       await expect(returnedA).toBeVisible();
-      await expect(page.locator('[data-continuity="mouse-before-standalone-switch"]')).toHaveCount(0);
+      await expect(returnedA).toHaveAttribute("data-continuity", "mouse-before-standalone-switch");
       await expectWheelScroll(page, returnedA, isolatedServer, runtimeTmuxSessionA);
       exitTmuxCopyMode(isolatedServer, runtimeTmuxSessionA);
       const standalonePaste = "standalone-bracketed-paste";
@@ -1723,7 +1771,7 @@ test.describe("inline workspace pane continuity", () => {
 
       const inlineA = page.locator(".detail-pane-workspace-slot .terminal-container").first();
       await expect(inlineA).toBeVisible();
-      await expect(page.locator('[data-continuity="mouse-before-inline-switch"]')).toHaveCount(0);
+      await expect(inlineA).toHaveAttribute("data-continuity", "mouse-before-inline-switch");
       await expectWheelScroll(page, inlineA, isolatedServer, runtimeTmuxSessionA);
       exitTmuxCopyMode(isolatedServer, runtimeTmuxSessionA);
       const inlinePaste = "inline-bracketed-paste";
@@ -1888,6 +1936,10 @@ test.describe("inline workspace pane continuity", () => {
         const output = observeTerminalOutput(page);
         isolatedServer = await startIsolatedWorkspaceE2EServer();
         api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
+        // This regression intentionally crosses a renderer/socket boundary;
+        // disable the released-session cache so workspace switching still
+        // exercises replay instead of reclaiming the same terminal.
+        await setRetainedSessions(api, 0);
         const workspaceA = await createIssueWorkspace(api, 10);
         const workspaceB = await createIssueWorkspace(api, 11);
 
@@ -2177,7 +2229,6 @@ test.describe("inline workspace pane continuity", () => {
       await expect.poll(async () => (await runtimeSockets()).length).toBe(1);
       const runtimeSocketURL = (await runtimeSockets())[0]!.url;
 
-      await page.context().setOffline(true);
       await page.evaluate((workspaceId) => {
         (
           window as unknown as {
@@ -2186,6 +2237,7 @@ test.describe("inline workspace pane continuity", () => {
         ).__closeRuntimeSockets?.(workspaceId);
       }, workspace.id);
       await expect.poll(async () => (await runtimeSockets())[0]?.closed).toBe(true);
+      await page.context().setOffline(true);
 
       runE2ETmuxCommand(isolatedServer, ["set-option", "-g", "-t", tmuxSession, "mouse", "off"]);
       writeFileSync(disableSignal, "disable\n", "utf8");
@@ -2351,7 +2403,6 @@ test.describe("inline workspace pane continuity", () => {
       });
       const cursorReportsBefore = output.cursorReports().length;
 
-      await page.context().setOffline(true);
       await page.evaluate((workspaceId) => {
         (
           window as unknown as {
@@ -2360,6 +2411,7 @@ test.describe("inline workspace pane continuity", () => {
         ).__closeSplitReplaySockets?.(workspaceId);
       }, workspace.id);
       await expect.poll(async () => (await runtimeSockets())[0]?.closed).toBe(true);
+      await page.context().setOffline(true);
 
       await page.context().setOffline(false);
       await expect
@@ -2384,16 +2436,87 @@ test.describe("inline workspace pane continuity", () => {
     }
   });
 
-  test("switching workspaces closes the previous workspace's live attachment", async ({ page }) => {
-    // The pool outlives the view, and a parked terminal keeps its websocket, so
-    // nothing hands one back on its own: browsing workspaces would leave a live
-    // tmux attachment per workspace visited. The view's release is the only
-    // thing that closes this one.
-    //
-    // Registry-level unit coverage cannot see a real socket, and an earlier
-    // attempt at this test navigated with page.goto — which closes every socket
-    // on its own and passed with the release removed. This switch is
-    // client-side, so the socket's fate is the behavior under test.
+  test("switching A to B to A reuses A's terminal and live attachment", async ({ page }) => {
+    test.skip(
+      !hasCommand("git") || !hasCommand("tmux", ["-V"]),
+      "git and tmux are required for the real workspace flow",
+    );
+
+    let isolatedServer: IsolatedE2EServer | null = null;
+    let api: APIRequestContext | null = null;
+    try {
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
+      api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
+      await setRetainedSessions(api, 1);
+      const workspaceA = await createIssueWorkspace(api, 10);
+      const workspaceB = await createIssueWorkspace(api, 11);
+      await trackSessionWebSockets(page);
+
+      await page.goto(`${isolatedServer.info.base_url}/terminal/${workspaceA.id}`);
+      const containerA = await openTerminalPanel(page);
+      await typeMarkerCommand(page, containerA, workspaceA.worktree_path, "retained-marker-a-before");
+      await containerA.evaluate((element) => element.setAttribute("data-retained-terminal-witness", "a"));
+      const originalSocket = (await sessionWebSockets(page, workspaceA.id))[0];
+      expect(originalSocket).toBeDefined();
+      expect(originalSocket!.closed).toBe(false);
+
+      await page.locator(".workspace-list-sidebar .ws-row", { hasText: DARK_MODE_ISSUE_TITLE }).click();
+      await expect(page).toHaveURL(new RegExp(`/terminal/${workspaceB.id}$`));
+      expect(await sessionWebSockets(page, workspaceA.id)).toEqual([originalSocket]);
+
+      const containerB = await openTerminalPanel(page);
+      await typeMarkerCommand(page, containerB, workspaceB.worktree_path, "retained-marker-b");
+
+      await page.locator(".workspace-list-sidebar .ws-row", { hasText: SAFARI_ISSUE_TITLE }).click();
+      await expect(page).toHaveURL(new RegExp(`/terminal/${workspaceA.id}$`));
+      const returnedA = page.locator('[data-retained-terminal-witness="a"]');
+      await expect(returnedA).toBeVisible();
+      await typeMarkerCommand(page, returnedA, workspaceA.worktree_path, "retained-marker-a-after");
+      expect(await sessionWebSockets(page, workspaceA.id)).toEqual([originalSocket]);
+    } finally {
+      await api?.dispose();
+      await isolatedServer?.stop();
+    }
+  });
+
+  test("switching workspaces closes the previous attachment when retention is disabled", async ({ page }) => {
+    test.skip(
+      !hasCommand("git") || !hasCommand("tmux", ["-V"]),
+      "git and tmux are required for the real workspace flow",
+    );
+
+    let isolatedServer: IsolatedE2EServer | null = null;
+    let api: APIRequestContext | null = null;
+    try {
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
+      api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
+      await setRetainedSessions(api, 0);
+      const workspaceA = await createIssueWorkspace(api, 10);
+      const workspaceB = await createIssueWorkspace(api, 11);
+      await trackSessionWebSockets(page);
+
+      await page.goto(`${isolatedServer.info.base_url}/terminal/${workspaceA.id}`);
+      const containerA = await openTerminalPanel(page);
+      await typeMarkerCommand(page, containerA, workspaceA.worktree_path, "disabled-retention-marker-a");
+      expect(await sessionWebSockets(page, workspaceA.id)).toHaveLength(1);
+
+      await page.locator(".workspace-list-sidebar .ws-row", { hasText: DARK_MODE_ISSUE_TITLE }).click();
+      await expect(page).toHaveURL(new RegExp(`/terminal/${workspaceB.id}$`));
+      await expect
+        .poll(async () => (await sessionWebSockets(page, workspaceA.id)).every((entry) => entry.closed), {
+          timeout: 15_000,
+        })
+        .toBe(true);
+
+      const containerB = await openTerminalPanel(page);
+      await typeMarkerCommand(page, containerB, workspaceB.worktree_path, "disabled-retention-marker-b");
+    } finally {
+      await api?.dispose();
+      await isolatedServer?.stop();
+    }
+  });
+
+  test("failed retention save preserves a released terminal until a successful retry", async ({ page }) => {
     test.skip(
       !hasCommand("git") || !hasCommand("tmux", ["-V"]),
       "git and tmux are required for the real workspace flow",
@@ -2406,49 +2529,67 @@ test.describe("inline workspace pane continuity", () => {
       api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
       const workspaceA = await createIssueWorkspace(api, 10);
       const workspaceB = await createIssueWorkspace(api, 11);
-
-      // Record every session websocket the app opens and whether it has closed.
-      // The real connection is untouched; only its lifecycle is observed.
-      await page.addInitScript(() => {
-        const log: Array<{ url: string; closed: boolean }> = [];
-        (window as unknown as { __wsLog: typeof log }).__wsLog = log;
-        const Native = window.WebSocket;
-        class TrackedWebSocket extends Native {
-          constructor(url: string | URL, protocols?: string | string[]) {
-            super(url, protocols);
-            const entry = { url: String(url), closed: false };
-            log.push(entry);
-            this.addEventListener("close", () => {
-              entry.closed = true;
-            });
-          }
-        }
-        window.WebSocket = TrackedWebSocket as unknown as typeof WebSocket;
-      });
-
-      const sessionSockets = (workspaceId: string) =>
-        page.evaluate((needle) => {
-          const log = (window as unknown as { __wsLog?: Array<{ url: string; closed: boolean }> }).__wsLog ?? [];
-          return log.filter((entry) => entry.url.includes(needle));
-        }, `/workspaces/${workspaceId}/runtime/sessions/`);
+      await trackSessionWebSockets(page);
 
       await page.goto(`${isolatedServer.info.base_url}/terminal/${workspaceA.id}`);
-      const containerA = await openTerminalPanel(page);
-      // Attached, not merely constructed: only a live socket can create this.
-      await typeMarkerCommand(page, containerA, workspaceA.worktree_path, "release-marker-a");
-      expect(await sessionSockets(workspaceA.id)).toHaveLength(1);
+      const terminal = await openTerminalPanel(page);
+      await typeMarkerCommand(page, terminal, workspaceA.worktree_path, "failed-retention-save-before");
+      await terminal.evaluate((element) => element.setAttribute("data-retention-save-witness", "a"));
+      const originalSocket = (await sessionWebSockets(page, workspaceA.id))[0];
+      expect(originalSocket).toBeDefined();
 
-      // Client-side switch through the workspace list, so nothing but the view's
-      // own release can close A's socket.
       await page.locator(".workspace-list-sidebar .ws-row", { hasText: DARK_MODE_ISSUE_TITLE }).click();
       await expect(page).toHaveURL(new RegExp(`/terminal/${workspaceB.id}$`));
-      await expect
-        .poll(async () => (await sessionSockets(workspaceA.id)).every((entry) => entry.closed), { timeout: 15_000 })
-        .toBe(true);
+      await openTerminalPanel(page);
 
-      // And the workspace switched to is fully live, not collateral damage.
-      const containerB = await openTerminalPanel(page);
-      await typeMarkerCommand(page, containerB, workspaceB.worktree_path, "release-marker-b");
+      await page.getByRole("button", { name: "Settings" }).click();
+      await expect(page).toHaveURL(/\/settings$/);
+      await openSettingsPanel(page, "Terminal");
+      const witness = page.locator('[data-retention-save-witness="a"]');
+      await expect(witness).toHaveCount(1);
+
+      let failNextSave = true;
+      await page.route("**/api/v1/settings", async (route) => {
+        if (route.request().method() !== "PUT") {
+          await route.fallback();
+          return;
+        }
+        if (failNextSave) {
+          failNextSave = false;
+          await route.fulfill({
+            status: 503,
+            contentType: "application/json",
+            body: JSON.stringify({ title: "Settings unavailable" }),
+          });
+          return;
+        }
+        await route.continue();
+      });
+
+      const retainedSessions = page.getByLabel("Retained terminal sessions");
+      const save = page.getByRole("button", { name: "Save", exact: true });
+      await retainedSessions.fill("0");
+      const failedSave = page.waitForResponse(
+        (response) => response.url().endsWith("/api/v1/settings") && response.request().method() === "PUT",
+      );
+      await save.click();
+      expect((await failedSave).status()).toBe(503);
+      await expect(retainedSessions).toHaveValue("10");
+      await expect(witness).toHaveCount(1);
+      expect(await sessionWebSockets(page, workspaceA.id)).toEqual([originalSocket]);
+
+      await retainedSessions.fill("0");
+      const successfulSave = page.waitForResponse(
+        (response) => response.url().endsWith("/api/v1/settings") && response.request().method() === "PUT",
+      );
+      await save.click();
+      expect((await successfulSave).status()).toBe(200);
+      await expect(witness).toHaveCount(0);
+      await expect
+        .poll(async () => (await sessionWebSockets(page, workspaceA.id)).every((entry) => entry.closed), {
+          timeout: 15_000,
+        })
+        .toBe(true);
     } finally {
       await api?.dispose();
       await isolatedServer?.stop();

--- a/frontend/tests/e2e-full/00-settings-terminal-font.spec.ts
+++ b/frontend/tests/e2e-full/00-settings-terminal-font.spec.ts
@@ -77,6 +77,7 @@ test("settings saves and reloads workspace terminal options", async ({ page }) =
   const scrollback = page.getByLabel("Scrollback");
   const lineHeight = page.getByLabel("Line height");
   const letterSpacing = page.getByLabel("Letter spacing");
+  const retainedSessions = page.getByLabel("Retained terminal sessions");
   const cursorBlink = page.getByLabel("Cursor blink");
   const saveButton = page.getByRole("button", {
     name: "Save",
@@ -87,12 +88,14 @@ test("settings saves and reloads workspace terminal options", async ({ page }) =
   await expect(scrollback).toHaveValue("1000");
   await expect(lineHeight).toHaveValue("1");
   await expect(letterSpacing).toHaveValue("0");
+  await expect(retainedSessions).toHaveValue("10");
   await expect(cursorBlink).toBeChecked();
 
   await fontSize.fill("18");
   await scrollback.fill("5000");
   await lineHeight.fill("1.15");
   await letterSpacing.fill("1");
+  await retainedSessions.fill("7");
   await cursorBlink.uncheck();
   await input.click();
   await input.pressSequentially('"Iosevka Term", monospace');
@@ -118,6 +121,7 @@ test("settings saves and reloads workspace terminal options", async ({ page }) =
           scrollback: number;
           line_height: number;
           letter_spacing: number;
+          retained_sessions: number;
           cursor_blink: boolean;
           font_ligatures: boolean;
           hide_tmux_status: boolean;
@@ -131,6 +135,7 @@ test("settings saves and reloads workspace terminal options", async ({ page }) =
       scrollback: 5000,
       line_height: 1.15,
       letter_spacing: 1,
+      retained_sessions: 7,
       cursor_blink: false,
       font_ligatures: false,
       hide_tmux_status: false,
@@ -143,6 +148,7 @@ test("settings saves and reloads workspace terminal options", async ({ page }) =
   await expect(page.getByLabel("Scrollback")).toHaveValue("5000");
   await expect(page.getByLabel("Line height")).toHaveValue("1.15");
   await expect(page.getByLabel("Letter spacing")).toHaveValue("1");
+  await expect(page.getByLabel("Retained terminal sessions")).toHaveValue("7");
   await expect(page.getByLabel("Cursor blink")).not.toBeChecked();
 });
 
@@ -213,6 +219,7 @@ test.describe("terminal options popover", () => {
         scrollback: 4200,
         line_height: 1.2,
         letter_spacing: 1,
+        retained_sessions: 10,
         cursor_blink: false,
         font_ligatures: true,
         hide_tmux_status: true,

--- a/frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts
+++ b/frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts
@@ -1202,12 +1202,21 @@ test("tmux drag-copy reaches the clipboard in tab and inline hosts", async ({ pa
       await setBrowserClipboard(page, "");
     }
 
+    await tabTerminal.evaluate((element) => {
+      element.setAttribute("data-clipboard-host-witness", "terminal");
+    });
+    const activeSocketsBeforeClose = output.activeSocketCount();
+    expect(activeSocketsBeforeClose).toBeGreaterThan(0);
     await page.locator(".terminal-panel.open").getByRole("button", { name: "Close terminal panel" }).first().click();
     await expect(tabTerminal).not.toBeVisible();
-    await expect.poll(() => output.activeSocketCount()).toBe(0);
+    await expect(page.locator('.session-pool-parking [data-clipboard-host-witness="terminal"]')).toHaveCount(1);
+    await expect.poll(() => output.activeSocketCount()).toBe(activeSocketsBeforeClose);
     await selectIssueByTitle(page, "Widget rendering broken on Safari");
-    const inlineTerminal = page.locator(".sole-embedded-session .terminal-container");
+    const inlineTerminal = page.locator(
+      '.sole-embedded-session .terminal-container[data-clipboard-host-witness="terminal"]',
+    );
     await expect(inlineTerminal).toBeVisible();
+    await expect.poll(() => output.activeSocketCount()).toBe(activeSocketsBeforeClose);
     await expect(inlineTerminal.locator("canvas, .xterm-screen").first()).toBeVisible();
     const inlineMarker = "inline clipboard — marker\u00a0value";
     await enableTmuxMouseAndRenderMarker(page, inlineTerminal, output, isolatedServer, tmuxSession, inlineMarker);

--- a/frontend/tests/profiling/README.md
+++ b/frontend/tests/profiling/README.md
@@ -2,7 +2,7 @@
 
 Developer tooling for diagnosing workspace switching latency. One
 command drives a real seeded backend (git worktrees + tmux), performs
-warm and cold workspace switches against workspaces running an
+retained-hit, forced-miss, and cold workspace switches against workspaces running an
 ordinary shell and an alternate-screen application (`less`), and
 captures stable timings plus browser- and Go-side traces for
 before/after comparison.
@@ -24,7 +24,7 @@ as the real-workspace e2e specs). Knobs, all optional:
 
 | Env var                         | Effect                                                                            |
 | ------------------------------- | --------------------------------------------------------------------------------- |
-| `KENN_FORGE_PROFILE_ITERATIONS` | Warm-switch iterations per scenario (default 3)                                   |
+| `KENN_FORGE_PROFILE_ITERATIONS` | Warm-switch iterations per hit/miss scenario (minimum and default 10)             |
 | `KENN_FORGE_PROFILE_OUT_DIR`    | Artifact directory (default `test-results/workspace-switch-profile/<timestamp>/`) |
 | `KENN_FORGE_PROFILE_GO_TRACE=0` | Skip the Go execution trace capture                                               |
 
@@ -32,7 +32,7 @@ as the real-workspace e2e specs). Knobs, all optional:
 
 The frontend emits User Timing entries via
 `src/lib/instrumentation/workspaceSwitchTiming.ts`. The instrumentation
-is always on: it records at most nine `performance.measure` calls per
+is always on: it records at most ten `performance.measure` calls per
 workspace switch and nothing else, so there is no production telemetry
 and no measurable steady-state cost. Repeated work inside one switch
 (runtime polling, reconnects, extra panes) does not re-record a phase,
@@ -45,15 +45,16 @@ Every measure is named `workspace-switch:<phase>` and its duration is
 the time from route selection (the terminal view reacting to the new
 workspace route) to that phase:
 
-| Phase                              | Meaning                                      |
-| ---------------------------------- | -------------------------------------------- |
-| `workspace-request-start` / `-end` | Workspace metadata API request               |
-| `runtime-request-start` / `-end`   | Runtime state (sessions) API request         |
-| `fonts-ready`                      | The pane's font-readiness wait resolved      |
-| `terminal-constructed`             | Terminal constructed and attached to the DOM |
-| `socket-open`                      | Terminal WebSocket reported open             |
-| `first-bytes`                      | First binary frame (start of tmux replay)    |
-| `first-paint`                      | Frame showing that payload has painted       |
+| Phase                              | Meaning                                             |
+| ---------------------------------- | --------------------------------------------------- |
+| `workspace-request-start` / `-end` | Workspace metadata API request                      |
+| `runtime-request-start` / `-end`   | Runtime state (sessions) API request                |
+| `fonts-ready`                      | The pane's font-readiness wait resolved             |
+| `terminal-constructed`             | Terminal constructed and attached to the DOM        |
+| `socket-open`                      | Terminal WebSocket reported open                    |
+| `first-bytes`                      | First binary frame (start of tmux replay)           |
+| `first-paint`                      | Frame showing that payload has painted              |
+| `retained-first-paint`             | Second frame after a retained wrapper is reattached |
 
 `first-paint` is recorded on the second animation frame after the
 first payload finished parsing, i.e. after the frame that renders it
@@ -62,6 +63,11 @@ switch — the first pane to reach a phase wins, and each measure's
 `detail.paneId` says which pane that was — except that `first-paint`
 is always recorded by the same pane as `first-bytes`, so
 `firstBytesToFirstPaint` describes one real terminal.
+
+On a retained hit there is deliberately no terminal construction, socket open,
+or replay. The pool records `retained-first-paint` after reparenting and
+recreating the renderer; the profiler uses it as that scenario's route-to-paint
+endpoint while preserving every existing phase name for miss comparisons.
 
 The xterm terminal emits these names. Derived values in the output answer the usual
 questions directly: time before terminal creation

--- a/frontend/tests/profiling/workspace-switch.spec.ts
+++ b/frontend/tests/profiling/workspace-switch.spec.ts
@@ -3,10 +3,10 @@
 //
 // The harness drives a real e2e backend (git worktrees + tmux) and
 // measures the workspace-switch:* User Timing marks emitted by
-// src/lib/instrumentation/workspaceSwitchTiming.ts across four
-// scenarios: warm and cold switches into a workspace running an
-// ordinary shell, and into one running an alternate-screen
-// application. Artifacts (timings.json, summary.txt, a Chromium
+// src/lib/instrumentation/workspaceSwitchTiming.ts across retained-hit,
+// forced-miss, and cold switches into workspaces running an ordinary
+// shell or an alternate-screen application. Artifacts (timings.json,
+// summary.txt, a Chromium
 // trace, and a Go execution trace) land in
 // test-results/workspace-switch-profile/<timestamp>/.
 
@@ -45,7 +45,7 @@ type SwitchMeasurement = {
 
 const frontendDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
-const iterations = Math.max(1, Number(process.env.KENN_FORGE_PROFILE_ITERATIONS ?? "3") || 3);
+const iterations = Math.max(10, Number(process.env.KENN_FORGE_PROFILE_ITERATIONS ?? "10") || 10);
 
 const outputDir =
   process.env.KENN_FORGE_PROFILE_OUT_DIR ??
@@ -55,11 +55,15 @@ const outputDir =
 // workspace with a running terminal session. A missing phase means
 // the wiring regressed, which would silently invalidate before/after
 // comparisons made with this harness.
-const requiredPhases = [
+const requiredRequestPhases = [
   "workspace-request-start",
   "workspace-request-end",
   "runtime-request-start",
   "runtime-request-end",
+];
+
+const requiredMissPhases = [
+  ...requiredRequestPhases,
   "fonts-ready",
   "terminal-constructed",
   "socket-open",
@@ -167,7 +171,7 @@ async function collectSwitchEntries(page: Page, workspaceId: string, sinceTime: 
         .getEntriesByType("measure")
         .some(
           (m) =>
-            m.name === "workspace-switch:first-paint" &&
+            (m.name === "workspace-switch:first-paint" || m.name === "workspace-switch:retained-first-paint") &&
             m.startTime > since &&
             (m as PerformanceMeasure).detail?.workspaceId === id,
         ),
@@ -200,7 +204,7 @@ function phaseDuration(entries: SwitchEntry[], phase: string): number | null {
 function deriveMetrics(entries: SwitchEntry[]): Record<string, number | null> {
   const d = (phase: string) => phaseDuration(entries, phase);
   const firstBytes = d("first-bytes");
-  const firstPaint = d("first-paint");
+  const firstPaint = d("retained-first-paint") ?? d("first-paint");
   return {
     routeToWorkspaceRequestStart: d("workspace-request-start"),
     routeToWorkspaceRequestEnd: d("workspace-request-end"),
@@ -213,6 +217,50 @@ function deriveMetrics(entries: SwitchEntry[]): Record<string, number | null> {
     routeToFirstPaint: firstPaint,
     firstBytesToFirstPaint: firstBytes !== null && firstPaint !== null ? firstPaint - firstBytes : null,
   };
+}
+
+async function setRetainedSessions(api: APIRequestContext, limit: number): Promise<void> {
+  const currentResponse = await api.get("/api/v1/settings");
+  expect(currentResponse.ok()).toBe(true);
+  const current = (await currentResponse.json()) as { terminal: Record<string, unknown> };
+  const updateResponse = await api.put("/api/v1/settings", {
+    data: {
+      terminal: {
+        ...current.terminal,
+        retained_sessions: limit,
+      },
+    },
+  });
+  expect(updateResponse.ok()).toBe(true);
+}
+
+async function primeWarmSwitches(
+  page: Page,
+  baseURL: string,
+  shellWorkspaceId: string,
+  altScreenWorkspaceId: string,
+): Promise<void> {
+  await page.goto(`${baseURL}/terminal/${altScreenWorkspaceId}`);
+  await collectSwitchEntries(page, altScreenWorkspaceId, -1);
+  let sinceTime = await page.evaluate(() => performance.now());
+  await spaSwitch(page, shellWorkspaceId);
+  await collectSwitchEntries(page, shellWorkspaceId, sinceTime);
+  sinceTime = await page.evaluate(() => performance.now());
+  await spaSwitch(page, altScreenWorkspaceId);
+  await collectSwitchEntries(page, altScreenWorkspaceId, sinceTime);
+}
+
+function percentile(values: number[], fraction: number): number {
+  const sorted = [...values].sort((left, right) => left - right);
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.floor((sorted.length - 1) * fraction)));
+  return sorted[index]!;
+}
+
+function firstPaintDurations(measurements: SwitchMeasurement[], scenario: string): number[] {
+  return measurements
+    .filter((measurement) => measurement.scenario === scenario)
+    .map((measurement) => measurement.derived.routeToFirstPaint)
+    .filter((duration): duration is number => duration !== null);
 }
 
 async function measureSwitch(
@@ -352,6 +400,7 @@ test.describe("workspace switch profiling", () => {
       );
 
       await openWorkspaceAndLaunchTerminal(page, baseURL, shellWorkspace.id);
+      await runShellCommandInTerminal(page, "yes 0123456789abcdef0123456789abcdef | head -c 65536");
       await openWorkspaceAndLaunchTerminal(page, baseURL, altScreenWorkspace.id);
       await runShellCommandInTerminal(page, `less ${pagerFile}`);
       await assertAlternateScreenActive(isolatedServer.info.config_path);
@@ -406,11 +455,24 @@ test.describe("workspace switch profiling", () => {
       });
 
       const measurements: SwitchMeasurement[] = [];
-      // The page currently shows the alt-screen workspace, so each
-      // iteration alternates shell -> alt-screen.
+      // First measure retained cache hits. Reload after changing the setting so
+      // startup hydration applies the new limit before either session is
+      // primed; external settings writes do not mutate the current SPA store.
+      await setRetainedSessions(api, 10);
+      await primeWarmSwitches(page, baseURL, shellWorkspace.id, altScreenWorkspace.id);
       for (let iteration = 0; iteration < iterations; iteration += 1) {
-        measurements.push(await measureWarmSwitch(page, shellWorkspace.id, "warm-ordinary-shell", iteration));
-        measurements.push(await measureWarmSwitch(page, altScreenWorkspace.id, "warm-alt-screen", iteration));
+        measurements.push(await measureWarmSwitch(page, shellWorkspace.id, "hit-ordinary-shell", iteration));
+        measurements.push(await measureWarmSwitch(page, altScreenWorkspace.id, "hit-alt-screen", iteration));
+      }
+
+      // Then force the old reconnect/replay path with retention disabled. The
+      // tmux sessions and their capped ordinary-buffer history remain live, so
+      // the only intended difference is browser-side terminal retention.
+      await setRetainedSessions(api, 0);
+      await primeWarmSwitches(page, baseURL, shellWorkspace.id, altScreenWorkspace.id);
+      for (let iteration = 0; iteration < iterations; iteration += 1) {
+        measurements.push(await measureWarmSwitch(page, shellWorkspace.id, "miss-ordinary-shell", iteration));
+        measurements.push(await measureWarmSwitch(page, altScreenWorkspace.id, "miss-alt-screen", iteration));
       }
 
       measurements.push(await measureColdLoad(page, baseURL, shellWorkspace.id, "cold-ordinary-shell"));
@@ -451,9 +513,22 @@ test.describe("workspace switch profiling", () => {
 
       for (const measurement of measurements) {
         const phases = measurement.entries.map((entry) => entry.name.replace("workspace-switch:", ""));
+        const requiredPhases = measurement.scenario.startsWith("hit-")
+          ? [...requiredRequestPhases, "retained-first-paint"]
+          : requiredMissPhases;
         for (const phase of requiredPhases) {
           expect(phases, `${measurement.scenario} #${measurement.iteration} must record ${phase}`).toContain(phase);
         }
+      }
+
+      for (const kind of ["ordinary-shell", "alt-screen"]) {
+        const hits = firstPaintDurations(measurements, `hit-${kind}`);
+        const misses = firstPaintDurations(measurements, `miss-${kind}`);
+        expect(hits).toHaveLength(iterations);
+        expect(misses).toHaveLength(iterations);
+        expect(percentile(hits, 0.75), `${kind} retained-hit p75 must beat forced-miss p25`).toBeLessThan(
+          percentile(misses, 0.25),
+        );
       }
     } finally {
       await api?.dispose();

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -4029,14 +4029,15 @@ type TelemetryEventResponse struct {
 
 // Terminal defines model for Terminal.
 type Terminal struct {
-	CursorBlink    bool    `json:"cursor_blink"`
-	FontFamily     string  `json:"font_family"`
-	FontLigatures  bool    `json:"font_ligatures"`
-	FontSize       int64   `json:"font_size"`
-	HideTmuxStatus bool    `json:"hide_tmux_status"`
-	LetterSpacing  int64   `json:"letter_spacing"`
-	LineHeight     float64 `json:"line_height"`
-	Scrollback     int64   `json:"scrollback"`
+	CursorBlink      bool    `json:"cursor_blink"`
+	FontFamily       string  `json:"font_family"`
+	FontLigatures    bool    `json:"font_ligatures"`
+	FontSize         int64   `json:"font_size"`
+	HideTmuxStatus   bool    `json:"hide_tmux_status"`
+	LetterSpacing    int64   `json:"letter_spacing"`
+	LineHeight       float64 `json:"line_height"`
+	RetainedSessions int64   `json:"retained_sessions"`
+	Scrollback       int64   `json:"scrollback"`
 }
 
 // TerminalClipboardInputBody defines model for TerminalClipboardInputBody.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -587,23 +587,25 @@ type Issues struct {
 }
 
 const (
-	DefaultTerminalFontSize      = 12
-	DefaultTerminalScrollback    = 1000
-	DefaultTerminalLineHeight    = 1.0
-	DefaultTerminalLetterSpacing = 0
-	DefaultTerminalCursorBlink   = true
-	DefaultTerminalFontLigatures = false
+	DefaultTerminalFontSize         = 12
+	DefaultTerminalScrollback       = 1000
+	DefaultTerminalLineHeight       = 1.0
+	DefaultTerminalLetterSpacing    = 0
+	DefaultTerminalCursorBlink      = true
+	DefaultTerminalFontLigatures    = false
+	DefaultTerminalRetainedSessions = 10
 )
 
 type Terminal struct {
-	FontFamily     string  `toml:"font_family,omitempty" json:"font_family"`
-	FontSize       int     `toml:"font_size,omitempty" json:"font_size"`
-	Scrollback     int     `toml:"scrollback,omitempty" json:"scrollback"`
-	LineHeight     float64 `toml:"line_height,omitempty" json:"line_height"`
-	LetterSpacing  int     `toml:"letter_spacing,omitempty" json:"letter_spacing"`
-	CursorBlink    *bool   `toml:"cursor_blink,omitempty" json:"cursor_blink" nullable:"false"`
-	FontLigatures  bool    `toml:"font_ligatures,omitempty" json:"font_ligatures"`
-	HideTmuxStatus bool    `toml:"hide_tmux_status,omitempty" json:"hide_tmux_status"`
+	FontFamily       string  `toml:"font_family,omitempty" json:"font_family"`
+	FontSize         int     `toml:"font_size,omitempty" json:"font_size"`
+	Scrollback       int     `toml:"scrollback,omitempty" json:"scrollback"`
+	LineHeight       float64 `toml:"line_height,omitempty" json:"line_height"`
+	LetterSpacing    int     `toml:"letter_spacing,omitempty" json:"letter_spacing"`
+	CursorBlink      *bool   `toml:"cursor_blink,omitempty" json:"cursor_blink" nullable:"false"`
+	FontLigatures    bool    `toml:"font_ligatures,omitempty" json:"font_ligatures"`
+	HideTmuxStatus   bool    `toml:"hide_tmux_status,omitempty" json:"hide_tmux_status"`
+	RetainedSessions *int    `toml:"retained_sessions,omitempty" json:"retained_sessions" nullable:"false"`
 }
 
 type Agent struct {
@@ -1503,6 +1505,16 @@ func (c *Config) validate() error {
 	if c.Terminal.CursorBlink == nil {
 		cursorBlink := DefaultTerminalCursorBlink
 		c.Terminal.CursorBlink = &cursorBlink
+	}
+	if c.Terminal.RetainedSessions == nil {
+		retainedSessions := DefaultTerminalRetainedSessions
+		c.Terminal.RetainedSessions = &retainedSessions
+	}
+	if *c.Terminal.RetainedSessions < 0 || *c.Terminal.RetainedSessions > 20 {
+		return fmt.Errorf(
+			"config: invalid terminal.retained_sessions %d: must be between 0 and 20",
+			*c.Terminal.RetainedSessions,
+		)
 	}
 	if err := c.validateAgents(); err != nil {
 		return err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2455,6 +2455,7 @@ line_height = 1.2
 letter_spacing = 1
 cursor_blink = false
 font_ligatures = true
+retained_sessions = 0
 `)
 	cfg, err := Load(path)
 	require.NoError(err)
@@ -2466,6 +2467,8 @@ font_ligatures = true
 	require.NotNil(cfg.Terminal.CursorBlink)
 	assert.False(*cfg.Terminal.CursorBlink)
 	assert.True(cfg.Terminal.FontLigatures)
+	require.NotNil(cfg.Terminal.RetainedSessions)
+	assert.Equal(0, *cfg.Terminal.RetainedSessions)
 
 	savePath := filepath.Join(t.TempDir(), "saved.toml")
 	require.NoError(cfg.Save(savePath))
@@ -2480,6 +2483,8 @@ font_ligatures = true
 	require.NotNil(cfg2.Terminal.CursorBlink)
 	assert.False(*cfg2.Terminal.CursorBlink)
 	assert.True(cfg2.Terminal.FontLigatures)
+	require.NotNil(cfg2.Terminal.RetainedSessions)
+	assert.Equal(0, *cfg2.Terminal.RetainedSessions)
 }
 
 func TestTerminalSettingsDefaults(t *testing.T) {
@@ -2500,6 +2505,25 @@ name = "b"
 	require.NotNil(cfg.Terminal.CursorBlink)
 	assert.True(*cfg.Terminal.CursorBlink)
 	assert.False(cfg.Terminal.FontLigatures)
+	require.NotNil(cfg.Terminal.RetainedSessions)
+	assert.Equal(DefaultTerminalRetainedSessions, *cfg.Terminal.RetainedSessions)
+}
+
+func TestTerminalRetainedSessionsValidation(t *testing.T) {
+	for _, retainedSessions := range []int{-1, 21} {
+		t.Run(fmt.Sprintf("value_%d", retainedSessions), func(t *testing.T) {
+			_, err := Load(writeConfig(t, fmt.Sprintf(`
+[[repos]]
+owner = "a"
+name = "b"
+
+[terminal]
+retained_sessions = %d
+`, retainedSessions)))
+
+			require.ErrorContains(t, err, "terminal.retained_sessions")
+		})
+	}
 }
 
 func TestIssueWorkspaceBranchStyleDefaultsToSlug(t *testing.T) {

--- a/internal/github/graphql_live_test.go
+++ b/internal/github/graphql_live_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestLiveGraphQLQueriesValidateAgainstGitHub(t *testing.T) {
 	skipUnlessLiveGitHubTests(t)
+	require := require.New(t)
 	token := requireLiveGitHubToken(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -31,7 +32,7 @@ func TestLiveGraphQLQueriesValidateAgainstGitHub(t *testing.T) {
 		"cursor":   (*githubv4.String)(nil),
 	}
 	err := client.Query(ctx, &prQuery, vars)
-	require.NoError(t, err, "bulk PR GraphQL query should validate against GitHub")
+	require.NoError(err, "bulk PR GraphQL query should validate against GitHub")
 
 	type prDetailQuery struct {
 		Repository struct {
@@ -44,26 +45,26 @@ func TestLiveGraphQLQueriesValidateAgainstGitHub(t *testing.T) {
 		"name":   githubv4.String("forge"),
 		"number": githubv4.Int(830),
 	})
-	require.NoError(t, err, "combined PR detail GraphQL query should validate against GitHub")
-	require.NotNil(t, detailQuery.Repository.PullRequest, "live PR fixture should exist")
-	require.NotEmpty(t, detailQuery.Repository.PullRequest.Comments.Nodes,
+	require.NoError(err, "combined PR detail GraphQL query should validate against GitHub")
+	require.NotNil(detailQuery.Repository.PullRequest, "live PR fixture should exist")
+	require.NotEmpty(detailQuery.Repository.PullRequest.Comments.Nodes,
 		"combined live query should return conversation comments")
-	require.NotEmpty(t, detailQuery.Repository.PullRequest.ReviewThreads.Nodes,
+	require.NotEmpty(detailQuery.Repository.PullRequest.ReviewThreads.Nodes,
 		"combined live query should return review threads")
-	require.NotEmpty(t, detailQuery.Repository.PullRequest.ReviewThreads.Nodes[0].Comments.Nodes,
+	require.NotEmpty(detailQuery.Repository.PullRequest.ReviewThreads.Nodes[0].Comments.Nodes,
 		"combined live query should return review-thread comments")
-	require.False(t,
+	require.False(
 		detailQuery.Repository.PullRequest.ReviewThreads.Nodes[0].Comments.Nodes[0].CreatedAt.IsZero(),
 		"combined live query should return review-comment creation time",
 	)
-	require.False(t,
+	require.False(
 		detailQuery.Repository.PullRequest.ReviewThreads.Nodes[0].Comments.Nodes[0].UpdatedAt.IsZero(),
 		"combined live query should return review-comment update time",
 	)
 
 	var issueQuery gqlIssueQuery
 	err = client.Query(ctx, &issueQuery, vars)
-	require.NoError(t, err, "bulk issue GraphQL query should validate against GitHub")
+	require.NoError(err, "bulk issue GraphQL query should validate against GitHub")
 
 	reviewClient := &liveClient{
 		httpClient:      httpClient,
@@ -73,12 +74,12 @@ func TestLiveGraphQLQueriesValidateAgainstGitHub(t *testing.T) {
 	threads, _, _, err := reviewClient.ListInventoryReviewThreadsPage(
 		ctx, "github.com", "kenn-io", "forge", 830, "",
 	)
-	require.NoError(t, err, "review-thread GraphQL query should validate against GitHub")
-	require.NotEmpty(t, threads, "live review fixture should contain a review thread")
-	require.NotEmpty(t, threads[0].Comments, "live review fixture should contain a review comment")
-	require.False(t, threads[0].Comments[0].CreatedAt.IsZero(),
+	require.NoError(err, "review-thread GraphQL query should validate against GitHub")
+	require.NotEmpty(threads, "live review fixture should contain a review thread")
+	require.NotEmpty(threads[0].Comments, "live review fixture should contain a review comment")
+	require.False(threads[0].Comments[0].CreatedAt.IsZero(),
 		"review-thread GraphQL query should return comment creation time")
-	require.False(t, threads[0].Comments[0].UpdatedAt.IsZero(),
+	require.False(threads[0].Comments[0].UpdatedAt.IsZero(),
 		"review-thread GraphQL query should return comment update time")
 
 	comments, _, _, err := reviewClient.listReviewThreadCommentsPage(
@@ -88,11 +89,11 @@ func TestLiveGraphQLQueriesValidateAgainstGitHub(t *testing.T) {
 			Phase: "comments", Thread: archiveReviewThreadCursor(threads[0]),
 		},
 	)
-	require.NoError(t, err, "review-thread comment GraphQL query should validate against GitHub")
-	require.NotEmpty(t, comments, "live review fixture should return its review thread")
-	require.NotEmpty(t, comments[0].Comments, "live review fixture should contain a review comment")
-	require.False(t, comments[0].Comments[0].CreatedAt.IsZero(),
+	require.NoError(err, "review-thread comment GraphQL query should validate against GitHub")
+	require.NotEmpty(comments, "live review fixture should return its review thread")
+	require.NotEmpty(comments[0].Comments, "live review fixture should contain a review comment")
+	require.False(comments[0].Comments[0].CreatedAt.IsZero(),
 		"paginated review-comment query should return creation time")
-	require.False(t, comments[0].Comments[0].UpdatedAt.IsZero(),
+	require.False(comments[0].Comments[0].UpdatedAt.IsZero(),
 		"paginated review-comment query should return update time")
 }

--- a/internal/github/graphql_test.go
+++ b/internal/github/graphql_test.go
@@ -151,6 +151,8 @@ func TestConvertGQLCommentsRecordsObservedVisibleComments(t *testing.T) {
 }
 
 func TestConvertGQLPRIncludesReviewThreads(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	reason := githubv4.ReportedContentClassifiersAbuse
 	line := 12
 	input := gqlPR{}
@@ -177,13 +179,13 @@ func TestConvertGQLPRIncludesReviewThreads(t *testing.T) {
 
 	bulk := convertGQLPR(&input)
 
-	require.True(t, bulk.ReviewThreadsComplete)
-	require.Len(t, bulk.ReviewThreads, 1)
+	require.True(bulk.ReviewThreadsComplete)
+	require.Len(bulk.ReviewThreads, 1)
 	thread := bulk.ReviewThreads[0]
-	assert.Equal(t, "PRRT_1", thread.ProviderThreadID)
-	assert.Equal(t, "3714845345", thread.ProviderCommentID)
-	assert.Equal(t, "hidden inline comment", thread.Body)
-	assert.JSONEq(t, `{"provider_hidden":true,"provider_hidden_reason":"ABUSE"}`, thread.MetadataJSON)
+	assert.Equal("PRRT_1", thread.ProviderThreadID)
+	assert.Equal("3714845345", thread.ProviderCommentID)
+	assert.Equal("hidden inline comment", thread.Body)
+	assert.JSONEq(`{"provider_hidden":true,"provider_hidden_reason":"ABUSE"}`, thread.MetadataJSON)
 }
 
 func TestGraphQLFetcherPaginatesCommentVisibility(t *testing.T) {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -17305,11 +17305,13 @@ func TestSyncOpenMRFromBulkRemovesDeletedCommentsWhenCommentsAreComplete(t *test
 }
 
 func TestSyncOpenMRFromBulkLeavesDetailStaleWhenReviewThreadsAreIncomplete(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	ctx := t.Context()
 	database := openTestDB(t)
 	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
 	repoID, err := database.UpsertRepo(ctx, verifiedGitHubRepoIdentity("github.com", repo.Owner, repo.Name))
-	require.NoError(t, err)
+	require.NoError(err)
 
 	now := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
 	line := 12
@@ -17336,12 +17338,12 @@ func TestSyncOpenMRFromBulkLeavesDetailStaleWhenReviewThreadsAreIncomplete(t *te
 		TimelineComplete: true,
 		CIComplete:       true,
 	}, false)
-	require.NoError(t, err)
+	require.NoError(err)
 
 	mr, err := database.GetMergeRequest(ctx, "github", "github.com", repo.Owner, repo.Name, 1)
-	require.NoError(t, err)
-	require.NotNil(t, mr)
-	require.NotNil(t, mr.DetailFetchedAt)
+	require.NoError(err)
+	require.NotNil(mr)
+	require.NotNil(mr.DetailFetchedAt)
 
 	err = syncer.syncOpenMRFromBulk(ctx, repo, repoID, &BulkPR{
 		PR:                    buildOpenPR(1, now),
@@ -17352,17 +17354,17 @@ func TestSyncOpenMRFromBulkLeavesDetailStaleWhenReviewThreadsAreIncomplete(t *te
 		TimelineComplete:      true,
 		CIComplete:            true,
 	}, false)
-	require.NoError(t, err)
+	require.NoError(err)
 
 	mr, err = database.GetMergeRequest(ctx, "github", "github.com", repo.Owner, repo.Name, 1)
-	require.NoError(t, err)
-	require.NotNil(t, mr)
-	assert.Nil(t, mr.DetailFetchedAt)
+	require.NoError(err)
+	require.NotNil(mr)
+	assert.Nil(mr.DetailFetchedAt)
 	threads, err := database.ListMRReviewThreads(ctx, mr.ID)
-	require.NoError(t, err)
-	require.Len(t, threads, 1)
-	assert.Equal(t, "thread-1", threads[0].ProviderThreadID)
-	assert.Zero(t, client.listIssueCommentsCalled.Load())
+	require.NoError(err)
+	require.Len(threads, 1)
+	assert.Equal("thread-1", threads[0].ProviderThreadID)
+	assert.Zero(client.listIssueCommentsCalled.Load())
 }
 
 // TestSyncOpenMRFromBulkPersistsWorkflowApproval verifies the GraphQL

--- a/internal/platform/persist_test.go
+++ b/internal/platform/persist_test.go
@@ -42,6 +42,8 @@ func TestDBMergeRequestCarriesProviderMergeableState(t *testing.T) {
 }
 
 func TestDBReviewThreadsCarriesCommentMetadataToReplies(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	events, threads := DBReviewThreads([]MergeRequestReviewThread{
 		{
 			ProviderThreadID:  "thread-1",
@@ -55,10 +57,10 @@ func TestDBReviewThreadsCarriesCommentMetadataToReplies(t *testing.T) {
 		},
 	})
 
-	require.Len(t, threads, 1)
-	require.Len(t, events, 2)
-	assert.JSONEq(t, threads[0].MetadataJSON, events[0].MetadataJSON)
-	assert.JSONEq(t, `{"provider_hidden":true,"provider_hidden_reason":"OFF_TOPIC"}`, events[1].MetadataJSON)
+	require.Len(threads, 1)
+	require.Len(events, 2)
+	assert.JSONEq(threads[0].MetadataJSON, events[0].MetadataJSON)
+	assert.JSONEq(`{"provider_hidden":true,"provider_hidden_reason":"OFF_TOPIC"}`, events[1].MetadataJSON)
 }
 
 func TestPreserveProviderHiddenMetadata(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -3139,17 +3139,13 @@ func TestAPIEnqueuePRSyncPersistsWorkflowApproval(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusAccepted, resp.StatusCode())
 
+	detailSyncKey := "pr:github:github.com:acme/widget#1"
 	require.Eventually(func() bool {
-		detail, dErr := client.HTTP.GetPullWithResponse(
-			t.Context(), "gh", "acme", "widget", 1,
-		)
-		if dErr != nil || detail.JSON200 == nil {
-			return false
-		}
-		wa := detail.JSON200.WorkflowApproval
-		return wa.Checked && wa.Required && wa.Count == 1
-	}, 3*time.Second, 25*time.Millisecond,
-		"GET should return persisted workflow_approval after async sync")
+		srv.detailSyncMu.Lock()
+		defer srv.detailSyncMu.Unlock()
+		_, inFlight := srv.detailSyncInFlight[detailSyncKey]
+		return !inFlight
+	}, 10*time.Second, time.Millisecond, "async detail sync should complete")
 
 	detail, err := client.HTTP.GetPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,

--- a/internal/server/e2etest/notifications_test.go
+++ b/internal/server/e2etest/notifications_test.go
@@ -174,7 +174,7 @@ func TestNotificationSyncReconcilesReusedRouteE2E(t *testing.T) {
 	assert := assert.New(t)
 	ctx := t.Context()
 	number := 7
-	firstActivityAt := time.Date(2026, 8, 3, 10, 0, 0, 0, time.UTC)
+	firstActivityAt := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
 	var activityAt atomic.Int64
 	activityAt.Store(firstActivityAt.UnixNano())
 	var listCalls atomic.Int32

--- a/internal/server/runtime_launch_rollback_test.go
+++ b/internal/server/runtime_launch_rollback_test.go
@@ -26,6 +26,8 @@ import (
 	"go.kenn.io/forge/internal/workspace/localruntime"
 )
 
+const runtimeRollbackEventuallyTimeout = 10 * time.Second
+
 type runtimeRollbackFakeTmux struct {
 	command            []string
 	recordPath         string
@@ -227,7 +229,7 @@ func waitForRuntimeWriterWait(t *testing.T, database *db.DB, baseline int64) {
 	t.Helper()
 	require.Eventually(t, func() bool {
 		return database.WriteDB().Stats().WaitCount > baseline
-	}, time.Second, 10*time.Millisecond)
+	}, runtimeRollbackEventuallyTimeout, 10*time.Millisecond)
 }
 
 func runtimeLaunchRequestBody(t *testing.T, sessionKey string) []byte {
@@ -361,7 +363,7 @@ func TestCommandSameKeyPersistenceOwnership(t *testing.T) {
 			)
 			require.Eventually(func() bool {
 				return len(fixture.server.runtime.ListSessions(scope)) == 1
-			}, time.Second, 10*time.Millisecond)
+			}, runtimeRollbackEventuallyTimeout, 10*time.Millisecond)
 			waitForRuntimeWriterWait(t, fixture.server.db, baseline)
 			generationOne := fixture.server.runtime.ListSessions(scope)[0]
 			assert.True(
@@ -384,7 +386,7 @@ func TestCommandSameKeyPersistenceOwnership(t *testing.T) {
 			require.Eventually(func() bool {
 				launches, err := os.ReadFile(fixture.tmux.launchHistoryPath)
 				return err == nil && len(strings.Fields(string(launches))) == 2
-			}, time.Second, 10*time.Millisecond)
+			}, runtimeRollbackEventuallyTimeout, 10*time.Millisecond)
 			require.NoError(transaction.Rollback())
 			bRecorder := awaitRuntimeResponse(t, bResponses)
 
@@ -435,7 +437,7 @@ func TestProjectWorktreeShellPersistenceOwnership(t *testing.T) {
 	)
 	require.Eventually(func() bool {
 		return len(fixture.server.runtime.ListSessions(scope)) == 1
-	}, time.Second, 10*time.Millisecond)
+	}, runtimeRollbackEventuallyTimeout, 10*time.Millisecond)
 	waitForRuntimeWriterWait(t, fixture.server.db, baseline)
 	generationOne := fixture.server.runtime.ListSessions(scope)[0]
 
@@ -454,7 +456,7 @@ func TestProjectWorktreeShellPersistenceOwnership(t *testing.T) {
 	require.Eventually(func() bool {
 		launches, err := os.ReadFile(fixture.tmux.launchHistoryPath)
 		return err == nil && len(strings.Fields(string(launches))) == 2
-	}, time.Second, 10*time.Millisecond)
+	}, runtimeRollbackEventuallyTimeout, 10*time.Millisecond)
 	require.NoError(transaction.Rollback())
 	bRecorder := awaitRuntimeResponse(t, bResponses)
 
@@ -509,17 +511,17 @@ func TestHostRuntimeLaunchPersistenceFailureRollsBackNewTmuxSession(
 	require.Eventually(func() bool {
 		_, err := os.Stat(fixture.tmux.attachStartedPath)
 		return err == nil
-	}, time.Second, 10*time.Millisecond)
+	}, runtimeRollbackEventuallyTimeout, 10*time.Millisecond)
 	require.Eventually(func() bool {
 		return len(fixture.server.runtime.ListSessions(hostRuntimeScope)) == 1
-	}, time.Second, 10*time.Millisecond)
+	}, runtimeRollbackEventuallyTimeout, 10*time.Millisecond)
 	waitForRuntimeWriterWait(t, fixture.server.db, baseline)
 	launched := fixture.server.runtime.ListSessions(hostRuntimeScope)[0]
 
 	require.NoError(os.WriteFile(fixture.tmux.exitAttachPath, nil, 0o600))
 	require.Eventually(func() bool {
 		return len(fixture.server.runtime.ListSessions(hostRuntimeScope)) == 0
-	}, time.Second, 10*time.Millisecond)
+	}, runtimeRollbackEventuallyTimeout, 10*time.Millisecond)
 	cancel()
 	recorder := awaitRuntimeResponse(t, responses)
 	require.NoError(transaction.Rollback())
@@ -652,13 +654,13 @@ func TestHostRuntimeLaunchPersistenceFailureLogsRollbackFailureAndPreservesPersi
 	require.Eventually(func() bool {
 		_, err := os.Stat(fixture.tmux.attachStartedPath)
 		return err == nil
-	}, time.Second, 10*time.Millisecond)
+	}, runtimeRollbackEventuallyTimeout, 10*time.Millisecond)
 	waitForRuntimeWriterWait(t, fixture.server.db, baseline)
 	launched := fixture.server.runtime.ListSessions(hostRuntimeScope)[0]
 	require.NoError(os.WriteFile(fixture.tmux.exitAttachPath, nil, 0o600))
 	require.Eventually(func() bool {
 		return len(fixture.server.runtime.ListSessions(hostRuntimeScope)) == 0
-	}, time.Second, 10*time.Millisecond)
+	}, runtimeRollbackEventuallyTimeout, 10*time.Millisecond)
 	cancel()
 	recorder := awaitRuntimeResponse(t, responses)
 	require.NoError(transaction.Rollback())
@@ -735,17 +737,17 @@ func TestProjectWorktreeRuntimeLaunchPersistenceFailureRollsBackNewTmuxSession(
 			require.Eventually(func() bool {
 				_, err := os.Stat(fixture.tmux.attachStartedPath)
 				return err == nil
-			}, time.Second, 10*time.Millisecond)
+			}, runtimeRollbackEventuallyTimeout, 10*time.Millisecond)
 			require.Eventually(func() bool {
 				return len(fixture.server.runtime.ListSessions(scope)) == 1
-			}, time.Second, 10*time.Millisecond)
+			}, runtimeRollbackEventuallyTimeout, 10*time.Millisecond)
 			waitForRuntimeWriterWait(t, fixture.server.db, baseline)
 			launched := fixture.server.runtime.ListSessions(scope)[0]
 
 			require.NoError(os.WriteFile(fixture.tmux.exitAttachPath, nil, 0o600))
 			require.Eventually(func() bool {
 				return len(fixture.server.runtime.ListSessions(scope)) == 0
-			}, time.Second, 10*time.Millisecond)
+			}, runtimeRollbackEventuallyTimeout, 10*time.Millisecond)
 			cancel()
 			recorder := awaitRuntimeResponse(t, responses)
 			require.NoError(transaction.Rollback())
@@ -940,13 +942,13 @@ func TestProjectWorktreeRuntimeLaunchPersistenceFailureLogsRollbackFailureAndPre
 	require.Eventually(func() bool {
 		_, err := os.Stat(fixture.tmux.attachStartedPath)
 		return err == nil
-	}, time.Second, 10*time.Millisecond)
+	}, runtimeRollbackEventuallyTimeout, 10*time.Millisecond)
 	waitForRuntimeWriterWait(t, fixture.server.db, baseline)
 	launched := fixture.server.runtime.ListSessions(scope)[0]
 	require.NoError(os.WriteFile(fixture.tmux.exitAttachPath, nil, 0o600))
 	require.Eventually(func() bool {
 		return len(fixture.server.runtime.ListSessions(scope)) == 0
-	}, time.Second, 10*time.Millisecond)
+	}, runtimeRollbackEventuallyTimeout, 10*time.Millisecond)
 	cancel()
 	recorder := awaitRuntimeResponse(t, responses)
 	require.NoError(transaction.Rollback())
@@ -1077,7 +1079,7 @@ func TestRuntimeSessionExitDuringPersistenceLeavesNoDurableRow(t *testing.T) {
 			)
 			require.Eventually(func() bool {
 				return len(fixture.server.runtime.ListSessions(scope)) == 1
-			}, time.Second, 10*time.Millisecond)
+			}, runtimeRollbackEventuallyTimeout, 10*time.Millisecond)
 			waitForRuntimeWriterWait(t, fixture.server.db, baseline)
 
 			// The command exits while its metadata write is still blocked, so
@@ -1086,7 +1088,7 @@ func TestRuntimeSessionExitDuringPersistenceLeavesNoDurableRow(t *testing.T) {
 			require.NoError(os.WriteFile(fixture.tmux.exitAttachPath, nil, 0o600))
 			require.Eventually(func() bool {
 				return len(fixture.server.runtime.ListSessions(scope)) == 0
-			}, time.Second, 10*time.Millisecond)
+			}, runtimeRollbackEventuallyTimeout, 10*time.Millisecond)
 
 			require.NoError(transaction.Rollback())
 			recorder := awaitRuntimeResponse(t, responses)

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -524,13 +524,14 @@ func TestHandleUpdateSettings(t *testing.T) {
 	issues := config.Issues{HideBots: true}
 	workspaces := config.Workspaces{AutoAssignOnCreate: true}
 	terminal := config.Terminal{
-		FontFamily:     "\"Fira Code\", monospace",
-		FontSize:       16,
-		Scrollback:     5000,
-		LineHeight:     1.15,
-		CursorBlink:    new(true),
-		FontLigatures:  true,
-		HideTmuxStatus: true,
+		FontFamily:       "\"Fira Code\", monospace",
+		FontSize:         16,
+		Scrollback:       5000,
+		LineHeight:       1.15,
+		CursorBlink:      new(true),
+		FontLigatures:    true,
+		HideTmuxStatus:   true,
+		RetainedSessions: new(4),
 	}
 	body := updateSettingsRequest{
 		Activity:   &activity,
@@ -556,6 +557,8 @@ func TestHandleUpdateSettings(t *testing.T) {
 	assert.InDelta(1.15, cfg2.Terminal.LineHeight, 0.001)
 	assert.True(cfg2.Terminal.FontLigatures)
 	assert.True(cfg2.Terminal.HideTmuxStatus)
+	require.NotNil(t, cfg2.Terminal.RetainedSessions)
+	assert.Equal(4, *cfg2.Terminal.RetainedSessions)
 }
 
 func TestHandleUpdateSettingsDisablesNativeStackProjectionImmediately(t *testing.T) {
@@ -634,11 +637,12 @@ docs = false
 `, &mockGH{})
 
 	terminal := config.Terminal{
-		FontFamily:    "\"Iosevka Term\", monospace",
-		FontSize:      15,
-		Scrollback:    2000,
-		LetterSpacing: 1,
-		CursorBlink:   new(true),
+		FontFamily:       "\"Iosevka Term\", monospace",
+		FontSize:         15,
+		Scrollback:       2000,
+		LetterSpacing:    1,
+		CursorBlink:      new(true),
+		RetainedSessions: new(config.DefaultTerminalRetainedSessions),
 	}
 	body := updateSettingsRequest{
 		Terminal: &terminal,

--- a/scripts/context-sync
+++ b/scripts/context-sync
@@ -36,7 +36,7 @@ require_file "skills/context-sync/SKILL.md"
 
 if [ -d "$root/docs/superpowers" ] &&
   find "$root/docs/superpowers" -type f -print -quit | grep -q .; then
-  printf 'context-sync: docs/superpowers must remain absent; extract durable contracts into context or Zensical docs\n' >&2
+  printf 'context-sync: docs/superpowers must remain absent; distill durable contracts into context topic docs, remove the transient artifacts, and do not convert them into ADRs\n' >&2
   status=1
 fi
 

--- a/scripts/context-sync.test.mjs
+++ b/scripts/context-sync.test.mjs
@@ -69,14 +69,12 @@ test("context sync rejects reintroduced Superpowers documents", async (t) => {
   await mkdir(specs, { recursive: true });
   await writeFile(path.join(specs, "completed-design.md"), "# Completed design\n");
 
-  await assert.rejects(
-    execFile(scriptPath, ["--check"], { cwd: root, env: isolatedGitEnv() }),
-    (error) => {
-      assert.match(error.stderr, /docs\/superpowers must remain absent/);
-      assert.match(error.stderr, /structural check failed/);
-      return true;
-    },
-  );
+  await assert.rejects(execFile(scriptPath, ["--check"], { cwd: root, env: isolatedGitEnv() }), (error) => {
+    assert.match(error.stderr, /docs\/superpowers must remain absent/);
+    assert.match(error.stderr, /do not convert them into ADRs/);
+    assert.match(error.stderr, /structural check failed/);
+    return true;
+  });
 });
 
 test("context sync fixtures ignore inherited hook repository bindings", async (t) => {

--- a/skills/context-sync/SKILL.md
+++ b/skills/context-sync/SKILL.md
@@ -145,8 +145,10 @@ unselected docs or code paths.
 ### Step 4: Check Design Decisions
 
 Compare the selected code and current conversation with `docs/adr/` and the selected
-topic docs. Identify durable decisions or maintainer-owned domain knowledge that are not
-captured, and state whether each belongs in an ADR, a topic doc, or `CLAUDE.md`.
+topic docs. Distill feature specs and implementation plans into current contracts in a
+topic doc or `CLAUDE.md`; never preserve those transient artifacts by converting them
+into ADRs. Reserve an ADR for independently required dated rationale that still binds
+the architecture.
 
 Only `--all` may search broader recent conversation history and recent commits. Focused
 audits use the current conversation and selected change range only.

--- a/skills/context-sync/context-guide.md
+++ b/skills/context-sync/context-guide.md
@@ -58,17 +58,19 @@ kenn-forge's durable agent context lives in two places:
   etc.). Deep enough to hold real rationale; narrow enough to load only when relevant.
 
 The README, Makefile, and source tree own discoverable inventories, key-file lists, and
-development commands. Do not copy them into the always-loaded hub. Transient design and
-implementation notes stay outside the long-lived repository documentation; durable,
-dated decisions live under `docs/adr/`.
+development commands. Do not copy them into the always-loaded hub. Superpowers design
+specs and implementation plans are temporary working artifacts: distill current
+contracts into the matching topic docs and delete the artifacts before committing.
+Never convert a transient spec into an ADR merely to retain it. Independently required,
+dated rationale that still constrains the code may live under `docs/adr/`.
 
 ### The Sorting Test
 
 When a new fact arrives, ask: does it describe the *whole project's* shape or workflow
-(→ root `CLAUDE.md`), one *concern in depth* (→ the matching `context/*.md`), a *dated
-decision* whose rationale still constrains the code (→ `docs/adr/`), or transient work
-(→ the task workspace, issue, or pull request)? Put durable facts in exactly one home
-and route them to it.
+(→ root `CLAUDE.md`), one *concern in depth* (→ the matching `context/*.md`), independently
+required dated rationale (→ `docs/adr/`), or transient design/planning work (→ the task
+workspace, issue, or pull request)? Put durable facts in exactly one home and route them
+to it; a completed feature spec becomes current contracts in topic docs, not an ADR.
 
 ## Anchored Claims
 
@@ -158,7 +160,7 @@ Silencing a failing guard without recording the decision is forbidden.
 | Kata daemon integration | `context/kata-mode.md`, `context/workspace-apis.md` | External authority and workspace contracts |
 | Docs mode integration | `context/docs-mode.md` | Local filesystem and git-publish boundary |
 | Repository source browsing | `context/repository-source-browser.md` | Read-only clone and ref coherence |
-| A decision chosen over an alternative | `docs/adr/NNNN-title.md` | Dated, durable rationale |
+| Independently required dated rationale | `docs/adr/NNNN-title.md` | Historical rationale that still constrains current architecture |
 
 Every new topic doc MUST get a routing reference from root `CLAUDE.md` (or from another
 reachable doc). Unreachable context is invisible to agents.
@@ -179,7 +181,7 @@ and route them by task trigger.
 
 ## When to Update Context
 
-- A maintainer explains a design decision → capture it promptly (ADR or topic doc).
+- A maintainer explains a design decision → capture the current contract in its topic doc; use an ADR only when the dated rationale is independently required.
 - A new provider, mode, or cross-cutting invariant lands → add/extend the topic doc and
   route to it from `CLAUDE.md`.
 - An agent makes a mistake context would have prevented → add the gotcha.


### PR DESCRIPTION
Sessions with long histories rebuilt xterm, opened a new WebSocket, and replayed buffered output every time a maintainer returned to a workspace. That made workspace switching visibly slower as session history grew.

This keeps recently released terminal sessions in a bounded least-recently-used cache. The default retains 10 sessions, settings allow 0 through 20, and zero restores immediate disposal. Claimed sessions remain presentation state even when their tab is hidden. Released sessions keep parsed terminal state and their socket, but surrender WebGL and leave the cache on disconnect, exit, deletion, generation replacement, or eviction. Retention-limit changes publish only after persistence succeeds, so cancellation and failed saves cannot destroy cached terminals; reversible visual settings continue to preview immediately. This trades bounded memory and background parsing for substantially lower return latency without retaining GPU contexts.

The profiling harness now compares at least 10 retained hits with forced misses at the 64 KiB replay cap. In the local isolated run, ordinary-shell hits painted in 14.0–21.9 ms versus 33.3–63.1 ms for misses; alternate-screen hits painted in 12.7–23.2 ms versus 30.7–83.0 ms. Both scenarios passed the required hit p75 below miss p25 threshold.

The terminal-retention design and plan were temporary workflow artifacts. Their current contracts are distilled into the runtime, UI, config, and testing context, and the repository guard rejects retained Superpowers documents with instructions not to convert them into ADRs. No Superpowers document or feature ADR is included in this pull request.

<details>
<summary>Validation</summary>

- Squashed-commit hooks passed, including the repository short Go suite and frontend checks.
- Focused persistence, settings-component, and session-host coverage passed: 50 tests, including overlapping retention-save reconciliation.
- Focused full-stack Chromium continuity coverage passed: retained A → B → A reuse and zero-retention socket closure.
- Context-sync regression coverage passed: 3 tests, including the no-Superpowers guard and inherited-hook isolation.
- Terminal pool browser coverage passed: 20 tests.
- `go test ./internal/config ./internal/server` passed.
- `make lint-check` passed with 0 issues.
- `make profile-workspace-switch` passed against an isolated backend with 10 hit and miss samples per terminal mode.

</details>