### PR TITLE
test: prevent hide-org persistence E2E timeouts

### DIFF
--- a/frontend/tests/e2e/activity-threaded-columns.spec.ts
+++ b/frontend/tests/e2e/activity-threaded-columns.spec.ts
@@ -193,7 +193,7 @@ test.describe("threaded activity columns", () => {
       localStorage.setItem("kenn-forge:groupingMode", "flat");
       localStorage.removeItem("kenn-forge:hideOrgName");
     });
-    await page.reload();
+    await page.reload({ waitUntil: "domcontentloaded" });
 
     const repoLabel = page.locator(".item-row .repo-chip__label").first();
     await expect(repoLabel).toHaveText("acme/widgets");
@@ -206,7 +206,7 @@ test.describe("threaded activity columns", () => {
     await expect(repoLabel).toHaveText("widgets");
 
     // Reload to verify the toggle persists via localStorage.
-    await page.reload();
+    await page.reload({ waitUntil: "domcontentloaded" });
     await expect(page.locator(".item-row .repo-chip__label").first()).toHaveText("widgets");
   });
 });


### PR DESCRIPTION
- Keep the hide-org persistence browser check focused on rendered app state instead of unrelated page resources.
- Prevent intermittent Chromium CI timeouts without weakening the preference assertions.