### PR TITLE
fix: make active panes follow DOM focus

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -336,6 +336,9 @@ Keyboard handlers must have one clear owner for each key press.
 - Preserve a focused node through no-destination `focusout` only for the immediate Effect-managed replacement window;
   keyed replacement restores focus, while an ordinary blur or document hiding cannot affect later DOM removal
   (`frontend/src/lib/components/shared/DetailPaneLayout.svelte::handleLayoutFocusOut`).
+- When focused content leaves a detail layout without `focusout`, release that layout's ownership. Reclaim layout focus
+  only for disconnected content; connected pooled terminals keep their own restoration path
+  (`frontend/src/lib/components/shared/DetailPaneLayout.svelte::observeMutation`).
 - A terminal dock tracks the exact focused descendant across silent session removal; it releases ownership when that
   node leaves the dock, restores a surviving dock only for disconnected content, and leaves connected pooled moves alone
   (`frontend/src/lib/components/terminal/DockedTerminalPanel.svelte::handleFocusOut`).

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -292,6 +292,9 @@ Keyboard handlers must have one clear owner for each key press.
 - Simultaneous panes activate on focus, pointer, or wheel input; only the active pane
   consumes window-level keys, and wheel stays event-local. Mark it with a subtle inset border
   without replacing control focus styling (`frontend/src/lib/components/shared/TabbedPanelTree.svelte`).
+- Nested pane trees paint ownership only while their containing pane is active; workspace
+  Workflow, Details, and bottom Terminal regions are sibling owners
+  (`frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte::renderedWorkspaceInputRegion`).
 - Focus Terminal reveals, it never maximizes: a closed workspace pane reopens
   alongside the detail and a visible one keeps its arrangement. Maximizing over
   the detail is only ever an explicit user action. Reopening also has to clear a

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -295,6 +295,9 @@ Keyboard handlers must have one clear owner for each key press.
 - Nested pane trees paint ownership only while their containing pane is active, and only
   the deepest active owner paints; workspace Workflow, Details, and bottom Terminal regions are siblings
   (`frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte::renderedWorkspaceInputRegion`).
+- A surface-hosted dock outside the pane tree can become the canonical owner; any pane activation revokes
+  that claim. Workspace window shortcuts run only while the validated workspace container owns the surface
+  (`frontend/src/lib/stores/paneLayout.svelte.ts::PaneRenderReport`).
 - Focus Terminal reveals, it never maximizes: a closed workspace pane reopens
   alongside the detail and a visible one keeps its arrangement. Maximizing over
   the detail is only ever an explicit user action. Reopening also has to clear a

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -330,6 +330,12 @@ Keyboard handlers must have one clear owner for each key press.
   command memory only; it never represents current focus. Workspace window
   shortcuts run only while the validated workspace container has DOM focus
   (`frontend/src/lib/stores/paneLayout.svelte.ts::PaneRenderReport`).
+- Pane keyboard ownership follows the exact rendered leaf and tab containing DOM focus;
+  nested tab identity never bubbles into an outer tree
+  (`frontend/src/lib/components/shared/TabbedPanelTree.svelte::handleLeafFocusIn`).
+- Preserve a focused node through no-destination `focusout` until the Effect-scoped layout observer tests connectivity;
+  keyed replacement releases ownership and restores focus, while connected pooled terminals stay untouched
+  (`frontend/src/lib/components/shared/DetailPaneLayout.svelte::handleLayoutFocusOut`).
 - Focus Terminal reveals, it never maximizes: a closed workspace pane reopens
   alongside the detail and a visible one keeps its arrangement. Maximizing over
   the detail is only ever an explicit user action. Reopening also has to clear a

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -310,6 +310,9 @@ Keyboard handlers must have one clear owner for each key press.
   pane and its containing pane, and only the deepest focused pane paints;
   workspace Workflow, Details, and bottom Terminal regions are siblings
   (`frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte::renderedWorkspaceInputRegion`).
+- If focused Workspace Details or bottom Terminal disappears while its host stays visible,
+  reclaim the Workspace root only when focus fell to `document.body`; parking never reclaims focus
+  (`frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte::workspaceRoot`).
 - A focused surface-hosted dock outside the pane tree becomes the live focused
   surface until focus leaves it. Persisted last-focused state is restoration and
   command memory only; it never represents current focus. Workspace window

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -319,7 +319,7 @@ Keyboard handlers must have one clear owner for each key press.
   pane and its containing pane, and only the deepest focused pane paints;
   workspace Workflow, Details, and bottom Terminal regions are siblings
   (`frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte::renderedWorkspaceInputRegion`).
-- If focused Workspace Details or bottom Terminal disappears while its host stays visible,
+- If focused Workspace Workflow, Details, or bottom Terminal becomes unready or disappears while its host stays visible,
   reclaim the Workspace root only when focus fell to `document.body`; parking never reclaims focus
   (`frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte::workspaceRoot`).
 - Standalone Workspace shortcuts accept unclaimed `document.body` focus, but a

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -310,6 +310,9 @@ Keyboard handlers must have one clear owner for each key press.
 - If a same-leaf tab change removes focused content without `focusout`, reclaim
   the layout only when focus fell to `document.body`
   (`frontend/src/lib/components/shared/DetailPaneLayout.svelte::reclaimFocus`).
+- Same-tab content identity replacement must also release disconnected focus;
+  renderer DOM removal is the signal because pane layout state does not change
+  (`frontend/src/lib/components/shared/DetailPaneLayout.svelte::observeMutation`).
 - Activity commit diffs use live pane `inputActive` for global shortcuts, not
   pane visibility (`frontend/src/lib/components/CommitDiffPanel.svelte::Props`).
 - Nested pane trees paint focus only while DOM focus is inside both the nested

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -334,7 +334,7 @@ Keyboard handlers must have one clear owner for each key press.
   nested tab identity never bubbles into an outer tree
   (`frontend/src/lib/components/shared/TabbedPanelTree.svelte::handleLeafFocusIn`).
 - Preserve a focused node through no-destination `focusout` only for the immediate Effect-managed replacement window;
-  keyed replacement restores focus, while an ordinary blur cannot affect later DOM removal
+  keyed replacement restores focus, while an ordinary blur or document hiding cannot affect later DOM removal
   (`frontend/src/lib/components/shared/DetailPaneLayout.svelte::handleLayoutFocusOut`).
 - A terminal dock tracks the exact focused descendant across silent session removal; it releases ownership when that
   node leaves the dock, restores a surviving dock only for disconnected content, and leaves connected pooled moves alone

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -289,14 +289,20 @@ Keyboard handlers must have one clear owner for each key press.
   command listeners: a command that opens detail UI must un-maximize first so it
   cannot build an invisible overlay
   (`frontend/src/lib/components/detail/PullDetail.svelte::onOpenLabelPickerCommand`).
-- Simultaneous panes activate on focus, pointer, or wheel input; only the active pane
-  consumes window-level keys, and wheel stays event-local. Mark it with a subtle inset border
-  without replacing control focus styling (`frontend/src/lib/components/shared/TabbedPanelTree.svelte`).
-- Nested pane trees paint ownership only while their containing pane is active, and only
-  the deepest active owner paints; workspace Workflow, Details, and bottom Terminal regions are siblings
+- A simultaneous pane is active exactly while DOM focus is inside it. Only that
+  focused pane consumes pane-scoped window keys. Pointer interaction changes the
+  active pane only when normal browser behavior moves focus; wheel input never
+  moves focus or changes the active pane. Mark actual focus with a subtle inset
+  border without replacing control focus styling
+  (`frontend/src/lib/components/shared/TabbedPanelTree.svelte`).
+- Nested pane trees paint focus only while DOM focus is inside both the nested
+  pane and its containing pane, and only the deepest focused pane paints;
+  workspace Workflow, Details, and bottom Terminal regions are siblings
   (`frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte::renderedWorkspaceInputRegion`).
-- A surface-hosted dock outside the pane tree can become the canonical owner; any pane activation revokes
-  that claim. Workspace window shortcuts run only while the validated workspace container owns the surface
+- A focused surface-hosted dock outside the pane tree becomes the live focused
+  surface until focus leaves it. Persisted last-focused state is restoration and
+  command memory only; it never represents current focus. Workspace window
+  shortcuts run only while the validated workspace container has DOM focus
   (`frontend/src/lib/stores/paneLayout.svelte.ts::PaneRenderReport`).
 - Focus Terminal reveals, it never maximizes: a closed workspace pane reopens
   alongside the detail and a visible one keeps its arrangement. Maximizing over

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -292,8 +292,8 @@ Keyboard handlers must have one clear owner for each key press.
 - Simultaneous panes activate on focus, pointer, or wheel input; only the active pane
   consumes window-level keys, and wheel stays event-local. Mark it with a subtle inset border
   without replacing control focus styling (`frontend/src/lib/components/shared/TabbedPanelTree.svelte`).
-- Nested pane trees paint ownership only while their containing pane is active; workspace
-  Workflow, Details, and bottom Terminal regions are sibling owners
+- Nested pane trees paint ownership only while their containing pane is active, and only
+  the deepest active owner paints; workspace Workflow, Details, and bottom Terminal regions are siblings
   (`frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte::renderedWorkspaceInputRegion`).
 - Focus Terminal reveals, it never maximizes: a closed workspace pane reopens
   alongside the detail and a visible one keeps its arrangement. Maximizing over

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -298,6 +298,14 @@ Keyboard handlers must have one clear owner for each key press.
   A dedicated Files route keeps global diff shortcuts only while no pane or
   external dock has live focus; this fallback never paints active-pane styling
   (`frontend/src/lib/views/PRListView.svelte::diffKeyboardActive`).
+- Focus callbacks carry the exact rendered leaf ID; never infer it from the
+  persisted tree because narrow layouts render one synthetic leaf
+  (`frontend/src/lib/components/shared/DetailPaneLayout.svelte::focusPane`).
+- If a same-leaf tab change removes focused content without `focusout`, reclaim
+  the layout only when focus fell to `document.body`
+  (`frontend/src/lib/components/shared/DetailPaneLayout.svelte::reclaimFocus`).
+- Activity commit diffs use live pane `inputActive` for global shortcuts, not
+  pane visibility (`frontend/src/lib/components/CommitDiffPanel.svelte::Props`).
 - Nested pane trees paint focus only while DOM focus is inside both the nested
   pane and its containing pane, and only the deepest focused pane paints;
   workspace Workflow, Details, and bottom Terminal regions are siblings

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -301,6 +301,9 @@ Keyboard handlers must have one clear owner for each key press.
 - Focus callbacks carry the exact rendered leaf ID; never infer it from the
   persisted tree because narrow layouts render one synthetic leaf
   (`frontend/src/lib/components/shared/DetailPaneLayout.svelte::focusPane`).
+- When a focused tab moves between rendered leaves, move live pane ownership
+  with that tab even if its old leaf still renders; pooled focus restoration
+  must not race a layout-host fallback (`frontend/src/lib/components/shared/DetailPaneLayout.svelte`).
 - If a same-leaf tab change removes focused content without `focusout`, reclaim
   the layout only when focus fell to `document.body`
   (`frontend/src/lib/components/shared/DetailPaneLayout.svelte::reclaimFocus`).

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -301,6 +301,9 @@ Keyboard handlers must have one clear owner for each key press.
 - Focus callbacks carry the exact rendered leaf ID; never infer it from the
   persisted tree because narrow layouts render one synthetic leaf
   (`frontend/src/lib/components/shared/DetailPaneLayout.svelte::focusPane`).
+- A focused tab header reports that exact tab, including an inactive one;
+  reporting only the leaf's selected tab misroutes ownership after dragging the
+  focused header (`frontend/src/lib/components/shared/TabbedPanelTree.svelte::handleLeafFocusIn`).
 - When a focused tab moves between rendered leaves, move live pane ownership
   with that tab even if its old leaf still renders; pooled focus restoration
   must not race a layout-host fallback (`frontend/src/lib/components/shared/DetailPaneLayout.svelte`).
@@ -316,6 +319,9 @@ Keyboard handlers must have one clear owner for each key press.
 - If focused Workspace Details or bottom Terminal disappears while its host stays visible,
   reclaim the Workspace root only when focus fell to `document.body`; parking never reclaims focus
   (`frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte::workspaceRoot`).
+- Standalone Workspace shortcuts accept unclaimed `document.body` focus, but a
+  concrete focus owner outside the Workspace root (including app chrome) blocks
+  them (`frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte::onKeydown`).
 - A focused surface-hosted dock outside the pane tree becomes the live focused
   surface until focus leaves it. Persisted last-focused state is restoration and
   command memory only; it never represents current focus. Workspace window

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -333,9 +333,12 @@ Keyboard handlers must have one clear owner for each key press.
 - Pane keyboard ownership follows the exact rendered leaf and tab containing DOM focus;
   nested tab identity never bubbles into an outer tree
   (`frontend/src/lib/components/shared/TabbedPanelTree.svelte::handleLeafFocusIn`).
-- Preserve a focused node through no-destination `focusout` until the Effect-scoped layout observer tests connectivity;
-  keyed replacement releases ownership and restores focus, while connected pooled terminals stay untouched
+- Preserve a focused node through no-destination `focusout` only for the immediate Effect-managed replacement window;
+  keyed replacement restores focus, while an ordinary blur cannot affect later DOM removal
   (`frontend/src/lib/components/shared/DetailPaneLayout.svelte::handleLayoutFocusOut`).
+- A terminal dock tracks the exact focused descendant across silent session removal; it releases ownership when that
+  node leaves the dock, restores a surviving dock only for disconnected content, and leaves connected pooled moves alone
+  (`frontend/src/lib/components/terminal/DockedTerminalPanel.svelte::handleFocusOut`).
 - Focus Terminal reveals, it never maximizes: a closed workspace pane reopens
   alongside the detail and a visible one keeps its arrangement. Maximizing over
   the detail is only ever an explicit user action. Reopening also has to clear a

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -295,6 +295,9 @@ Keyboard handlers must have one clear owner for each key press.
   moves focus or changes the active pane. Mark actual focus with a subtle inset
   border without replacing control focus styling
   (`frontend/src/lib/components/shared/TabbedPanelTree.svelte`).
+  A dedicated Files route keeps global diff shortcuts only while no pane or
+  external dock has live focus; this fallback never paints active-pane styling
+  (`frontend/src/lib/views/PRListView.svelte::diffKeyboardActive`).
 - Nested pane trees paint focus only while DOM focus is inside both the nested
   pane and its containing pane, and only the deepest focused pane paints;
   workspace Workflow, Details, and bottom Terminal regions are siblings

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -289,6 +289,9 @@ Keyboard handlers must have one clear owner for each key press.
   command listeners: a command that opens detail UI must un-maximize first so it
   cannot build an invisible overlay
   (`frontend/src/lib/components/detail/PullDetail.svelte::onOpenLabelPickerCommand`).
+- Simultaneous panes activate on focus, pointer, or wheel input; only the active pane
+  consumes window-level keys, and wheel stays event-local. Mark it with a subtle inset border
+  without replacing control focus styling (`frontend/src/lib/components/shared/TabbedPanelTree.svelte`).
 - Focus Terminal reveals, it never maximizes: a closed workspace pane reopens
   alongside the detail and a visible one keeps its arrangement. Maximizing over
   the detail is only ever an explicit user action. Reopening also has to clear a

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -330,6 +330,9 @@ Keyboard handlers must have one clear owner for each key press.
   command memory only; it never represents current focus. Workspace window
   shortcuts run only while the validated workspace container has DOM focus
   (`frontend/src/lib/stores/paneLayout.svelte.ts::PaneRenderReport`).
+- Resetting pane arrangement preserves a live external dock claim; only dock focusout,
+  unmount, or renderer teardown releases DOM input ownership
+  (`frontend/src/lib/stores/paneLayout.svelte.ts::reset`).
 - Pane keyboard ownership follows the exact rendered leaf and tab containing DOM focus;
   nested tab identity never bubbles into an outer tree
   (`frontend/src/lib/components/shared/TabbedPanelTree.svelte::handleLeafFocusIn`).

--- a/docs/adr/0005-active-pane-input-ownership.md
+++ b/docs/adr/0005-active-pane-input-ownership.md
@@ -6,10 +6,10 @@ Accepted
 
 ## Context
 
-Pull request conversation and files panes can be visible simultaneously. The
-files pane currently installs a window-level Page Up/Page Down handler, so it
-can scroll after the user has moved to the conversation pane. Focus events alone
-do not solve ownership because blank pane surfaces are not focusable.
+Pull request, Issue, Activity, and Workspaces workflow panes can be visible
+simultaneously. A pull request files pane can install a window-level Page
+Up/Page Down handler and scroll after the user has moved elsewhere. Focus events
+alone do not solve ownership because blank pane surfaces are not focusable.
 
 Without a visible active state, users also cannot predict which pane will
 receive a global keyboard action.
@@ -27,6 +27,9 @@ glow, or motion, and does not replace focus-visible styling on controls.
 
 Dedicated files routes retain global diff paging. Workspace diff panels retain
 their focus-local paging.
+
+The contract applies to every shared detail-pane tree and to the standalone
+Workspaces workflow tree.
 
 ## Consequences
 

--- a/docs/adr/0005-active-pane-input-ownership.md
+++ b/docs/adr/0005-active-pane-input-ownership.md
@@ -1,0 +1,37 @@
+# ADR 0005: Active Pane Owns Input
+
+## Status
+
+Accepted
+
+## Context
+
+Pull request conversation and files panes can be visible simultaneously. The
+files pane currently installs a window-level Page Up/Page Down handler, so it
+can scroll after the user has moved to the conversation pane. Focus events alone
+do not solve ownership because blank pane surfaces are not focusable.
+
+Without a visible active state, users also cannot predict which pane will
+receive a global keyboard action.
+
+## Decision
+
+Focus, pointer, or wheel interaction makes a pane active. Only the active pane
+may consume window-level keyboard paging, while wheel scrolling remains local
+to its event target. A locally targeted Page Up/Page Down event may be handled
+immediately while active state settles.
+
+The active pane is shown with a one-pixel inset border mixed from the existing
+blue accent and normal pane border. The indicator introduces no layout shift,
+glow, or motion, and does not replace focus-visible styling on controls.
+
+Dedicated files routes retain global diff paging. Workspace diff panels retain
+their focus-local paging.
+
+## Consequences
+
+- Page Up/Page Down follows the pane the user last interacted with.
+- Wheel input never scrolls a different pane.
+- Pane ownership is visible without competing with review and status colors.
+- Pointer and wheel input participate in the same ownership model as keyboard
+  focus.

--- a/docs/adr/0005-active-pane-input-ownership.md
+++ b/docs/adr/0005-active-pane-input-ownership.md
@@ -1,4 +1,4 @@
-# ADR 0005: Active Pane Owns Input
+# ADR 0005: Active Pane Follows DOM Focus
 
 ## Status
 
@@ -8,18 +8,23 @@ Accepted
 
 Pull request, Issue, Activity, and Workspaces workflow panes can be visible
 simultaneously. A pull request files pane can install a window-level Page
-Up/Page Down handler and scroll after the user has moved elsewhere. Focus events
-alone do not solve ownership because blank pane surfaces are not focusable.
+Up/Page Down handler and scroll after DOM focus has moved elsewhere.
 
 Without a visible active state, users also cannot predict which pane will
 receive a global keyboard action.
 
 ## Decision
 
-Focus, pointer, or wheel interaction makes a pane active. Only the active pane
-may consume window-level keyboard paging, while wheel scrolling remains local
-to its event target. A locally targeted Page Up/Page Down event may be handled
-immediately while active state settles.
+The active pane is the pane containing actual DOM focus. Only that pane may
+consume pane-scoped window-level keyboard paging. Pointer interaction changes
+the active pane only when the browser moves focus as a normal consequence of
+that interaction. Wheel scrolling remains local to its event target and never
+changes focus or the active pane.
+
+Programmatic `focus()` is still focus. In particular, deliberate terminal focus
+restoration when switching items with a workspace updates the active pane
+because it moves DOM focus. Persisted last-focused state remains useful for
+restoration and command targeting, but never stands in for current focus.
 
 The active pane is shown with a one-pixel inset border mixed from the existing
 blue accent and normal pane border. The indicator introduces no layout shift,
@@ -33,8 +38,8 @@ Workspaces workflow tree.
 
 ## Consequences
 
-- Page Up/Page Down follows the pane the user last interacted with.
+- Page Up/Page Down follows the pane containing DOM focus.
 - Wheel input never scrolls a different pane.
-- Pane ownership is visible without competing with review and status colors.
-- Pointer and wheel input participate in the same ownership model as keyboard
+- Pane focus is visible without competing with review and status colors.
+- Pointer and wheel input do not create a second ownership model beside browser
   focus.

--- a/frontend/src/lib/browser/animation-frame.ts
+++ b/frontend/src/lib/browser/animation-frame.ts
@@ -23,6 +23,18 @@ export const nextAnimationFrame = Effect.gen(function* () {
   });
 });
 
+export const nextAnimationFrameOrDocumentHidden = Effect.suspend(() => {
+  if (document.visibilityState === "hidden") return Effect.void;
+  const documentHidden = Effect.callback<void>((resume) => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") resume(Effect.void);
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return Effect.sync(() => document.removeEventListener("visibilitychange", handleVisibilityChange));
+  });
+  return Effect.raceFirst(Effect.asVoid(nextAnimationFrame), documentHidden);
+});
+
 export interface AnimationFrameScheduler {
   readonly cancel: () => void;
   readonly schedule: () => boolean;

--- a/frontend/src/lib/components/CommitDiffPanel.svelte
+++ b/frontend/src/lib/components/CommitDiffPanel.svelte
@@ -14,6 +14,7 @@
     name: string;
     repoPath: string;
     commitSha: string;
+    inputActive?: boolean;
   }
 
   const {
@@ -23,6 +24,7 @@
     name,
     repoPath,
     commitSha,
+    inputActive = true,
   }: Props = $props();
 
   onMount(() => {
@@ -50,6 +52,7 @@
         {repoPath}
         number={0}
         loadOnMount={false}
+        keyboardActive={inputActive}
         richPreviewEnabled={false}
         contextExpansionEnabled={false}
       />

--- a/frontend/src/lib/components/detail/PullDetailPane.svelte
+++ b/frontend/src/lib/components/detail/PullDetailPane.svelte
@@ -127,7 +127,6 @@
       initialScrollTop={filesScrollPositions[scrollKey] ?? 0}
       onScrollTopChange={rememberFilesScroll}
       {keyboardActive}
-      pageKeyboardActive={true}
     />
   {/key}
 {/if}

--- a/frontend/src/lib/components/detail/PullDetailPane.svelte
+++ b/frontend/src/lib/components/detail/PullDetailPane.svelte
@@ -24,6 +24,8 @@
     tabKey: string;
     /** Whether this pane is on screen; the diff mounts only when it is. */
     visible: boolean;
+    /** Whether this pane owns window-level keyboard commands. */
+    keyboardActive: boolean;
     pr: PullRequestRouteRef;
     /** The loaded detail, already confirmed to belong to `pr`, or null. */
     detail: PullDetailResponse | null;
@@ -37,6 +39,7 @@
   const {
     tabKey,
     visible,
+    keyboardActive,
     pr,
     detail,
     autoSync = "background",
@@ -123,6 +126,8 @@
       reviewThreads={reviewThreadsFromEvents(detail?.events)}
       initialScrollTop={filesScrollPositions[scrollKey] ?? 0}
       onScrollTopChange={rememberFilesScroll}
+      {keyboardActive}
+      pageKeyboardActive={true}
     />
   {/key}
 {/if}

--- a/frontend/src/lib/components/diff/DiffFilesLayout.svelte
+++ b/frontend/src/lib/components/diff/DiffFilesLayout.svelte
@@ -28,6 +28,8 @@
     reviewThreads?: ReviewThread[];
     initialScrollTop?: number;
     onScrollTopChange?: ((scrollTop: number) => void) | undefined;
+    keyboardActive?: boolean;
+    pageKeyboardActive?: boolean;
   }
 
   const {
@@ -43,6 +45,8 @@
     reviewThreads = [],
     initialScrollTop = 0,
     onScrollTopChange,
+    keyboardActive = true,
+    pageKeyboardActive = keyboardActive,
   }: Props = $props();
 
   const reviewDraftGate = $derived(operationGate(operations?.review_draft));
@@ -204,6 +208,8 @@
         canReplyToThreads={(capabilities?.thread_reply ?? false)
           && !replyThreadGate.unavailable}
         {reviewUnavailableReason}
+        {keyboardActive}
+        {pageKeyboardActive}
         supportedReviewActions={capabilities?.supported_review_actions ?? []}
         nativeMultilineRanges={capabilities?.native_multiline_ranges ?? false}
         {initialScrollTop}

--- a/frontend/src/lib/components/diff/DiffFilesLayout.test.ts
+++ b/frontend/src/lib/components/diff/DiffFilesLayout.test.ts
@@ -78,7 +78,10 @@ function operations(overrides: Partial<RepoOperations>): RepoOperations {
   };
 }
 
-function renderLayout(repoOperations: RepoOperations): void {
+function renderLayout(
+  repoOperations: RepoOperations,
+  keyboard?: { keyboardActive: boolean; pageKeyboardActive: boolean },
+): void {
   render(DiffFilesLayout, {
     props: {
       provider: "gitlab",
@@ -90,6 +93,7 @@ function renderLayout(repoOperations: RepoOperations): void {
       diffHeadSHA: "head",
       capabilities,
       operations: repoOperations,
+      ...keyboard,
     },
   });
 }
@@ -115,5 +119,21 @@ describe("DiffFilesLayout operation gates", () => {
     expect(screen.getByTestId("review-unavailable-reason").textContent).toBe(
       "No user credential for writes on gitlab.com",
     );
+  });
+
+  it("defaults to global paging but allows callers to keep page keys local", () => {
+    renderLayout(operations({}));
+
+    expect(screen.getByTestId("keyboard-active").textContent).toBe("true");
+    expect(screen.getByTestId("page-keyboard-active").textContent).toBe("true");
+
+    cleanup();
+    renderLayout(operations({}), {
+      keyboardActive: false,
+      pageKeyboardActive: true,
+    });
+
+    expect(screen.getByTestId("keyboard-active").textContent).toBe("false");
+    expect(screen.getByTestId("page-keyboard-active").textContent).toBe("true");
   });
 });

--- a/frontend/src/lib/components/diff/DiffFilesLayoutTestView.svelte
+++ b/frontend/src/lib/components/diff/DiffFilesLayoutTestView.svelte
@@ -2,13 +2,19 @@
   interface Props {
     reviewDraftMutation?: boolean;
     reviewUnavailableReason?: string | undefined;
+    keyboardActive?: boolean;
+    pageKeyboardActive?: boolean;
   }
 
   const {
     reviewDraftMutation = false,
     reviewUnavailableReason = undefined,
+    keyboardActive = true,
+    pageKeyboardActive = keyboardActive,
   }: Props = $props();
 </script>
 
 <div data-testid="review-draft-mutation">{String(reviewDraftMutation)}</div>
 <div data-testid="review-unavailable-reason">{reviewUnavailableReason ?? ""}</div>
+<div data-testid="keyboard-active">{String(keyboardActive)}</div>
+<div data-testid="page-keyboard-active">{String(pageKeyboardActive)}</div>

--- a/frontend/src/lib/components/diff/DiffToolbar.svelte
+++ b/frontend/src/lib/components/diff/DiffToolbar.svelte
@@ -238,8 +238,6 @@
 
 <style>
   .diff-toolbar {
-    position: relative;
-    z-index: 60;
     display: flex;
     align-items: center;
     gap: 16px;

--- a/frontend/src/lib/components/diff/DiffView.svelte
+++ b/frontend/src/lib/components/diff/DiffView.svelte
@@ -589,7 +589,19 @@
   }
 
   function handleDiffAreaKeydown(e: KeyboardEvent): void {
-    if (!pageKeyboardActive || keyboardActive) return;
+    if (keyboardActive) return;
+    if (!pageKeyboardActive) {
+      if (
+        !isTextEntryTarget(e.target) &&
+        (e.key === "PageDown" || e.key === "PageUp") &&
+        !e.metaKey &&
+        !e.ctrlKey &&
+        !e.altKey
+      ) {
+        e.preventDefault();
+      }
+      return;
+    }
     handlePageKeydown(e);
   }
 

--- a/frontend/src/lib/components/diff/DiffView.test.ts
+++ b/frontend/src/lib/components/diff/DiffView.test.ts
@@ -371,6 +371,25 @@ describe("DiffView", () => {
     }
   });
 
