### PR TITLE
fix: bound manual session stops

### DIFF
--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -158,6 +158,9 @@ stale tabs.
 
 - Runtime lists returned by `/workspaces/{id}/runtime` are the authoritative
   backend view of live launched sessions.
+- Manual stop settlement must bound every awaited stage and publish confirmed local absence before any
+  best-effort refresh; no stalled transport, authority read, or presenter may retain the pending control
+  (`frontend/src/lib/components/terminal/workspace-runtime-workflow.ts::makeWorkspaceRuntimeWorkflow`).
 - Application workflow launch settlement precedes presenter delivery. Accept confirmed sessions immediately, reject only
   definite failures, and leave uncertain launches unsettled until reconciliation decides them
   (`frontend/src/lib/components/terminal/workspace-runtime-workflow.ts::storeAndPresentMutation`).

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -2316,9 +2316,9 @@
       }
       case "Stop":
         return Effect.gen(function* () {
-          yield* fetchRuntimeProgram({ force: true });
-          if (!isCurrentWorkspace(id, hostKey)) return false;
+          const stoppedSession = runtimeSessions.find((session) => session.key === state.request.sessionKey);
           yield* Effect.sync(() => {
+            if (stoppedSession !== undefined) markSessionClosed(stoppedSession);
             unmountSessionTerminal(state.request.sessionKey);
             const groups = closeSessionInTerminalGroups(terminalLayout.terminalGroups, state.request.sessionKey);
             terminalLayout = normalizeLayoutForSessions(
@@ -2328,6 +2328,8 @@
             if (activeTabKey === `session:${state.request.sessionKey}`) selectFallbackTab();
             clearRuntimeMutationPending(state);
           });
+          yield* fetchRuntimeProgram({ force: true });
+          if (!isCurrentWorkspace(id, hostKey)) return false;
           return true;
         });
       case "Rename":

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -1785,6 +1785,32 @@ describe("WorkspaceTerminalView", () => {
     await waitFor(() => expect(mocks.stopWorkspaceSession).toHaveBeenCalledWith("ws-1", "ws-1_shell_a", undefined));
   });
 
+  it("settles a stopped session before its forced runtime refresh returns", async () => {
+    localStorage.setItem("kenn-forge-workspace-active-tab:ws-1", "home");
+    mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithTwoTerminalSessions());
+    mocks.stopWorkspaceSession.mockResolvedValue(undefined);
+
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+      },
+    });
+
+    await fireEvent.click(await screen.findByRole("button", { name: "Open terminal panel" }));
+    await waitFor(() => expect(sockets).toHaveLength(1));
+    await fireEvent.click(screen.getByRole("button", { name: "Close Shell" }));
+    const confirm = await screen.findByRole("dialog", { name: "Stop Shell?" });
+    const stalledRefresh = deferred<ReturnType<typeof runtimeWithTwoTerminalSessions>>();
+    mocks.getWorkspaceRuntime.mockReturnValue(stalledRefresh.promise);
+
+    await fireEvent.click(within(confirm).getByRole("button", { name: "Stop session" }));
+    await waitFor(() => expect(mocks.stopWorkspaceSession).toHaveBeenCalledWith("ws-1", "ws-1_shell_a", undefined));
+
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Stop Shell?" })).toBeNull());
+    expect(screen.queryByRole("button", { name: "Close Shell" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Shell 2 Running" })).toBeTruthy();
+  });
+
   it("uses an in-app modal when renaming a tab", async () => {
     const prompt = vi.fn();
     vi.stubGlobal("prompt", prompt);

--- a/frontend/src/lib/components/terminal/workspace-runtime-workflow.test.ts
+++ b/frontend/src/lib/components/terminal/workspace-runtime-workflow.test.ts
@@ -823,6 +823,83 @@ describe("WorkspaceRuntimeWorkflow", () => {
     ),
   );
 
+  it.effect("bounds stop reconciliation when runtime authority never returns", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const readStarted = yield* Deferred.make<void>();
+        const readInterrupted = yield* Deferred.make<void>();
+        const states: WorkspaceRuntimeMutationState[] = [];
+        const port: WorkspaceRuntimePort = {
+          read: () =>
+            Deferred.succeed(readStarted, undefined).pipe(
+              Effect.andThen(Effect.never),
+              Effect.onInterrupt(() => Deferred.succeed(readInterrupted, undefined)),
+            ),
+          launch: unusedPortMethod,
+          rename: unusedPortMethod,
+          stop: () =>
+            Effect.fail(TransientTransportError.make({ operation: "stop workspace session", cause: "response lost" })),
+          refresh: unusedPortMethod,
+          retry: unusedPortMethod,
+          delete: unusedPortMethod,
+        };
+        const workflow = yield* makeWorkspaceRuntimeWorkflow(port);
+        const target = { workspaceId: "ws-1" };
+        yield* workflow.claimPresenter(target, "route", (state) =>
+          Effect.sync(() => {
+            states.push(state);
+            return state.kind !== "pending";
+          }),
+        );
+
+        yield* workflow.stop(target, "ws-1:helper");
+        yield* Deferred.await(readStarted);
+        yield* TestClock.adjust("10 seconds");
+        yield* Effect.yieldNow;
+
+        assert.isTrue(yield* Deferred.isDone(readInterrupted));
+        assert.deepStrictEqual(
+          states.map((state) => state.kind),
+          ["pending", "uncertain"],
+        );
+      }),
+    ),
+  );
+
+  it.effect("bounds successful stop presentation when its observer never returns", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const presentationStarted = yield* Deferred.make<void>();
+        const presentationInterrupted = yield* Deferred.make<void>();
+        const port: WorkspaceRuntimePort = {
+          read: () => Effect.succeed(emptyRuntime),
+          launch: unusedPortMethod,
+          rename: unusedPortMethod,
+          stop: () => Effect.void,
+          refresh: unusedPortMethod,
+          retry: unusedPortMethod,
+          delete: unusedPortMethod,
+        };
+        const workflow = yield* makeWorkspaceRuntimeWorkflow(port);
+        const target = { workspaceId: "ws-1" };
+        yield* workflow.claimPresenter(target, "route", (state) => {
+          if (state.kind !== "succeeded" || state.operation !== "Stop") return Effect.succeed(false);
+          return Deferred.succeed(presentationStarted, undefined).pipe(
+            Effect.andThen(Effect.never),
+            Effect.onInterrupt(() => Deferred.succeed(presentationInterrupted, undefined)),
+          );
+        });
+
+        yield* workflow.stop(target, "ws-1:helper");
+        yield* Deferred.await(presentationStarted);
+        yield* TestClock.adjust("10 seconds");
+        yield* Effect.yieldNow;
+
+        assert.isTrue(yield* Deferred.isDone(presentationInterrupted));
+      }),
+    ),
+  );
+
   it.effect("delivers a completed rename only to the replacement presenter", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/frontend/src/lib/components/terminal/workspace-runtime-workflow.test.ts
+++ b/frontend/src/lib/components/terminal/workspace-runtime-workflow.test.ts
@@ -777,6 +777,52 @@ describe("WorkspaceRuntimeWorkflow", () => {
     ),
   );
 
+  it.effect("reconciles a stop when the transport never returns", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const stopStarted = yield* Deferred.make<void>();
+        const stopInterrupted = yield* Deferred.make<void>();
+        const stopSettled = yield* Deferred.make<void>();
+        const states: WorkspaceRuntimeMutationState[] = [];
+        const port: WorkspaceRuntimePort = {
+          read: () => Effect.succeed(emptyRuntime),
+          launch: unusedPortMethod,
+          rename: unusedPortMethod,
+          stop: () =>
+            Deferred.succeed(stopStarted, undefined).pipe(
+              Effect.andThen(Effect.never),
+              Effect.onInterrupt(() => Deferred.succeed(stopInterrupted, undefined)),
+            ),
+          refresh: unusedPortMethod,
+          retry: unusedPortMethod,
+          delete: unusedPortMethod,
+        };
+        const workflow = yield* makeWorkspaceRuntimeWorkflow(port);
+        const target = { workspaceId: "ws-1" };
+        yield* workflow.claimPresenter(target, "route", (state) =>
+          Effect.gen(function* () {
+            states.push(state);
+            if (state.kind !== "succeeded" || state.operation !== "Stop") return false;
+            yield* Deferred.succeed(stopSettled, undefined);
+            return true;
+          }),
+        );
+
+        yield* workflow.stop(target, "ws-1:helper");
+        yield* Deferred.await(stopStarted);
+        yield* TestClock.adjust("30 seconds");
+        yield* Effect.yieldNow;
+
+        assert.isTrue(yield* Deferred.isDone(stopSettled));
+        assert.isTrue(yield* Deferred.isDone(stopInterrupted));
+        assert.deepStrictEqual(
+          states.map((state) => state.kind),
+          ["pending", "succeeded"],
+        );
+      }),
+    ),
+  );
+
   it.effect("delivers a completed rename only to the replacement presenter", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/frontend/src/lib/components/terminal/workspace-runtime-workflow.ts
+++ b/frontend/src/lib/components/terminal/workspace-runtime-workflow.ts
@@ -31,6 +31,7 @@ import type { WorkflowPreset } from "./workflow-presets.js";
 import { decodeWorkspaceDetail, type WorkspaceDetail } from "./workspace-detail.js";
 
 const acceptedLaunchReconciliationWindowMillis = 15_000;
+const workspaceRuntimeStopTimeout = Duration.seconds(10);
 
 export interface WorkspaceRuntimeTarget {
   readonly workspaceId: string;
@@ -972,9 +973,22 @@ export function makeWorkspaceRuntimeWorkflow(
           return;
         }
         case "Stop": {
+          const operation =
+            request.target.hostKey === undefined ? "stop workspace session" : "stop fleet workspace session";
           yield* runRecoverableMutation(
             request,
-            port.stop(request.target, request.sessionKey),
+            port.stop(request.target, request.sessionKey).pipe(
+              Effect.timeoutOrElse({
+                duration: workspaceRuntimeStopTimeout,
+                orElse: () =>
+                  Effect.fail(
+                    TransientTransportError.make({
+                      operation,
+                      cause: new Error("timed out waiting for the session to stop"),
+                    }),
+                  ),
+              }),
+            ),
             reconcileStop(request),
             () => ({ kind: "succeeded", operation: "Stop", request }),
           );

--- a/frontend/src/lib/components/terminal/workspace-runtime-workflow.ts
+++ b/frontend/src/lib/components/terminal/workspace-runtime-workflow.ts
@@ -562,7 +562,15 @@ export function makeWorkspaceRuntimeWorkflow(
                 return;
               }
 
-              const acknowledged = yield* presenter.observe(state);
+              const observation = presenter.observe(state);
+              const acknowledged = yield* state.kind === "succeeded" && state.operation === "Stop"
+                ? observation.pipe(
+                    Effect.timeoutOrElse({
+                      duration: workspaceRuntimeStopTimeout,
+                      orElse: () => Effect.succeed(true),
+                    }),
+                  )
+                : observation;
               if (!acknowledged) return;
               yield* mutationLock.withPermit(
                 Effect.gen(function* () {
@@ -697,7 +705,16 @@ export function makeWorkspaceRuntimeWorkflow(
         return session === undefined || session.status === "exited"
           ? { _tag: "Applied", state: { kind: "succeeded", operation: "Stop", request } }
           : { _tag: "NotApplied" };
-      });
+      }).pipe(
+        Effect.timeoutOrElse({
+          duration: workspaceRuntimeStopTimeout,
+          orElse: () =>
+            Effect.succeed({
+              _tag: "Unknown",
+              cause: new Error("timed out waiting for runtime authority after stopping the session"),
+            } satisfies WorkspaceRuntimeReconciliation),
+        }),
+      );
 
     const reconcileDelete = (
       request: AcceptedWorkspaceRuntimeDeleteRequest,


### PR DESCRIPTION
A manual session stop is a staged Effect chain: transport, runtime-authority reconciliation, and presenter settlement. Any unbounded stage could retain the pending control indefinitely. Bound each stage and publish confirmed local absence before the best-effort refresh so stalled follow-up reads cannot strand the operation.

- Add virtual-time regressions for stalled stop transport, authority reads, and presenter work.
- Cover local stop settlement while the forced runtime refresh remains pending.

<details>
<summary>Validation</summary>

- Full frontend unit suite: 3,894 passed, 2 skipped.
- Workspace terminal component suite: 123 passed.
- Isolated Chromium/tmux stop flow: 1 passed.
- Frontend checks and non-mutating lint passed.

</details>

<sup>generated by a clanker</sup>