+  it("prevents native PageDown scrolling while the focused diff is inactive", () => {
+    const diff = makeDiffStore();
+    const { container } = renderDiffView(diff, {
+      keyboardActive: false,
+      pageKeyboardActive: false,
+    });
+    const diffArea = container.querySelector(".kit-scrollbox__viewport") as HTMLDivElement;
+    diffArea.focus();
+    const pageDown = new KeyboardEvent("keydown", {
+      key: "PageDown",
+      bubbles: true,
+      cancelable: true,
+    });
+
+    diffArea.dispatchEvent(pageDown);
+
+    expect(pageDown.defaultPrevented).toBe(true);
+  });
+
   it("cancels pending programmatic scroll when the user wheels the diff pane", async () => {
     let scrollTarget: DiffScrollTarget | null = { path: "b.ts" };
     const consumeScrollTarget = vi.fn(() => {

--- a/frontend/src/lib/components/shared/DetailPaneLayout.svelte
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.svelte
@@ -347,8 +347,9 @@
 
   // Pane identity can replace focused content without changing the pane tree,
   // selected tab, or emitting focusout. Observe the renderer boundary itself:
-  // a pooled terminal parked elsewhere stays connected, while removed content
-  // does not and must release keyboard ownership.
+  // any node that leaves this layout releases its ownership. Only disconnected
+  // content needs layout focus recovery; a connected pooled terminal owns its
+  // own restoration while it moves through parking.
   $effect(() => {
     const el = host;
     if (!el || typeof MutationObserver === "undefined") return;
@@ -359,11 +360,11 @@
             el,
             () => {
               const focused = focusedInputElement;
-              if (focused === null || focused.isConnected) return;
+              if (focused === null || el.contains(focused)) return;
               focusedInputLeafID = null;
               focusedInputTabKey = null;
               focusedInputElement = null;
-              reclaimFocus();
+              if (!focused.isConnected) reclaimFocus();
             },
             { childList: true, subtree: true },
           ).pipe(Effect.andThen(Effect.never)),

--- a/frontend/src/lib/components/shared/DetailPaneLayout.svelte
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.svelte
@@ -16,6 +16,7 @@
   import type { PaneLayoutStore, PaneTabSpec } from "../../stores/paneLayout.svelte.js";
   import type { AppExecution } from "../../app/runtime.js";
   import { getAppRuntime } from "../../app/runtime-context.js";
+  import { nextAnimationFrame } from "../../browser/animation-frame.js";
   import { observeMutation, observeResize } from "../../browser/observers.js";
 
   interface Props {
@@ -70,6 +71,7 @@
   }: Props = $props();
   const runtime = getAppRuntime();
   let focusExecution: AppExecution<void, never> | null = null;
+  let focusRecordExecution: AppExecution<void, never> | null = null;
 
   /**
    * The workspace pane draws its own tab strip: one tab per session, plus the dock.
@@ -297,6 +299,8 @@
   }
 
   function handleLayoutFocusIn(event: FocusEvent & { currentTarget: HTMLElement }): void {
+    focusRecordExecution?.interrupt();
+    focusRecordExecution = null;
     const target = event.target;
     if (target instanceof HTMLElement && target.closest(".tabbed-panel-leaf") !== null) {
       focusedInputElement = target;
@@ -316,7 +320,29 @@
     // focused node. Keep that exact node until the mutation observer can test
     // whether it disconnected; a real destination outside the layout no
     // longer needs the record.
-    if (next !== null) focusedInputElement = null;
+    if (next !== null) {
+      focusRecordExecution?.interrupt();
+      focusRecordExecution = null;
+      focusedInputElement = null;
+      return;
+    }
+    const blurred = focusedInputElement;
+    focusRecordExecution?.interrupt();
+    focusRecordExecution = runtime.runCommand(
+      nextAnimationFrame.pipe(
+        Effect.andThen(Effect.sync(() => {
+          if (focusedInputElement === blurred && blurred?.isConnected) {
+            focusedInputElement = null;
+          }
+          focusRecordExecution = null;
+        })),
+      ),
+      {
+        operation: "release detail pane focus record",
+        safeContext: {},
+        onFailure: () => {},
+      },
+    );
   }
 
   // Pane identity can replace focused content without changing the pane tree,

--- a/frontend/src/lib/components/shared/DetailPaneLayout.svelte
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.svelte
@@ -21,7 +21,7 @@
   interface Props {
     layout: PaneLayoutStore;
     tabs: PaneTabSpec[];
-    renderPane: Snippet<[string, boolean]>;
+    renderPane: Snippet<[string, boolean, boolean]>;
     paneIcon?: Snippet<[TabbedPanelDescriptor]> | undefined;
     tablistLabel?: string;
     leafLabel?: string;
@@ -140,6 +140,12 @@
       .map((leaf) => leaf.activeTabKey)
       .filter((key): key is string => key !== null && key !== undefined),
   );
+  const activeInputTabKey = $derived.by(() => {
+    const focused = layout.lastFocusedTabKey();
+    if (focused !== null && onScreenTabs.includes(focused)) return focused;
+    if (routeTabKey !== undefined && onScreenTabs.includes(routeTabKey)) return routeTabKey;
+    return onScreenTabs[0] ?? "";
+  });
 
   // Publish the renderer-only facts the command layer needs: that a layout is
   // mounted here at all, which panes it offers, which are on screen, and whether
@@ -271,6 +277,7 @@
     }
     if (appliedRouteTabKey === key) return;
     appliedRouteTabKey = key;
+    lastReportedFocus = key;
     untrack(() => {
       layout.activateTab(key);
       layout.noteFocused(key);
@@ -313,7 +320,7 @@
         dragScope={layout.dragScope}
         node={activeTree}
         tabs={descriptors}
-        activeTabKey={layout.lastFocusedTabKey() ?? routeTabKey ?? onScreenTabs[0] ?? ""}
+        activeTabKey={activeInputTabKey}
         {tablistLabel}
         {leafLabel}
         resizeLabel="Resize detail panes"
@@ -346,7 +353,7 @@
         soloChromeTabKeys={flattened ? [] : SOLO_CHROME_TAB_KEYS}
       >
         {#snippet renderTab(tabKey, visible)}
-          {@render renderPane(tabKey, visible)}
+          {@render renderPane(tabKey, visible, tabKey === activeInputTabKey)}
         {/snippet}
       </TabbedPanelTree>
     </div>

--- a/frontend/src/lib/components/shared/DetailPaneLayout.svelte
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.svelte
@@ -313,7 +313,7 @@
         dragScope={layout.dragScope}
         node={activeTree}
         tabs={descriptors}
-        activeTabKey={routeTabKey ?? layout.lastFocusedTabKey() ?? ""}
+        activeTabKey={layout.lastFocusedTabKey() ?? routeTabKey ?? ""}
         {tablistLabel}
         {leafLabel}
         resizeLabel="Resize detail panes"

--- a/frontend/src/lib/components/shared/DetailPaneLayout.svelte
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.svelte
@@ -251,9 +251,9 @@
   let lastReportedFocus: string | null = null;
 
   function focusPane(tabKey: string): void {
+    layout.noteFocused(tabKey);
     if (lastReportedFocus === tabKey) return;
     lastReportedFocus = tabKey;
-    layout.noteFocused(tabKey);
     onFocusPane?.(tabKey);
   }
 

--- a/frontend/src/lib/components/shared/DetailPaneLayout.svelte
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.svelte
@@ -312,7 +312,11 @@
     if (next instanceof Node && event.currentTarget.contains(next)) return;
     focusedInputLeafID = null;
     focusedInputTabKey = null;
-    focusedInputElement = null;
+    // Chromium reports no next target while a keyed subtree removes the
+    // focused node. Keep that exact node until the mutation observer can test
+    // whether it disconnected; a real destination outside the layout no
+    // longer needs the record.
+    if (next !== null) focusedInputElement = null;
   }
 
   // Pane identity can replace focused content without changing the pane tree,

--- a/frontend/src/lib/components/shared/DetailPaneLayout.svelte
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.svelte
@@ -16,7 +16,7 @@
   import type { PaneLayoutStore, PaneTabSpec } from "../../stores/paneLayout.svelte.js";
   import type { AppExecution } from "../../app/runtime.js";
   import { getAppRuntime } from "../../app/runtime-context.js";
-  import { observeResize } from "../../browser/observers.js";
+  import { observeMutation, observeResize } from "../../browser/observers.js";
 
   interface Props {
     layout: PaneLayoutStore;
@@ -314,6 +314,35 @@
     focusedInputTabKey = null;
     focusedInputElement = null;
   }
+
+  // Pane identity can replace focused content without changing the pane tree,
+  // selected tab, or emitting focusout. Observe the renderer boundary itself:
+  // a pooled terminal parked elsewhere stays connected, while removed content
+  // does not and must release keyboard ownership.
+  $effect(() => {
+    const el = host;
+    if (!el || typeof MutationObserver === "undefined") return;
+    const execution = untrack(() =>
+      runtime.runCommand(
+        Effect.scoped(
+          observeMutation(
+            el,
+            () => {
+              const focused = focusedInputElement;
+              if (focused === null || focused.isConnected) return;
+              focusedInputLeafID = null;
+              focusedInputTabKey = null;
+              focusedInputElement = null;
+              reclaimFocus();
+            },
+            { childList: true, subtree: true },
+          ).pipe(Effect.andThen(Effect.never)),
+        ),
+        { operation: "observe detail pane focus", safeContext: {}, onFailure: () => {} },
+      ),
+    );
+    return execution.interrupt;
+  });
 
   // A zoom must not survive the disappearance of what was zoomed. The store
   // cannot see availability, so masking it at render time is not enough: a

--- a/frontend/src/lib/components/shared/DetailPaneLayout.svelte
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.svelte
@@ -141,6 +141,7 @@
       .filter((key): key is string => key !== null && key !== undefined),
   );
   const activeInputTabKey = $derived.by(() => {
+    if (layout.externalInputActive()) return "";
     const focused = layout.lastFocusedTabKey();
     if (focused !== null && onScreenTabs.includes(focused)) return focused;
     if (routeTabKey !== undefined && onScreenTabs.includes(routeTabKey)) return routeTabKey;
@@ -156,7 +157,15 @@
     // Null until the host has been measured. Width decides whether structural
     // edits are allowed at all, and an unmeasured host defaulting to "not
     // flattened" exposes those commands for a frame on a narrow layout.
-    const report = measured ? { editableTabs, onScreenTabs, flattened, soloChromeTabs } : null;
+    const report = measured
+      ? {
+          activeInputTabKey: activeInputTabKey || null,
+          editableTabs,
+          onScreenTabs,
+          flattened,
+          soloChromeTabs,
+        }
+      : null;
     // Untracked because the store compares against the previous report before
     // writing: reading it here would make this effect both a reader and a writer
     // of the same state and it would re-run itself forever.

--- a/frontend/src/lib/components/shared/DetailPaneLayout.svelte
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.svelte
@@ -86,6 +86,7 @@
   let hostWidth = $state(0);
   let focusedInputLeafID = $state<string | null>(null);
   let focusedInputTabKey = $state<string | null>(null);
+  let focusedInputElement: HTMLElement | null = null;
 
   const availableTabs = $derived(tabs.filter((tab) => tab.available).map((tab) => tab.key));
   const hideableTabKeys = $derived(tabs.filter((tab) => tab.hideable === true).map((tab) => tab.key));
@@ -148,15 +149,21 @@
     return renderedLeaves.find((leaf) => leaf.id === focusedInputLeafID)?.activeTabKey ?? "";
   });
 
-  // A focused pane can disappear without dispatching focusout (for example when
-  // it is hidden, becomes unavailable, or is covered by another leaf's zoom).
-  // Forget that live focus immediately so revealing it later cannot resurrect a
-  // border for focus that no longer exists.
+  // A focused pane can disappear or move to another rendered leaf without
+  // dispatching focusout (for example when hidden, covered by a zoom, or split).
+  // Follow the exact rendered tab when it moved; otherwise forget live focus so
+  // revealing removed content later cannot resurrect a stale ownership border.
   $effect.pre(() => {
-    if (focusedInputLeafID === null || renderedLeaves.some((leaf) => leaf.id === focusedInputLeafID)) return;
+    if (focusedInputLeafID === null) return;
+    const focusedLeaf = renderedLeaves.find((leaf) => leaf.id === focusedInputLeafID);
+    if (focusedLeaf?.activeTabKey === focusedInputTabKey) return;
     const replacement = renderedLeaves.find((leaf) => leaf.activeTabKey === focusedInputTabKey);
+    // The leaf still exists and no other rendered leaf took its focused tab: this
+    // is an ordinary same-leaf selection change, handled by the effect below.
+    if (focusedLeaf && !replacement) return;
+    const focusedDescendant = focusedInputElement;
     focusedInputLeafID = replacement?.id ?? null;
-    if (replacement) reclaimFocus();
+    if (replacement) reclaimFocus(focusedDescendant);
   });
 
   // Publish the renderer-only facts the command layer needs: that a layout is
@@ -210,13 +217,18 @@
    * a pane declined restoration and stranded focus. Focus already elsewhere is
    * never stolen, so a background close leaves the user's control alone.
    */
-  function reclaimFocus(): void {
+  function reclaimFocus(preferredTarget: HTMLElement | null = null): void {
     focusExecution?.interrupt();
     focusExecution = runtime.runCommand(
       Effect.promise(() => tick()).pipe(
         Effect.andThen(Effect.sync(() => {
           const focused = document.activeElement;
-          if (focused === null || focused === document.body) host?.focus();
+          if (focused !== null && focused !== document.body) return;
+          if (preferredTarget?.isConnected) {
+            if (host?.contains(preferredTarget)) preferredTarget.focus();
+            return;
+          }
+          host?.focus();
         })),
       ),
       {
@@ -286,9 +298,13 @@
 
   function handleLayoutFocusIn(event: FocusEvent & { currentTarget: HTMLElement }): void {
     const target = event.target;
-    if (target instanceof Element && target.closest(".tabbed-panel-leaf") !== null) return;
+    if (target instanceof HTMLElement && target.closest(".tabbed-panel-leaf") !== null) {
+      focusedInputElement = target;
+      return;
+    }
     focusedInputLeafID = null;
     focusedInputTabKey = null;
+    focusedInputElement = null;
   }
 
   function handleLayoutFocusOut(event: FocusEvent & { currentTarget: HTMLElement }): void {
@@ -296,6 +312,7 @@
     if (next instanceof Node && event.currentTarget.contains(next)) return;
     focusedInputLeafID = null;
     focusedInputTabKey = null;
+    focusedInputElement = null;
   }
 
   // A zoom must not survive the disappearance of what was zoomed. The store

--- a/frontend/src/lib/components/shared/DetailPaneLayout.svelte
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.svelte
@@ -225,6 +225,19 @@
     );
   }
 
+  // A tab change can remove the focused pane body without a focusout event.
+  // Check after the DOM update through reclaimFocus(): a clicked tab or any
+  // other deliberate destination keeps focus, while a stranded <body> focus
+  // moves to the layout host and clears pane keyboard ownership.
+  let lastFocusedLeafSelection: { leafID: string; tabKey: string } | null = null;
+  $effect(() => {
+    const leafID = focusedInputLeafID;
+    const tabKey = leafID === null ? null : renderedLeaves.find((leaf) => leaf.id === leafID)?.activeTabKey ?? null;
+    const previous = lastFocusedLeafSelection;
+    lastFocusedLeafSelection = leafID !== null && tabKey !== null ? { leafID, tabKey } : null;
+    if (previous?.leafID === leafID && tabKey !== null && previous.tabKey !== tabKey) reclaimFocus();
+  });
+
   /**
    * Closing a pane unmounts its body. Focus that lived inside it — the terminal,
    * a diff comment box, the close button — would fall to `<body>`, stranding
@@ -259,8 +272,8 @@
   // since a surface that rewrites the URL on focus must not do so on every click.
   let lastReportedFocus: string | null = null;
 
-  function focusPane(tabKey: string): void {
-    focusedInputLeafID = layout.leafIDForTab(tabKey);
+  function focusPane(tabKey: string, leafID: string): void {
+    focusedInputLeafID = leafID;
     layout.setExternalInputActive(false);
     layout.noteFocused(tabKey);
     if (lastReportedFocus === tabKey) return;

--- a/frontend/src/lib/components/shared/DetailPaneLayout.svelte
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.svelte
@@ -313,7 +313,7 @@
         dragScope={layout.dragScope}
         node={activeTree}
         tabs={descriptors}
-        activeTabKey={layout.lastFocusedTabKey() ?? routeTabKey ?? ""}
+        activeTabKey={layout.lastFocusedTabKey() ?? routeTabKey ?? onScreenTabs[0] ?? ""}
         {tablistLabel}
         {leafLabel}
         resizeLabel="Resize detail panes"

--- a/frontend/src/lib/components/shared/DetailPaneLayout.svelte
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.svelte
@@ -84,6 +84,7 @@
 
   let host = $state<HTMLElement | null>(null);
   let hostWidth = $state(0);
+  let focusedInputLeafID = $state<string | null>(null);
 
   const availableTabs = $derived(tabs.filter((tab) => tab.available).map((tab) => tab.key));
   const hideableTabKeys = $derived(tabs.filter((tab) => tab.hideable === true).map((tab) => tab.key));
@@ -142,10 +143,18 @@
   );
   const activeInputTabKey = $derived.by(() => {
     if (layout.externalInputActive()) return "";
-    const focused = layout.lastFocusedTabKey();
-    if (focused !== null && onScreenTabs.includes(focused)) return focused;
-    if (routeTabKey !== undefined && onScreenTabs.includes(routeTabKey)) return routeTabKey;
-    return onScreenTabs[0] ?? "";
+    if (focusedInputLeafID === null) return "";
+    return renderedLeaves.find((leaf) => leaf.id === focusedInputLeafID)?.activeTabKey ?? "";
+  });
+
+  // A focused pane can disappear without dispatching focusout (for example when
+  // it is hidden, becomes unavailable, or is covered by another leaf's zoom).
+  // Forget that live focus immediately so revealing it later cannot resurrect a
+  // border for focus that no longer exists.
+  $effect(() => {
+    if (focusedInputLeafID !== null && !renderedLeaves.some((leaf) => leaf.id === focusedInputLeafID)) {
+      focusedInputLeafID = null;
+    }
   });
 
   // Publish the renderer-only facts the command layer needs: that a layout is
@@ -251,10 +260,24 @@
   let lastReportedFocus: string | null = null;
 
   function focusPane(tabKey: string): void {
+    focusedInputLeafID = layout.leafIDForTab(tabKey);
+    layout.setExternalInputActive(false);
     layout.noteFocused(tabKey);
     if (lastReportedFocus === tabKey) return;
     lastReportedFocus = tabKey;
     onFocusPane?.(tabKey);
+  }
+
+  function handleLayoutFocusIn(event: FocusEvent & { currentTarget: HTMLElement }): void {
+    const target = event.target;
+    if (target instanceof Element && target.closest(".tabbed-panel-leaf") !== null) return;
+    focusedInputLeafID = null;
+  }
+
+  function handleLayoutFocusOut(event: FocusEvent & { currentTarget: HTMLElement }): void {
+    const next = event.relatedTarget;
+    if (next instanceof Node && event.currentTarget.contains(next)) return;
+    focusedInputLeafID = null;
   }
 
   // A zoom must not survive the disappearance of what was zoomed. The store
@@ -322,7 +345,13 @@
      stored pane tree is the only record that the session moved. Every ordinary
      mutation refuses such a source, so the branch has to be here. -->
 <!-- tabindex so the layout can hold focus itself after a pane closes under it. -->
-<div class="detail-pane-layout" bind:this={host} tabindex="-1">
+<div
+  class="detail-pane-layout"
+  bind:this={host}
+  tabindex="-1"
+  onfocusin={handleLayoutFocusIn}
+  onfocusout={handleLayoutFocusOut}
+>
   {#if activeTree}
     <div class="detail-pane-tree">
       <TabbedPanelTree

--- a/frontend/src/lib/components/shared/DetailPaneLayout.svelte
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.svelte
@@ -16,7 +16,7 @@
   import type { PaneLayoutStore, PaneTabSpec } from "../../stores/paneLayout.svelte.js";
   import type { AppExecution } from "../../app/runtime.js";
   import { getAppRuntime } from "../../app/runtime-context.js";
-  import { nextAnimationFrame } from "../../browser/animation-frame.js";
+  import { nextAnimationFrameOrDocumentHidden } from "../../browser/animation-frame.js";
   import { observeMutation, observeResize } from "../../browser/observers.js";
 
   interface Props {
@@ -329,7 +329,7 @@
     const blurred = focusedInputElement;
     focusRecordExecution?.interrupt();
     focusRecordExecution = runtime.runCommand(
-      nextAnimationFrame.pipe(
+      nextAnimationFrameOrDocumentHidden.pipe(
         Effect.andThen(Effect.sync(() => {
           if (focusedInputElement === blurred && blurred?.isConnected) {
             focusedInputElement = null;

--- a/frontend/src/lib/components/shared/DetailPaneLayout.svelte
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.svelte
@@ -85,6 +85,7 @@
   let host = $state<HTMLElement | null>(null);
   let hostWidth = $state(0);
   let focusedInputLeafID = $state<string | null>(null);
+  let focusedInputTabKey = $state<string | null>(null);
 
   const availableTabs = $derived(tabs.filter((tab) => tab.available).map((tab) => tab.key));
   const hideableTabKeys = $derived(tabs.filter((tab) => tab.hideable === true).map((tab) => tab.key));
@@ -151,10 +152,11 @@
   // it is hidden, becomes unavailable, or is covered by another leaf's zoom).
   // Forget that live focus immediately so revealing it later cannot resurrect a
   // border for focus that no longer exists.
-  $effect(() => {
-    if (focusedInputLeafID !== null && !renderedLeaves.some((leaf) => leaf.id === focusedInputLeafID)) {
-      focusedInputLeafID = null;
-    }
+  $effect.pre(() => {
+    if (focusedInputLeafID === null || renderedLeaves.some((leaf) => leaf.id === focusedInputLeafID)) return;
+    const replacement = renderedLeaves.find((leaf) => leaf.activeTabKey === focusedInputTabKey);
+    focusedInputLeafID = replacement?.id ?? null;
+    if (replacement) reclaimFocus();
   });
 
   // Publish the renderer-only facts the command layer needs: that a layout is
@@ -274,6 +276,7 @@
 
   function focusPane(tabKey: string, leafID: string): void {
     focusedInputLeafID = leafID;
+    focusedInputTabKey = tabKey;
     layout.setExternalInputActive(false);
     layout.noteFocused(tabKey);
     if (lastReportedFocus === tabKey) return;
@@ -285,12 +288,14 @@
     const target = event.target;
     if (target instanceof Element && target.closest(".tabbed-panel-leaf") !== null) return;
     focusedInputLeafID = null;
+    focusedInputTabKey = null;
   }
 
   function handleLayoutFocusOut(event: FocusEvent & { currentTarget: HTMLElement }): void {
     const next = event.relatedTarget;
     if (next instanceof Node && event.currentTarget.contains(next)) return;
     focusedInputLeafID = null;
+    focusedInputTabKey = null;
   }
 
   // A zoom must not survive the disappearance of what was zoomed. The store

--- a/frontend/src/lib/components/shared/DetailPaneLayout.test.ts
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.test.ts
@@ -505,6 +505,7 @@ describe("detail pane layout", () => {
     conversationFocusTarget.focus();
     await vi.waitFor(() => expect(layout.paneRender()?.activeInputTabKey).toBe("conversation"));
 
+    fireEvent.focusOut(conversationFocusTarget, { relatedTarget: null });
     await rerender({ layout, paneIdentity: "second" });
 
     await vi.waitFor(() => {

--- a/frontend/src/lib/components/shared/DetailPaneLayout.test.ts
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.test.ts
@@ -387,11 +387,14 @@ describe("detail pane layout", () => {
     expect(screen.getByRole("tab", { name: "Files" }).getAttribute("aria-selected")).toBe("true");
   });
 
-  it("marks the first on-screen pane active when the remembered pane is not rendered", async () => {
+  it("does not invent a focused pane when the focused pane stops rendering", async () => {
     const layout = store(splitTree());
     const { rerender } = render(DetailPaneLayoutTestHarness, { layout, routeTabKey: "conversation" });
     const activePaneKey = () =>
       document.querySelector(".tabbed-panel-leaf.input-active [data-pane-key]")?.getAttribute("data-pane-key");
+
+    expect(activePaneKey()).toBeUndefined();
+    expect(layout.paneRender()?.activeInputTabKey).toBeNull();
 
     fireEvent.focusIn(screen.getByTestId("pane-workspace"));
     expect(activePaneKey()).toBe("workspace");
@@ -399,42 +402,70 @@ describe("detail pane layout", () => {
 
     layout.setHidden("workspace", true);
     flushSync();
-    expect(activePaneKey()).toBe("conversation");
-    expect(layout.paneRender()?.activeInputTabKey).toBe("conversation");
+    expect(activePaneKey()).toBeUndefined();
+    expect(layout.paneRender()?.activeInputTabKey).toBeNull();
 
     layout.setHidden("workspace", false);
     flushSync();
     fireEvent.focusIn(screen.getByTestId("pane-workspace"));
     await rerender({ layout, routeTabKey: "conversation", workspaceAvailable: false });
-    expect(activePaneKey()).toBe("conversation");
+    expect(activePaneKey()).toBeUndefined();
+    expect(layout.paneRender()?.activeInputTabKey).toBeNull();
 
     await rerender({ layout, routeTabKey: "conversation", workspaceAvailable: true });
     fireEvent.focusIn(screen.getByTestId("pane-workspace"));
     layout.toggleZoom("leaf-detail");
     flushSync();
-    expect(activePaneKey()).toBe("conversation");
-    expect(layout.paneRender()?.activeInputTabKey).toBe("conversation");
+    expect(activePaneKey()).toBeUndefined();
+    expect(layout.paneRender()?.activeInputTabKey).toBeNull();
   });
 
-  it("lets the same pane reclaim keyboard ownership from an external surface", () => {
+  it("moves keyboard ownership only when DOM focus moves", () => {
     const layout = store(splitTree());
     render(DetailPaneLayoutTestHarness, { layout, routeTabKey: "conversation" });
     const activePaneKey = () =>
       document.querySelector(".tabbed-panel-leaf.input-active [data-pane-key]")?.getAttribute("data-pane-key");
 
-    fireEvent.pointerDown(screen.getByTestId("pane-workspace"));
+    fireEvent.focusIn(screen.getByTestId("pane-workspace"));
     expect(activePaneKey()).toBe("workspace");
+    expect(screen.getByTestId("pane-workspace").getAttribute("data-input-active")).toBe("true");
+
+    fireEvent.pointerDown(screen.getByTestId("pane-conversation"));
+    fireEvent.wheel(screen.getByTestId("pane-conversation"));
+    expect(activePaneKey()).toBe("workspace");
+    expect(screen.getByTestId("pane-conversation").getAttribute("data-input-active")).toBe("false");
 
     layout.setExternalInputActive(true);
     flushSync();
     expect(activePaneKey()).toBeUndefined();
     expect(layout.paneRender()?.activeInputTabKey).toBeNull();
 
-    // Re-enter the pane that owned input immediately before the external dock.
-    fireEvent.pointerDown(screen.getByTestId("pane-workspace"));
+    layout.noteFocused("conversation");
+    expect(layout.externalInputActive()).toBe(true);
+
+    fireEvent.focusIn(screen.getByTestId("pane-workspace"));
     expect(layout.externalInputActive()).toBe(false);
     expect(activePaneKey()).toBe("workspace");
     expect(layout.paneRender()?.activeInputTabKey).toBe("workspace");
+
+    fireEvent.focusOut(screen.getByTestId("pane-workspace"), { relatedTarget: document.body });
+    expect(activePaneKey()).toBeUndefined();
+    expect(layout.paneRender()?.activeInputTabKey).toBeNull();
+  });
+
+  it("keeps the focused leaf active when its selected tab changes", () => {
+    const layout = store(splitTree());
+    render(DetailPaneLayoutTestHarness, { layout, routeTabKey: "conversation" });
+    const filesTab = screen.getByRole("tab", { name: "Files" });
+    const detailLeaf = filesTab.closest(".tabbed-panel-leaf");
+
+    fireEvent.focusIn(filesTab);
+    expect(detailLeaf?.classList.contains("input-active")).toBe(true);
+
+    fireEvent.click(filesTab);
+    expect(filesTab.getAttribute("aria-selected")).toBe("true");
+    expect(detailLeaf?.classList.contains("input-active")).toBe(true);
+    expect(layout.paneRender()?.activeInputTabKey).toBe("files");
   });
 
   it("keeps a zoom on a non-route leaf when the tab list re-derives", async () => {

--- a/frontend/src/lib/components/shared/DetailPaneLayout.test.ts
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.test.ts
@@ -395,10 +395,12 @@ describe("detail pane layout", () => {
 
     fireEvent.focusIn(screen.getByTestId("pane-workspace"));
     expect(activePaneKey()).toBe("workspace");
+    expect(layout.paneRender()?.activeInputTabKey).toBe("workspace");
 
     layout.setHidden("workspace", true);
     flushSync();
     expect(activePaneKey()).toBe("conversation");
+    expect(layout.paneRender()?.activeInputTabKey).toBe("conversation");
 
     layout.setHidden("workspace", false);
     flushSync();
@@ -411,6 +413,24 @@ describe("detail pane layout", () => {
     layout.toggleZoom("leaf-detail");
     flushSync();
     expect(activePaneKey()).toBe("conversation");
+    expect(layout.paneRender()?.activeInputTabKey).toBe("conversation");
+  });
+
+  it("relinquishes pane keyboard ownership to an external surface", () => {
+    const layout = store(splitTree());
+    render(DetailPaneLayoutTestHarness, { layout, routeTabKey: "conversation" });
+    const activePaneKey = () =>
+      document.querySelector(".tabbed-panel-leaf.input-active [data-pane-key]")?.getAttribute("data-pane-key");
+
+    layout.setExternalInputActive(true);
+    flushSync();
+    expect(activePaneKey()).toBeUndefined();
+    expect(layout.paneRender()?.activeInputTabKey).toBeNull();
+
+    fireEvent.pointerDown(screen.getByTestId("pane-workspace"));
+    expect(layout.externalInputActive()).toBe(false);
+    expect(activePaneKey()).toBe("workspace");
+    expect(layout.paneRender()?.activeInputTabKey).toBe("workspace");
   });
 
   it("keeps a zoom on a non-route leaf when the tab list re-derives", async () => {

--- a/frontend/src/lib/components/shared/DetailPaneLayout.test.ts
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.test.ts
@@ -416,17 +416,21 @@ describe("detail pane layout", () => {
     expect(layout.paneRender()?.activeInputTabKey).toBe("conversation");
   });
 
-  it("relinquishes pane keyboard ownership to an external surface", () => {
+  it("lets the same pane reclaim keyboard ownership from an external surface", () => {
     const layout = store(splitTree());
     render(DetailPaneLayoutTestHarness, { layout, routeTabKey: "conversation" });
     const activePaneKey = () =>
       document.querySelector(".tabbed-panel-leaf.input-active [data-pane-key]")?.getAttribute("data-pane-key");
+
+    fireEvent.pointerDown(screen.getByTestId("pane-workspace"));
+    expect(activePaneKey()).toBe("workspace");
 
     layout.setExternalInputActive(true);
     flushSync();
     expect(activePaneKey()).toBeUndefined();
     expect(layout.paneRender()?.activeInputTabKey).toBeNull();
 
+    // Re-enter the pane that owned input immediately before the external dock.
     fireEvent.pointerDown(screen.getByTestId("pane-workspace"));
     expect(layout.externalInputActive()).toBe(false);
     expect(activePaneKey()).toBe("workspace");

--- a/frontend/src/lib/components/shared/DetailPaneLayout.test.ts
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.test.ts
@@ -533,6 +533,28 @@ describe("detail pane layout", () => {
     expect(layout.paneRender()?.activeInputTabKey).toBeNull();
   });
 
+  it("forgets a connected focus target when the document hides before the next frame", async () => {
+    const layout = store(mergedTree());
+    const { rerender } = render(DetailPaneLayoutTestHarness, { layout, paneIdentity: "first" });
+    const conversationFocusTarget = screen.getByTestId("pane-focus-target-conversation");
+    vi.spyOn(window, "requestAnimationFrame").mockReturnValue(1);
+    const visibilityState = vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
+
+    conversationFocusTarget.focus();
+    await vi.waitFor(() => expect(layout.paneRender()?.activeInputTabKey).toBe("conversation"));
+
+    conversationFocusTarget.blur();
+    expect(document.activeElement).toBe(document.body);
+    visibilityState.mockReturnValue("hidden");
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    await rerender({ layout, paneIdentity: "second" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(document.activeElement).toBe(document.body);
+    expect(layout.paneRender()?.activeInputTabKey).toBeNull();
+  });
+
   it("drops stale ownership when a focused inactive tab moves to another leaf", async () => {
     const layout = store(mergedTree());
     render(DetailPaneLayoutTestHarness, { layout });

--- a/frontend/src/lib/components/shared/DetailPaneLayout.test.ts
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.test.ts
@@ -555,6 +555,20 @@ describe("detail pane layout", () => {
     expect(layout.paneRender()?.activeInputTabKey).toBeNull();
   });
 
+  it("releases layout ownership when focused content is reparented outside it", async () => {
+    const layout = store(mergedTree());
+    render(DetailPaneLayoutTestHarness, { layout });
+    const conversationFocusTarget = screen.getByTestId("pane-focus-target-conversation");
+
+    conversationFocusTarget.focus();
+    await vi.waitFor(() => expect(layout.paneRender()?.activeInputTabKey).toBe("conversation"));
+
+    document.body.append(conversationFocusTarget);
+
+    await vi.waitFor(() => expect(layout.paneRender()?.activeInputTabKey).toBeNull());
+    expect(document.activeElement).not.toBe(document.querySelector(".detail-pane-layout"));
+  });
+
   it("drops stale ownership when a focused inactive tab moves to another leaf", async () => {
     const layout = store(mergedTree());
     render(DetailPaneLayoutTestHarness, { layout });

--- a/frontend/src/lib/components/shared/DetailPaneLayout.test.ts
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.test.ts
@@ -497,6 +497,22 @@ describe("detail pane layout", () => {
     });
   });
 
+  it("reclaims focus when same-tab content identity replaces the focused body", async () => {
+    const layout = store(mergedTree());
+    const { rerender } = render(DetailPaneLayoutTestHarness, { layout, paneIdentity: "first" });
+    const conversationFocusTarget = screen.getByTestId("pane-focus-target-conversation");
+
+    conversationFocusTarget.focus();
+    await vi.waitFor(() => expect(layout.paneRender()?.activeInputTabKey).toBe("conversation"));
+
+    await rerender({ layout, paneIdentity: "second" });
+
+    await vi.waitFor(() => {
+      expect(document.activeElement?.classList.contains("detail-pane-layout")).toBe(true);
+      expect(layout.paneRender()?.activeInputTabKey).toBeNull();
+    });
+  });
+
   it("drops stale ownership when a focused inactive tab moves to another leaf", async () => {
     const layout = store(mergedTree());
     render(DetailPaneLayoutTestHarness, { layout });

--- a/frontend/src/lib/components/shared/DetailPaneLayout.test.ts
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.test.ts
@@ -497,6 +497,23 @@ describe("detail pane layout", () => {
     });
   });
 
+  it("drops stale ownership when a focused inactive tab moves to another leaf", async () => {
+    const layout = store(mergedTree());
+    render(DetailPaneLayoutTestHarness, { layout });
+    const filesTab = screen.getByRole("tab", { name: "Files" });
+
+    filesTab.focus();
+    expect(filesTab).toBe(document.activeElement);
+    await vi.waitFor(() => expect(layout.paneRender()?.activeInputTabKey).toBe("conversation"));
+
+    flushSync(() => layout.splitTab("files", "leaf-all", "horizontal", "after"));
+
+    await vi.waitFor(() => {
+      expect(document.activeElement?.classList.contains("detail-pane-layout")).toBe(true);
+      expect(layout.paneRender()?.activeInputTabKey).toBeNull();
+    });
+  });
+
   it("keeps a zoom on a non-route leaf when the tab list re-derives", async () => {
     // Route authority is a transition, not an invariant. The deep-link effect
     // also tracks `tabs`, whose identity changes on unrelated store state — the

--- a/frontend/src/lib/components/shared/DetailPaneLayout.test.ts
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.test.ts
@@ -169,6 +169,18 @@ describe("detail pane layout", () => {
     expect(layout.paneRender()?.onScreenTabs).toHaveLength(1);
   });
 
+  it("assigns narrow-layout input ownership to the rendered synthetic leaf", () => {
+    mockWidth(600);
+    const layout = store(splitTree());
+    render(DetailPaneLayoutTestHarness, { layout });
+    const conversation = screen.getByTestId("pane-conversation");
+
+    fireEvent.focusIn(conversation);
+
+    expect(conversation.getAttribute("data-input-active")).toBe("true");
+    expect(layout.paneRender()?.activeInputTabKey).toBe("conversation");
+  });
+
   it("publishes no report until the host has been measured", () => {
     // Width decides whether structural edits are allowed at all; defaulting an
     // unmeasured host to "not flattened" offers those commands for a frame on a
@@ -466,6 +478,23 @@ describe("detail pane layout", () => {
     expect(filesTab.getAttribute("aria-selected")).toBe("true");
     expect(detailLeaf?.classList.contains("input-active")).toBe(true);
     expect(layout.paneRender()?.activeInputTabKey).toBe("files");
+  });
+
+  it("reclaims focus when same-leaf tab replacement unmounts the focused body", async () => {
+    const layout = store(mergedTree());
+    render(DetailPaneLayoutTestHarness, { layout });
+    const conversationFocusTarget = screen.getByTestId("pane-focus-target-conversation");
+
+    conversationFocusTarget.focus();
+    fireEvent.focusIn(conversationFocusTarget);
+    expect(layout.paneRender()?.activeInputTabKey).toBe("conversation");
+
+    flushSync(() => layout.activateTab("files"));
+
+    await vi.waitFor(() => {
+      expect(document.activeElement?.classList.contains("detail-pane-layout")).toBe(true);
+      expect(layout.paneRender()?.activeInputTabKey).toBeNull();
+    });
   });
 
   it("keeps a zoom on a non-route leaf when the tab list re-derives", async () => {

--- a/frontend/src/lib/components/shared/DetailPaneLayout.test.ts
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.test.ts
@@ -387,6 +387,32 @@ describe("detail pane layout", () => {
     expect(screen.getByRole("tab", { name: "Files" }).getAttribute("aria-selected")).toBe("true");
   });
 
+  it("marks the first on-screen pane active when the remembered pane is not rendered", async () => {
+    const layout = store(splitTree());
+    const { rerender } = render(DetailPaneLayoutTestHarness, { layout, routeTabKey: "conversation" });
+    const activePaneKey = () =>
+      document.querySelector(".tabbed-panel-leaf.input-active [data-pane-key]")?.getAttribute("data-pane-key");
+
+    fireEvent.focusIn(screen.getByTestId("pane-workspace"));
+    expect(activePaneKey()).toBe("workspace");
+
+    layout.setHidden("workspace", true);
+    flushSync();
+    expect(activePaneKey()).toBe("conversation");
+
+    layout.setHidden("workspace", false);
+    flushSync();
+    fireEvent.focusIn(screen.getByTestId("pane-workspace"));
+    await rerender({ layout, routeTabKey: "conversation", workspaceAvailable: false });
+    expect(activePaneKey()).toBe("conversation");
+
+    await rerender({ layout, routeTabKey: "conversation", workspaceAvailable: true });
+    fireEvent.focusIn(screen.getByTestId("pane-workspace"));
+    layout.toggleZoom("leaf-detail");
+    flushSync();
+    expect(activePaneKey()).toBe("conversation");
+  });
+
   it("keeps a zoom on a non-route leaf when the tab list re-derives", async () => {
     // Route authority is a transition, not an invariant. The deep-link effect
     // also tracks `tabs`, whose identity changes on unrelated store state — the
@@ -438,6 +464,27 @@ describe("detail pane layout", () => {
     fireEvent.focusIn(screen.getByTestId("pane-workspace"));
 
     expect(onFocusPane).toHaveBeenCalledWith("workspace");
+  });
+
+  it("reports focus after an external route transition changes the owner", async () => {
+    const layout = store(splitTree());
+    const onFocusPane = vi.fn();
+    const { rerender } = render(DetailPaneLayoutTestHarness, {
+      layout,
+      routeTabKey: "conversation",
+      onFocusPane,
+    });
+
+    fireEvent.focusIn(screen.getByTestId("pane-workspace"));
+    expect(onFocusPane).toHaveBeenLastCalledWith("workspace");
+
+    await rerender({ layout, routeTabKey: "files", onFocusPane });
+    expect(layout.lastFocusedTabKey()).toBe("files");
+    onFocusPane.mockClear();
+
+    fireEvent.focusIn(screen.getByTestId("pane-workspace"));
+    expect(onFocusPane).toHaveBeenCalledWith("workspace");
+    expect(layout.lastFocusedTabKey()).toBe("workspace");
   });
 
   it("records the focused pane for a surface that wants no notification", () => {

--- a/frontend/src/lib/components/shared/DetailPaneLayout.test.ts
+++ b/frontend/src/lib/components/shared/DetailPaneLayout.test.ts
@@ -514,6 +514,25 @@ describe("detail pane layout", () => {
     });
   });
 
+  it("forgets a connected focus target after a no-destination blur", async () => {
+    const layout = store(mergedTree());
+    const { rerender } = render(DetailPaneLayoutTestHarness, { layout, paneIdentity: "first" });
+    const conversationFocusTarget = screen.getByTestId("pane-focus-target-conversation");
+
+    conversationFocusTarget.focus();
+    await vi.waitFor(() => expect(layout.paneRender()?.activeInputTabKey).toBe("conversation"));
+
+    conversationFocusTarget.blur();
+    expect(document.activeElement).toBe(document.body);
+    await new Promise(requestAnimationFrame);
+
+    await rerender({ layout, paneIdentity: "second" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(document.activeElement).toBe(document.body);
+    expect(layout.paneRender()?.activeInputTabKey).toBeNull();
+  });
+
   it("drops stale ownership when a focused inactive tab moves to another leaf", async () => {
     const layout = store(mergedTree());
     render(DetailPaneLayoutTestHarness, { layout });

--- a/frontend/src/lib/components/shared/DetailPaneLayoutTestHarness.svelte
+++ b/frontend/src/lib/components/shared/DetailPaneLayoutTestHarness.svelte
@@ -23,6 +23,8 @@
      * changes on unrelated state — including as a consequence of a zoom.
      */
     tabsNonce?: number;
+    /** Replaces pane content without changing its leaf or selected tab. */
+    paneIdentity?: string;
   }
 
   const runtime = makeAppRuntime();
@@ -40,6 +42,7 @@
     withLeafExtras = false,
     labelFromRender = false,
     tabsNonce = 0,
+    paneIdentity = "initial",
   }: Props = $props();
 
   const workspaceLabel = $derived(
@@ -69,15 +72,17 @@
   paneLeafExtras={withLeafExtras ? leafExtras : undefined}
 >
   {#snippet renderPane(tabKey, visible, inputActive)}
-    <section
-      data-testid={`pane-${tabKey}`}
-      data-visible={String(visible)}
-      data-input-active={String(inputActive)}
-    >
-      Pane {tabKey}
-      {#if visible}
-        <button type="button" data-testid={`pane-focus-target-${tabKey}`}>Focus {tabKey}</button>
-      {/if}
-    </section>
+    {#key paneIdentity}
+      <section
+        data-testid={`pane-${tabKey}`}
+        data-visible={String(visible)}
+        data-input-active={String(inputActive)}
+      >
+        Pane {tabKey}
+        {#if visible}
+          <button type="button" data-testid={`pane-focus-target-${tabKey}`}>Focus {tabKey}</button>
+        {/if}
+      </section>
+    {/key}
   {/snippet}
 </DetailPaneLayout>

--- a/frontend/src/lib/components/shared/DetailPaneLayoutTestHarness.svelte
+++ b/frontend/src/lib/components/shared/DetailPaneLayoutTestHarness.svelte
@@ -68,8 +68,12 @@
   {onFocusPane}
   paneLeafExtras={withLeafExtras ? leafExtras : undefined}
 >
-  {#snippet renderPane(tabKey, visible, _inputActive)}
-    <section data-testid={`pane-${tabKey}`} data-visible={String(visible)}>
+  {#snippet renderPane(tabKey, visible, inputActive)}
+    <section
+      data-testid={`pane-${tabKey}`}
+      data-visible={String(visible)}
+      data-input-active={String(inputActive)}
+    >
       Pane {tabKey}
     </section>
   {/snippet}

--- a/frontend/src/lib/components/shared/DetailPaneLayoutTestHarness.svelte
+++ b/frontend/src/lib/components/shared/DetailPaneLayoutTestHarness.svelte
@@ -75,6 +75,9 @@
       data-input-active={String(inputActive)}
     >
       Pane {tabKey}
+      {#if visible}
+        <button type="button" data-testid={`pane-focus-target-${tabKey}`}>Focus {tabKey}</button>
+      {/if}
     </section>
   {/snippet}
 </DetailPaneLayout>

--- a/frontend/src/lib/components/shared/DetailPaneLayoutTestHarness.svelte
+++ b/frontend/src/lib/components/shared/DetailPaneLayoutTestHarness.svelte
@@ -68,7 +68,7 @@
   {onFocusPane}
   paneLeafExtras={withLeafExtras ? leafExtras : undefined}
 >
-  {#snippet renderPane(tabKey, visible)}
+  {#snippet renderPane(tabKey, visible, _inputActive)}
     <section data-testid={`pane-${tabKey}`} data-visible={String(visible)}>
       Pane {tabKey}
     </section>

--- a/frontend/src/lib/components/shared/TabbedPanelTree.svelte
+++ b/frontend/src/lib/components/shared/TabbedPanelTree.svelte
@@ -915,6 +915,16 @@
     pointer-events: none;
   }
 
+  /* Nested workspace surfaces are the actual keyboard owner. Keep the outer
+     detail leaf structural so only the deepest active pane is highlighted. */
+  .tabbed-panel-leaf.input-active:has(
+      .tabbed-panel-leaf.input-active,
+      :global(.terminal-panel.input-active),
+      :global(.right-sidebar.input-active)
+    )::after {
+    content: none;
+  }
+
   /*
    * Over the pane, not beside it: a strip-less leaf gives its whole height to the
    * pane, so these have nowhere to sit in flow. The z-index is the same fight the
@@ -1043,6 +1053,10 @@
     height: var(--chrome-active-accent-width);
     background: var(--accent-blue);
     pointer-events: none;
+  }
+
+  .tabbed-panel-leaf.input-active > .tabbed-panel-tabs > .tabbed-panel-tab.active::before {
+    content: none;
   }
 
   .tabbed-panel-tab.dragging {

--- a/frontend/src/lib/components/shared/TabbedPanelTree.svelte
+++ b/frontend/src/lib/components/shared/TabbedPanelTree.svelte
@@ -570,6 +570,7 @@
       },
     ]}
     aria-label={leafLabel}
+    onfocusin={onFocusPane ? () => onFocusPane(node.activeTabKey) : undefined}
   >
     {#if !soloChrome}
     <div
@@ -678,9 +679,6 @@
           ]}
           data-pane-key={tabKey}
           role="presentation"
-          onfocusin={onFocusPane ? () => onFocusPane(tabKey) : undefined}
-          onpointerdown={onFocusPane ? () => onFocusPane(tabKey) : undefined}
-          onwheel={onFocusPane ? () => onFocusPane(tabKey) : undefined}
         >
           {@render renderTab(tabKey, paneVisible(tabKey))}
         </div>

--- a/frontend/src/lib/components/shared/TabbedPanelTree.svelte
+++ b/frontend/src/lib/components/shared/TabbedPanelTree.svelte
@@ -492,7 +492,8 @@
   function handleLeafFocusIn(event: FocusEvent, leaf: TabbedPanelLeaf): void {
     const target = event.target;
     const focusedTab = target instanceof Element ? target.closest<HTMLElement>("[data-tabbed-panel-tab-key]") : null;
-    onFocusPane?.(focusedTab?.dataset.tabbedPanelTabKey ?? leaf.activeTabKey, leaf.id);
+    const focusedOuterTab = focusedTab?.closest(".tabbed-panel-leaf") === event.currentTarget ? focusedTab : null;
+    onFocusPane?.(focusedOuterTab?.dataset.tabbedPanelTabKey ?? leaf.activeTabKey, leaf.id);
   }
 
   function measureSplit(): number {

--- a/frontend/src/lib/components/shared/TabbedPanelTree.svelte
+++ b/frontend/src/lib/components/shared/TabbedPanelTree.svelte
@@ -39,6 +39,8 @@
     node: TabbedPanelNode | undefined;
     tabs: TabbedPanelDescriptor[];
     activeTabKey: string;
+    /** Whether this tree owns input within a larger, nested pane surface. */
+    inputActive?: boolean;
     renderTab: Snippet<[string, boolean]>;
     tabIcon?: Snippet<[TabbedPanelDescriptor]> | undefined;
     tabActions?: Snippet<[TabbedPanelDescriptor]> | undefined;
@@ -100,6 +102,7 @@
     node,
     tabs,
     activeTabKey,
+    inputActive = true,
     renderTab,
     tabIcon = undefined,
     tabActions = undefined,
@@ -563,7 +566,7 @@
       "tabbed-panel-leaf",
       {
         "solo-chrome": soloChrome,
-        "input-active": node.activeTabKey === activeTabKey,
+        "input-active": inputActive && node.activeTabKey === activeTabKey,
       },
     ]}
     aria-label={leafLabel}
@@ -724,6 +727,7 @@
         node={node.first}
         {tabs}
         {activeTabKey}
+        {inputActive}
         {renderTab}
         {tabIcon}
         {tabActions}
@@ -776,6 +780,7 @@
         node={node.second}
         {tabs}
         {activeTabKey}
+        {inputActive}
         {renderTab}
         {tabIcon}
         {tabActions}

--- a/frontend/src/lib/components/shared/TabbedPanelTree.svelte
+++ b/frontend/src/lib/components/shared/TabbedPanelTree.svelte
@@ -79,7 +79,7 @@
      * this to follow the user between two simultaneously visible panes, where
      * there is no tab to click.
      */
-    onFocusPane?: ((tabKey: string) => void) | undefined;
+    onFocusPane?: ((tabKey: string, leafID: string) => void) | undefined;
     onMoveTabBefore?: ((sourceTabKey: string, targetTabKey: string) => void) | undefined;
     onAppendTabToLeaf?: ((sourceTabKey: string, leafID: string) => void) | undefined;
     onSplitTab?:
@@ -570,7 +570,7 @@
       },
     ]}
     aria-label={leafLabel}
-    onfocusin={onFocusPane ? () => onFocusPane(node.activeTabKey) : undefined}
+    onfocusin={onFocusPane ? () => onFocusPane(node.activeTabKey, node.id) : undefined}
   >
     {#if !soloChrome}
     <div

--- a/frontend/src/lib/components/shared/TabbedPanelTree.svelte
+++ b/frontend/src/lib/components/shared/TabbedPanelTree.svelte
@@ -558,7 +558,16 @@
        the tick, with nothing left to render. -->
 {:else if node.type === "leaf"}
   {@const soloChrome = node.tabs.length === 1 && soloChromeTabKeys.includes(node.tabs[0]!)}
-  <section class={["tabbed-panel-leaf", { "solo-chrome": soloChrome }]} aria-label={leafLabel}>
+  <section
+    class={[
+      "tabbed-panel-leaf",
+      {
+        "solo-chrome": soloChrome,
+        "input-active": node.activeTabKey === activeTabKey,
+      },
+    ]}
+    aria-label={leafLabel}
+  >
     {#if !soloChrome}
     <div
       class={["tabbed-panel-tabs", { "drag-sorting": draggedTabKey !== null }]}
@@ -665,7 +674,10 @@
             },
           ]}
           data-pane-key={tabKey}
+          role="presentation"
           onfocusin={onFocusPane ? () => onFocusPane(tabKey) : undefined}
+          onpointerdown={onFocusPane ? () => onFocusPane(tabKey) : undefined}
+          onwheel={onFocusPane ? () => onFocusPane(tabKey) : undefined}
         >
           {@render renderTab(tabKey, paneVisible(tabKey))}
         </div>
@@ -886,6 +898,16 @@
     border: var(--chrome-border-width) solid var(--border-default);
     border-top: 0;
     background: var(--bg-surface);
+  }
+
+  .tabbed-panel-leaf.input-active::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 30;
+    border: var(--chrome-border-width) solid
+      color-mix(in srgb, var(--accent-blue) 48%, var(--border-default));
+    pointer-events: none;
   }
 
   /*

--- a/frontend/src/lib/components/shared/TabbedPanelTree.svelte
+++ b/frontend/src/lib/components/shared/TabbedPanelTree.svelte
@@ -489,6 +489,12 @@
     return `--dragged-tab-width: ${width}px;`;
   }
 
+  function handleLeafFocusIn(event: FocusEvent, leaf: TabbedPanelLeaf): void {
+    const target = event.target;
+    const focusedTab = target instanceof Element ? target.closest<HTMLElement>("[data-tabbed-panel-tab-key]") : null;
+    onFocusPane?.(focusedTab?.dataset.tabbedPanelTabKey ?? leaf.activeTabKey, leaf.id);
+  }
+
   function measureSplit(): number {
     // Reached from a ResizeObserver batch, which can be delivered after the
     // parent stopped being a split.
@@ -570,7 +576,7 @@
       },
     ]}
     aria-label={leafLabel}
-    onfocusin={onFocusPane ? () => onFocusPane(node.activeTabKey, node.id) : undefined}
+    onfocusin={onFocusPane ? (event) => handleLeafFocusIn(event, node) : undefined}
   >
     {#if !soloChrome}
     <div

--- a/frontend/src/lib/components/shared/TabbedPanelTree.test.ts
+++ b/frontend/src/lib/components/shared/TabbedPanelTree.test.ts
@@ -82,7 +82,7 @@ describe("TabbedPanelTree", () => {
     expect(screen.getByLabelText("Feed updating").classList.contains("kit-status-dot--working")).toBe(true);
   });
 
-  it("shows one active input pane and reports pointer and wheel activation", async () => {
+  it("reports focus while pointer and wheel leave the active pane unchanged", async () => {
     const onFocusPane = vi.fn();
     const view = render(TabbedPanelTreeTestHarness, {
       props: {
@@ -98,7 +98,10 @@ describe("TabbedPanelTree", () => {
 
     await fireEvent.pointerDown(screen.getByTestId("panel-files"));
     await fireEvent.wheel(screen.getByTestId("panel-detail"));
+    expect(onFocusPane).not.toHaveBeenCalled();
 
+    await fireEvent.focusIn(screen.getByTestId("panel-files"));
+    await fireEvent.focusIn(screen.getByTestId("panel-detail"));
     expect(onFocusPane).toHaveBeenNthCalledWith(1, "files");
     expect(onFocusPane).toHaveBeenNthCalledWith(2, "detail");
 

--- a/frontend/src/lib/components/shared/TabbedPanelTree.test.ts
+++ b/frontend/src/lib/components/shared/TabbedPanelTree.test.ts
@@ -82,6 +82,36 @@ describe("TabbedPanelTree", () => {
     expect(screen.getByLabelText("Feed updating").classList.contains("kit-status-dot--working")).toBe(true);
   });
 
+  it("shows one active input pane and reports pointer and wheel activation", async () => {
+    const onFocusPane = vi.fn();
+    const view = render(TabbedPanelTreeTestHarness, {
+      props: {
+        node: splitNode(),
+        activeTabKey: "detail",
+        onFocusPane,
+      },
+    });
+
+    const activeLeaves = () => Array.from(document.querySelectorAll<HTMLElement>(".tabbed-panel-leaf.input-active"));
+    expect(activeLeaves()).toHaveLength(1);
+    expect(activeLeaves()[0]?.contains(screen.getByTestId("panel-detail"))).toBe(true);
+
+    await fireEvent.pointerDown(screen.getByTestId("panel-files"));
+    await fireEvent.wheel(screen.getByTestId("panel-detail"));
+
+    expect(onFocusPane).toHaveBeenNthCalledWith(1, "files");
+    expect(onFocusPane).toHaveBeenNthCalledWith(2, "detail");
+
+    await view.rerender({
+      node: splitNode(),
+      activeTabKey: "files",
+      onFocusPane,
+    });
+
+    expect(activeLeaves()).toHaveLength(1);
+    expect(activeLeaves()[0]?.contains(screen.getByTestId("panel-files"))).toBe(true);
+  });
+
   it("shows a moving insertion slot while sorting tabs", async () => {
     vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
       callback(0);

--- a/frontend/src/lib/components/shared/TabbedPanelTree.test.ts
+++ b/frontend/src/lib/components/shared/TabbedPanelTree.test.ts
@@ -102,8 +102,8 @@ describe("TabbedPanelTree", () => {
 
     await fireEvent.focusIn(screen.getByTestId("panel-files"));
     await fireEvent.focusIn(screen.getByTestId("panel-detail"));
-    expect(onFocusPane).toHaveBeenNthCalledWith(1, "files");
-    expect(onFocusPane).toHaveBeenNthCalledWith(2, "detail");
+    expect(onFocusPane).toHaveBeenNthCalledWith(1, "files", "leaf-2");
+    expect(onFocusPane).toHaveBeenNthCalledWith(2, "detail", "leaf-1");
 
     await view.rerender({
       node: splitNode(),

--- a/frontend/src/lib/components/shared/TabbedPanelTree.test.ts
+++ b/frontend/src/lib/components/shared/TabbedPanelTree.test.ts
@@ -115,6 +115,24 @@ describe("TabbedPanelTree", () => {
     expect(activeLeaves()[0]?.contains(screen.getByTestId("panel-files"))).toBe(true);
   });
 
+  it("keeps nested tab focus scoped to the outer leaf", async () => {
+    const onFocusPane = vi.fn();
+    render(TabbedPanelTreeTestHarness, {
+      props: { node: leafNode(), onFocusPane },
+    });
+    const outerPanel = screen.getByTestId("panel-detail");
+    const nestedLeaf = document.createElement("section");
+    nestedLeaf.className = "tabbed-panel-leaf";
+    const nestedTab = document.createElement("button");
+    nestedTab.dataset.tabbedPanelTabKey = "nested-session";
+    nestedLeaf.append(nestedTab);
+    outerPanel.append(nestedLeaf);
+
+    await fireEvent.focusIn(nestedTab);
+
+    expect(onFocusPane).toHaveBeenCalledWith("detail", "leaf-1");
+  });
+
   it("shows a moving insertion slot while sorting tabs", async () => {
     vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
       callback(0);

--- a/frontend/src/lib/components/shared/TabbedPanelTreeTestHarness.svelte
+++ b/frontend/src/lib/components/shared/TabbedPanelTreeTestHarness.svelte
@@ -25,7 +25,7 @@
         ) => void)
       | undefined;
     onRatioChange?: ((splitID: string, ratio: number) => void) | undefined;
-    onFocusPane?: ((tabKey: string) => void) | undefined;
+    onFocusPane?: ((tabKey: string, leafID: string) => void) | undefined;
     disabled?: boolean;
     zoomedLeafID?: string | null;
     /** Render the per-leaf action cluster; off by default so existing cases are unaffected. */

--- a/frontend/src/lib/components/shared/TabbedPanelTreeTestHarness.svelte
+++ b/frontend/src/lib/components/shared/TabbedPanelTreeTestHarness.svelte
@@ -25,6 +25,7 @@
         ) => void)
       | undefined;
     onRatioChange?: ((splitID: string, ratio: number) => void) | undefined;
+    onFocusPane?: ((tabKey: string) => void) | undefined;
     disabled?: boolean;
     zoomedLeafID?: string | null;
     /** Render the per-leaf action cluster; off by default so existing cases are unaffected. */
@@ -45,6 +46,7 @@
     onAppendTabToLeaf,
     onSplitTab,
     onRatioChange,
+    onFocusPane,
     disabled = false,
     zoomedLeafID = null,
     withLeafActions = false,
@@ -81,6 +83,7 @@
   {onAppendTabToLeaf}
   {onSplitTab}
   {onRatioChange}
+  {onFocusPane}
   leafActions={withLeafActions ? leafActions : undefined}
 >
   {#snippet renderTab(tabKey, active)}

--- a/frontend/src/lib/components/terminal/DockedTerminalPanel.svelte
+++ b/frontend/src/lib/components/terminal/DockedTerminalPanel.svelte
@@ -51,6 +51,7 @@
     hostVisible?: boolean;
     inputActive?: boolean;
     onInputActivate?: (() => void) | undefined;
+    onInputDeactivate?: (() => void) | undefined;
     /** Shared detail-surface scope when terminal sessions may become top-level panes. */
     dragScope?: string | undefined;
     /** Maps a runtime session to its top-level detail-pane key. */
@@ -96,6 +97,7 @@
     hostVisible = true,
     inputActive = false,
     onInputActivate = undefined,
+    onInputDeactivate = undefined,
     dragScope = undefined,
     paneKeyForSession = undefined,
     headerActions = undefined,
@@ -190,6 +192,12 @@
   function resizePanel(event: SplitResizeEvent): void {
     onResize?.(clampTerminalHeight(resizeStartHeight - event.delta));
   }
+
+  function handleFocusOut(event: FocusEvent & { currentTarget: HTMLElement }): void {
+    const next = event.relatedTarget;
+    if (next instanceof Node && event.currentTarget.contains(next)) return;
+    onInputDeactivate?.();
+  }
 </script>
 
 <section
@@ -197,8 +205,7 @@
   style={dock === "bottom" && open ? `height: ${height}px` : undefined}
   aria-label="Terminal panel"
   onfocusin={() => onInputActivate?.()}
-  onpointerdown={() => onInputActivate?.()}
-  onwheelcapture={() => onInputActivate?.()}
+  onfocusout={handleFocusOut}
   ondragover={handleDragOver}
   ondrop={handleDrop}
 >

--- a/frontend/src/lib/components/terminal/DockedTerminalPanel.svelte
+++ b/frontend/src/lib/components/terminal/DockedTerminalPanel.svelte
@@ -16,7 +16,7 @@
   import TerminalSplitTree from "./TerminalSplitTree.svelte";
   import type { AppExecution } from "../../app/runtime.js";
   import { getAppRuntime } from "../../app/runtime-context.js";
-  import { nextAnimationFrame } from "../../browser/animation-frame.js";
+  import { nextAnimationFrameOrDocumentHidden } from "../../browser/animation-frame.js";
   import { observeMutation } from "../../browser/observers.js";
   import {
     clearActiveTerminalDrag,
@@ -230,7 +230,7 @@
     const blurred = focusedInputElement;
     focusRecordExecution?.interrupt();
     focusRecordExecution = runtime.runCommand(
-      nextAnimationFrame.pipe(
+      nextAnimationFrameOrDocumentHidden.pipe(
         Effect.andThen(Effect.sync(() => {
           if (focusedInputElement === blurred && panel?.contains(blurred) === true) {
             focusedInputElement = null;

--- a/frontend/src/lib/components/terminal/DockedTerminalPanel.svelte
+++ b/frontend/src/lib/components/terminal/DockedTerminalPanel.svelte
@@ -49,6 +49,8 @@
     // workflow-tab placement while another tab is selected. Forwarded to
     // TerminalSplitTree, which makes it every leaf's visibility.
     hostVisible?: boolean;
+    inputActive?: boolean;
+    onInputActivate?: (() => void) | undefined;
     /** Shared detail-surface scope when terminal sessions may become top-level panes. */
     dragScope?: string | undefined;
     /** Maps a runtime session to its top-level detail-pane key. */
@@ -92,6 +94,8 @@
     loading = false,
     disabled = false,
     hostVisible = true,
+    inputActive = false,
+    onInputActivate = undefined,
     dragScope = undefined,
     paneKeyForSession = undefined,
     headerActions = undefined,
@@ -189,9 +193,12 @@
 </script>
 
 <section
-  class={["terminal-panel", dock, { open }]}
+  class={["terminal-panel", dock, { open, "input-active": inputActive }]}
   style={dock === "bottom" && open ? `height: ${height}px` : undefined}
   aria-label="Terminal panel"
+  onfocusin={() => onInputActivate?.()}
+  onpointerdown={() => onInputActivate?.()}
+  onwheel={() => onInputActivate?.()}
   ondragover={handleDragOver}
   ondrop={handleDrop}
 >
@@ -362,11 +369,22 @@
 
 <style>
   .terminal-panel {
+    position: relative;
     flex-shrink: 0;
     min-height: 30px;
     border-top: var(--chrome-border-width) solid var(--border-default);
     background: var(--bg-surface);
     color: var(--text-primary);
+  }
+
+  .terminal-panel.input-active::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 30;
+    border: var(--chrome-border-width) solid
+      color-mix(in srgb, var(--accent-blue) 48%, var(--border-default));
+    pointer-events: none;
   }
 
   .terminal-panel.top {

--- a/frontend/src/lib/components/terminal/DockedTerminalPanel.svelte
+++ b/frontend/src/lib/components/terminal/DockedTerminalPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import type { Snippet } from "svelte";
+  import { Effect } from "effect";
+  import { tick, untrack, type Snippet } from "svelte";
   import { SplitResizeHandle, type SplitResizeEvent } from "@kenn-io/kit-ui";
   import { clearActiveTabbedPanelDrag, startTabbedPanelTabDrag } from "../shared/tabbed-panel-drag.js";
   import type { RuntimeSession } from "../../api/types.js";
@@ -13,6 +14,10 @@
   import Rows2Icon from "@lucide/svelte/icons/rows-2";
   import MoveIcon from "@lucide/svelte/icons/move";
   import TerminalSplitTree from "./TerminalSplitTree.svelte";
+  import type { AppExecution } from "../../app/runtime.js";
+  import { getAppRuntime } from "../../app/runtime-context.js";
+  import { nextAnimationFrame } from "../../browser/animation-frame.js";
+  import { observeMutation } from "../../browser/observers.js";
   import {
     clearActiveTerminalDrag,
     readRuntimeSessionDrag,
@@ -116,7 +121,13 @@
     onRatioChange,
     onSplitSession,
   }: Props = $props();
+  const runtime = getAppRuntime();
 
+  let panel = $state<HTMLElement | null>(null);
+  let focusedInputElement: HTMLElement | null = null;
+  let focusExecution: AppExecution<void, never> | null = null;
+  let focusRecordExecution: AppExecution<void, never> | null = null;
+  let inputOwned = false;
   let resizeStartHeight = 0;
 
   const visibleKeys = $derived(collectSessionKeys(tree));
@@ -193,18 +204,100 @@
     onResize?.(clampTerminalHeight(resizeStartHeight - event.delta));
   }
 
+  function handleFocusIn(event: FocusEvent): void {
+    focusExecution?.interrupt();
+    focusExecution = null;
+    focusRecordExecution?.interrupt();
+    focusRecordExecution = null;
+    focusedInputElement = event.target instanceof HTMLElement ? event.target : null;
+    inputOwned = true;
+    onInputActivate?.();
+  }
+
   function handleFocusOut(event: FocusEvent & { currentTarget: HTMLElement }): void {
     const next = event.relatedTarget;
     if (next instanceof Node && event.currentTarget.contains(next)) return;
-    onInputDeactivate?.();
+    if (inputOwned) {
+      inputOwned = false;
+      onInputDeactivate?.();
+    }
+    if (next !== null) {
+      focusRecordExecution?.interrupt();
+      focusRecordExecution = null;
+      focusedInputElement = null;
+      return;
+    }
+    const blurred = focusedInputElement;
+    focusRecordExecution?.interrupt();
+    focusRecordExecution = runtime.runCommand(
+      nextAnimationFrame.pipe(
+        Effect.andThen(Effect.sync(() => {
+          if (focusedInputElement === blurred && panel?.contains(blurred) === true) {
+            focusedInputElement = null;
+          }
+          focusRecordExecution = null;
+        })),
+      ),
+      {
+        operation: "release terminal dock focus record",
+        safeContext: { workspaceId },
+        onFailure: () => {},
+      },
+    );
   }
+
+  function reclaimPanelFocus(): void {
+    focusExecution?.interrupt();
+    focusExecution = runtime.runCommand(
+      Effect.promise(() => tick()).pipe(
+        Effect.andThen(Effect.sync(() => {
+          focusExecution = null;
+          if (document.activeElement === document.body) panel?.focus();
+        })),
+      ),
+      {
+        operation: "restore terminal dock focus",
+        safeContext: { workspaceId },
+        onFailure: () => {},
+      },
+    );
+  }
+
+  $effect(() => {
+    const el = panel;
+    if (!el || typeof MutationObserver === "undefined") return;
+    const execution = untrack(() =>
+      runtime.runCommand(
+        Effect.scoped(
+          observeMutation(
+            el,
+            () => {
+              const focused = focusedInputElement;
+              if (focused === null || el.contains(focused)) return;
+              focusedInputElement = null;
+              if (inputOwned) {
+                inputOwned = false;
+                onInputDeactivate?.();
+              }
+              if (!focused.isConnected) reclaimPanelFocus();
+            },
+            { childList: true, subtree: true },
+          ).pipe(Effect.andThen(Effect.never)),
+        ),
+        { operation: "observe terminal dock focus", safeContext: { workspaceId }, onFailure: () => {} },
+      ),
+    );
+    return execution.interrupt;
+  });
 </script>
 
 <section
+  bind:this={panel}
+  tabindex="-1"
   class={["terminal-panel", dock, { open, "input-active": inputActive }]}
   style={dock === "bottom" && open ? `height: ${height}px` : undefined}
   aria-label="Terminal panel"
-  onfocusin={() => onInputActivate?.()}
+  onfocusin={handleFocusIn}
   onfocusout={handleFocusOut}
   ondragover={handleDragOver}
   ondrop={handleDrop}

--- a/frontend/src/lib/components/terminal/DockedTerminalPanel.svelte
+++ b/frontend/src/lib/components/terminal/DockedTerminalPanel.svelte
@@ -198,7 +198,7 @@
   aria-label="Terminal panel"
   onfocusin={() => onInputActivate?.()}
   onpointerdown={() => onInputActivate?.()}
-  onwheel={() => onInputActivate?.()}
+  onwheelcapture={() => onInputActivate?.()}
   ondragover={handleDragOver}
   ondrop={handleDrop}
 >

--- a/frontend/src/lib/components/terminal/DockedTerminalPanel.test.ts
+++ b/frontend/src/lib/components/terminal/DockedTerminalPanel.test.ts
@@ -129,4 +129,64 @@ describe("DockedTerminalPanel", () => {
 
     expect(onInputDeactivate).toHaveBeenCalledOnce();
   });
+
+  it("releases input ownership when the focused session disappears", async () => {
+    const onInputActivate = vi.fn();
+    const onInputDeactivate = vi.fn();
+    const view = renderDockedTerminalPanel({
+      sessions,
+      tree: {
+        type: "split",
+        id: "split-a-b",
+        direction: "horizontal",
+        ratio: 0.5,
+        first: { type: "leaf", id: "leaf-a", sessionKey: sessions[0]!.key },
+        second: { type: "leaf", id: "leaf-b", sessionKey: sessions[1]!.key },
+      },
+      activeSessionKey: sessions[0]!.key,
+      onInputActivate,
+      onInputDeactivate,
+    });
+    const focusedSession = document.querySelector<HTMLElement>(".session-terminal-slot");
+    expect(focusedSession).not.toBeNull();
+    const focusTarget = document.createElement("button");
+    focusedSession?.append(focusTarget);
+    focusTarget.focus();
+    await vi.waitFor(() => expect(onInputActivate).toHaveBeenCalled());
+
+    await view.rerender({
+      component: DockedTerminalPanelTestHarness,
+      sessions: [sessions[1]!],
+      tree: { type: "leaf", id: "leaf-b", sessionKey: sessions[1]!.key },
+      activeSessionKey: sessions[1]!.key,
+      onInputActivate,
+      onInputDeactivate,
+    });
+
+    const panel = screen.getByRole("region", { name: "Terminal panel" });
+    await vi.waitFor(() => {
+      expect(onInputDeactivate).toHaveBeenCalledOnce();
+      expect(document.activeElement).toBe(panel);
+    });
+  });
+
+  it("leaves focus with a connected session moved outside the dock", async () => {
+    const onInputDeactivate = vi.fn();
+    renderDockedTerminalPanel({
+      sessions: [sessions[0]!],
+      tree: { type: "leaf", id: "leaf-a", sessionKey: sessions[0]!.key },
+      activeSessionKey: sessions[0]!.key,
+      onInputDeactivate,
+    });
+    const focusedSession = document.querySelector<HTMLElement>(".session-terminal-slot");
+    expect(focusedSession).not.toBeNull();
+    const focusTarget = document.createElement("button");
+    focusedSession?.append(focusTarget);
+    focusTarget.focus();
+
+    document.body.append(focusTarget);
+
+    await vi.waitFor(() => expect(onInputDeactivate).toHaveBeenCalledOnce());
+    expect(document.activeElement).not.toBe(screen.getByRole("region", { name: "Terminal panel" }));
+  });
 });

--- a/frontend/src/lib/components/terminal/DockedTerminalPanel.test.ts
+++ b/frontend/src/lib/components/terminal/DockedTerminalPanel.test.ts
@@ -107,4 +107,15 @@ describe("DockedTerminalPanel", () => {
     await fireEvent.keyDown(handle, { key: "ArrowUp" });
     expect(onResize).not.toHaveBeenCalled();
   });
+
+  it("claims input before a terminal child consumes wheel propagation", async () => {
+    const onInputActivate = vi.fn();
+    renderDockedTerminalPanel({ onInputActivate });
+    const child = screen.getByRole("separator", { name: "Resize terminal panel" });
+    child.addEventListener("wheel", (event) => event.stopPropagation());
+
+    await fireEvent.wheel(child);
+
+    expect(onInputActivate).toHaveBeenCalledOnce();
+  });
 });

--- a/frontend/src/lib/components/terminal/DockedTerminalPanel.test.ts
+++ b/frontend/src/lib/components/terminal/DockedTerminalPanel.test.ts
@@ -39,6 +39,7 @@ describe("DockedTerminalPanel", () => {
     cleanup();
     clearActiveTerminalDrag();
     clearActiveTabbedPanelDrag();
+    vi.restoreAllMocks();
   });
 
   it("publishes and clears a detail-pane payload from the terminal selector", async () => {
@@ -188,5 +189,42 @@ describe("DockedTerminalPanel", () => {
 
     await vi.waitFor(() => expect(onInputDeactivate).toHaveBeenCalledOnce());
     expect(document.activeElement).not.toBe(screen.getByRole("region", { name: "Terminal panel" }));
+  });
+
+  it("does not reclaim a blurred session after the document hides", async () => {
+    const view = renderDockedTerminalPanel({
+      sessions,
+      tree: {
+        type: "split",
+        id: "split-a-b",
+        direction: "horizontal",
+        ratio: 0.5,
+        first: { type: "leaf", id: "leaf-a", sessionKey: sessions[0]!.key },
+        second: { type: "leaf", id: "leaf-b", sessionKey: sessions[1]!.key },
+      },
+      activeSessionKey: sessions[0]!.key,
+    });
+    vi.spyOn(window, "requestAnimationFrame").mockReturnValue(1);
+    const visibilityState = vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
+    const focusedSession = document.querySelector<HTMLElement>(".session-terminal-slot");
+    expect(focusedSession).not.toBeNull();
+    const focusTarget = document.createElement("button");
+    focusedSession?.append(focusTarget);
+    focusTarget.focus();
+
+    focusTarget.blur();
+    expect(document.activeElement).toBe(document.body);
+    visibilityState.mockReturnValue("hidden");
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    await view.rerender({
+      component: DockedTerminalPanelTestHarness,
+      sessions: [sessions[1]!],
+      tree: { type: "leaf", id: "leaf-b", sessionKey: sessions[1]!.key },
+      activeSessionKey: sessions[1]!.key,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(document.activeElement).toBe(document.body);
   });
 });

--- a/frontend/src/lib/components/terminal/DockedTerminalPanel.test.ts
+++ b/frontend/src/lib/components/terminal/DockedTerminalPanel.test.ts
@@ -108,14 +108,25 @@ describe("DockedTerminalPanel", () => {
     expect(onResize).not.toHaveBeenCalled();
   });
 
-  it("claims input before a terminal child consumes wheel propagation", async () => {
+  it("reports input activation only when DOM focus enters the panel", async () => {
     const onInputActivate = vi.fn();
-    renderDockedTerminalPanel({ onInputActivate });
+    const onInputDeactivate = vi.fn();
+    renderDockedTerminalPanel({ onInputActivate, onInputDeactivate });
+    const panel = screen.getByRole("region", { name: "Terminal panel" });
     const child = screen.getByRole("separator", { name: "Resize terminal panel" });
     child.addEventListener("wheel", (event) => event.stopPropagation());
 
-    await fireEvent.wheel(child);
+    await fireEvent.wheel(panel);
+    await fireEvent.pointerDown(panel);
+
+    expect(onInputActivate).not.toHaveBeenCalled();
+
+    await fireEvent.focusIn(child);
 
     expect(onInputActivate).toHaveBeenCalledOnce();
+
+    await fireEvent.focusOut(child, { relatedTarget: document.body });
+
+    expect(onInputDeactivate).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/lib/components/terminal/DockedTerminalPanelTestHarness.svelte
+++ b/frontend/src/lib/components/terminal/DockedTerminalPanelTestHarness.svelte
@@ -13,6 +13,7 @@
     dragScope?: string;
     paneKeyForSession?: (sessionKey: string) => string | null;
     onInputActivate?: () => void;
+    onInputDeactivate?: () => void;
   }
 
   let {
@@ -25,6 +26,7 @@
     dragScope = undefined,
     paneKeyForSession = undefined,
     onInputActivate = undefined,
+    onInputDeactivate = undefined,
   }: Props = $props();
 </script>
 
@@ -42,4 +44,5 @@
   {dragScope}
   {paneKeyForSession}
   {onInputActivate}
+  {onInputDeactivate}
 />

--- a/frontend/src/lib/components/terminal/DockedTerminalPanelTestHarness.svelte
+++ b/frontend/src/lib/components/terminal/DockedTerminalPanelTestHarness.svelte
@@ -12,6 +12,7 @@
     activeSessionKey?: string | null;
     dragScope?: string;
     paneKeyForSession?: (sessionKey: string) => string | null;
+    onInputActivate?: () => void;
   }
 
   let {
@@ -23,6 +24,7 @@
     activeSessionKey = null,
     dragScope = undefined,
     paneKeyForSession = undefined,
+    onInputActivate = undefined,
   }: Props = $props();
 </script>
 
@@ -39,4 +41,5 @@
   {onResize}
   {dragScope}
   {paneKeyForSession}
+  {onInputActivate}
 />

--- a/frontend/src/lib/components/terminal/InlineWorkspacePaneHarness.svelte
+++ b/frontend/src/lib/components/terminal/InlineWorkspacePaneHarness.svelte
@@ -36,7 +36,7 @@
 
 <div class="harness-root">
   <DetailPaneLayout {layout} {tabs}>
-    {#snippet renderPane(tabKey, visible)}
+    {#snippet renderPane(tabKey, visible, _inputActive)}
       {#if tabKey === "workspace" && visible && controller}
         <div class="harness-workspace-slot" {@attach controller.slotAttachment}></div>
       {:else if tabKey === "workspace" && visible}

--- a/frontend/src/lib/components/terminal/WorkflowSplitTree.svelte
+++ b/frontend/src/lib/components/terminal/WorkflowSplitTree.svelte
@@ -46,6 +46,7 @@
     node: WorkflowNode;
     tabs: WorkflowTabDescriptor[];
     activeTabKey: WorkflowTabKey;
+    inputActive?: boolean;
     renderTab: Snippet<[WorkflowTabKey, boolean]>;
     disabled?: boolean;
     onSelectTab?: ((tabKey: WorkflowTabKey) => void) | undefined;
@@ -75,6 +76,7 @@
     node,
     tabs,
     activeTabKey,
+    inputActive = true,
     renderTab: renderWorkflowTab,
     disabled = false,
     onSelectTab,
@@ -150,6 +152,7 @@
   {node}
   {tabs}
   {activeTabKey}
+  {inputActive}
   {disabled}
   tablistLabel="Workflow group tabs"
   leafLabel="Workflow group"

--- a/frontend/src/lib/components/terminal/WorkflowSplitTree.svelte
+++ b/frontend/src/lib/components/terminal/WorkflowSplitTree.svelte
@@ -49,6 +49,7 @@
     renderTab: Snippet<[WorkflowTabKey, boolean]>;
     disabled?: boolean;
     onSelectTab?: ((tabKey: WorkflowTabKey) => void) | undefined;
+    onFocusPane?: ((tabKey: WorkflowTabKey) => void) | undefined;
     onMoveTabBefore?:
       | ((sourceTabKey: WorkflowTabKey, targetTabKey: WorkflowTabKey) => void)
       | undefined;
@@ -77,6 +78,7 @@
     renderTab: renderWorkflowTab,
     disabled = false,
     onSelectTab,
+    onFocusPane,
     onMoveTabBefore,
     onAppendTabToLeaf,
     onSplitTab,
@@ -156,6 +158,10 @@
   onSelectTab={(tabKey) => {
     if (disabled) return;
     onSelectTab?.(workflowTabFrom(tabKey));
+  }}
+  onFocusPane={(tabKey) => {
+    if (disabled) return;
+    onFocusPane?.(workflowTabFrom(tabKey));
   }}
   onMoveTabBefore={(source, target) =>
     !disabled && onMoveTabBefore?.(workflowTabFrom(source), workflowTabFrom(target))}

--- a/frontend/src/lib/components/terminal/WorkflowSplitTree.svelte
+++ b/frontend/src/lib/components/terminal/WorkflowSplitTree.svelte
@@ -163,7 +163,6 @@
     onSelectTab?.(workflowTabFrom(tabKey));
   }}
   onFocusPane={(tabKey) => {
-    if (disabled) return;
     onFocusPane?.(workflowTabFrom(tabKey));
   }}
   onMoveTabBefore={(source, target) =>

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.host-visible.browser.svelte.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.host-visible.browser.svelte.ts
@@ -210,6 +210,61 @@ describe("WorkspaceTerminalView hostVisible", () => {
     await Effect.runPromise(runtime.disposeEffect);
   });
 
+  it("clears workflow focus ownership when the host is parked", async () => {
+    const api = createMockApiFetch([
+      (request) =>
+        request.url.pathname === "/api/v1/workspaces/ws-1/runtime" && request.method === "GET"
+          ? jsonResponse(agentRuntime)
+          : null,
+      workspaceRoutes(),
+    ]);
+    const originalFetch = globalThis.fetch;
+    const originalEventSource = globalThis.EventSource;
+    globalThis.fetch = api.fetch;
+    globalThis.EventSource = NoopEventSource as unknown as typeof EventSource;
+    vi.stubGlobal("WebSocket", ControlledWebSocket);
+    localStorage.setItem("kenn-forge-workspace-active-tab:ws-1", "session:ws-1:helper");
+
+    let hostVisible = $state(true);
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const settingsStore = createSettingsStore();
+    const instance = mount(WorkspaceTerminalView, {
+      target,
+      props: {
+        runtime,
+        workspaceId: "ws-1",
+        hideWorkspaceList: true,
+        hideRightSidebar: true,
+        get hostVisible() {
+          return hostVisible;
+        },
+      },
+      context: new Map([[STORES_KEY, { settings: settingsStore }]]),
+    });
+
+    try {
+      await vi.waitFor(() => expect(target.querySelector(".xterm-helper-textarea")).not.toBeNull(), WAIT);
+      const terminalInput = target.querySelector<HTMLElement>(".xterm-helper-textarea");
+      if (terminalInput === null) throw new Error("agent terminal focus target was not created");
+
+      terminalInput.focus();
+      await vi.waitFor(() => expect(target.querySelectorAll(".workspace-stage .input-active")).toHaveLength(1), WAIT);
+
+      hostVisible = false;
+      flushSync();
+
+      expect(target.querySelectorAll(".workspace-stage .input-active")).toHaveLength(0);
+    } finally {
+      flushSync(() => unmount(instance));
+      target.remove();
+      globalThis.fetch = originalFetch;
+      globalThis.EventSource = originalEventSource;
+      vi.unstubAllGlobals();
+      localStorage.removeItem("kenn-forge-workspace-active-tab:ws-1");
+    }
+  });
+
   it("unmounts an open dialog while hidden and restores it when visible", async () => {
     const api = createMockApiFetch([workspaceRoutes()]);
     const originalFetch = globalThis.fetch;

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -1573,6 +1573,14 @@
   $effect(() => {
     if (!hostVisible || hideRightSidebar || !workspaceContainerInputActive) return;
     function onKeydown(e: KeyboardEvent): void {
+      const focusTarget = e.target instanceof Node ? e.target : document.activeElement;
+      if (
+        focusTarget !== null &&
+        focusTarget !== document.body &&
+        workspaceRoot?.contains(focusTarget) !== true
+      ) {
+        return;
+      }
       if (
         e.key === "]" &&
         (e.metaKey || e.ctrlKey) &&

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -678,7 +678,7 @@
   type WorkspaceInputRegion = "workflow" | "details" | "terminal";
   let workspaceInputRegion = $state<WorkspaceInputRegion>("workflow");
   const workspaceContainerInputActive = $derived(
-    surfaceLayout === null || surfaceLayout.lastFocusedTabKey() === "workspace",
+    surfaceLayout === null || surfaceLayout.paneRender()?.activeInputTabKey === "workspace",
   );
   const renderedWorkspaceInputRegion = $derived.by<WorkspaceInputRegion>(() => {
     if (workspaceInputRegion === "details" && (hideRightSidebar || !sidebarOpen)) return "workflow";
@@ -1209,6 +1209,13 @@
       terminalLayout.dock === "bottom" &&
       terminalSessions.length > 0,
   );
+  const externalDockVisible = $derived(workspacePaneEmpty || workspacePaneRowOnly);
+
+  $effect(() => {
+    const layout = surfaceLayout;
+    if (layout === null || externalDockVisible) return;
+    untrack(() => layout.setExternalInputActive(false));
+  });
   const externalControlsVisible = $derived(
     workspacePaneEmpty ||
       workspacePaneRowOnly ||
@@ -1478,7 +1485,7 @@
   // is parked in a hidden host (it would swallow Cmd/Ctrl+] on unrelated
   // pages) or while the right sidebar isn't rendered at all.
   $effect(() => {
-    if (!hostVisible || hideRightSidebar) return;
+    if (!hostVisible || hideRightSidebar || !workspaceContainerInputActive) return;
     function onKeydown(e: KeyboardEvent): void {
       if (
         e.key === "]" &&
@@ -4522,8 +4529,13 @@
                 loading={terminalLaunching}
                 disabled={actionsBlocked}
                 hostVisible={dockHostVisible}
-                inputActive={workspaceContainerInputActive && renderedWorkspaceInputRegion === "terminal"}
-                onInputActivate={() => activateWorkspaceInputRegion("terminal")}
+                inputActive={external
+                  ? (surfaceLayout?.externalInputActive() ?? false)
+                  : workspaceContainerInputActive && renderedWorkspaceInputRegion === "terminal"}
+                onInputActivate={() => {
+                  activateWorkspaceInputRegion("terminal");
+                  if (external) surfaceLayout?.setExternalInputActive(true);
+                }}
                 onToggle={() => void toggleTerminalPanel()}
                 onNewTerminal={() => void launchTerminalSession()}
                 onSplit={(direction) => void splitTerminal(direction)}

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -65,6 +65,7 @@
     createTerminalGroup,
     defaultTerminalLayout,
     findLeafBySession,
+    findWorkflowLeafByTab,
     firstLeaf,
     moveWorkflowTabBefore,
     normalizeTerminalLayout,
@@ -676,11 +677,14 @@
   // record of which sessions have been promoted out of this container.
   const surfaceLayout = $derived(paneSurface ? getPaneLayoutStore(paneSurface) : null);
   type WorkspaceInputRegion = "workflow" | "details" | "terminal";
+  let workspaceRoot = $state<HTMLElement | null>(null);
   let workspaceInputRegion = $state<WorkspaceInputRegion | null>(null);
+  let focusedWorkflowTabKey = $state<WorkflowTabKey | null>(null);
   const workspaceContainerInputActive = $derived(
     surfaceLayout === null || surfaceLayout.paneRender()?.activeInputTabKey === "workspace",
   );
   const renderedWorkspaceInputRegion = $derived.by<WorkspaceInputRegion | null>(() => {
+    if (!hostVisible) return null;
     if (workspaceInputRegion === "details" && (hideRightSidebar || !sidebarOpen)) return null;
     if (workspaceInputRegion === "terminal" && terminalLayout.dock !== "bottom") {
       return null;
@@ -690,6 +694,7 @@
 
   $effect(() => {
     if (workspaceInputRegion !== null && renderedWorkspaceInputRegion === null) {
+      if (workspaceInputRegion === "workflow") focusedWorkflowTabKey = null;
       workspaceInputRegion = null;
     }
   });
@@ -704,7 +709,10 @@
   ): void {
     const next = event.relatedTarget;
     if (next instanceof Node && event.currentTarget.contains(next)) return;
-    if (workspaceInputRegion === region) workspaceInputRegion = null;
+    if (workspaceInputRegion === region) {
+      if (region === "workflow") focusedWorkflowTabKey = null;
+      workspaceInputRegion = null;
+    }
   }
 
   function sessionPaneKeyFor(session: RuntimeSession): string {
@@ -1211,6 +1219,42 @@
           workflowTabDescriptors.map((tab) => tab.key),
       ),
   );
+  function workflowContentKeyFor(tabKey: WorkflowTabKey | null): string | null {
+    if (tabKey === null) return soleEmbeddedSessionHostKey;
+    const leaf = findWorkflowLeafByTab(renderedWorkflowTree, tabKey);
+    return leaf === null ? null : `${leaf.id}|${leaf.activeTabKey}`;
+  }
+
+  const workflowInputContentKey = $derived(workflowContentKeyFor(focusedWorkflowTabKey));
+  let lastWorkflowInputContentKey = untrack(() => workflowInputContentKey);
+
+  $effect.pre(() => {
+    const contentKey = workflowInputContentKey;
+    const contentChanged = contentKey !== lastWorkflowInputContentKey;
+    lastWorkflowInputContentKey = contentKey;
+    const shouldRestore = untrack(() => workspaceInputRegion === "workflow" && hostVisible);
+    if (!contentChanged || !shouldRestore) return;
+    // A focused session can disappear without focusout. Inspect the updated DOM
+    // before clearing ownership or moving focus; a live destination always wins.
+    const execution = appRuntime.runCommand(
+      Effect.promise(() => tick()).pipe(
+        Effect.andThen(Effect.sync(() => {
+          if (!hostVisible) return;
+          const focused = document.activeElement;
+          if (focused !== null && focused !== document.body) return;
+          focusedWorkflowTabKey = null;
+          workspaceInputRegion = null;
+          workspaceRoot?.focus();
+        })),
+      ),
+      {
+        operation: "workspace.restore.focus",
+        safeContext: { surface: "workspace", region: "workflow" },
+        onFailure: () => undefined,
+      },
+    );
+    return execution.interrupt;
+  });
   const workspacePaneEmpty = $derived(
     controlsInPane &&
       runtimeSessions.length > 0 &&
@@ -1915,6 +1959,12 @@
     const sessionKey = sessionKeyFromWorkflowTab(key);
     if (sessionKey) mountSessionTerminal(sessionKey);
     selectWorkspaceTab(key);
+  }
+
+  function handleWorkflowPaneFocus(key: WorkflowTabKey): void {
+    focusedWorkflowTabKey = key;
+    lastWorkflowInputContentKey = workflowContentKeyFor(key);
+    handleWorkflowTabActivation(key);
   }
 
   function restoreWorkspaceTabSelection(key: WorkflowTabKey): void {
@@ -3850,6 +3900,8 @@
 
 <div
   class="terminal-view"
+  bind:this={workspaceRoot}
+  tabindex="-1"
   inert={modalOpen}
 >
   {#snippet inlineCollapseControl()}
@@ -4203,7 +4255,7 @@
                       inputActive={workspaceContainerInputActive && renderedWorkspaceInputRegion === "workflow"}
                       disabled={actionsBlocked}
                       onSelectTab={handleWorkflowTabActivation}
-                      onFocusPane={handleWorkflowTabActivation}
+                      onFocusPane={handleWorkflowPaneFocus}
                       onMoveTabBefore={moveWorkflowTabBeforeTarget}
                       onAppendTabToLeaf={appendWorkflowTabToGroup}
                       onSplitTab={splitWorkflowTabIntoGroup}

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -1285,7 +1285,10 @@
     // A focused session can disappear without focusout. Inspect the updated DOM
     // before clearing ownership or moving focus. Connected pooled terminals own
     // their reparenting handoff; only disconnected content falls back to the root.
-    const execution = appRuntime.runCommand(
+    // Focusout can clear the recorded tab while the DOM update is settling.
+    // Keep this bounded recovery independent of that effect rerun so it still
+    // gets to inspect the updated DOM and restore a disconnected descendant.
+    appRuntime.runCommand(
       Effect.promise(() => tick()).pipe(
         Effect.andThen(Effect.sync(() => {
           if (!hostVisible) return;
@@ -1304,7 +1307,6 @@
         onFailure: () => undefined,
       },
     );
-    return execution.interrupt;
   });
   const workspacePaneEmpty = $derived(
     controlsInPane &&

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -1213,8 +1213,9 @@
 
   $effect(() => {
     const layout = surfaceLayout;
-    if (layout === null || externalDockVisible) return;
-    untrack(() => layout.setExternalInputActive(false));
+    if (layout === null) return;
+    if (!externalDockVisible) untrack(() => layout.setExternalInputActive(false));
+    return () => untrack(() => layout.setExternalInputActive(false));
   });
   const externalControlsVisible = $derived(
     workspacePaneEmpty ||

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -692,6 +692,35 @@
     return workspaceInputRegion;
   });
 
+  $effect.pre(() => {
+    const detailsVisible = hostVisible && !hideRightSidebar && sidebarOpen;
+    const terminalVisible = hostVisible && terminalLayout.dock === "bottom";
+    const focusedRegion = untrack(() => workspaceInputRegion);
+    const focusedRegionDisappears =
+      (focusedRegion === "details" && !detailsVisible) ||
+      (focusedRegion === "terminal" && !terminalVisible);
+    if (!focusedRegionDisappears || !hostVisible) return;
+
+    // Capture disappearance before Svelte removes the focused region. Chromium
+    // then reports focusout after the DOM update, which is too late to know which
+    // workspace sibling owned focus. Reclaim only when the browser has nowhere
+    // better to put it; a replacement control or modal always keeps ownership.
+    const execution = appRuntime.runCommand(
+      Effect.promise(() => tick()).pipe(
+        Effect.andThen(Effect.sync(() => {
+          if (!hostVisible || document.activeElement !== document.body) return;
+          workspaceRoot?.focus();
+        })),
+      ),
+      {
+        operation: "workspace.restore.focus",
+        safeContext: { surface: "workspace", region: focusedRegion },
+        onFailure: () => undefined,
+      },
+    );
+    return execution.interrupt;
+  });
+
   $effect(() => {
     if (workspaceInputRegion !== null && renderedWorkspaceInputRegion === null) {
       if (workspaceInputRegion === "workflow") focusedWorkflowTabKey = null;
@@ -1547,7 +1576,8 @@
       if (
         e.key === "]" &&
         (e.metaKey || e.ctrlKey) &&
-        !e.defaultPrevented
+        !e.defaultPrevented &&
+        getStackDepth() === 0
       ) {
         e.preventDefault();
         toggleRightSidebar();

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -1868,6 +1868,16 @@
     rememberActiveTab(key);
   }
 
+  function handleWorkflowTabActivation(key: WorkflowTabKey): void {
+    if (key === "terminal") {
+      terminalLayout = { ...terminalLayout, open: true };
+    }
+    if (key === activeTabKey) return;
+    const sessionKey = sessionKeyFromWorkflowTab(key);
+    if (sessionKey) mountSessionTerminal(sessionKey);
+    selectWorkspaceTab(key);
+  }
+
   function restoreWorkspaceTabSelection(key: WorkflowTabKey): void {
     activeTabKey = key;
     rememberActiveTab(key);
@@ -4150,14 +4160,8 @@
                       tabs={workflowTabDescriptors}
                       {activeTabKey}
                       disabled={actionsBlocked}
-                      onSelectTab={(tabKey) => {
-                        if (tabKey === "terminal") {
-                          terminalLayout = { ...terminalLayout, open: true };
-                        }
-                        const sessionKey = sessionKeyFromWorkflowTab(tabKey);
-                        if (sessionKey) mountSessionTerminal(sessionKey);
-                        selectWorkspaceTab(tabKey);
-                      }}
+                      onSelectTab={handleWorkflowTabActivation}
+                      onFocusPane={handleWorkflowTabActivation}
                       onMoveTabBefore={moveWorkflowTabBeforeTarget}
                       onAppendTabToLeaf={appendWorkflowTabToGroup}
                       onSplitTab={splitWorkflowTabIntoGroup}

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -685,7 +685,13 @@
   );
   const renderedWorkspaceInputRegion = $derived.by<WorkspaceInputRegion | null>(() => {
     if (!hostVisible) return null;
-    if (workspaceInputRegion === "details" && (hideRightSidebar || !sidebarOpen)) return null;
+    if (workspaceInputRegion === "workflow" && !runtimeLive) return null;
+    if (
+      workspaceInputRegion === "details" &&
+      (!workspaceDetailsReady || hideRightSidebar || !sidebarOpen)
+    ) {
+      return null;
+    }
     if (workspaceInputRegion === "terminal" && terminalLayout.dock !== "bottom") {
       return null;
     }
@@ -693,10 +699,13 @@
   });
 
   $effect.pre(() => {
-    const detailsVisible = hostVisible && !hideRightSidebar && sidebarOpen;
+    const workflowVisible = hostVisible && runtimeLive;
+    const detailsVisible =
+      hostVisible && workspaceDetailsReady && !hideRightSidebar && sidebarOpen;
     const terminalVisible = hostVisible && terminalLayout.dock === "bottom";
     const focusedRegion = untrack(() => workspaceInputRegion);
     const focusedRegionDisappears =
+      (focusedRegion === "workflow" && !workflowVisible) ||
       (focusedRegion === "details" && !detailsVisible) ||
       (focusedRegion === "terminal" && !terminalVisible);
     if (!focusedRegionDisappears || !hostVisible) return;
@@ -705,7 +714,10 @@
     // then reports focusout after the DOM update, which is too late to know which
     // workspace sibling owned focus. Reclaim only when the browser has nowhere
     // better to put it; a replacement control or modal always keeps ownership.
-    const execution = appRuntime.runCommand(
+    // Readiness settles in phases during a workspace switch. Keep this bounded
+    // one-tick command independent of effect reruns so the next phase cannot
+    // interrupt the recovery before it observes the updated DOM.
+    appRuntime.runCommand(
       Effect.promise(() => tick()).pipe(
         Effect.andThen(Effect.sync(() => {
           if (!hostVisible || document.activeElement !== document.body) return;
@@ -718,7 +730,6 @@
         onFailure: () => undefined,
       },
     );
-    return execution.interrupt;
   });
 
   $effect(() => {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -675,6 +675,22 @@
   // The surface this view is embedded in, whose stored pane tree is the sole
   // record of which sessions have been promoted out of this container.
   const surfaceLayout = $derived(paneSurface ? getPaneLayoutStore(paneSurface) : null);
+  type WorkspaceInputRegion = "workflow" | "details" | "terminal";
+  let workspaceInputRegion = $state<WorkspaceInputRegion>("workflow");
+  const workspaceContainerInputActive = $derived(
+    surfaceLayout === null || surfaceLayout.lastFocusedTabKey() === "workspace",
+  );
+  const renderedWorkspaceInputRegion = $derived.by<WorkspaceInputRegion>(() => {
+    if (workspaceInputRegion === "details" && (hideRightSidebar || !sidebarOpen)) return "workflow";
+    if (workspaceInputRegion === "terminal" && (!terminalLayout.open || terminalLayout.dock !== "bottom")) {
+      return "workflow";
+    }
+    return workspaceInputRegion;
+  });
+
+  function activateWorkspaceInputRegion(region: WorkspaceInputRegion): void {
+    workspaceInputRegion = region;
+  }
 
   function sessionPaneKeyFor(session: RuntimeSession): string {
     return sessionPaneKey(workspaceId, workspaceHostKey, session.key);
@@ -1336,9 +1352,11 @@
     if (actionsBlocked) return;
     if (sidebarOpen && sidebarTab === tab) {
       sidebarOpen = false;
+      activateWorkspaceInputRegion("workflow");
     } else {
       setSidebarTab(tab);
       sidebarOpen = true;
+      activateWorkspaceInputRegion("details");
     }
   }
 
@@ -1383,6 +1401,7 @@
 
   function toggleRightSidebar(): void {
     sidebarOpen = !sidebarOpen;
+    activateWorkspaceInputRegion(sidebarOpen ? "details" : "workflow");
   }
 
   function handleWorkspaceListResize(width: number): void {
@@ -4135,6 +4154,9 @@
                 class="workspace-stage"
                 role="region"
                 aria-label="Workflow panes"
+                onfocusin={() => activateWorkspaceInputRegion("workflow")}
+                onpointerdown={() => activateWorkspaceInputRegion("workflow")}
+                onwheel={() => activateWorkspaceInputRegion("workflow")}
                 ondragover={handleWorkflowDragOver}
                 ondrop={handleWorkflowDrop}
               >
@@ -4159,6 +4181,7 @@
                       node={renderedWorkflowTree}
                       tabs={workflowTabDescriptors}
                       {activeTabKey}
+                      inputActive={workspaceContainerInputActive && renderedWorkspaceInputRegion === "workflow"}
                       disabled={actionsBlocked}
                       onSelectTab={handleWorkflowTabActivation}
                       onFocusPane={handleWorkflowTabActivation}
@@ -4275,8 +4298,18 @@
               onResize={handleSidebarResize}
             />
             <div
-              class="right-sidebar"
+              class={[
+                "right-sidebar",
+                {
+                  "input-active": workspaceContainerInputActive && renderedWorkspaceInputRegion === "details",
+                },
+              ]}
               style="width: {renderedRightSidebarWidth}px"
+              role="region"
+              aria-label="Workspace details pane"
+              onfocusin={() => activateWorkspaceInputRegion("details")}
+              onpointerdown={() => activateWorkspaceInputRegion("details")}
+              onwheel={() => activateWorkspaceInputRegion("details")}
             >
               {#if workspaceDetailsReady && workspace}
                 {#snippet kataTaskPanel()}
@@ -4489,6 +4522,8 @@
                 loading={terminalLaunching}
                 disabled={actionsBlocked}
                 hostVisible={dockHostVisible}
+                inputActive={workspaceContainerInputActive && renderedWorkspaceInputRegion === "terminal"}
+                onInputActivate={() => activateWorkspaceInputRegion("terminal")}
                 onToggle={() => void toggleTerminalPanel()}
                 onNewTerminal={() => void launchTerminalSession()}
                 onSplit={(direction) => void splitTerminal(direction)}
@@ -5101,6 +5136,16 @@
     z-index: 2;
     flex-shrink: 0;
     overflow: hidden;
+  }
+
+  .right-sidebar.input-active::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 90;
+    border: var(--chrome-border-width) solid
+      color-mix(in srgb, var(--accent-blue) 48%, var(--border-default));
+    pointer-events: none;
   }
 
   .right-sidebar:has(:global(.kit-modal-overlay)) {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -676,20 +676,35 @@
   // record of which sessions have been promoted out of this container.
   const surfaceLayout = $derived(paneSurface ? getPaneLayoutStore(paneSurface) : null);
   type WorkspaceInputRegion = "workflow" | "details" | "terminal";
-  let workspaceInputRegion = $state<WorkspaceInputRegion>("workflow");
+  let workspaceInputRegion = $state<WorkspaceInputRegion | null>(null);
   const workspaceContainerInputActive = $derived(
     surfaceLayout === null || surfaceLayout.paneRender()?.activeInputTabKey === "workspace",
   );
-  const renderedWorkspaceInputRegion = $derived.by<WorkspaceInputRegion>(() => {
-    if (workspaceInputRegion === "details" && (hideRightSidebar || !sidebarOpen)) return "workflow";
-    if (workspaceInputRegion === "terminal" && (!terminalLayout.open || terminalLayout.dock !== "bottom")) {
-      return "workflow";
+  const renderedWorkspaceInputRegion = $derived.by<WorkspaceInputRegion | null>(() => {
+    if (workspaceInputRegion === "details" && (hideRightSidebar || !sidebarOpen)) return null;
+    if (workspaceInputRegion === "terminal" && terminalLayout.dock !== "bottom") {
+      return null;
     }
     return workspaceInputRegion;
   });
 
+  $effect(() => {
+    if (workspaceInputRegion !== null && renderedWorkspaceInputRegion === null) {
+      workspaceInputRegion = null;
+    }
+  });
+
   function activateWorkspaceInputRegion(region: WorkspaceInputRegion): void {
     workspaceInputRegion = region;
+  }
+
+  function deactivateWorkspaceInputRegion(
+    region: WorkspaceInputRegion,
+    event: FocusEvent & { currentTarget: HTMLElement },
+  ): void {
+    const next = event.relatedTarget;
+    if (next instanceof Node && event.currentTarget.contains(next)) return;
+    if (workspaceInputRegion === region) workspaceInputRegion = null;
   }
 
   function sessionPaneKeyFor(session: RuntimeSession): string {
@@ -1360,11 +1375,9 @@
     if (actionsBlocked) return;
     if (sidebarOpen && sidebarTab === tab) {
       sidebarOpen = false;
-      activateWorkspaceInputRegion("workflow");
     } else {
       setSidebarTab(tab);
       sidebarOpen = true;
-      activateWorkspaceInputRegion("details");
     }
   }
 
@@ -1409,7 +1422,6 @@
 
   function toggleRightSidebar(): void {
     sidebarOpen = !sidebarOpen;
-    activateWorkspaceInputRegion(sidebarOpen ? "details" : "workflow");
   }
 
   function handleWorkspaceListResize(width: number): void {
@@ -4163,8 +4175,7 @@
                 role="region"
                 aria-label="Workflow panes"
                 onfocusin={() => activateWorkspaceInputRegion("workflow")}
-                onpointerdown={() => activateWorkspaceInputRegion("workflow")}
-                onwheel={() => activateWorkspaceInputRegion("workflow")}
+                onfocusout={(event) => deactivateWorkspaceInputRegion("workflow", event)}
                 ondragover={handleWorkflowDragOver}
                 ondrop={handleWorkflowDrop}
               >
@@ -4316,8 +4327,7 @@
               role="region"
               aria-label="Workspace details pane"
               onfocusin={() => activateWorkspaceInputRegion("details")}
-              onpointerdown={() => activateWorkspaceInputRegion("details")}
-              onwheel={() => activateWorkspaceInputRegion("details")}
+              onfocusout={(event) => deactivateWorkspaceInputRegion("details", event)}
             >
               {#if workspaceDetailsReady && workspace}
                 {#snippet kataTaskPanel()}
@@ -4536,6 +4546,10 @@
                 onInputActivate={() => {
                   activateWorkspaceInputRegion("terminal");
                   if (external) surfaceLayout?.setExternalInputActive(true);
+                }}
+                onInputDeactivate={() => {
+                  if (workspaceInputRegion === "terminal") workspaceInputRegion = null;
+                  if (external) surfaceLayout?.setExternalInputActive(false);
                 }}
                 onToggle={() => void toggleTerminalPanel()}
                 onNewTerminal={() => void launchTerminalSession()}

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -680,6 +680,7 @@
   let workspaceRoot = $state<HTMLElement | null>(null);
   let workspaceInputRegion = $state<WorkspaceInputRegion | null>(null);
   let focusedWorkflowTabKey = $state<WorkflowTabKey | null>(null);
+  let focusedWorkflowInputElement: HTMLElement | null = null;
   const workspaceContainerInputActive = $derived(
     surfaceLayout === null || surfaceLayout.paneRender()?.activeInputTabKey === "workspace",
   );
@@ -734,7 +735,10 @@
 
   $effect(() => {
     if (workspaceInputRegion !== null && renderedWorkspaceInputRegion === null) {
-      if (workspaceInputRegion === "workflow") focusedWorkflowTabKey = null;
+      if (workspaceInputRegion === "workflow") {
+        focusedWorkflowTabKey = null;
+        focusedWorkflowInputElement = null;
+      }
       workspaceInputRegion = null;
     }
   });
@@ -750,7 +754,10 @@
     const next = event.relatedTarget;
     if (next instanceof Node && event.currentTarget.contains(next)) return;
     if (workspaceInputRegion === region) {
-      if (region === "workflow") focusedWorkflowTabKey = null;
+      if (region === "workflow") {
+        focusedWorkflowTabKey = null;
+        focusedWorkflowInputElement = null;
+      }
       workspaceInputRegion = null;
     }
   }
@@ -1274,8 +1281,10 @@
     lastWorkflowInputContentKey = contentKey;
     const shouldRestore = untrack(() => workspaceInputRegion === "workflow" && hostVisible);
     if (!contentChanged || !shouldRestore) return;
+    const focusedInput = untrack(() => focusedWorkflowInputElement);
     // A focused session can disappear without focusout. Inspect the updated DOM
-    // before clearing ownership or moving focus; a live destination always wins.
+    // before clearing ownership or moving focus. Connected pooled terminals own
+    // their reparenting handoff; only disconnected content falls back to the root.
     const execution = appRuntime.runCommand(
       Effect.promise(() => tick()).pipe(
         Effect.andThen(Effect.sync(() => {
@@ -1283,7 +1292,9 @@
           const focused = document.activeElement;
           if (focused !== null && focused !== document.body) return;
           focusedWorkflowTabKey = null;
+          focusedWorkflowInputElement = null;
           workspaceInputRegion = null;
+          if (focusedInput?.isConnected) return;
           workspaceRoot?.focus();
         })),
       ),
@@ -4275,7 +4286,11 @@
                 class="workspace-stage"
                 role="region"
                 aria-label="Workflow panes"
-                onfocusin={() => activateWorkspaceInputRegion("workflow")}
+                onfocusin={(event) => {
+                  activateWorkspaceInputRegion("workflow");
+                  focusedWorkflowInputElement =
+                    event.target instanceof HTMLElement ? event.target : null;
+                }}
                 onfocusout={(event) => deactivateWorkspaceInputRegion("workflow", event)}
                 ondragover={handleWorkflowDragOver}
                 ondrop={handleWorkflowDrop}

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -557,6 +557,7 @@ function persistedTwoSessionWorkflowLayout(firstKey: string, secondKey: string) 
  */
 function noteWorkspacePaneRendered(surface: "prs" | "issues" | "activity"): void {
   getPaneLayoutStore(surface).notePaneRender({
+    activeInputTabKey: "workspace",
     editableTabs: ["conversation", "workspace"],
     onScreenTabs: ["conversation", "workspace"],
     flattened: false,
@@ -929,7 +930,7 @@ describe("WorkspaceTerminalView", () => {
       },
     });
 
-    await screen.findByRole("tab", { name: /Helper/ });
+    await screen.findByRole("region", { name: "Workflow panes" });
     await waitFor(() => expect(sockets).toHaveLength(1));
 
     sockets[0]!.onmessage?.(
@@ -3203,6 +3204,7 @@ describe("WorkspaceTerminalView", () => {
     // here leaves nothing on screen naming it - the inner strip is the one bar
     // that pane has.
     getPaneLayoutStore("prs").notePaneRender({
+      activeInputTabKey: "workspace",
       editableTabs: ["conversation", "workspace"],
       onScreenTabs: ["conversation", "workspace"],
       flattened: false,
@@ -3267,7 +3269,7 @@ describe("WorkspaceTerminalView", () => {
     expect(activePaneKey()).toBe("session:ws-1:helper");
   });
 
-  it("does not paint a nested workflow owner while its outer detail pane is inactive", async () => {
+  it("uses the renderer-validated outer owner for nested workflow chrome", async () => {
     localStorage.setItem("kenn-forge-workspace-active-tab:ws-1", "session:ws-1:helper");
     localStorage.setItem(
       "kenn-forge-workspace-terminal-layout:ws-1",
@@ -3276,6 +3278,13 @@ describe("WorkspaceTerminalView", () => {
     mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithTwoWorkflowSessions());
     const surfaceLayout = getPaneLayoutStore("prs");
     surfaceLayout.noteFocused("conversation");
+    surfaceLayout.notePaneRender({
+      activeInputTabKey: "conversation",
+      editableTabs: ["conversation", "workspace"],
+      onScreenTabs: ["conversation", "workspace"],
+      flattened: false,
+      soloChromeTabs: [],
+    });
 
     render(WorkspaceTerminalView, {
       props: {
@@ -3288,8 +3297,53 @@ describe("WorkspaceTerminalView", () => {
     const activeWorkflowLeaves = () => document.querySelectorAll(".workspace-stage .tabbed-panel-leaf.input-active");
     expect(activeWorkflowLeaves()).toHaveLength(0);
 
-    surfaceLayout.noteFocused("workspace");
+    // The renderer can select workspace as a fallback while persisted focus still
+    // names a hidden or zoom-covered pane. Nested ownership follows this report,
+    // not the stale focus history.
+    surfaceLayout.notePaneRender({
+      activeInputTabKey: "workspace",
+      editableTabs: ["conversation", "workspace"],
+      onScreenTabs: ["workspace"],
+      flattened: false,
+      soloChromeTabs: ["workspace"],
+    });
     await waitFor(() => expect(activeWorkflowLeaves()).toHaveLength(1));
+  });
+
+  it("gates the workspace sidebar shortcut on the renderer-validated owner", async () => {
+    claimForPrs();
+    const surfaceLayout = getPaneLayoutStore("prs");
+    surfaceLayout.notePaneRender({
+      activeInputTabKey: "conversation",
+      editableTabs: ["conversation", "workspace"],
+      onScreenTabs: ["conversation", "workspace"],
+      flattened: false,
+      soloChromeTabs: [],
+    });
+
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+        paneSurface: "prs" as const,
+      },
+    });
+    await screen.findByRole("region", { name: "Workflow panes" });
+
+    await fireEvent.keyDown(window, { key: "]", ctrlKey: true });
+    expect(document.querySelector(".right-sidebar")).toBeNull();
+
+    surfaceLayout.notePaneRender({
+      activeInputTabKey: "workspace",
+      editableTabs: ["conversation", "workspace"],
+      onScreenTabs: ["conversation", "workspace"],
+      flattened: false,
+      soloChromeTabs: ["workspace"],
+    });
+    await waitFor(() =>
+      expect(document.querySelector(".workspace-stage .tabbed-panel-leaf.input-active")).not.toBeNull(),
+    );
+    await fireEvent.keyDown(window, { key: "]", ctrlKey: true });
+    expect(document.querySelector(".right-sidebar")).not.toBeNull();
   });
 
   it("keeps the workspace header for a sole standalone session", async () => {
@@ -4081,6 +4135,7 @@ describe("WorkspaceTerminalView", () => {
     // chrome suppressed, so the pane has nowhere to hang a controls button and no
     // tab of its own to name the session.
     getPaneLayoutStore("prs").notePaneRender({
+      activeInputTabKey: "workspace",
       flattened: true,
       editableTabs: [],
       onScreenTabs: ["workspace"],
@@ -4288,6 +4343,20 @@ describe("WorkspaceTerminalView", () => {
       expect(controller.dockRow()).not.toBeNull();
 
       const externalDock = await screen.findByRole("region", { name: "Terminal panel" });
+      const layout = getPaneLayoutStore("prs");
+      expect(layout.externalInputActive()).toBe(false);
+      await fireEvent.pointerDown(externalDock);
+      expect(layout.externalInputActive()).toBe(true);
+      expect(externalDock.classList.contains("input-active")).toBe(true);
+
+      layout.noteFocused(paneKey);
+      await waitFor(() => expect(layout.externalInputActive()).toBe(false));
+      expect(externalDock.classList.contains("input-active")).toBe(false);
+
+      await fireEvent.wheel(externalDock);
+      expect(layout.externalInputActive()).toBe(true);
+      expect(externalDock.classList.contains("input-active")).toBe(true);
+
       render(WorkspacePaneControls, { props: { showStripActions: false } });
       expect(screen.getAllByRole("button", { name: /^Delete workspace / })).toHaveLength(1);
       expect(screen.getAllByRole("button", { name: "Workspace controls" })).toHaveLength(2);
@@ -4304,7 +4373,6 @@ describe("WorkspaceTerminalView", () => {
 
       await fireEvent.click(within(externalDock).getByRole("button", { name: "Move Shell to a pane" }));
       const shellPaneKey = sessionPaneKey("ws-1", undefined, "ws-1_shell_a");
-      const layout = getPaneLayoutStore("prs");
       await waitFor(() => expect(layout.hasTab(shellPaneKey)).toBe(true));
 
       layout.demoteTab(shellPaneKey);

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -3241,7 +3241,7 @@ describe("WorkspaceTerminalView", () => {
     expect(await screen.findAllByRole("tablist", { name: "Workflow group tabs" })).not.toHaveLength(0);
   });
 
-  it("moves active input ownership between standalone workflow panes", async () => {
+  it("moves active input ownership only when standalone workflow focus moves", async () => {
     localStorage.setItem("kenn-forge-workspace-active-tab:ws-1", "session:ws-1:helper");
     localStorage.setItem(
       "kenn-forge-workspace-terminal-layout:ws-1",
@@ -3260,13 +3260,42 @@ describe("WorkspaceTerminalView", () => {
     const reviewerPane = document.querySelector<HTMLElement>('[data-pane-key="session:ws-1:reviewer"]')!;
     const activePaneKey = () =>
       document.querySelector(".tabbed-panel-leaf.input-active [data-pane-key]")?.getAttribute("data-pane-key");
-    expect(activePaneKey()).toBe("session:ws-1:helper");
+    expect(activePaneKey()).toBeUndefined();
 
     await fireEvent.pointerDown(reviewerPane);
+    await fireEvent.wheel(reviewerPane);
+    expect(activePaneKey()).toBeUndefined();
+
+    await fireEvent.focusIn(reviewerPane);
     expect(activePaneKey()).toBe("session:ws-1:reviewer");
 
     await fireEvent.wheel(helperPane);
+    await fireEvent.pointerDown(helperPane);
+    expect(activePaneKey()).toBe("session:ws-1:reviewer");
+
+    await fireEvent.focusIn(helperPane);
     expect(activePaneKey()).toBe("session:ws-1:helper");
+
+    await fireEvent.focusOut(helperPane, { relatedTarget: document.body });
+    expect(activePaneKey()).toBeUndefined();
+  });
+
+  it("keeps a focused bottom dock active while its header opens the panel", async () => {
+    localStorage.setItem("kenn-forge-workspace-active-tab:ws-1", "home");
+    mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithTerminalSession());
+
+    render(WorkspaceTerminalView, { props: { workspaceId: "ws-1" } });
+
+    const toggle = await screen.findByRole("button", { name: "Open terminal panel" });
+    const panel = toggle.closest(".terminal-panel");
+    expect(panel).not.toBeNull();
+
+    await fireEvent.focusIn(toggle);
+    expect(panel?.classList.contains("input-active")).toBe(true);
+
+    await fireEvent.click(toggle);
+    expect(panel?.classList.contains("open")).toBe(true);
+    expect(panel?.classList.contains("input-active")).toBe(true);
   });
 
   it("uses the renderer-validated outer owner for nested workflow chrome", async () => {
@@ -4358,17 +4387,21 @@ describe("WorkspaceTerminalView", () => {
       const externalDock = await screen.findByRole("region", { name: "Terminal panel" });
       const layout = getPaneLayoutStore("prs");
       expect(layout.externalInputActive()).toBe(false);
+      await fireEvent.wheel(externalDock);
       await fireEvent.pointerDown(externalDock);
+      expect(layout.externalInputActive()).toBe(false);
+      expect(externalDock.classList.contains("input-active")).toBe(false);
+
+      await fireEvent.focusIn(externalDock);
       expect(layout.externalInputActive()).toBe(true);
       expect(externalDock.classList.contains("input-active")).toBe(true);
 
       layout.noteFocused(paneKey);
-      await waitFor(() => expect(layout.externalInputActive()).toBe(false));
-      expect(externalDock.classList.contains("input-active")).toBe(false);
-
-      await fireEvent.wheel(externalDock);
       expect(layout.externalInputActive()).toBe(true);
-      expect(externalDock.classList.contains("input-active")).toBe(true);
+
+      await fireEvent.focusOut(externalDock, { relatedTarget: document.body });
+      expect(layout.externalInputActive()).toBe(false);
+      expect(externalDock.classList.contains("input-active")).toBe(false);
 
       render(WorkspacePaneControls, { props: { showStripActions: false } });
       expect(screen.getAllByRole("button", { name: /^Delete workspace / })).toHaveLength(1);

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -1,5 +1,6 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/svelte";
 import { Effect } from "effect";
+import { flushSync } from "svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { RuntimeSession } from "../../api/types.js";
 import { makeAppRuntime, type OwnedAppRuntime } from "../../app/runtime.js";
@@ -947,6 +948,75 @@ describe("WorkspaceTerminalView", () => {
     await waitFor(() => expect(screen.queryByRole("tab", { name: /Helper/ })).toBeNull());
     expect(screen.getByRole("tab", { name: /Home/ }).getAttribute("aria-selected")).toBe("true");
     expect(localStorage.getItem("kenn-forge-workspace-active-tab:ws-1")).toBe("home");
+  });
+
+  it("restores workspace focus when the focused workflow content exits", async () => {
+    localStorage.setItem(
+      "kenn-forge-workspace-terminal-layout:ws-1",
+      JSON.stringify({
+        version: 1,
+        open: false,
+        dock: "bottom",
+        height: 300,
+        activeSessionKey: null,
+        tree: null,
+        sessionRegions: { "ws-1:helper": "workflow", "ws-1:reviewer": "workflow" },
+        workflowMode: "tabs",
+        workflowTree: {
+          type: "leaf",
+          id: "wf-sessions",
+          tabs: ["session:ws-1:helper", "session:ws-1:reviewer"],
+          activeTabKey: "session:ws-1:helper",
+        },
+        customSessionLabels: {},
+      }),
+    );
+    mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithTwoWorkflowSessions());
+    claimForPrs();
+    noteWorkspacePaneRendered("prs");
+    const runCommand = mocks.runtime.runCommand.bind(mocks.runtime);
+    const recoveryStarted = deferred<void>();
+    const releaseRecovery = deferred<void>();
+    vi.spyOn(mocks.runtime, "runCommand").mockImplementation((program, options) =>
+      runCommand(
+        options.operation === "workspace.restore.focus"
+          ? Effect.sync(() => recoveryStarted.resolve()).pipe(
+              Effect.andThen(Effect.promise(() => releaseRecovery.promise)),
+              Effect.andThen(program),
+            )
+          : program,
+        options,
+      ),
+    );
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+        paneSurface: "prs" as const,
+      },
+    });
+
+    const focusTarget = await screen.findByRole("button", { name: "Move Helper to terminal" });
+    focusTarget.focus();
+    expect(document.activeElement).toBe(focusTarget);
+    const workflowStage = screen.getByRole("region", { name: "Workflow panes" });
+    await waitFor(() =>
+      expect(document.querySelectorAll(".workspace-stage .tabbed-panel-leaf.input-active")).toHaveLength(1),
+    );
+    await waitFor(() => expect(sockets).toHaveLength(1));
+
+    sockets[0]!.onmessage?.(
+      new MessageEvent("message", {
+        data: JSON.stringify({ type: "exited", code: 0 }),
+      }),
+    );
+    await recoveryStarted.promise;
+    workflowStage.dispatchEvent(new FocusEvent("focusout", { bubbles: true, relatedTarget: document.body }));
+    flushSync();
+    releaseRecovery.resolve();
+
+    await waitFor(() => expect(screen.queryByRole("tab", { name: /Helper/ })).toBeNull());
+    expect(focusTarget.isConnected).toBe(false);
+    await waitFor(() => expect(document.activeElement).toBe(document.querySelector(".terminal-view")));
   });
 
   it("starts the runtime request before workspace metadata resolves without fetching it twice", async () => {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -4297,6 +4297,19 @@ describe("WorkspaceTerminalView", () => {
     expect(activeHostedSession("prs")?.label).toBe("Helper");
   });
 
+  it("releases external input ownership when the hosted view leaves a surface", async () => {
+    const layout = getPaneLayoutStore("prs");
+    const { rerender } = render(WorkspaceTerminalView, {
+      props: { workspaceId: "ws-1", paneSurface: "prs" as const },
+    });
+    layout.setExternalInputActive(true);
+    expect(layout.externalInputActive()).toBe(true);
+
+    await rerender({ workspaceId: "ws-1", paneSurface: undefined });
+
+    expect(layout.externalInputActive()).toBe(false);
+  });
+
   describe("promoted sessions", () => {
     it("gives a parked row-only dock the sole workspace actions and live dialogs", async () => {
       localStorage.setItem(

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -5,6 +5,7 @@ import type { RuntimeSession } from "../../api/types.js";
 import { makeAppRuntime, type OwnedAppRuntime } from "../../app/runtime.js";
 import { createDiffStore } from "../../stores/diff.svelte.js";
 import { clearActiveTabbedPanelDrag, startTabbedPanelTabDrag } from "../shared/tabbed-panel-drag.js";
+import { pushModalFrame } from "../../stores/keyboard/modal-stack.svelte.js";
 import { getPaneLayoutStore, resetPaneLayoutStoresForTest } from "../../stores/paneLayout.svelte.js";
 import { sessionPaneKey } from "../../stores/session-pane-key.js";
 import {
@@ -3420,6 +3421,17 @@ describe("WorkspaceTerminalView", () => {
     );
     await fireEvent.keyDown(window, { key: "]", ctrlKey: true });
     expect(document.querySelector(".right-sidebar")).not.toBeNull();
+
+    await fireEvent.keyDown(window, { key: "]", ctrlKey: true });
+    expect(document.querySelector(".right-sidebar")).toBeNull();
+
+    const releaseModal = pushModalFrame("workspace-sidebar-shortcut-test", []);
+    try {
+      await fireEvent.keyDown(window, { key: "]", ctrlKey: true });
+      expect(document.querySelector(".right-sidebar")).toBeNull();
+    } finally {
+      releaseModal();
+    }
   });
 
   it("keeps the workspace header for a sole standalone session", async () => {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -3239,6 +3239,34 @@ describe("WorkspaceTerminalView", () => {
     expect(await screen.findAllByRole("tablist", { name: "Workflow group tabs" })).not.toHaveLength(0);
   });
 
+  it("moves active input ownership between standalone workflow panes", async () => {
+    localStorage.setItem("kenn-forge-workspace-active-tab:ws-1", "session:ws-1:helper");
+    localStorage.setItem(
+      "kenn-forge-workspace-terminal-layout:ws-1",
+      persistedTwoSessionWorkflowLayout("ws-1:helper", "ws-1:reviewer"),
+    );
+    mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithTwoWorkflowSessions());
+
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+      },
+    });
+
+    await screen.findByRole("tab", { name: /Reviewer/ });
+    const helperPane = document.querySelector<HTMLElement>('[data-pane-key="session:ws-1:helper"]')!;
+    const reviewerPane = document.querySelector<HTMLElement>('[data-pane-key="session:ws-1:reviewer"]')!;
+    const activePaneKey = () =>
+      document.querySelector(".tabbed-panel-leaf.input-active [data-pane-key]")?.getAttribute("data-pane-key");
+    expect(activePaneKey()).toBe("session:ws-1:helper");
+
+    await fireEvent.pointerDown(reviewerPane);
+    expect(activePaneKey()).toBe("session:ws-1:reviewer");
+
+    await fireEvent.wheel(helperPane);
+    expect(activePaneKey()).toBe("session:ws-1:helper");
+  });
+
   it("keeps the workspace header for a sole standalone session", async () => {
     render(WorkspaceTerminalView, {
       props: {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -1380,81 +1380,107 @@ describe("WorkspaceTerminalView", () => {
     });
   });
 
-  it("removes the old sidebar and waits for matching runtime before loading the new diff", async () => {
-    window.__BASE_PATH__ = window.location.origin;
-    localStorage.setItem("kenn-forge-workspace-sidebar-open", "true");
-    localStorage.setItem("kenn-forge-workspace-sidebar-tab:ws-1", "diff");
-    const workspaceB = { ...workspaceResponse, id: "ws-2", git_head_ref: "feature/two" };
-    const workspaceBGate = deferred<typeof workspaceB>();
-    const runtimeBGate = deferred<ReturnType<typeof runtimeWithStaleSession>>();
-    const eventListeners: Array<Record<string, (event: MessageEvent) => void>> = [];
-    const loadWorkspaceDiff = vi.spyOn(mocks.diffStore, "loadWorkspaceDiff").mockResolvedValue();
+  it.each(["details", "workflow"] as const)(
+    "releases %s focus while waiting for matching workspace state",
+    async (focusedRegion) => {
+      window.__BASE_PATH__ = window.location.origin;
+      localStorage.setItem("kenn-forge-workspace-sidebar-open", "true");
+      localStorage.setItem("kenn-forge-workspace-sidebar-tab:ws-1", "diff");
+      const workspaceB = { ...workspaceResponse, id: "ws-2", git_head_ref: "feature/two" };
+      const workspaceBGate = deferred<typeof workspaceB>();
+      const runtimeBGate = deferred<ReturnType<typeof runtimeWithStaleSession>>();
+      const eventListeners: Array<Record<string, (event: MessageEvent) => void>> = [];
+      const loadWorkspaceDiff = vi.spyOn(mocks.diffStore, "loadWorkspaceDiff").mockResolvedValue();
 
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockImplementation((input: Request | URL | string) => {
-        const path = fetchPath(input);
-        if (path.endsWith("/workspaces/ws-1")) return Promise.resolve(Response.json(workspaceResponse));
-        if (path.endsWith("/workspaces/ws-2")) {
-          return workspaceBGate.promise.then((workspace) => Response.json(workspace));
-        }
-        if (path.endsWith("/api/v1/workspaces")) {
-          return Promise.resolve(Response.json({ workspaces: [workspaceResponse, workspaceB] }));
-        }
-        return Promise.resolve(Response.json({}));
-      }),
-    );
-    vi.stubGlobal(
-      "EventSource",
-      class {
-        private listeners: Record<string, (event: MessageEvent) => void> = {};
-        constructor() {
-          eventListeners.push(this.listeners);
-        }
-        addEventListener(type: string, callback: (event: MessageEvent) => void): void {
-          this.listeners[type] = callback;
-        }
-        close(): void {}
-      },
-    );
-    mocks.getWorkspaceRuntime
-      .mockResolvedValueOnce(runtimeWithStaleSession())
-      .mockReturnValueOnce(runtimeBGate.promise);
-
-    const { rerender } = render(WorkspaceTerminalView, {
-      props: { workspaceId: "ws-1" },
-      context: new Map([[STORES_KEY, { diff: mocks.diffStore }]]),
-    });
-    await waitFor(() => expect(loadWorkspaceDiff).toHaveBeenCalledWith("ws-1", "head", false, expect.anything()));
-
-    await rerender({ workspaceId: "ws-2" });
-
-    // Liveness gating unmounts the stale ws-1 view entirely while ws-2
-    // loads: the old toolbar and sidebar are gone, not lingering behind
-    // action guards.
-    expect(await screen.findByText("Setting up workspace...")).toBeTruthy();
-    expect(screen.queryByRole("region", { name: "Workspace Diff" })).toBeNull();
-    expect(loadWorkspaceDiff).toHaveBeenCalledTimes(1);
-
-    eventListeners
-      .findLast((listeners) => listeners.workspace_diff_ready !== undefined)
-      ?.workspace_diff_ready?.(
-        new MessageEvent("workspace_diff_ready", {
-          data: JSON.stringify({ workspace_id: "ws-2", version: "generation:2" }),
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockImplementation((input: Request | URL | string) => {
+          const path = fetchPath(input);
+          if (path.endsWith("/workspaces/ws-1")) return Promise.resolve(Response.json(workspaceResponse));
+          if (path.endsWith("/workspaces/ws-2")) {
+            return workspaceBGate.promise.then((workspace) => Response.json(workspace));
+          }
+          if (path.endsWith("/api/v1/workspaces")) {
+            return Promise.resolve(Response.json({ workspaces: [workspaceResponse, workspaceB] }));
+          }
+          return Promise.resolve(Response.json({}));
         }),
       );
-    workspaceBGate.resolve(workspaceB);
-    // ws-2's payload landed but its runtime is still pending: the ready
-    // view mounts with the details-loading sub-state and the diff still
-    // waits for the matching runtime.
-    expect(await screen.findByText("Loading workspace details...")).toBeTruthy();
-    expect(screen.queryByRole("region", { name: "Workspace Diff" })).toBeNull();
-    expect(loadWorkspaceDiff).toHaveBeenCalledTimes(1);
+      vi.stubGlobal(
+        "EventSource",
+        class {
+          private listeners: Record<string, (event: MessageEvent) => void> = {};
+          constructor() {
+            eventListeners.push(this.listeners);
+          }
+          addEventListener(type: string, callback: (event: MessageEvent) => void): void {
+            this.listeners[type] = callback;
+          }
+          close(): void {}
+        },
+      );
+      mocks.getWorkspaceRuntime
+        .mockResolvedValueOnce(runtimeWithStaleSession())
+        .mockReturnValueOnce(runtimeBGate.promise);
 
-    runtimeBGate.resolve(runtimeWithStaleSession());
-    await waitFor(() => expect(loadWorkspaceDiff).toHaveBeenCalledWith("ws-2", "head", false, expect.anything()));
-    expect(screen.queryByText("Loading workspace details...")).toBeNull();
-  });
+      const { rerender } = render(WorkspaceTerminalView, {
+        props: { workspaceId: "ws-1" },
+        context: new Map([[STORES_KEY, { diff: mocks.diffStore }]]),
+      });
+      await waitFor(() => expect(loadWorkspaceDiff).toHaveBeenCalledWith("ws-1", "head", false, expect.anything()));
+
+      const inputOwner =
+        focusedRegion === "details"
+          ? await screen.findByRole("region", { name: "Workspace details pane" })
+          : await waitFor(() => {
+              const pane = document.querySelector<HTMLElement>('[data-pane-key="session:ws-1:helper"]');
+              expect(pane).not.toBeNull();
+              return pane!;
+            });
+      const focusTarget = document.createElement("button");
+      inputOwner.append(focusTarget);
+      focusTarget.focus();
+      expect(document.activeElement).toBe(focusTarget);
+      if (focusedRegion === "details") {
+        await waitFor(() => expect(inputOwner.classList.contains("input-active")).toBe(true));
+      } else {
+        await waitFor(() =>
+          expect(document.querySelectorAll(".workspace-stage .tabbed-panel-leaf.input-active")).toHaveLength(1),
+        );
+      }
+
+      await rerender({ workspaceId: "ws-2" });
+
+      // Liveness gating unmounts the stale ws-1 view entirely while ws-2
+      // loads: the old toolbar and sidebar are gone, not lingering behind
+      // action guards.
+      expect(await screen.findByText("Setting up workspace...")).toBeTruthy();
+      expect(screen.queryByRole("region", { name: "Workspace Diff" })).toBeNull();
+      expect(loadWorkspaceDiff).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(document.activeElement).toBe(document.querySelector(".terminal-view")));
+      expect(document.querySelector(".right-sidebar.input-active")).toBeNull();
+      expect(document.querySelector(".workspace-stage .tabbed-panel-leaf.input-active")).toBeNull();
+
+      eventListeners
+        .findLast((listeners) => listeners.workspace_diff_ready !== undefined)
+        ?.workspace_diff_ready?.(
+          new MessageEvent("workspace_diff_ready", {
+            data: JSON.stringify({ workspace_id: "ws-2", version: "generation:2" }),
+          }),
+        );
+      workspaceBGate.resolve(workspaceB);
+      // ws-2's payload landed but its runtime is still pending: the ready
+      // view mounts with the details-loading sub-state and the diff still
+      // waits for the matching runtime.
+      expect(await screen.findByText("Loading workspace details...")).toBeTruthy();
+      expect(screen.queryByRole("region", { name: "Workspace Diff" })).toBeNull();
+      expect(loadWorkspaceDiff).toHaveBeenCalledTimes(1);
+
+      runtimeBGate.resolve(runtimeWithStaleSession());
+      await waitFor(() => expect(loadWorkspaceDiff).toHaveBeenCalledWith("ws-2", "head", false, expect.anything()));
+      expect(screen.queryByText("Loading workspace details...")).toBeNull();
+    },
+  );
 
   it("renders matching workspace details when runtime loading fails", async () => {
     window.__BASE_PATH__ = window.location.origin;

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -3280,6 +3280,53 @@ describe("WorkspaceTerminalView", () => {
     expect(activePaneKey()).toBeUndefined();
   });
 
+  it("moves workflow focus ownership while workspace actions are blocked", async () => {
+    localStorage.setItem("kenn-forge-workspace-active-tab:ws-1", "session:ws-1:helper");
+    localStorage.setItem(
+      "kenn-forge-workspace-terminal-layout:ws-1",
+      persistedTwoSessionWorkflowLayout("ws-1:helper", "ws-1:reviewer"),
+    );
+    mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithTwoWorkflowSessions());
+
+    render(WorkspaceTerminalView, { props: { workspaceId: "ws-1" } });
+    const reviewerPane = await waitFor(() => {
+      const pane = document.querySelector<HTMLElement>('[data-pane-key="session:ws-1:reviewer"]');
+      expect(pane).not.toBeNull();
+      return pane!;
+    });
+    const activePaneKey = () =>
+      document.querySelector(".tabbed-panel-leaf.input-active [data-pane-key]")?.getAttribute("data-pane-key");
+
+    beginWorkspaceDeletion("ws-1", undefined);
+    await fireEvent.focusIn(reviewerPane);
+
+    expect(activePaneKey()).toBe("session:ws-1:reviewer");
+    endWorkspaceDeletion("ws-1", undefined);
+  });
+
+  it("clears workflow focus ownership when the host is parked", async () => {
+    localStorage.setItem("kenn-forge-workspace-active-tab:ws-1", "session:ws-1:helper");
+    localStorage.setItem(
+      "kenn-forge-workspace-terminal-layout:ws-1",
+      persistedTwoSessionWorkflowLayout("ws-1:helper", "ws-1:reviewer"),
+    );
+    mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithTwoWorkflowSessions());
+
+    const view = render(WorkspaceTerminalView, { props: { workspaceId: "ws-1", hostVisible: true } });
+    const reviewerPane = await waitFor(() => {
+      const pane = document.querySelector<HTMLElement>('[data-pane-key="session:ws-1:reviewer"]');
+      expect(pane).not.toBeNull();
+      return pane!;
+    });
+
+    await fireEvent.focusIn(reviewerPane);
+    expect(document.querySelectorAll(".workspace-stage .tabbed-panel-leaf.input-active")).toHaveLength(1);
+
+    await view.rerender({ workspaceId: "ws-1", hostVisible: false });
+
+    expect(document.querySelectorAll(".workspace-stage .tabbed-panel-leaf.input-active")).toHaveLength(0);
+  });
+
   it("keeps a focused bottom dock active while its header opens the panel", async () => {
     localStorage.setItem("kenn-forge-workspace-active-tab:ws-1", "home");
     mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithTerminalSession());

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -6,7 +6,11 @@ import { makeAppRuntime, type OwnedAppRuntime } from "../../app/runtime.js";
 import { createDiffStore } from "../../stores/diff.svelte.js";
 import { clearActiveTabbedPanelDrag, startTabbedPanelTabDrag } from "../shared/tabbed-panel-drag.js";
 import { pushModalFrame } from "../../stores/keyboard/modal-stack.svelte.js";
-import { getPaneLayoutStore, resetPaneLayoutStoresForTest } from "../../stores/paneLayout.svelte.js";
+import {
+  getPaneLayoutStore,
+  promoteSessionBesideWorkspace,
+  resetPaneLayoutStoresForTest,
+} from "../../stores/paneLayout.svelte.js";
 import { sessionPaneKey } from "../../stores/session-pane-key.js";
 import {
   beginWorkspaceCreate,
@@ -4425,6 +4429,48 @@ describe("WorkspaceTerminalView", () => {
   });
 
   describe("promoted sessions", () => {
+    it("leaves a connected focused workflow terminal to the pool during promotion", async () => {
+      localStorage.setItem("kenn-forge-workspace-active-tab:ws-1", "session:ws-1:helper");
+      localStorage.setItem(
+        "kenn-forge-workspace-terminal-layout:ws-1",
+        persistedTwoSessionWorkflowLayout("ws-1:helper", "ws-1:reviewer"),
+      );
+      mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithTwoWorkflowSessions());
+      claimForPrs();
+      noteWorkspacePaneRendered("prs");
+
+      render(WorkspaceTerminalView, {
+        props: {
+          workspaceId: "ws-1",
+          paneSurface: "prs" as const,
+        },
+      });
+
+      const terminal = await waitFor(() => {
+        const element = document.querySelector<HTMLElement>(
+          '[data-pane-key="session:ws-1:helper"] .terminal-container',
+        );
+        expect(element).not.toBeNull();
+        return element!;
+      });
+      const focusTarget = document.createElement("textarea");
+      terminal.append(focusTarget);
+      focusTarget.focus();
+      await waitFor(() =>
+        expect(document.querySelector(".workspace-stage .tabbed-panel-leaf.input-active")).not.toBeNull(),
+      );
+
+      const layout = getPaneLayoutStore("prs");
+      const paneKey = sessionPaneKey("ws-1", undefined, "ws-1:helper");
+      expect(promoteSessionBesideWorkspace(layout, paneKey)).toBe(true);
+
+      await waitFor(() => expect(layout.hasTab(paneKey)).toBe(true));
+      await waitFor(() => expect(terminal.closest(".workspace-stage")).toBeNull());
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(document.activeElement).not.toBe(document.querySelector(".terminal-view"));
+      expect(focusTarget.isConnected).toBe(true);
+    });
+
     it("gives a parked row-only dock the sole workspace actions and live dialogs", async () => {
       localStorage.setItem(
         "kenn-forge-workspace-terminal-layout:ws-1",

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -3267,6 +3267,31 @@ describe("WorkspaceTerminalView", () => {
     expect(activePaneKey()).toBe("session:ws-1:helper");
   });
 
+  it("does not paint a nested workflow owner while its outer detail pane is inactive", async () => {
+    localStorage.setItem("kenn-forge-workspace-active-tab:ws-1", "session:ws-1:helper");
+    localStorage.setItem(
+      "kenn-forge-workspace-terminal-layout:ws-1",
+      persistedTwoSessionWorkflowLayout("ws-1:helper", "ws-1:reviewer"),
+    );
+    mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithTwoWorkflowSessions());
+    const surfaceLayout = getPaneLayoutStore("prs");
+    surfaceLayout.noteFocused("conversation");
+
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+        paneSurface: "prs" as const,
+      },
+    });
+
+    await screen.findByRole("tab", { name: /Reviewer/ });
+    const activeWorkflowLeaves = () => document.querySelectorAll(".workspace-stage .tabbed-panel-leaf.input-active");
+    expect(activeWorkflowLeaves()).toHaveLength(0);
+
+    surfaceLayout.noteFocused("workspace");
+    await waitFor(() => expect(activeWorkflowLeaves()).toHaveLength(1));
+  });
+
   it("keeps the workspace header for a sole standalone session", async () => {
     render(WorkspaceTerminalView, {
       props: {

--- a/frontend/src/lib/stores/keyboard/actions.test.ts
+++ b/frontend/src/lib/stores/keyboard/actions.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { getPaneLayoutStore, resetPaneLayoutStoresForTest, type PaneLayoutStore } from "../paneLayout.svelte.js";
 import { sessionPaneKey } from "../session-pane-key.js";
+import { pendingSessionFocus } from "../session-host.svelte.js";
 
 import { defaultActions, setStoreInstances } from "./actions.js";
 import { navigate } from "../router.svelte.ts";
@@ -637,6 +638,7 @@ describe("session pane commands", () => {
     // Its own leaf, not stacked behind the workspace pane: a promotion the user
     // cannot see reads as a command that did nothing.
     expect(layout.leafIDForTab(paneKey)).not.toBe(layout.leafIDForTab("workspace"));
+    expect(pendingSessionFocus(hosted.hostKey)).toBe("explicit");
     // Offered once. Repeating it would move the tab the user just placed.
     expect(action.when(context)).toBe(false);
   });

--- a/frontend/src/lib/stores/keyboard/actions.test.ts
+++ b/frontend/src/lib/stores/keyboard/actions.test.ts
@@ -615,7 +615,13 @@ describe("session pane commands", () => {
 
   /** Stand in for a mounted, unflattened DetailPaneLayout on the PRs surface. */
   function noteRendered(layout: PaneLayoutStore, tabs: readonly string[]): void {
-    layout.notePaneRender({ flattened: false, editableTabs: [...tabs], onScreenTabs: [...tabs], soloChromeTabs: [] });
+    layout.notePaneRender({
+      activeInputTabKey: tabs[0] ?? null,
+      flattened: false,
+      editableTabs: [...tabs],
+      onScreenTabs: [...tabs],
+      soloChromeTabs: [],
+    });
   }
 
   it("promotes the shown session beside the workspace pane", () => {
@@ -642,6 +648,7 @@ describe("session pane commands", () => {
     // the render report can say the terminal is not visible.
     noteRendered(layout, ["conversation", "workspace"]);
     layout.notePaneRender({
+      activeInputTabKey: "conversation",
       flattened: false,
       editableTabs: ["conversation", "workspace"],
       onScreenTabs: ["conversation"],

--- a/frontend/src/lib/stores/keyboard/actions.ts
+++ b/frontend/src/lib/stores/keyboard/actions.ts
@@ -20,7 +20,8 @@ import {
   type PaneSurfaceKey,
 } from "../paneLayout.svelte.js";
 import { isSessionPaneKey } from "../session-pane-key.js";
-import { activeHostedSession, hostedWorkspaceLauncher } from "../workspace-host.svelte.js";
+import { requestSessionFocus } from "../session-host.svelte.js";
+import { activeHostedSession, hostedSessionRegistryKey, hostedWorkspaceLauncher } from "../workspace-host.svelte.js";
 import type { ConfigRepo } from "../../api/types.js";
 import type { StoreInstances } from "../../types.js";
 import type { Action, Context, PreviewBlock } from "./types.js";
@@ -700,7 +701,9 @@ export const defaultActions: Action[] = [
     when: (ctx) => sessionPromotionTarget(ctx) !== null,
     handler: (ctx) => {
       const target = sessionPromotionTarget(ctx);
-      if (target !== null) promoteSessionBesideWorkspace(target.layout, target.paneKey);
+      if (target === null || !promoteSessionBesideWorkspace(target.layout, target.paneKey)) return;
+      const hostKey = hostedSessionRegistryKey(target.paneKey);
+      if (hostKey !== null) requestSessionFocus(hostKey);
     },
   },
   {

--- a/frontend/src/lib/stores/paneLayout.svelte.test.ts
+++ b/frontend/src/lib/stores/paneLayout.svelte.test.ts
@@ -160,15 +160,14 @@ describe("pane layout store", () => {
     expect(s.lastFocusedTabKey()).toBe("workspace");
   });
 
-  it("clears an external input owner when a pane claims focus", () => {
+  it("does not treat remembered focus as a live focus change", () => {
     const s = store();
     s.setExternalInputActive(true);
     expect(s.externalInputActive()).toBe(true);
 
     s.noteFocused("files");
-    expect(s.externalInputActive()).toBe(false);
+    expect(s.externalInputActive()).toBe(true);
 
-    s.setExternalInputActive(true);
     s.reset();
     expect(s.externalInputActive()).toBe(false);
   });

--- a/frontend/src/lib/stores/paneLayout.svelte.test.ts
+++ b/frontend/src/lib/stores/paneLayout.svelte.test.ts
@@ -160,7 +160,7 @@ describe("pane layout store", () => {
     expect(s.lastFocusedTabKey()).toBe("workspace");
   });
 
-  it("does not treat remembered focus as a live focus change", () => {
+  it("preserves live external focus while resetting remembered layout", () => {
     const s = store();
     s.setExternalInputActive(true);
     expect(s.externalInputActive()).toBe(true);
@@ -169,7 +169,7 @@ describe("pane layout store", () => {
     expect(s.externalInputActive()).toBe(true);
 
     s.reset();
-    expect(s.externalInputActive()).toBe(false);
+    expect(s.externalInputActive()).toBe(true);
   });
 
   it("ignores a focus note for a tab it does not know", () => {

--- a/frontend/src/lib/stores/paneLayout.svelte.test.ts
+++ b/frontend/src/lib/stores/paneLayout.svelte.test.ts
@@ -160,6 +160,19 @@ describe("pane layout store", () => {
     expect(s.lastFocusedTabKey()).toBe("workspace");
   });
 
+  it("clears an external input owner when a pane claims focus", () => {
+    const s = store();
+    s.setExternalInputActive(true);
+    expect(s.externalInputActive()).toBe(true);
+
+    s.noteFocused("files");
+    expect(s.externalInputActive()).toBe(false);
+
+    s.setExternalInputActive(true);
+    s.reset();
+    expect(s.externalInputActive()).toBe(false);
+  });
+
   it("ignores a focus note for a tab it does not know", () => {
     const s = store();
     s.noteFocused("nonsense");
@@ -260,7 +273,13 @@ describe("promoted session panes", () => {
 
   it("promotes beside the workspace pane when it is on screen", () => {
     const layout = store();
-    const onScreen = { editableTabs: TABS, onScreenTabs: TABS, flattened: false, soloChromeTabs: [] };
+    const onScreen = {
+      activeInputTabKey: "conversation",
+      editableTabs: TABS,
+      onScreenTabs: TABS,
+      flattened: false,
+      soloChromeTabs: [],
+    };
 
     // Nothing rendered yet, so there is no evidence the split would land anywhere
     // the user can see it.
@@ -290,6 +309,7 @@ describe("promoted session panes", () => {
       }),
     ).toBe(true);
     layout.notePaneRender({
+      activeInputTabKey: "conversation",
       editableTabs: ["conversation", reviewerPane],
       onScreenTabs: ["conversation", reviewerPane],
       flattened: false,
@@ -305,6 +325,7 @@ describe("promoted session panes", () => {
     const layout = store();
     layout.noteFocused("conversation");
     layout.notePaneRender({
+      activeInputTabKey: "conversation",
       editableTabs: ["conversation", "files"],
       onScreenTabs: ["conversation", "files"],
       flattened: false,

--- a/frontend/src/lib/stores/paneLayout.svelte.ts
+++ b/frontend/src/lib/stores/paneLayout.svelte.ts
@@ -38,7 +38,7 @@ export const PANE_LAYOUT_STORAGE_PREFIX = "kenn-forge-pane-layout-v1:";
 
 /** The state only the renderer knows, published for consumers outside the tree. */
 export interface PaneRenderReport {
-  /** The renderer-validated input owner, or null while an external dock owns the surface. */
+  /** The rendered tab containing DOM focus, or null while focus is elsewhere. */
   activeInputTabKey: string | null;
   /**
    * Tabs a structural edit may target: present in the rendered tree and not
@@ -115,9 +115,9 @@ export interface PaneLayoutStore {
   paneRender(): PaneRenderReport | null;
   /** Called by the rendering host; null on teardown. */
   notePaneRender(report: PaneRenderReport | null): void;
-  /** True while a surface-owned control outside the pane tree owns keyboard input. */
+  /** True while DOM focus is inside a surface dock outside the pane tree. */
   externalInputActive(): boolean;
-  /** Claim or release input for a surface-owned control outside the pane tree. */
+  /** Report DOM focus entering or leaving a surface dock outside the pane tree. */
   setExternalInputActive(active: boolean): void;
   /**
    * Whether splitting this tab out would change anything — it shares its leaf.
@@ -275,7 +275,6 @@ export function createPaneLayoutStore(
       // last-focused and every rule keyed off it would read a stale value. Still
       // validated: an arbitrary string must not be persisted as the winner.
       if (!knownTabs.includes(tabKey) && !(keepIfStored?.(tabKey) ?? false)) return;
-      externalInputActive = false;
       if (state.lastFocusedTabKey === tabKey) return;
       commit({ ...state, lastFocusedTabKey: tabKey });
     },

--- a/frontend/src/lib/stores/paneLayout.svelte.ts
+++ b/frontend/src/lib/stores/paneLayout.svelte.ts
@@ -38,6 +38,8 @@ export const PANE_LAYOUT_STORAGE_PREFIX = "kenn-forge-pane-layout-v1:";
 
 /** The state only the renderer knows, published for consumers outside the tree. */
 export interface PaneRenderReport {
+  /** The renderer-validated input owner, or null while an external dock owns the surface. */
+  activeInputTabKey: string | null;
   /**
    * Tabs a structural edit may target: present in the rendered tree and not
    * masked out of it.
@@ -113,6 +115,10 @@ export interface PaneLayoutStore {
   paneRender(): PaneRenderReport | null;
   /** Called by the rendering host; null on teardown. */
   notePaneRender(report: PaneRenderReport | null): void;
+  /** True while a surface-owned control outside the pane tree owns keyboard input. */
+  externalInputActive(): boolean;
+  /** Claim or release input for a surface-owned control outside the pane tree. */
+  setExternalInputActive(active: boolean): void;
   /**
    * Whether splitting this tab out would change anything — it shares its leaf.
    * Callers that offer a split control need this to avoid a dead affordance,
@@ -178,6 +184,7 @@ export function createPaneLayoutStore(
     parseTabbedPanelLayout(readStored(surface), knownTabs, defaultTree, keepIfStored),
   );
   let render = $state<PaneRenderReport | null>(null);
+  let externalInputActive = $state(false);
 
   function commit(next: TabbedPanelLayoutState): void {
     state = next;
@@ -229,11 +236,13 @@ export function createPaneLayoutStore(
     notePaneRender: (report) => {
       if (report === null) {
         render = null;
+        externalInputActive = false;
         return;
       }
       const current = render;
       if (
         current !== null &&
+        current.activeInputTabKey === report.activeInputTabKey &&
         current.flattened === report.flattened &&
         sameTabList(current.editableTabs, report.editableTabs) &&
         sameTabList(current.onScreenTabs, report.onScreenTabs) &&
@@ -242,11 +251,19 @@ export function createPaneLayoutStore(
         return;
       }
       render = {
+        activeInputTabKey: report.activeInputTabKey,
         editableTabs: [...report.editableTabs],
         onScreenTabs: [...report.onScreenTabs],
         flattened: report.flattened,
         soloChromeTabs: [...report.soloChromeTabs],
       };
+    },
+
+    externalInputActive: () => externalInputActive,
+
+    setExternalInputActive: (active) => {
+      if (externalInputActive === active) return;
+      externalInputActive = active;
     },
 
     canSplitTab: (tabKey) => (findTabbedPanelLeafByTab(state.tree, tabKey)?.tabs.length ?? 0) > 1,
@@ -258,6 +275,7 @@ export function createPaneLayoutStore(
       // last-focused and every rule keyed off it would read a stale value. Still
       // validated: an arbitrary string must not be persisted as the winner.
       if (!knownTabs.includes(tabKey) && !(keepIfStored?.(tabKey) ?? false)) return;
+      externalInputActive = false;
       if (state.lastFocusedTabKey === tabKey) return;
       commit({ ...state, lastFocusedTabKey: tabKey });
     },
@@ -359,7 +377,10 @@ export function createPaneLayoutStore(
       });
     },
 
-    reset: () => commit(parseTabbedPanelLayout(null, knownTabs, defaultTree, keepIfStored)),
+    reset: () => {
+      externalInputActive = false;
+      commit(parseTabbedPanelLayout(null, knownTabs, defaultTree, keepIfStored));
+    },
   };
 
   return store;

--- a/frontend/src/lib/stores/paneLayout.svelte.ts
+++ b/frontend/src/lib/stores/paneLayout.svelte.ts
@@ -377,7 +377,6 @@ export function createPaneLayoutStore(
     },
 
     reset: () => {
-      externalInputActive = false;
       commit(parseTabbedPanelLayout(null, knownTabs, defaultTree, keepIfStored));
     },
   };

--- a/frontend/src/lib/stores/workspace-host.test.ts
+++ b/frontend/src/lib/stores/workspace-host.test.ts
@@ -841,6 +841,7 @@ describe("promotable sessions", () => {
     publishHostedSessions({ workspaceId: "ws-a", hostKey: undefined }, [{ ...sessions[0]!, label: "codex (proxy)" }]);
     const layout = getPaneLayoutStore("prs");
     layout.notePaneRender({
+      activeInputTabKey: "workspace",
       editableTabs: ["conversation", "workspace"],
       onScreenTabs: ["conversation", "workspace"],
       flattened: false,
@@ -855,6 +856,7 @@ describe("promotable sessions", () => {
     prs.claim(identityA, refA);
     publishHostedSessions({ workspaceId: "ws-a", hostKey: undefined }, [{ ...sessions[0]!, label: "codex (proxy)" }]);
     getPaneLayoutStore("prs").notePaneRender({
+      activeInputTabKey: "workspace",
       editableTabs: ["conversation", "workspace"],
       onScreenTabs: ["conversation", "workspace"],
       flattened: true,
@@ -893,6 +895,7 @@ describe("a workspace spread across several panes", () => {
     publishHostedSessions({ workspaceId: "ws-a", hostKey: undefined }, sessions);
     const layout = getPaneLayoutStore("prs");
     layout.notePaneRender({
+      activeInputTabKey: "workspace",
       editableTabs: ["conversation", "files", "workspace"],
       onScreenTabs: ["conversation", "files", "workspace"],
       flattened: false,
@@ -1169,6 +1172,7 @@ describe("a workspace spread across several panes", () => {
     // touch, and one for the doomed workspace, which it must.
     const issuesLayout = getPaneLayoutStore("issues");
     issuesLayout.notePaneRender({
+      activeInputTabKey: "workspace",
       editableTabs: ["conversation", "workspace"],
       onScreenTabs: ["conversation", "workspace"],
       flattened: false,

--- a/frontend/src/lib/views/ActivityFeedView.svelte
+++ b/frontend/src/lib/views/ActivityFeedView.svelte
@@ -573,6 +573,7 @@
             <PullDetailPane
               {tabKey}
               {visible}
+              keyboardActive={tabKey === effectiveDetailTab}
               pr={drawerPRSelection}
               detail={selectedPullDetail}
               autoSync="background"

--- a/frontend/src/lib/views/ActivityFeedView.svelte
+++ b/frontend/src/lib/views/ActivityFeedView.svelte
@@ -554,6 +554,7 @@
                 name={commitDrawer.name}
                 repoPath={commitDrawer.repoPath}
                 commitSha={commitDrawer.commitSha}
+                {inputActive}
               />
             {/key}
           {:else if tabKey === "workspace" && inlineWorkspace && visible}

--- a/frontend/src/lib/views/ActivityFeedView.svelte
+++ b/frontend/src/lib/views/ActivityFeedView.svelte
@@ -544,7 +544,7 @@
         onFocusPane={handlePaneFocus}
         paneLeafExtras={workspacePaneControls ? workspaceLeafExtras : undefined}
       >
-        {#snippet renderPane(tabKey, visible)}
+        {#snippet renderPane(tabKey, visible, inputActive)}
           {#if tabKey === "commit" && commitDrawer && visible}
             {#key commitDrawer.commitSha}
               <CommitDiffPanel
@@ -573,7 +573,7 @@
             <PullDetailPane
               {tabKey}
               {visible}
-              keyboardActive={tabKey === effectiveDetailTab}
+              keyboardActive={inputActive}
               pr={drawerPRSelection}
               detail={selectedPullDetail}
               autoSync="background"

--- a/frontend/src/lib/views/ActivityFeedView.test.ts
+++ b/frontend/src/lib/views/ActivityFeedView.test.ts
@@ -188,7 +188,11 @@ describe("ActivityFeedView detail panes", () => {
 
     expect(screen.getByRole("tab", { name: "Commit" })).toBeTruthy();
     expect(screen.queryByRole("tab", { name: "Conversation" })).toBeNull();
-    expect(screen.getByTestId("commit-diff-panel")).toBeTruthy();
+    const commitPanel = screen.getByTestId("commit-diff-panel");
+    expect(commitPanel.dataset.inputActive).toBe("false");
+
+    await fireEvent.focusIn(commitPanel);
+    expect(commitPanel.dataset.inputActive).toBe("true");
   });
 
   it("renders a promoted session's pane in the activity drawer", () => {

--- a/frontend/src/lib/views/ActivityFeedView.test.ts
+++ b/frontend/src/lib/views/ActivityFeedView.test.ts
@@ -137,7 +137,7 @@ describe("ActivityFeedView detail panes", () => {
       "conversation",
     );
     expect(bodies.find((el) => el.getAttribute("data-tab-key") === "conversation")?.dataset.keyboardActive).toBe(
-      "true",
+      "false",
     );
     expect(bodies.find((el) => el.getAttribute("data-tab-key") === "files")?.dataset.keyboardActive).toBe("false");
   });
@@ -153,7 +153,7 @@ describe("ActivityFeedView detail panes", () => {
     expect(screen.queryByTestId("pull-detail-pane")).toBeNull();
   });
 
-  it("moves diff keyboard ownership with the live activity pane", async () => {
+  it("moves diff keyboard routing only with live activity focus", async () => {
     renderActivity({ drawerItem: prDrawer(), pullDetail: pullDetailFixture(12) });
     const layout = getPaneLayoutStore("activity");
     layout.splitTab("files", layout.leafIDForTab("files")!, "horizontal", "after");
@@ -162,14 +162,19 @@ describe("ActivityFeedView detail panes", () => {
     const bodies = screen.getAllByTestId("pull-detail-pane");
     const conversation = bodies.find((body) => body.dataset.tabKey === "conversation")!;
     const files = bodies.find((body) => body.dataset.tabKey === "files")!;
-    expect(conversation.dataset.keyboardActive).toBe("true");
+    expect(conversation.dataset.keyboardActive).toBe("false");
     expect(files.dataset.keyboardActive).toBe("false");
 
     await fireEvent.pointerDown(files);
+    await fireEvent.wheel(conversation);
+    expect(conversation.dataset.keyboardActive).toBe("false");
+    expect(files.dataset.keyboardActive).toBe("false");
+
+    await fireEvent.focusIn(files);
     expect(conversation.dataset.keyboardActive).toBe("false");
     expect(files.dataset.keyboardActive).toBe("true");
 
-    await fireEvent.wheel(conversation);
+    await fireEvent.focusIn(conversation);
     expect(conversation.dataset.keyboardActive).toBe("true");
     expect(files.dataset.keyboardActive).toBe("false");
   });

--- a/frontend/src/lib/views/ActivityFeedView.test.ts
+++ b/frontend/src/lib/views/ActivityFeedView.test.ts
@@ -136,6 +136,10 @@ describe("ActivityFeedView detail panes", () => {
     expect(bodies.find((el) => el.getAttribute("data-visible") === "true")?.getAttribute("data-tab-key")).toBe(
       "conversation",
     );
+    expect(bodies.find((el) => el.getAttribute("data-tab-key") === "conversation")?.dataset.keyboardActive).toBe(
+      "true",
+    );
+    expect(bodies.find((el) => el.getAttribute("data-tab-key") === "files")?.dataset.keyboardActive).toBe("false");
   });
 
   it("offers no diff pane for an issue selection", () => {

--- a/frontend/src/lib/views/ActivityFeedView.test.ts
+++ b/frontend/src/lib/views/ActivityFeedView.test.ts
@@ -1,5 +1,5 @@
-import { cleanup, render, screen } from "@testing-library/svelte";
-import { createRawSnippet, type Snippet } from "svelte";
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { createRawSnippet, tick, type Snippet } from "svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { STORES_KEY } from "../context.js";
 import { resetModalStack } from "../stores/keyboard/modal-stack.svelte.js";
@@ -151,6 +151,27 @@ describe("ActivityFeedView detail panes", () => {
     expect(screen.queryByRole("tab", { name: "Files changed" })).toBeNull();
     expect(screen.getByTestId("issue-detail")).toBeTruthy();
     expect(screen.queryByTestId("pull-detail-pane")).toBeNull();
+  });
+
+  it("moves diff keyboard ownership with the live activity pane", async () => {
+    renderActivity({ drawerItem: prDrawer(), pullDetail: pullDetailFixture(12) });
+    const layout = getPaneLayoutStore("activity");
+    layout.splitTab("files", layout.leafIDForTab("files")!, "horizontal", "after");
+    await tick();
+
+    const bodies = screen.getAllByTestId("pull-detail-pane");
+    const conversation = bodies.find((body) => body.dataset.tabKey === "conversation")!;
+    const files = bodies.find((body) => body.dataset.tabKey === "files")!;
+    expect(conversation.dataset.keyboardActive).toBe("true");
+    expect(files.dataset.keyboardActive).toBe("false");
+
+    await fireEvent.pointerDown(files);
+    expect(conversation.dataset.keyboardActive).toBe("false");
+    expect(files.dataset.keyboardActive).toBe("true");
+
+    await fireEvent.wheel(conversation);
+    expect(conversation.dataset.keyboardActive).toBe("true");
+    expect(files.dataset.keyboardActive).toBe("false");
   });
 
   it("offers the commit pane for a branch commit selection", async () => {

--- a/frontend/src/lib/views/ActivityFeedViewTestCommitDiffPanel.svelte
+++ b/frontend/src/lib/views/ActivityFeedViewTestCommitDiffPanel.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   interface Props {
     commitSha: string;
+    inputActive?: boolean;
   }
 
-  const { commitSha }: Props = $props();
+  const { commitSha, inputActive = true }: Props = $props();
 </script>
 
-<div data-testid="commit-diff-panel">Commit {commitSha}</div>
+<div data-testid="commit-diff-panel" data-input-active={String(inputActive)}>Commit {commitSha}</div>

--- a/frontend/src/lib/views/ActivityFeedViewTestPullDetailPane.svelte
+++ b/frontend/src/lib/views/ActivityFeedViewTestPullDetailPane.svelte
@@ -4,17 +4,19 @@
   interface Props {
     tabKey: string;
     visible: boolean;
+    keyboardActive?: boolean;
     pr: { owner: string; name: string; number: number };
     inlineWorkspace?: InlineWorkspaceController | null;
   }
 
-  const { tabKey, visible, pr, inlineWorkspace = null }: Props = $props();
+  const { tabKey, visible, keyboardActive = true, pr, inlineWorkspace = null }: Props = $props();
 </script>
 
 <div
   data-testid="pull-detail-pane"
   data-tab-key={tabKey}
   data-visible={String(visible)}
+  data-keyboard-active={String(keyboardActive)}
   data-has-inline-workspace={inlineWorkspace !== null}
 >
   PR {pr.owner}/{pr.name}#{pr.number} {tabKey}

--- a/frontend/src/lib/views/IssueListView.svelte
+++ b/frontend/src/lib/views/IssueListView.svelte
@@ -143,7 +143,7 @@
         paneLeafExtras={workspacePaneControls ? workspaceLeafExtras : undefined}
         onFocusPane={handlePaneFocus}
       >
-        {#snippet renderPane(tabKey, visible)}
+        {#snippet renderPane(tabKey, visible, _inputActive)}
           {#if tabKey === "conversation"}
             <IssueDetail
               owner={selectedIssue.owner}

--- a/frontend/src/lib/views/IssueListView.test.ts
+++ b/frontend/src/lib/views/IssueListView.test.ts
@@ -162,7 +162,7 @@ describe("IssueListView inline workspace", () => {
     expect(controller.notePaneFocused).toHaveBeenCalledWith(paneKey);
   });
 
-  it("moves active input ownership between issue and workspace panes", async () => {
+  it("moves the active border only when focus moves between issue and workspace", async () => {
     const { controller } = createClaimTestController("issues");
     renderIssueListView({
       inlineWorkspace: controller,
@@ -171,12 +171,16 @@ describe("IssueListView inline workspace", () => {
 
     const activePaneKey = () =>
       document.querySelector(".tabbed-panel-leaf.input-active [data-pane-key]")?.getAttribute("data-pane-key");
-    expect(activePaneKey()).toBe("conversation");
+    expect(activePaneKey()).toBeUndefined();
 
     await fireEvent.pointerDown(document.querySelector(".detail-pane-workspace-slot")!);
+    await fireEvent.wheel(screen.getByTestId("issue-detail"));
+    expect(activePaneKey()).toBeUndefined();
+
+    await fireEvent.focusIn(document.querySelector(".detail-pane-workspace-slot")!);
     expect(activePaneKey()).toBe("workspace");
 
-    await fireEvent.wheel(screen.getByTestId("issue-detail"));
+    await fireEvent.focusIn(screen.getByTestId("issue-detail"));
     expect(activePaneKey()).toBe("conversation");
   });
 

--- a/frontend/src/lib/views/IssueListView.test.ts
+++ b/frontend/src/lib/views/IssueListView.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/svelte";
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
 import { createRawSnippet, tick, type Snippet } from "svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { SIDEBAR_KEY, STORES_KEY } from "../context.js";
@@ -160,6 +160,24 @@ describe("IssueListView inline workspace", () => {
     // Focus is the host's only report of which pane the user is working in, and an
     // expand or a Focus Terminal has to act on that one rather than the container.
     expect(controller.notePaneFocused).toHaveBeenCalledWith(paneKey);
+  });
+
+  it("moves active input ownership between issue and workspace panes", async () => {
+    const { controller } = createClaimTestController("issues");
+    renderIssueListView({
+      inlineWorkspace: controller,
+      detail: issueDetailFixture({ id: "ws-1", status: "ready" }),
+    });
+
+    const activePaneKey = () =>
+      document.querySelector(".tabbed-panel-leaf.input-active [data-pane-key]")?.getAttribute("data-pane-key");
+    expect(activePaneKey()).toBe("conversation");
+
+    await fireEvent.pointerDown(document.querySelector(".detail-pane-workspace-slot")!);
+    expect(activePaneKey()).toBe("workspace");
+
+    await fireEvent.wheel(screen.getByTestId("issue-detail"));
+    expect(activePaneKey()).toBe("conversation");
   });
 
   it("offers the workspace controls in the leaf holding a promoted session", () => {

--- a/frontend/src/lib/views/PRListView.svelte
+++ b/frontend/src/lib/views/PRListView.svelte
@@ -265,6 +265,7 @@
             <PullDetailPane
               {tabKey}
               {visible}
+              keyboardActive={tabKey === detailTab}
               pr={selectedPR}
               detail={selectedDetail}
               autoSync={autoSyncDetail}

--- a/frontend/src/lib/views/PRListView.svelte
+++ b/frontend/src/lib/views/PRListView.svelte
@@ -131,6 +131,13 @@
     selectDetailTab(tabKey);
   }
 
+  function diffKeyboardActive(tabKey: string, inputActive: boolean): boolean {
+    if (inputActive) return true;
+    if (tabKey !== "files" || detailTab !== "files") return false;
+    const render = paneLayout.paneRender();
+    return render !== null && render.activeInputTabKey === null && !paneLayout.externalInputActive();
+  }
+
   function handleStackMemberNavigate(ref: PullRequestRouteRef): boolean | void {
     if (onStackMemberNavigate) return onStackMemberNavigate(ref);
     if (routeFamily !== "focus") return undefined;
@@ -265,7 +272,7 @@
             <PullDetailPane
               {tabKey}
               {visible}
-              keyboardActive={inputActive}
+              keyboardActive={diffKeyboardActive(tabKey, inputActive)}
               pr={selectedPR}
               detail={selectedDetail}
               autoSync={autoSyncDetail}

--- a/frontend/src/lib/views/PRListView.svelte
+++ b/frontend/src/lib/views/PRListView.svelte
@@ -14,6 +14,7 @@
   import type { TabbedPanelLeaf } from "../components/shared/tabbed-panel-layout.js";
   import { getPaneLayoutStore, type PaneTabSpec } from "../stores/paneLayout.svelte.js";
   import { isSessionPaneKey } from "../stores/session-pane-key.js";
+  import { getStackDepth } from "../stores/keyboard/modal-stack.svelte.js";
   import type { DetailSyncMode } from "../stores/detail.svelte.js";
   import {
     buildFocusPullRequestRoute,
@@ -134,6 +135,7 @@
   function diffKeyboardActive(tabKey: string, inputActive: boolean): boolean {
     if (inputActive) return true;
     if (tabKey !== "files" || detailTab !== "files") return false;
+    if (getStackDepth() > 0) return false;
     const render = paneLayout.paneRender();
     return render !== null && render.activeInputTabKey === null && !paneLayout.externalInputActive();
   }

--- a/frontend/src/lib/views/PRListView.svelte
+++ b/frontend/src/lib/views/PRListView.svelte
@@ -246,7 +246,7 @@
         onFocusPane={handlePaneFocus}
         paneLeafExtras={workspacePaneControls ? workspaceLeafExtras : undefined}
       >
-        {#snippet renderPane(tabKey, visible)}
+        {#snippet renderPane(tabKey, visible, inputActive)}
           {#if tabKey === "workspace" && inlineWorkspace && visible}
             <!-- Portal target for the single live terminal subtree, which the
                  frontend host reparents in here. Mounted only while visible: a slot
@@ -265,7 +265,7 @@
             <PullDetailPane
               {tabKey}
               {visible}
-              keyboardActive={tabKey === detailTab}
+              keyboardActive={inputActive}
               pr={selectedPR}
               detail={selectedDetail}
               autoSync={autoSyncDetail}

--- a/frontend/src/lib/views/PRListView.test.ts
+++ b/frontend/src/lib/views/PRListView.test.ts
@@ -223,7 +223,7 @@ describe("PRListView detail panes", () => {
     expect(navigate).toHaveBeenCalledWith("/pulls/github/acme/widgets/12/files", { replace: true });
   });
 
-  it("keeps global diff paging with the active route pane", async () => {
+  it("enables diff paging only after focus enters the routed files pane", async () => {
     renderPRListView({ detailTab: "conversation" });
     const layout = getPaneLayoutStore("prs");
     layout.splitTab("files", layout.leafIDForTab("files")!, "horizontal", "after");
@@ -240,11 +240,15 @@ describe("PRListView detail panes", () => {
     filesLayout.splitTab("files", filesLayout.leafIDForTab("files")!, "horizontal", "after");
     await tick();
 
+    expect(screen.getByTestId("diff-files").dataset.keyboardActive).toBe("false");
+    expect(screen.getByTestId("diff-files").dataset.pageKeyboardActive).toBe("false");
+
+    await fireEvent.focusIn(screen.getByTestId("diff-files"));
     expect(screen.getByTestId("diff-files").dataset.keyboardActive).toBe("true");
     expect(screen.getByTestId("diff-files").dataset.pageKeyboardActive).toBe("true");
   });
 
-  it("moves visible input ownership before route navigation settles", async () => {
+  it("moves visible keyboard routing only when focus moves", async () => {
     renderPRListView({ detailTab: "conversation" });
     const layout = getPaneLayoutStore("prs");
     layout.splitTab("files", layout.leafIDForTab("files")!, "horizontal", "after");
@@ -252,15 +256,21 @@ describe("PRListView detail panes", () => {
 
     const activePaneKey = () =>
       document.querySelector(".tabbed-panel-leaf.input-active [data-pane-key]")?.getAttribute("data-pane-key");
-    expect(activePaneKey()).toBe("conversation");
+    expect(activePaneKey()).toBeUndefined();
     expect(screen.getByTestId("diff-files").dataset.keyboardActive).toBe("false");
 
     await fireEvent.pointerDown(screen.getByTestId("diff-files"));
+    await fireEvent.wheel(screen.getByTestId("pull-detail"));
+    expect(activePaneKey()).toBeUndefined();
+    expect(screen.getByTestId("diff-files").dataset.keyboardActive).toBe("false");
+    expect(screen.getByTestId("diff-files").dataset.pageKeyboardActive).toBe("false");
+
+    await fireEvent.focusIn(screen.getByTestId("diff-files"));
     expect(activePaneKey()).toBe("files");
     expect(screen.getByTestId("diff-files").dataset.keyboardActive).toBe("true");
     expect(screen.getByTestId("diff-files").dataset.pageKeyboardActive).toBe("true");
 
-    await fireEvent.wheel(screen.getByTestId("pull-detail"));
+    await fireEvent.focusIn(screen.getByTestId("pull-detail"));
     expect(activePaneKey()).toBe("conversation");
     expect(screen.getByTestId("diff-files").dataset.keyboardActive).toBe("false");
     expect(screen.getByTestId("diff-files").dataset.pageKeyboardActive).toBe("false");

--- a/frontend/src/lib/views/PRListView.test.ts
+++ b/frontend/src/lib/views/PRListView.test.ts
@@ -230,7 +230,7 @@ describe("PRListView detail panes", () => {
     await tick();
 
     expect(screen.getByTestId("diff-files").dataset.keyboardActive).toBe("false");
-    expect(screen.getByTestId("diff-files").dataset.pageKeyboardActive).toBe("true");
+    expect(screen.getByTestId("diff-files").dataset.pageKeyboardActive).toBe("false");
 
     cleanup();
     resetPaneLayoutStoresForTest();
@@ -258,10 +258,12 @@ describe("PRListView detail panes", () => {
     await fireEvent.pointerDown(screen.getByTestId("diff-files"));
     expect(activePaneKey()).toBe("files");
     expect(screen.getByTestId("diff-files").dataset.keyboardActive).toBe("true");
+    expect(screen.getByTestId("diff-files").dataset.pageKeyboardActive).toBe("true");
 
     await fireEvent.wheel(screen.getByTestId("pull-detail"));
     expect(activePaneKey()).toBe("conversation");
     expect(screen.getByTestId("diff-files").dataset.keyboardActive).toBe("false");
+    expect(screen.getByTestId("diff-files").dataset.pageKeyboardActive).toBe("false");
   });
 
   it("pushes history when the other route pane is covered by a zoom", async () => {

--- a/frontend/src/lib/views/PRListView.test.ts
+++ b/frontend/src/lib/views/PRListView.test.ts
@@ -223,7 +223,7 @@ describe("PRListView detail panes", () => {
     expect(navigate).toHaveBeenCalledWith("/pulls/github/acme/widgets/12/files", { replace: true });
   });
 
-  it("enables diff paging only after focus enters the routed files pane", async () => {
+  it("keeps dedicated files shortcuts until live focus chooses another pane", async () => {
     renderPRListView({ detailTab: "conversation" });
     const layout = getPaneLayoutStore("prs");
     layout.splitTab("files", layout.leafIDForTab("files")!, "horizontal", "after");
@@ -240,6 +240,10 @@ describe("PRListView detail panes", () => {
     filesLayout.splitTab("files", filesLayout.leafIDForTab("files")!, "horizontal", "after");
     await tick();
 
+    expect(screen.getByTestId("diff-files").dataset.keyboardActive).toBe("true");
+    expect(screen.getByTestId("diff-files").dataset.pageKeyboardActive).toBe("true");
+
+    await fireEvent.focusIn(screen.getByTestId("pull-detail"));
     expect(screen.getByTestId("diff-files").dataset.keyboardActive).toBe("false");
     expect(screen.getByTestId("diff-files").dataset.pageKeyboardActive).toBe("false");
 

--- a/frontend/src/lib/views/PRListView.test.ts
+++ b/frontend/src/lib/views/PRListView.test.ts
@@ -2,7 +2,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
 import { createRawSnippet, flushSync, tick, type Snippet } from "svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { NAVIGATE_KEY, SIDEBAR_KEY, STORES_KEY } from "../context.js";
-import { resetModalStack } from "../stores/keyboard/modal-stack.svelte.js";
+import { pushModalFrame, resetModalStack } from "../stores/keyboard/modal-stack.svelte.js";
 import { getPaneLayoutStore, resetPaneLayoutStoresForTest } from "../stores/paneLayout.svelte.js";
 import { sessionPaneKey } from "../stores/session-pane-key.js";
 import type { PullRequestRouteRef } from "../routes.js";
@@ -250,6 +250,22 @@ describe("PRListView detail panes", () => {
     await fireEvent.focusIn(screen.getByTestId("diff-files"));
     expect(screen.getByTestId("diff-files").dataset.keyboardActive).toBe("true");
     expect(screen.getByTestId("diff-files").dataset.pageKeyboardActive).toBe("true");
+  });
+
+  it("suspends dedicated files shortcuts while a modal owns the keyboard", async () => {
+    renderPRListView({ detailTab: "files" });
+    const layout = getPaneLayoutStore("prs");
+    layout.splitTab("files", layout.leafIDForTab("files")!, "horizontal", "after");
+    await tick();
+
+    expect(screen.getByTestId("diff-files").dataset.keyboardActive).toBe("true");
+
+    const popModal = pushModalFrame("test-dialog", []);
+    await tick();
+
+    expect(screen.getByTestId("diff-files").dataset.keyboardActive).toBe("false");
+    expect(screen.getByTestId("diff-files").dataset.pageKeyboardActive).toBe("false");
+    popModal();
   });
 
   it("moves visible keyboard routing only when focus moves", async () => {

--- a/frontend/src/lib/views/PRListView.test.ts
+++ b/frontend/src/lib/views/PRListView.test.ts
@@ -223,6 +223,44 @@ describe("PRListView detail panes", () => {
     expect(navigate).toHaveBeenCalledWith("/pulls/github/acme/widgets/12/files", { replace: true });
   });
 
+  it("keeps global diff paging with the active route pane", async () => {
+    renderPRListView({ detailTab: "conversation" });
+    const layout = getPaneLayoutStore("prs");
+    layout.splitTab("files", layout.leafIDForTab("files")!, "horizontal", "after");
+    await tick();
+
+    expect(screen.getByTestId("diff-files").dataset.keyboardActive).toBe("false");
+    expect(screen.getByTestId("diff-files").dataset.pageKeyboardActive).toBe("true");
+
+    cleanup();
+    resetPaneLayoutStoresForTest();
+
+    renderPRListView({ detailTab: "files" });
+    const filesLayout = getPaneLayoutStore("prs");
+    filesLayout.splitTab("files", filesLayout.leafIDForTab("files")!, "horizontal", "after");
+    await tick();
+
+    expect(screen.getByTestId("diff-files").dataset.keyboardActive).toBe("true");
+    expect(screen.getByTestId("diff-files").dataset.pageKeyboardActive).toBe("true");
+  });
+
+  it("moves visible input ownership before route navigation settles", async () => {
+    renderPRListView({ detailTab: "conversation" });
+    const layout = getPaneLayoutStore("prs");
+    layout.splitTab("files", layout.leafIDForTab("files")!, "horizontal", "after");
+    await tick();
+
+    const activePaneKey = () =>
+      document.querySelector(".tabbed-panel-leaf.input-active [data-pane-key]")?.getAttribute("data-pane-key");
+    expect(activePaneKey()).toBe("conversation");
+
+    await fireEvent.pointerDown(screen.getByTestId("diff-files"));
+    expect(activePaneKey()).toBe("files");
+
+    await fireEvent.wheel(screen.getByTestId("pull-detail"));
+    expect(activePaneKey()).toBe("conversation");
+  });
+
   it("pushes history when the other route pane is covered by a zoom", async () => {
     // Split apart, then maximize the files leaf: the stored tree still says two
     // leaves, but only one pane is on screen, so moving to it is a navigation

--- a/frontend/src/lib/views/PRListView.test.ts
+++ b/frontend/src/lib/views/PRListView.test.ts
@@ -253,12 +253,15 @@ describe("PRListView detail panes", () => {
     const activePaneKey = () =>
       document.querySelector(".tabbed-panel-leaf.input-active [data-pane-key]")?.getAttribute("data-pane-key");
     expect(activePaneKey()).toBe("conversation");
+    expect(screen.getByTestId("diff-files").dataset.keyboardActive).toBe("false");
 
     await fireEvent.pointerDown(screen.getByTestId("diff-files"));
     expect(activePaneKey()).toBe("files");
+    expect(screen.getByTestId("diff-files").dataset.keyboardActive).toBe("true");
 
     await fireEvent.wheel(screen.getByTestId("pull-detail"));
     expect(activePaneKey()).toBe("conversation");
+    expect(screen.getByTestId("diff-files").dataset.keyboardActive).toBe("false");
   });
 
   it("pushes history when the other route pane is covered by a zoom", async () => {

--- a/frontend/src/lib/views/PRListViewTestDiffFilesLayout.svelte
+++ b/frontend/src/lib/views/PRListViewTestDiffFilesLayout.svelte
@@ -5,9 +5,19 @@
     number: number;
     initialScrollTop?: number;
     onScrollTopChange?: (scrollTop: number) => void;
+    keyboardActive?: boolean;
+    pageKeyboardActive?: boolean;
   }
 
-  const { owner, name, number, initialScrollTop = 0, onScrollTopChange }: Props = $props();
+  const {
+    owner,
+    name,
+    number,
+    initialScrollTop = 0,
+    onScrollTopChange,
+    keyboardActive = true,
+    pageKeyboardActive = keyboardActive,
+  }: Props = $props();
 </script>
 
 <!-- The real layout restores initialScrollTop and reports scrolls back; the
@@ -15,6 +25,8 @@
 <div
   data-testid="diff-files"
   data-initial-scroll-top={String(initialScrollTop)}
+  data-keyboard-active={String(keyboardActive)}
+  data-page-keyboard-active={String(pageKeyboardActive)}
   role="presentation"
   onscroll={(event) => onScrollTopChange?.((event.currentTarget as HTMLElement).scrollTop)}
 >

--- a/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
+++ b/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
@@ -1169,19 +1169,25 @@ test.describe("inline workspace pane continuity", () => {
 
       await surfaceDock.hover();
       await page.mouse.wheel(0, 120);
-      await expect(surfaceDock).toHaveClass(/input-active/);
-      const beforeExternalPageDown = await diffArea.evaluate((area) => Math.round(area.scrollTop));
+      await expect(surfaceDock).not.toHaveClass(/input-active/);
+      const filesLeaf = diffArea.locator("xpath=ancestor::*[contains(@class, 'tabbed-panel-leaf')][1]");
+      await expect(filesLeaf).toHaveClass(/input-active/);
+      const beforeFocusedPageDown = await diffArea.evaluate((area) => Math.round(area.scrollTop));
       await page.keyboard.press("PageDown");
       await expect
         .poll(async () => diffArea.evaluate((area) => Math.round(area.scrollTop)))
-        .toBe(beforeExternalPageDown);
+        .toBeGreaterThan(beforeFocusedPageDown);
 
+      await surfaceDock.getByRole("button", { name: "Open terminal panel", exact: true }).focus();
+      await expect(surfaceDock).toHaveClass(/input-active/);
       await diffArea.evaluate((area) => {
         area.scrollTop = 0;
       });
+      await page.keyboard.press("PageDown");
+      await expect.poll(async () => diffArea.evaluate((area) => Math.round(area.scrollTop))).toBe(0);
+
       await diffArea.click({ position: { x: 24, y: 80 } });
       await expect(surfaceDock).not.toHaveClass(/input-active/);
-      const filesLeaf = diffArea.locator("xpath=ancestor::*[contains(@class, 'tabbed-panel-leaf')][1]");
       await expect(filesLeaf).toHaveClass(/input-active/);
       await expect
         .poll(async () => {

--- a/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
+++ b/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
@@ -217,6 +217,21 @@ async function createIssueWorkspace(api: APIRequestContext, issueNumber: number)
   return waitForWorkspaceReady(api, workspace.id);
 }
 
+async function createPullWorkspace(api: APIRequestContext, pullNumber: number): Promise<WorkspaceStatusResponse> {
+  const response = await api.post("/api/v1/workspaces", {
+    data: {
+      provider: "github",
+      platform_host: "github.com",
+      owner: "acme",
+      name: "widgets",
+      mr_number: pullNumber,
+    },
+  });
+  expect(response.status()).toBe(202);
+  const workspace = (await response.json()) as WorkspaceStatusResponse;
+  return waitForWorkspaceReady(api, workspace.id);
+}
+
 async function runningRuntimeTmuxSession(api: APIRequestContext, workspaceId: string): Promise<string> {
   const response = await api.get(`/api/v1/workspaces/${workspaceId}/runtime`);
   expect(response.ok()).toBe(true);
@@ -1097,9 +1112,9 @@ test.describe("inline workspace pane continuity", () => {
     try {
       isolatedServer = await startIsolatedWorkspaceE2EServer();
       api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
-      const workspace = await createIssueWorkspace(api, 10);
+      const workspace = await createPullWorkspace(api, 1);
 
-      await page.goto(`${isolatedServer.info.base_url}/issues/github/acme/widgets/10`);
+      await page.goto(`${isolatedServer.info.base_url}/pulls/github/acme/widgets/1/files`);
       await expect(page.locator(".detail-pane-workspace-slot .workspace-host-wrapper")).toBeVisible();
       await dismissWorkspaceLauncher(page);
       await openTerminalPanel(page);
@@ -1136,6 +1151,31 @@ test.describe("inline workspace pane continuity", () => {
       await expect(page.locator(".detail-pane-workspace-slot")).toHaveCount(0);
       const surfaceDock = page.locator(".detail-host > .terminal-panel");
       await expect(surfaceDock).toBeVisible();
+
+      const diffArea = page.locator(".diff-area .kit-scrollbox__viewport");
+      await expect(diffArea).toBeVisible();
+      await page.locator(".diff-content").evaluate((content) => {
+        const spacer = document.createElement("div");
+        spacer.style.height = "2000px";
+        spacer.dataset.testScrollSpacer = "true";
+        content.append(spacer);
+      });
+      await diffArea.evaluate((area) => {
+        area.scrollTop = 0;
+      });
+      await diffArea.click({ position: { x: 24, y: 80 } });
+      await page.keyboard.press("PageDown");
+      await expect.poll(async () => diffArea.evaluate((area) => Math.round(area.scrollTop))).toBeGreaterThan(0);
+
+      await surfaceDock.hover();
+      await page.mouse.wheel(0, 120);
+      await expect(surfaceDock).toHaveClass(/input-active/);
+      const beforeExternalPageDown = await diffArea.evaluate((area) => Math.round(area.scrollTop));
+      await page.keyboard.press("PageDown");
+      await expect
+        .poll(async () => diffArea.evaluate((area) => Math.round(area.scrollTop)))
+        .toBe(beforeExternalPageDown);
+
       await typeMarkerCommand(page, promotedTerminal, workspace.worktree_path, "row-only-promoted");
       await surfaceDock.getByRole("button", { name: "Open terminal panel", exact: true }).click();
       const dockedTerminal = surfaceDock.locator(".terminal-container");

--- a/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
+++ b/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
@@ -1176,6 +1176,20 @@ test.describe("inline workspace pane continuity", () => {
         .poll(async () => diffArea.evaluate((area) => Math.round(area.scrollTop)))
         .toBe(beforeExternalPageDown);
 
+      await diffArea.evaluate((area) => {
+        area.scrollTop = 0;
+      });
+      await diffArea.click({ position: { x: 24, y: 80 } });
+      await expect(surfaceDock).not.toHaveClass(/input-active/);
+      const filesLeaf = diffArea.locator("xpath=ancestor::*[contains(@class, 'tabbed-panel-leaf')][1]");
+      await expect(filesLeaf).toHaveClass(/input-active/);
+      await expect
+        .poll(async () => {
+          await page.keyboard.press("PageDown");
+          return diffArea.evaluate((area) => Math.round(area.scrollTop));
+        })
+        .toBeGreaterThan(0);
+
       await typeMarkerCommand(page, promotedTerminal, workspace.worktree_path, "row-only-promoted");
       await surfaceDock.getByRole("button", { name: "Open terminal panel", exact: true }).click();
       const dockedTerminal = surfaceDock.locator(".terminal-container");

--- a/frontend/tests/e2e-full/00-workspace-tab-persistence.spec.ts
+++ b/frontend/tests/e2e-full/00-workspace-tab-persistence.spec.ts
@@ -537,13 +537,24 @@ test.describe("workspace tab persistence", () => {
       await page.locator(".panel-toggle-group .panel-toggle-btn", { hasText: "Diff" }).click();
       await expect(page.getByRole("region", { name: "Workspace Diff" })).toBeVisible();
 
-      await page.locator(".workspace-list-sidebar .ws-row", { hasText: "Add dark mode support" }).click();
+      const detailsFocusTarget = page.locator(".right-sidebar button").first();
+      await detailsFocusTarget.focus();
+      await expect(page.locator(".right-sidebar")).toHaveClass(/input-active/);
+
+      // DOM activation preserves the focused details control through the
+      // in-place route change, exercising the path where removed content does
+      // not deliver a usable focusout before the loading placeholder renders.
+      await page
+        .locator(".workspace-list-sidebar .ws-row", { hasText: "Add dark mode support" })
+        .evaluate((row) => (row as HTMLElement).click());
       await expect(page).toHaveURL(new RegExp(`/terminal/${workspaceB.id}$`));
       // While B's detail payload is still gated, liveness rendering
       // replaces A's entire ready view with the loading state rather
       // than leaving a stale toolbar and sidebar mounted.
       await expect(page.getByText("Setting up workspace...")).toBeVisible();
       await expect(page.getByRole("region", { name: "Workspace Diff" })).toHaveCount(0);
+      await expect(page.locator(".terminal-view")).toBeFocused();
+      await expect(page.locator(".right-sidebar.input-active")).toHaveCount(0);
 
       await page.waitForFunction(
         (workspaceID) =>

--- a/frontend/tests/e2e-full/activity-drawer.spec.ts
+++ b/frontend/tests/e2e-full/activity-drawer.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Locator, type Page } from "@playwright/test";
 import type { DiffFile, DiffLine, DiffResult, FilesResult } from "../../src/lib/api/types.js";
+import { splitFocusedPane } from "../e2e/support/paneCommands.js";
 
 type DiffFixtureFile = Omit<DiffFile, "patch"> & { patch?: string };
 type DiffFixture = Omit<DiffResult, "files"> & {
@@ -1271,6 +1272,39 @@ test.describe("activity split view", () => {
     await conversationTab.click();
     await expect(conversationTab).toHaveAttribute("aria-selected", "true");
     await expect(filesTab).toHaveAttribute("aria-selected", "false");
+  });
+
+  test("activity detail paging follows the live pane owner", async ({ page }) => {
+    await page.setViewportSize({ width: 1600, height: 1000 });
+    await mockDiffForAllPRs(page, multiFileDiff);
+    await page.goto("/");
+    await waitForActivityTable(page);
+
+    const detail = await openActivityPRSplit(page);
+    await splitFocusedPane(page, "right");
+    const conversationPane = detail.locator('[data-pane-key="conversation"]');
+    const filesPane = detail.locator('[data-pane-key="files"]');
+    const conversationLeaf = conversationPane.locator("xpath=ancestor::*[contains(@class, 'tabbed-panel-leaf')][1]");
+    const filesLeaf = filesPane.locator("xpath=ancestor::*[contains(@class, 'tabbed-panel-leaf')][1]");
+    const diffArea = detail.locator(".diff-area .kit-scrollbox__viewport");
+    await expect(diffArea).toBeVisible();
+    await expect.poll(async () => diffArea.evaluate((area) => area.scrollHeight > area.clientHeight)).toBe(true);
+
+    await filesPane.click({ position: { x: 24, y: 80 } });
+    await expect(filesLeaf).toHaveClass(/input-active/);
+    await expect(conversationLeaf).not.toHaveClass(/input-active/);
+    await diffArea.evaluate((area) => {
+      area.scrollTop = 0;
+    });
+    await page.keyboard.press("PageDown");
+    await expect.poll(async () => diffArea.evaluate((area) => Math.round(area.scrollTop))).toBeGreaterThan(0);
+
+    await conversationPane.click({ position: { x: 24, y: 80 } });
+    await expect(conversationLeaf).toHaveClass(/input-active/);
+    await expect(filesLeaf).not.toHaveClass(/input-active/);
+    const beforeInactivePageDown = await diffArea.evaluate((area) => Math.round(area.scrollTop));
+    await page.keyboard.press("PageDown");
+    await expect.poll(async () => diffArea.evaluate((area) => Math.round(area.scrollTop))).toBe(beforeInactivePageDown);
   });
 
   test("activity split view highlights matching activity rows", async ({ page }) => {

--- a/frontend/tests/e2e-full/activity-drawer.spec.ts
+++ b/frontend/tests/e2e-full/activity-drawer.spec.ts
@@ -1274,7 +1274,7 @@ test.describe("activity split view", () => {
     await expect(filesTab).toHaveAttribute("aria-selected", "false");
   });
 
-  test("activity detail paging follows the live pane owner", async ({ page }) => {
+  test("activity detail paging follows DOM focus", async ({ page }) => {
     await page.setViewportSize({ width: 1600, height: 1000 });
     await mockDiffForAllPRs(page, multiFileDiff);
     await page.goto("/");
@@ -1290,7 +1290,7 @@ test.describe("activity split view", () => {
     await expect(diffArea).toBeVisible();
     await expect.poll(async () => diffArea.evaluate((area) => area.scrollHeight > area.clientHeight)).toBe(true);
 
-    await filesPane.click({ position: { x: 24, y: 80 } });
+    await filesLeaf.getByRole("tab").focus();
     await expect(filesLeaf).toHaveClass(/input-active/);
     await expect(conversationLeaf).not.toHaveClass(/input-active/);
     await diffArea.evaluate((area) => {
@@ -1299,7 +1299,7 @@ test.describe("activity split view", () => {
     await page.keyboard.press("PageDown");
     await expect.poll(async () => diffArea.evaluate((area) => Math.round(area.scrollTop))).toBeGreaterThan(0);
 
-    await conversationPane.click({ position: { x: 24, y: 80 } });
+    await conversationLeaf.getByRole("tab").focus();
     await expect(conversationLeaf).toHaveClass(/input-active/);
     await expect(filesLeaf).not.toHaveClass(/input-active/);
     const beforeInactivePageDown = await diffArea.evaluate((area) => Math.round(area.scrollTop));

--- a/frontend/tests/e2e-full/issue-list.spec.ts
+++ b/frontend/tests/e2e-full/issue-list.spec.ts
@@ -198,7 +198,7 @@ test.describe("issue list mutations", () => {
   });
 });
 
-test.describe("issue detail pane input ownership", () => {
+test.describe("issue detail pane focus", () => {
   let server: IsolatedE2EServer | undefined;
 
   test.beforeAll(async () => {
@@ -209,7 +209,7 @@ test.describe("issue detail pane input ownership", () => {
     await server?.stop();
   });
 
-  test("keeps one active border across issue, workspace, and terminal panes", async ({ page }) => {
+  test("keeps one focused border across issue, workspace, and terminal panes", async ({ page }) => {
     if (!server) throw new Error("issue workspace e2e server was not started");
     const baseURL = server.info.base_url;
     const created = await page.request.post(`${baseURL}/api/v1/issues/github/acme/widgets/10/workspace`, {
@@ -234,20 +234,21 @@ test.describe("issue detail pane input ownership", () => {
     const workspacePane = page.locator('[data-pane-key="workspace"]');
     const conversationLeaf = conversationPane.locator("xpath=ancestor::*[contains(@class, 'tabbed-panel-leaf')][1]");
     const workspaceLeaf = workspacePane.locator("xpath=ancestor::*[contains(@class, 'tabbed-panel-leaf')][1]");
-    await conversationPane.click({ position: { x: 24, y: 80 } });
+    await conversationLeaf.getByRole("tab").focus();
     await expect(conversationLeaf).toHaveClass(/input-active/);
     await expect(workspaceLeaf).not.toHaveClass(/input-active/);
 
-    await workspacePane.click({ position: { x: 24, y: 80 } });
+    const terminalToggle = workspaceLeaf.getByRole("button", { name: "Open terminal panel" });
+    await terminalToggle.focus();
     await expect(workspaceLeaf).toHaveClass(/input-active/);
     await expect(conversationLeaf).not.toHaveClass(/input-active/);
 
-    await workspaceLeaf.getByRole("button", { name: "Open terminal panel" }).click();
+    await terminalToggle.click();
     const terminalPanel = workspaceLeaf.locator(".terminal-panel.bottom.open");
     await expect(terminalPanel).toBeVisible();
-    await terminalPanel.click({ position: { x: 24, y: 80 } });
+    await terminalPanel.locator(".panel-title").focus();
     await expect(terminalPanel).toHaveClass(/input-active/);
-    const ownershipChrome = await workspaceLeaf.evaluate((leaf) => {
+    const focusChrome = await workspaceLeaf.evaluate((leaf) => {
       const terminal = leaf.querySelector<HTMLElement>(".terminal-panel.input-active");
       if (!terminal) throw new Error("Active terminal panel is missing");
       const outer = getComputedStyle(leaf, "::after");
@@ -257,13 +258,13 @@ test.describe("issue detail pane input ownership", () => {
         outerContent: outer.content,
       };
     });
-    expect(ownershipChrome.innerWidths).toEqual(["1px", "1px", "1px", "1px"]);
-    expect(ownershipChrome.outerContent).toBe("none");
+    expect(focusChrome.innerWidths).toEqual(["1px", "1px", "1px", "1px"]);
+    expect(focusChrome.outerContent).toBe("none");
 
     await conversationPane.hover();
     await page.mouse.wheel(0, 120);
-    await expect(conversationLeaf).toHaveClass(/input-active/);
-    await expect(workspaceLeaf).not.toHaveClass(/input-active/);
+    await expect(terminalPanel).toHaveClass(/input-active/);
+    await expect(conversationLeaf).not.toHaveClass(/input-active/);
   });
 });
 

--- a/frontend/tests/e2e-full/issue-list.spec.ts
+++ b/frontend/tests/e2e-full/issue-list.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type Page } from "@playwright/test";
-import { startIsolatedE2EServer, type IsolatedE2EServer } from "./support/e2eServer";
+import { startIsolatedE2EServer, startIsolatedWorkspaceE2EServer, type IsolatedE2EServer } from "./support/e2eServer";
 import type { components } from "../../src/lib/api/generated/schema.js";
 
 // Seeded issues (6 total):
@@ -38,6 +38,29 @@ async function selectIssueGrouping(page: Page, label: string): Promise<void> {
 
 const longRepoName = "widgets-with-an-extremely-long-repository-name";
 const longRepoPath = `acme/${longRepoName}`;
+
+type WorkspaceStatusResponse = {
+  id: string;
+  status: string;
+  error_message?: string | null;
+};
+
+async function waitForWorkspaceReady(page: Page, baseURL: string, workspaceId: string): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const response = await page.request.get(`${baseURL}/api/v1/workspaces/${workspaceId}`);
+        expect(response.ok()).toBe(true);
+        const workspace = (await response.json()) as WorkspaceStatusResponse;
+        if (workspace.status === "error") {
+          throw new Error(workspace.error_message ?? `workspace ${workspaceId} failed to become ready`);
+        }
+        return workspace.status;
+      },
+      { timeout: 15_000 },
+    )
+    .toBe("ready");
+}
 
 async function mockLongIssueRepoSlug(page: Page): Promise<void> {
   await page.route(
@@ -172,6 +195,52 @@ test.describe("issue list mutations", () => {
 
     await page.reload();
     await expect(page.locator(".issue-detail .issue-state-chip")).toHaveText("Open");
+  });
+});
+
+test.describe("issue detail pane input ownership", () => {
+  let server: IsolatedE2EServer | undefined;
+
+  test.beforeAll(async () => {
+    server = await startIsolatedWorkspaceE2EServer();
+  });
+
+  test.afterAll(async () => {
+    await server?.stop();
+  });
+
+  test("moves the active border between a seeded issue and its workspace pane", async ({ page }) => {
+    if (!server) throw new Error("issue workspace e2e server was not started");
+    const baseURL = server.info.base_url;
+    const created = await page.request.post(`${baseURL}/api/v1/issues/github/acme/widgets/10/workspace`, {
+      data: {},
+    });
+    expect(created.status()).toBe(202);
+    const workspace = (await created.json()) as WorkspaceStatusResponse;
+    await waitForWorkspaceReady(page, baseURL, workspace.id);
+    const launched = await page.request.post(`${baseURL}/api/v1/workspaces/${workspace.id}/runtime/sessions`, {
+      data: { target_key: "plain_shell", display_region: "workflow" },
+    });
+    expect(launched.status(), await launched.text()).toBe(200);
+
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto(`${baseURL}/issues/github/acme/widgets/10`);
+
+    const conversationPane = page.locator('[data-pane-key="conversation"]');
+    const workspacePane = page.locator('[data-pane-key="workspace"]');
+    const conversationLeaf = conversationPane.locator("xpath=ancestor::*[contains(@class, 'tabbed-panel-leaf')][1]");
+    const workspaceLeaf = workspacePane.locator("xpath=ancestor::*[contains(@class, 'tabbed-panel-leaf')][1]");
+    await expect(conversationLeaf).toHaveClass(/input-active/);
+    await expect(workspaceLeaf).not.toHaveClass(/input-active/);
+
+    await workspacePane.click({ position: { x: 24, y: 80 } });
+    await expect(workspaceLeaf).toHaveClass(/input-active/);
+    await expect(conversationLeaf).not.toHaveClass(/input-active/);
+
+    await conversationPane.hover();
+    await page.mouse.wheel(0, 120);
+    await expect(conversationLeaf).toHaveClass(/input-active/);
+    await expect(workspaceLeaf).not.toHaveClass(/input-active/);
   });
 });
 

--- a/frontend/tests/e2e-full/issue-list.spec.ts
+++ b/frontend/tests/e2e-full/issue-list.spec.ts
@@ -209,7 +209,7 @@ test.describe("issue detail pane input ownership", () => {
     await server?.stop();
   });
 
-  test("moves the active border between a seeded issue and its workspace pane", async ({ page }) => {
+  test("keeps one active border across issue, workspace, and terminal panes", async ({ page }) => {
     if (!server) throw new Error("issue workspace e2e server was not started");
     const baseURL = server.info.base_url;
     const created = await page.request.post(`${baseURL}/api/v1/issues/github/acme/widgets/10/workspace`, {
@@ -222,6 +222,10 @@ test.describe("issue detail pane input ownership", () => {
       data: { target_key: "plain_shell", display_region: "workflow" },
     });
     expect(launched.status(), await launched.text()).toBe(200);
+    const docked = await page.request.post(`${baseURL}/api/v1/workspaces/${workspace.id}/runtime/sessions`, {
+      data: { target_key: "plain_shell", display_region: "terminal" },
+    });
+    expect(docked.status(), await docked.text()).toBe(200);
 
     await page.setViewportSize({ width: 1440, height: 900 });
     await page.goto(`${baseURL}/issues/github/acme/widgets/10`);
@@ -230,12 +234,31 @@ test.describe("issue detail pane input ownership", () => {
     const workspacePane = page.locator('[data-pane-key="workspace"]');
     const conversationLeaf = conversationPane.locator("xpath=ancestor::*[contains(@class, 'tabbed-panel-leaf')][1]");
     const workspaceLeaf = workspacePane.locator("xpath=ancestor::*[contains(@class, 'tabbed-panel-leaf')][1]");
+    await conversationPane.click({ position: { x: 24, y: 80 } });
     await expect(conversationLeaf).toHaveClass(/input-active/);
     await expect(workspaceLeaf).not.toHaveClass(/input-active/);
 
     await workspacePane.click({ position: { x: 24, y: 80 } });
     await expect(workspaceLeaf).toHaveClass(/input-active/);
     await expect(conversationLeaf).not.toHaveClass(/input-active/);
+
+    await workspaceLeaf.getByRole("button", { name: "Open terminal panel" }).click();
+    const terminalPanel = workspaceLeaf.locator(".terminal-panel.bottom.open");
+    await expect(terminalPanel).toBeVisible();
+    await terminalPanel.click({ position: { x: 24, y: 80 } });
+    await expect(terminalPanel).toHaveClass(/input-active/);
+    const ownershipChrome = await workspaceLeaf.evaluate((leaf) => {
+      const terminal = leaf.querySelector<HTMLElement>(".terminal-panel.input-active");
+      if (!terminal) throw new Error("Active terminal panel is missing");
+      const outer = getComputedStyle(leaf, "::after");
+      const inner = getComputedStyle(terminal, "::after");
+      return {
+        innerWidths: [inner.borderTopWidth, inner.borderRightWidth, inner.borderBottomWidth, inner.borderLeftWidth],
+        outerContent: outer.content,
+      };
+    });
+    expect(ownershipChrome.innerWidths).toEqual(["1px", "1px", "1px", "1px"]);
+    expect(ownershipChrome.outerContent).toBe("none");
 
     await conversationPane.hover();
     await page.mouse.wheel(0, 120);

--- a/frontend/tests/e2e-full/issue-list.spec.ts
+++ b/frontend/tests/e2e-full/issue-list.spec.ts
@@ -234,7 +234,9 @@ test.describe("issue detail pane focus", () => {
     const workspacePane = page.locator('[data-pane-key="workspace"]');
     const conversationLeaf = conversationPane.locator("xpath=ancestor::*[contains(@class, 'tabbed-panel-leaf')][1]");
     const workspaceLeaf = workspacePane.locator("xpath=ancestor::*[contains(@class, 'tabbed-panel-leaf')][1]");
-    await conversationLeaf.getByRole("tab").focus();
+    const conversationTab = conversationLeaf.getByRole("tab", { name: "Conversation" });
+    await conversationTab.focus();
+    await expect(conversationTab).toBeFocused();
     await expect(conversationLeaf).toHaveClass(/input-active/);
     await expect(workspaceLeaf).not.toHaveClass(/input-active/);
 

--- a/frontend/tests/e2e-full/terminal-focus-pane-move.spec.ts
+++ b/frontend/tests/e2e-full/terminal-focus-pane-move.spec.ts
@@ -22,6 +22,10 @@ type WorkspaceStatusResponse = {
   error_message?: string | null;
 };
 
+type WorkspaceRuntimeResponse = {
+  sessions?: Array<{ key: string; status: string }>;
+};
+
 const preMarker = "TERM_FOCUS_PRE_MOVE";
 const postMarker = "TERM_FOCUS_POST_MOVE";
 const clipboardMarker = "TERM_FOCUS_TMUX_CLIP";
@@ -74,6 +78,13 @@ async function launchShell(
 
 async function launchDockedShell(api: APIRequestContext, workspaceId: string): Promise<void> {
   await launchShell(api, workspaceId, "terminal");
+}
+
+async function runningSessionKeys(api: APIRequestContext, workspaceId: string): Promise<string[]> {
+  const response = await api.get(`/api/v1/workspaces/${workspaceId}/runtime`);
+  expect(response.ok()).toBe(true);
+  const runtime = (await response.json()) as WorkspaceRuntimeResponse;
+  return (runtime.sessions ?? []).filter((session) => session.status === "running").map((session) => session.key);
 }
 
 async function focusedSessionHost(page: Page): Promise<string | null> {
@@ -334,6 +345,52 @@ test("terminal acquires keyboard focus on every item switch, not just the first"
     await page.locator("aside button", { hasText: "#10" }).first().click();
     await expect.poll(() => focusedSessionHost(page), { timeout: 15_000 }).toContain(first.id);
     await expect.poll(() => activeElementDescription(page)).toContain("xterm-helper-textarea");
+  } finally {
+    await api?.dispose();
+    await isolatedServer?.stop();
+  }
+});
+
+test("dock reclaims focus when its focused session stops", async ({ page }) => {
+  test.skip(!hasCommand("git") || !hasCommand("tmux", ["-V"]), "git and tmux are required for the real workspace flow");
+  await page.setViewportSize({ width: 1440, height: 900 });
+
+  let isolatedServer: IsolatedE2EServer | null = null;
+  let api: APIRequestContext | null = null;
+  try {
+    isolatedServer = await startIsolatedWorkspaceE2EServer();
+    api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
+    const workspace = await createIssueWorkspace(api);
+    await launchDockedShell(api, workspace.id);
+    await launchDockedShell(api, workspace.id);
+    await launchDockedShell(api, workspace.id);
+    const sessionKeys = await runningSessionKeys(api, workspace.id);
+    expect(sessionKeys).toHaveLength(3);
+
+    await page.goto(`${isolatedServer.info.base_url}/issues/github/acme/widgets/10`);
+    await expect(page.locator(".detail-pane-workspace-slot .workspace-host-wrapper")).toBeVisible();
+    const panel = await openTerminalPanel(page);
+    const focusedTerminal = panel.locator(".terminal-container").first();
+    await focusedTerminal.click({ position: { x: 10, y: 10 } });
+    const focusedHostKey = await focusedSessionHost(page);
+    if (focusedHostKey === null) {
+      throw new Error("Expected the focused dock terminal to expose its session host key");
+    }
+    const focusedSessionKey = sessionKeys.find((key) => focusedHostKey?.includes(key));
+    if (focusedSessionKey === undefined) {
+      throw new Error(`Focused terminal ${focusedHostKey} did not match a running session`);
+    }
+
+    const response = await api.delete(
+      `/api/v1/workspaces/${workspace.id}/runtime/sessions/${encodeURIComponent(focusedSessionKey)}`,
+      { data: {} },
+    );
+    expect(response.status(), await response.text()).toBe(204);
+
+    await expect(page.locator(`[data-session-host="${focusedHostKey}"]`)).toHaveCount(0);
+    await expect(panel).toBeFocused();
+    await expect(panel).toHaveClass(/input-active/);
+    await expect(panel.locator(".terminal-container")).toBeVisible();
   } finally {
     await api?.dispose();
     await isolatedServer?.stop();

--- a/frontend/tests/e2e-full/terminal-focus-pane-move.spec.ts
+++ b/frontend/tests/e2e-full/terminal-focus-pane-move.spec.ts
@@ -269,6 +269,8 @@ test("terminal keeps keyboard focus across a pane move without a click", async (
     // The only terminal click in the scenario under test.
     await movedTerminal.click({ position: { x: 10, y: 10 } });
     await expect.poll(() => activeElementDescription(page)).toContain("xterm-helper-textarea");
+    const sourceOwner = page.locator('.tabbed-panel-leaf:has([data-pane-key="conversation"])');
+    await expect(sourceOwner).toHaveClass(/input-active/);
     await typeMarker(page, preMarker);
     await expect.poll(() => terminal.sent(preMarker), { timeout: 15_000 }).toBe(true);
     await expect.poll(() => terminal.received(preMarker), { timeout: 15_000 }).toBe(true);
@@ -287,9 +289,18 @@ test("terminal keeps keyboard focus across a pane move without a click", async (
     await expect(page.locator('[data-focus-source-slot="true"]')).toHaveCount(0);
     await expect(movedTerminal).toBeVisible();
 
-    // The regression: focus must come back to xterm on its own, and keystrokes
-    // must reach the live tmux session with no further click.
+    // The source leaf must release its keyboard claim while the focused terminal
+    // passes through parking. The pool restores focus in the destination, which
+    // becomes the layout's only owner; the old source border must not survive.
     await expect.poll(() => activeElementDescription(page)).toContain("xterm-helper-textarea");
+    const destinationOwner = page.locator(
+      '.tabbed-panel-leaf:has(.session-terminal-slot [data-focus-reparent-witness="live-terminal"])',
+    );
+    await expect(sourceOwner).not.toHaveClass(/input-active/);
+    await expect(destinationOwner).toHaveClass(/input-active/);
+    await expect(page.locator(".detail-pane-layout .tabbed-panel-leaf.input-active")).toHaveCount(1);
+
+    // Keystrokes must still reach the live tmux session with no further click.
     await typeMarker(page, postMarker);
     await expect.poll(() => terminal.sent(postMarker), { timeout: 15_000 }).toBe(true);
     await expect.poll(() => terminal.received(postMarker), { timeout: 15_000 }).toBe(true);

--- a/frontend/tests/e2e-full/terminal-focus-pane-move.spec.ts
+++ b/frontend/tests/e2e-full/terminal-focus-pane-move.spec.ts
@@ -195,32 +195,34 @@ test("terminal keeps keyboard focus across a pane move without a click", async (
       baseURL: isolatedServer.info.base_url,
     });
     const workspace = await createIssueWorkspace(api);
-    // Two real tmux shells in the bottom dock: with two sessions each dock leaf
-    // keeps its own "Move ... to a pane" control, so the promotion below runs
-    // through the real handler without focusing a palette or button first.
-    await launchDockedShell(api, workspace.id);
-    await launchDockedShell(api, workspace.id);
+    await launchShell(api, workspace.id, "workflow");
 
     await page.goto(`${isolatedServer.info.base_url}/issues/github/acme/widgets/10`);
     await expect(page.locator(".detail-pane-workspace-slot .workspace-host-wrapper")).toBeVisible();
-    const panel = await openTerminalPanel(page);
-    const chosenLeaf = panel.locator('.terminal-leaf:has(button[aria-label$=" to a pane"])').first();
-    const inlineTerminal = chosenLeaf.locator(".terminal-container");
+    const inlineTerminal = page.locator(".workspace-stage .terminal-container");
     await expect(inlineTerminal).toBeVisible();
     await expect(inlineTerminal.locator("canvas, .xterm-screen").first()).toBeVisible();
-    const promote = chosenLeaf.getByRole("button", { name: /^Move .+ to a pane$/ });
-    await expect(promote).toBeVisible();
 
-    // Promotion is setup for the pane-move scenario. Stamp the exact live
-    // xterm node first, so the assertions below prove the pane move carried,
-    // rather than rebuilt, the same real tmux terminal.
+    // Start promotion with xterm holding DOM focus. The command palette restores
+    // that saved focus before the handler reparents the terminal through parking,
+    // so the workspace and pool recovery paths overlap exactly as they do in use.
     await inlineTerminal.evaluate((element) => {
       element.setAttribute("data-focus-reparent-witness", "live-terminal");
     });
-    await promote.click();
+    await inlineTerminal.click({ position: { x: 10, y: 10 } });
+    await expect.poll(() => activeElementDescription(page)).toContain("xterm-helper-textarea");
+    await page.keyboard.press("Meta+Shift+k");
+    const promotionPalette = page.getByRole("dialog", { name: "Command palette" });
+    await expect(promotionPalette).toBeVisible();
+    await page.getByRole("textbox", { name: "Search command palette" }).fill("Move terminal session to a pane");
+    await expect(promotionPalette.getByRole("button", { name: /Move terminal session to a pane/ })).toBeVisible();
+    await page.keyboard.press("Enter");
+    await expect(promotionPalette).not.toBeVisible();
+
     const movedTerminal = page.locator('.session-terminal-slot [data-focus-reparent-witness="live-terminal"]');
-    await expect(page.locator('.terminal-panel [data-focus-reparent-witness="live-terminal"]')).toHaveCount(0);
+    await expect(page.locator('.workspace-stage [data-focus-reparent-witness="live-terminal"]')).toHaveCount(0);
     await expect(movedTerminal).toBeVisible();
+    await expect.poll(() => activeElementDescription(page)).toContain("xterm-helper-textarea");
 
     await movedTerminal.evaluate((element) => {
       element
@@ -266,7 +268,7 @@ test("terminal keeps keyboard focus across a pane move without a click", async (
       element.closest(".session-terminal-slot")?.setAttribute("data-focus-source-slot", "true");
     });
 
-    // The only terminal click in the scenario under test.
+    // Refocus after drag setup so the split below starts from the same contract.
     await movedTerminal.click({ position: { x: 10, y: 10 } });
     await expect.poll(() => activeElementDescription(page)).toContain("xterm-helper-textarea");
     const sourceOwner = page.locator('.tabbed-panel-leaf:has([data-pane-key="conversation"])');

--- a/frontend/tests/e2e/default-branch-activity.spec.ts
+++ b/frontend/tests/e2e/default-branch-activity.spec.ts
@@ -516,6 +516,19 @@ test.describe("default branch activity", () => {
     await expect.poll(() => pierreDiffCount(diffFile, "[data-expand-button]")).toBe(0);
     await expect.poll(() => filePreviewRequests).toBe(0);
     await expect.poll(() => page.evaluate(() => window.__kenn_forgeOpenedURL)).toBe("");
+
+    const dispatchPageDown = () =>
+      page.evaluate(() => {
+        const event = new KeyboardEvent("keydown", { key: "PageDown", bubbles: true, cancelable: true });
+        window.dispatchEvent(event);
+        return event.defaultPrevented;
+      });
+    await expect(dispatchPageDown()).resolves.toBe(false);
+
+    const activityLeaf = page.locator(".activity-detail .tabbed-panel-leaf");
+    await page.getByRole("region", { name: "Changed file diffs" }).focus();
+    await expect(activityLeaf).toHaveClass(/input-active/);
+    await expect(dispatchPageDown()).resolves.toBe(true);
   });
 });
 

--- a/frontend/tests/e2e/pr-detail-panes.spec.ts
+++ b/frontend/tests/e2e/pr-detail-panes.spec.ts
@@ -281,7 +281,7 @@ test("routes page keys by focus while wheel input remains focus-neutral", async 
   await page.keyboard.press("PageDown");
   await expect.poll(async () => diffArea.evaluate((area) => Math.round(area.scrollTop))).toBe(afterWheel);
 
-  await filesLeaf.getByRole("tab").focus();
+  await filesLeaf.getByRole("tab", { name: "Files changed" }).focus();
   await expect(filesLeaf).toHaveClass(/input-active/);
   await expect(conversationLeaf).not.toHaveClass(/input-active/);
 

--- a/frontend/tests/e2e/pr-detail-panes.spec.ts
+++ b/frontend/tests/e2e/pr-detail-panes.spec.ts
@@ -231,7 +231,7 @@ test("splits the PR detail panes apart and remembers the dragged ratio", async (
   await expect.poll(async () => firstPaneWidth(page)).toBeLessThan(before - 150);
 });
 
-test("routes page keys and wheel input to the active pane", async ({ page }) => {
+test("routes page keys by focus while wheel input remains focus-neutral", async ({ page }) => {
   await page.setViewportSize({ width: 1600, height: 1000 });
   await page.goto("/pulls/github/acme/widgets/42");
   await expect(page.locator(".detail-title")).toContainText("Add browser regression coverage");
@@ -253,7 +253,7 @@ test("routes page keys and wheel input to the active pane", async ({ page }) => 
   });
   await expect.poll(async () => diffArea.evaluate((area) => area.scrollHeight > area.clientHeight)).toBe(true);
 
-  await conversationPane.click({ position: { x: 24, y: 80 } });
+  await conversationLeaf.getByRole("tab").focus();
   await expect(page.locator(".tabbed-panel-leaf.input-active")).toHaveCount(1);
   await expect(conversationLeaf).toHaveClass(/input-active/);
   await expect(filesLeaf).not.toHaveClass(/input-active/);
@@ -273,9 +273,17 @@ test("routes page keys and wheel input to the active pane", async ({ page }) => 
   await diffArea.hover();
   await page.mouse.wheel(0, 360);
   await expect(page.locator(".tabbed-panel-leaf.input-active")).toHaveCount(1);
+  await expect(conversationLeaf).toHaveClass(/input-active/);
+  await expect(filesLeaf).not.toHaveClass(/input-active/);
+  await expect.poll(async () => diffArea.evaluate((area) => Math.round(area.scrollTop))).toBeGreaterThan(0);
+
+  const afterWheel = await diffArea.evaluate((area) => Math.round(area.scrollTop));
+  await page.keyboard.press("PageDown");
+  await expect.poll(async () => diffArea.evaluate((area) => Math.round(area.scrollTop))).toBe(afterWheel);
+
+  await filesLeaf.getByRole("tab").focus();
   await expect(filesLeaf).toHaveClass(/input-active/);
   await expect(conversationLeaf).not.toHaveClass(/input-active/);
-  await expect.poll(async () => diffArea.evaluate((area) => Math.round(area.scrollTop))).toBeGreaterThan(0);
 
   const filesPaneChrome = await filesLeaf.evaluate((leaf) => {
     const outline = getComputedStyle(leaf, "::after");
@@ -305,9 +313,9 @@ test("routes page keys and wheel input to the active pane", async ({ page }) => 
   expect(filesPaneChrome.tabAccentContent).toBe("none");
   expect(filesPaneChrome.toolbarZIndex).toBe("auto");
 
-  const afterWheel = await diffArea.evaluate((area) => Math.round(area.scrollTop));
+  const afterFocus = await diffArea.evaluate((area) => Math.round(area.scrollTop));
   await page.keyboard.press("PageDown");
-  await expect.poll(async () => diffArea.evaluate((area) => Math.round(area.scrollTop))).toBeGreaterThan(afterWheel);
+  await expect.poll(async () => diffArea.evaluate((area) => Math.round(area.scrollTop))).toBeGreaterThan(afterFocus);
 });
 
 async function detailPaneHostWidth(page: Page): Promise<number> {

--- a/frontend/tests/e2e/pr-detail-panes.spec.ts
+++ b/frontend/tests/e2e/pr-detail-panes.spec.ts
@@ -71,6 +71,7 @@ async function fulfillJson(route: Route, body: unknown): Promise<void> {
 
 async function mockSplitViewPR(page: Page): Promise<void> {
   const detailPath = "**/api/v1/pulls/github/acme/widgets/42";
+  const replacementDetailPath = "**/api/v1/pulls/github/acme/widgets/55";
 
   await page.route(detailPath, async (route) => {
     if (route.request().method() !== "GET") {
@@ -143,6 +144,12 @@ async function mockSplitViewPR(page: Page): Promise<void> {
     await fulfillJson(route, diffResponse);
   });
   await page.route(`${detailPath}/diff**`, async (route) => {
+    await fulfillJson(route, diffResponse);
+  });
+  await page.route(`${replacementDetailPath}/files`, async (route) => {
+    await fulfillJson(route, diffResponse);
+  });
+  await page.route(`${replacementDetailPath}/diff**`, async (route) => {
     await fulfillJson(route, diffResponse);
   });
 }
@@ -396,4 +403,21 @@ test("restores layout focus when a focused pane is replaced across the flatten t
   await page.setViewportSize({ width: 1280, height: 900 });
   await expect(page.locator(".tabbed-panel-split-child")).toHaveCount(2);
   await expect(layout).toBeFocused();
+});
+
+test("restores layout focus when history replaces focused same-tab content", async ({ page }) => {
+  await page.goto("/pulls/github/acme/widgets/42/files");
+  const layout = page.locator(".detail-pane-layout");
+  const diffArea = page.locator(".diff-area .kit-scrollbox__viewport");
+  await diffArea.focus();
+  await expect(diffArea).toBeFocused();
+
+  await page.evaluate(() => {
+    window.history.pushState(null, "", "/pulls/github/acme/widgets/55/files");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  });
+
+  await expect(page.locator(".detail-title")).toContainText("Refactor theme system");
+  await expect(layout).toBeFocused();
+  await expect(page.locator(".tabbed-panel-leaf.input-active")).toHaveCount(0);
 });

--- a/frontend/tests/e2e/pr-detail-panes.spec.ts
+++ b/frontend/tests/e2e/pr-detail-panes.spec.ts
@@ -277,6 +277,34 @@ test("routes page keys and wheel input to the active pane", async ({ page }) => 
   await expect(conversationLeaf).not.toHaveClass(/input-active/);
   await expect.poll(async () => diffArea.evaluate((area) => Math.round(area.scrollTop))).toBeGreaterThan(0);
 
+  const filesPaneChrome = await filesLeaf.evaluate((leaf) => {
+    const outline = getComputedStyle(leaf, "::after");
+    const toolbar = leaf.querySelector<HTMLElement>(".diff-toolbar");
+    const activeTab = leaf.querySelector<HTMLElement>(".tabbed-panel-tab.active");
+    if (!toolbar || !activeTab) throw new Error("Files pane chrome is missing");
+    const tabAccent = getComputedStyle(activeTab, "::before");
+    return {
+      outlineColors: [
+        outline.borderTopColor,
+        outline.borderRightColor,
+        outline.borderBottomColor,
+        outline.borderLeftColor,
+      ],
+      outlineWidths: [
+        outline.borderTopWidth,
+        outline.borderRightWidth,
+        outline.borderBottomWidth,
+        outline.borderLeftWidth,
+      ],
+      tabAccentContent: tabAccent.content,
+      toolbarZIndex: getComputedStyle(toolbar).zIndex,
+    };
+  });
+  expect(new Set(filesPaneChrome.outlineColors).size).toBe(1);
+  expect(filesPaneChrome.outlineWidths).toEqual(["1px", "1px", "1px", "1px"]);
+  expect(filesPaneChrome.tabAccentContent).toBe("none");
+  expect(filesPaneChrome.toolbarZIndex).toBe("auto");
+
   const afterWheel = await diffArea.evaluate((area) => Math.round(area.scrollTop));
   await page.keyboard.press("PageDown");
   await expect.poll(async () => diffArea.evaluate((area) => Math.round(area.scrollTop))).toBeGreaterThan(afterWheel);

--- a/frontend/tests/e2e/pr-detail-panes.spec.ts
+++ b/frontend/tests/e2e/pr-detail-panes.spec.ts
@@ -318,6 +318,29 @@ test("routes page keys by focus while wheel input remains focus-neutral", async 
   await expect.poll(async () => diffArea.evaluate((area) => Math.round(area.scrollTop))).toBeGreaterThan(afterFocus);
 });
 
+test("keeps page keys out of the files diff while a modal owns focus", async ({ page }) => {
+  await page.setViewportSize({ width: 1600, height: 1000 });
+  await page.goto("/pulls/github/acme/widgets/42/files");
+  const diffArea = page.locator(".diff-area .kit-scrollbox__viewport");
+  await page.locator(".diff-content").evaluate((content) => {
+    const spacer = document.createElement("div");
+    spacer.style.height = "2000px";
+    content.append(spacer);
+  });
+  await diffArea.evaluate((area) => {
+    area.scrollTop = 0;
+  });
+
+  await page.keyboard.press("Meta+K");
+  const palette = page.getByRole("dialog", { name: "Command palette" });
+  await expect(palette).toBeVisible();
+  await expect(palette.getByRole("textbox", { name: "Search command palette" })).toBeFocused();
+
+  await page.keyboard.press("PageDown");
+
+  await expect.poll(async () => diffArea.evaluate((area) => Math.round(area.scrollTop))).toBe(0);
+});
+
 async function detailPaneHostWidth(page: Page): Promise<number> {
   return Math.round(await page.locator(".detail-pane-layout").evaluate((el) => el.getBoundingClientRect().width));
 }
@@ -351,4 +374,26 @@ test("keeps the arrangement at an ordinary window width and flattens below 720px
   // Back above the threshold the split the user made is still there.
   await page.setViewportSize({ width: 1280, height: 900 });
   await expect(page.locator(".tabbed-panel-split-child")).toHaveCount(2);
+});
+
+test("restores layout focus when a focused pane is replaced across the flatten threshold", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto("/pulls/github/acme/widgets/42");
+  await splitFocusedPane(page, "right");
+
+  const layout = page.locator(".detail-pane-layout");
+  const filesTab = page.getByRole("tab", { name: "Files changed" });
+  await filesTab.focus();
+  await expect(filesTab).toBeFocused();
+
+  await page.setViewportSize({ width: 700, height: 900 });
+  await expect.poll(async () => detailPaneHostWidth(page)).toBeLessThan(720);
+  await expect(layout).toBeFocused();
+
+  await filesTab.focus();
+  await expect(filesTab).toBeFocused();
+
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await expect(page.locator(".tabbed-panel-split-child")).toHaveCount(2);
+  await expect(layout).toBeFocused();
 });

--- a/frontend/tests/e2e/pr-detail-panes.spec.ts
+++ b/frontend/tests/e2e/pr-detail-panes.spec.ts
@@ -231,6 +231,57 @@ test("splits the PR detail panes apart and remembers the dragged ratio", async (
   await expect.poll(async () => firstPaneWidth(page)).toBeLessThan(before - 150);
 });
 
+test("routes page keys and wheel input to the active pane", async ({ page }) => {
+  await page.setViewportSize({ width: 1600, height: 1000 });
+  await page.goto("/pulls/github/acme/widgets/42");
+  await expect(page.locator(".detail-title")).toContainText("Add browser regression coverage");
+
+  await splitFocusedPane(page, "right");
+  await expect(page.locator(".files-layout")).toBeVisible();
+
+  const conversationPane = page.locator('[data-pane-key="conversation"]');
+  const filesPane = page.locator('[data-pane-key="files"]');
+  const conversationLeaf = conversationPane.locator("xpath=ancestor::*[contains(@class, 'tabbed-panel-leaf')][1]");
+  const filesLeaf = filesPane.locator("xpath=ancestor::*[contains(@class, 'tabbed-panel-leaf')][1]");
+  const diffArea = page.locator(".diff-area .kit-scrollbox__viewport");
+
+  await page.locator(".diff-content").evaluate((content) => {
+    const spacer = document.createElement("div");
+    spacer.style.height = "2000px";
+    spacer.dataset.testScrollSpacer = "true";
+    content.append(spacer);
+  });
+  await expect.poll(async () => diffArea.evaluate((area) => area.scrollHeight > area.clientHeight)).toBe(true);
+
+  await conversationPane.click({ position: { x: 24, y: 80 } });
+  await expect(page.locator(".tabbed-panel-leaf.input-active")).toHaveCount(1);
+  await expect(conversationLeaf).toHaveClass(/input-active/);
+  await expect(filesLeaf).not.toHaveClass(/input-active/);
+  const activeBorder = await conversationLeaf.evaluate((leaf) => {
+    const style = getComputedStyle(leaf, "::after");
+    return { color: style.borderTopColor, width: style.borderTopWidth };
+  });
+  expect(activeBorder.color).not.toBe("rgba(0, 0, 0, 0)");
+  expect(activeBorder.width).toBe("1px");
+
+  await diffArea.evaluate((area) => {
+    area.scrollTop = 0;
+  });
+  await page.keyboard.press("PageDown");
+  await expect.poll(async () => diffArea.evaluate((area) => Math.round(area.scrollTop))).toBe(0);
+
+  await diffArea.hover();
+  await page.mouse.wheel(0, 360);
+  await expect(page.locator(".tabbed-panel-leaf.input-active")).toHaveCount(1);
+  await expect(filesLeaf).toHaveClass(/input-active/);
+  await expect(conversationLeaf).not.toHaveClass(/input-active/);
+  await expect.poll(async () => diffArea.evaluate((area) => Math.round(area.scrollTop))).toBeGreaterThan(0);
+
+  const afterWheel = await diffArea.evaluate((area) => Math.round(area.scrollTop));
+  await page.keyboard.press("PageDown");
+  await expect.poll(async () => diffArea.evaluate((area) => Math.round(area.scrollTop))).toBeGreaterThan(afterWheel);
+});
+
 async function detailPaneHostWidth(page: Page): Promise<number> {
   return Math.round(await page.locator(".detail-pane-layout").evaluate((el) => el.getBoundingClientRect().width));
 }

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -2965,6 +2965,49 @@ test.describe("sidebar toggle behavior", () => {
     await page.keyboard.press("Meta+]");
     await expect(page.locator(".right-sidebar")).toHaveCount(0);
   });
+
+  test("Cmd+] leaves the workspace sidebar closed while the command palette owns focus", async ({ page }) => {
+    await page.goto("/terminal/ws-123");
+
+    await page.keyboard.press("Meta+K");
+    const palette = page.getByRole("dialog", { name: "Command palette" });
+    await expect(palette).toBeVisible();
+    await expect(palette.getByRole("textbox", { name: "Search command palette" })).toBeFocused();
+
+    await page.keyboard.press("Meta+]");
+
+    await expect(page.locator(".right-sidebar")).toHaveCount(0);
+    await expect(palette.getByRole("textbox", { name: "Search command palette" })).toBeFocused();
+  });
+
+  test("closing focused workspace details returns focus to the workspace", async ({ page }) => {
+    await page.goto("/terminal/ws-123");
+    await page.locator(".panel-toggle-btn", { hasText: "PR" }).click();
+
+    const details = page.getByRole("region", { name: "Workspace details pane" });
+    const detailsViewport = details.locator(".kit-scrollbox__viewport").first();
+    await detailsViewport.focus();
+    await expect(detailsViewport).toBeFocused();
+
+    await page.keyboard.press("Meta+]");
+
+    await expect(details).toHaveCount(0);
+    await expect(page.locator(".terminal-view")).toBeFocused();
+  });
+
+  test("moving the focused bottom terminal into Workflow returns focus to the workspace", async ({ page }) => {
+    await page.goto("/terminal/ws-123");
+    await page.getByRole("button", { name: "Open terminal panel" }).click();
+
+    const moveToWorkflow = page.getByRole("button", { name: "Move terminal panel to workflow" });
+    await moveToWorkflow.focus();
+    await expect(moveToWorkflow).toBeFocused();
+    await moveToWorkflow.click();
+
+    await expect(page.locator(".terminal-panel.bottom")).toHaveCount(0);
+    await expect(page.getByRole("tab", { name: "Terminal" })).toBeVisible();
+    await expect(page.locator(".terminal-view")).toBeFocused();
+  });
 });
 
 test.describe("workspace list fleet inventory", () => {

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -1745,6 +1745,40 @@ test.describe("workspace launch home", () => {
     expect(Math.abs(metrics.delta.bottom)).toBeLessThanOrEqual(0.5);
   });
 
+  test("moves active ownership between standalone workflow panes", async ({ page }) => {
+    await setupTerminalMocks(page, {
+      runtime: workflowDragRuntime(),
+    });
+    await page.addInitScript((layout) => {
+      localStorage.setItem("kenn-forge-workspace-terminal-layout:ws-123", JSON.stringify(layout));
+      localStorage.setItem("kenn-forge-workspace-active-tab:ws-123", "session:ws-123:codex");
+    }, workflowDragLayout());
+
+    await page.goto("/terminal/ws-123");
+    const codexPane = page.locator('[data-pane-key="session:ws-123:codex"]');
+    const reviewerPane = page.locator('[data-pane-key="session:ws-123:reviewer"]');
+    const codexLeaf = codexPane.locator("xpath=ancestor::*[contains(@class, 'tabbed-panel-leaf')][1]");
+    const reviewerLeaf = reviewerPane.locator("xpath=ancestor::*[contains(@class, 'tabbed-panel-leaf')][1]");
+
+    await expect(page.locator(".workspace-stage .tabbed-panel-leaf.input-active")).toHaveCount(1);
+    await expect(codexLeaf).toHaveClass(/input-active/);
+    const activeBorder = await codexLeaf.evaluate((leaf) => {
+      const style = getComputedStyle(leaf, "::after");
+      return { color: style.borderTopColor, width: style.borderTopWidth };
+    });
+    expect(activeBorder.color).not.toBe("rgba(0, 0, 0, 0)");
+    expect(activeBorder.width).toBe("1px");
+
+    await reviewerPane.click({ position: { x: 24, y: 80 } });
+    await expect(reviewerLeaf).toHaveClass(/input-active/);
+    await expect(codexLeaf).not.toHaveClass(/input-active/);
+
+    await codexPane.hover();
+    await page.mouse.wheel(0, 120);
+    await expect(codexLeaf).toHaveClass(/input-active/);
+    await expect(reviewerLeaf).not.toHaveClass(/input-active/);
+  });
+
   test("shows one Workspaces option in the compact page menu on terminal routes", async ({ page }) => {
     await page.setViewportSize({ width: 1000, height: 720 });
     await setupTerminalMocks(page, {

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -2980,6 +2980,18 @@ test.describe("sidebar toggle behavior", () => {
     await expect(palette.getByRole("textbox", { name: "Search command palette" })).toBeFocused();
   });
 
+  test("Cmd+] leaves the workspace sidebar closed while application chrome owns focus", async ({ page }) => {
+    await page.goto("/terminal/ws-123");
+    const settings = page.getByRole("button", { name: "Settings" });
+    await settings.focus();
+    await expect(settings).toBeFocused();
+
+    await page.keyboard.press("Meta+]");
+
+    await expect(page.locator(".right-sidebar")).toHaveCount(0);
+    await expect(settings).toBeFocused();
+  });
+
   test("closing focused workspace details returns focus to the workspace", async ({ page }) => {
     await page.goto("/terminal/ws-123");
     await page.locator(".panel-toggle-btn", { hasText: "PR" }).click();

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -1764,10 +1764,13 @@ test.describe("workspace launch home", () => {
     await expect(codexLeaf).toHaveClass(/input-active/);
     const activeBorder = await codexLeaf.evaluate((leaf) => {
       const style = getComputedStyle(leaf, "::after");
-      return { color: style.borderTopColor, width: style.borderTopWidth };
+      return {
+        colors: [style.borderTopColor, style.borderRightColor, style.borderBottomColor, style.borderLeftColor],
+        widths: [style.borderTopWidth, style.borderRightWidth, style.borderBottomWidth, style.borderLeftWidth],
+      };
     });
-    expect(activeBorder.color).not.toBe("rgba(0, 0, 0, 0)");
-    expect(activeBorder.width).toBe("1px");
+    expect(activeBorder.colors.every((color) => color !== "rgba(0, 0, 0, 0)")).toBe(true);
+    expect(activeBorder.widths).toEqual(["1px", "1px", "1px", "1px"]);
 
     await reviewerPane.click({ position: { x: 24, y: 80 } });
     await expect(reviewerLeaf).toHaveClass(/input-active/);
@@ -1777,6 +1780,17 @@ test.describe("workspace launch home", () => {
     await page.mouse.wheel(0, 120);
     await expect(codexLeaf).toHaveClass(/input-active/);
     await expect(reviewerLeaf).not.toHaveClass(/input-active/);
+
+    await page.locator(".panel-toggle-btn", { hasText: "Diff" }).click();
+    const rightSidebar = page.locator(".right-sidebar");
+    await expect(rightSidebar).toBeVisible();
+    await rightSidebar.click({ position: { x: 24, y: 100 } });
+    await expect(rightSidebar).toHaveClass(/input-active/);
+    await expect(page.locator(".workspace-stage .tabbed-panel-leaf.input-active")).toHaveCount(0);
+
+    await codexPane.click({ position: { x: 24, y: 80 } });
+    await expect(codexLeaf).toHaveClass(/input-active/);
+    await expect(rightSidebar).not.toHaveClass(/input-active/);
   });
 
   test("shows one Workspaces option in the compact page menu on terminal routes", async ({ page }) => {

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -1745,7 +1745,7 @@ test.describe("workspace launch home", () => {
     expect(Math.abs(metrics.delta.bottom)).toBeLessThanOrEqual(0.5);
   });
 
-  test("moves active ownership between standalone workflow panes", async ({ page }) => {
+  test("moves active focus between standalone workflow panes", async ({ page }) => {
     await setupTerminalMocks(page, {
       runtime: workflowDragRuntime(),
     });
@@ -1760,7 +1760,8 @@ test.describe("workspace launch home", () => {
     const codexLeaf = codexPane.locator("xpath=ancestor::*[contains(@class, 'tabbed-panel-leaf')][1]");
     const reviewerLeaf = reviewerPane.locator("xpath=ancestor::*[contains(@class, 'tabbed-panel-leaf')][1]");
 
-    await expect(page.locator(".workspace-stage .tabbed-panel-leaf.input-active")).toHaveCount(1);
+    await expect(page.locator(".workspace-stage .tabbed-panel-leaf.input-active")).toHaveCount(0);
+    await codexLeaf.getByRole("tab", { name: /^Codex/ }).focus();
     await expect(codexLeaf).toHaveClass(/input-active/);
     const activeBorder = await codexLeaf.evaluate((leaf) => {
       const style = getComputedStyle(leaf, "::after");
@@ -1772,23 +1773,23 @@ test.describe("workspace launch home", () => {
     expect(activeBorder.colors.every((color) => color !== "rgba(0, 0, 0, 0)")).toBe(true);
     expect(activeBorder.widths).toEqual(["1px", "1px", "1px", "1px"]);
 
-    await reviewerPane.click({ position: { x: 24, y: 80 } });
+    await reviewerLeaf.getByRole("tab", { name: /^Reviewer/ }).focus();
     await expect(reviewerLeaf).toHaveClass(/input-active/);
     await expect(codexLeaf).not.toHaveClass(/input-active/);
 
     await codexPane.hover();
     await page.mouse.wheel(0, 120);
-    await expect(codexLeaf).toHaveClass(/input-active/);
-    await expect(reviewerLeaf).not.toHaveClass(/input-active/);
+    await expect(reviewerLeaf).toHaveClass(/input-active/);
+    await expect(codexLeaf).not.toHaveClass(/input-active/);
 
     await page.locator(".panel-toggle-btn", { hasText: "Diff" }).click();
     const rightSidebar = page.locator(".right-sidebar");
     await expect(rightSidebar).toBeVisible();
-    await rightSidebar.click({ position: { x: 24, y: 100 } });
+    await rightSidebar.locator(".kit-scrollbox__viewport").focus();
     await expect(rightSidebar).toHaveClass(/input-active/);
     await expect(page.locator(".workspace-stage .tabbed-panel-leaf.input-active")).toHaveCount(0);
 
-    await codexPane.click({ position: { x: 24, y: 80 } });
+    await codexLeaf.getByRole("tab", { name: /^Codex/ }).focus();
     await expect(codexLeaf).toHaveClass(/input-active/);
     await expect(rightSidebar).not.toHaveClass(/input-active/);
   });


### PR DESCRIPTION
Split panes could show an active border on one surface while Page Up or Page Down routed to another. Mousewheel was incorrectly treated as focus, so the UI could claim a pane was active even though browser focus had not moved.

This change makes actual DOM focus the only live source of active-pane state across PR, Issue, Activity, and Workspaces layouts. Wheel scrolling stays local and does not change focus. Deliberate terminal focus still changes the active pane because it moves DOM focus.

Narrow layouts use the exact leaf identity rendered on screen. Responsive flatten and unflatten transitions preserve that renderer-owned identity and reclaim focus only when the browser strands it on the document body. Same-leaf tab replacement uses the same rule.

Workflow focus ownership continues to update while workspace mutations are blocked. Parking a workspace host or removing focused Workflow content clears stale ownership. Readiness changes and Workflow content replacement run bounded post-render recovery independently of reactive reruns, and restore the Workspace root only when no deliberate destination received focus. Connected pooled terminals keep their own restoration path. Successful command-palette promotion queues focus for the exact promoted session. Activity commit diffs use the same live focus ownership as other review panes.

A dedicated Files route retains global diff shortcuts only while no pane, external dock, or modal has live ownership. Once one of those scopes claims the keyboard, the Files diff stops consuming shortcuts.

Workspace sidebar shortcuts yield to active modal frames. If focused Workspace Details or bottom Terminal disappears while the host stays visible, focus returns to the Workspace root only when the browser leaves focus on the document body. Resetting pane arrangement preserves a live external dock claim; DOM focusout, dock unmount, or renderer teardown releases it.

<details>
<summary>Validation</summary>

- Workspace terminal component suite: 132 passed.
- Formatting, kit UI checks, Svelte checks, Effect diagnostics, and repository lint passed; only existing lint warnings remain.
- Svelte autofixer reported no issues.
- Full-stack Chromium terminal focus and pane-move suite: 3 passed, including promotion, input, and focus recovery.
- Context structural validation passed.
- Exact-head CI passed every applicable build, lint, unit, browser, mock e2e, full-stack e2e, documentation, and RoboRev e2e job in Chromium and Firefox.

</details>

<sup>generated by a clanker</sup>