### PR TITLE
Stop activity persistence tests waiting for full page load

### DIFF
--- a/frontend/tests/e2e/activity-threaded-columns.spec.ts
+++ b/frontend/tests/e2e/activity-threaded-columns.spec.ts
@@ -193,7 +193,7 @@ test.describe("threaded activity columns", () => {
       localStorage.setItem("kenn-forge:groupingMode", "flat");
       localStorage.removeItem("kenn-forge:hideOrgName");
     });
-    await page.reload();
+    await page.reload({ waitUntil: "domcontentloaded" });
 
     const repoLabel = page.locator(".item-row .repo-chip__label").first();
     await expect(repoLabel).toHaveText("acme/widgets");
@@ -206,7 +206,7 @@ test.describe("threaded activity columns", () => {
     await expect(repoLabel).toHaveText("widgets");
 
     // Reload to verify the toggle persists via localStorage.
-    await page.reload();
+    await page.reload({ waitUntil: "domcontentloaded" });
     await expect(page.locator(".item-row .repo-chip__label").first()).toHaveText("widgets");
   });
 });


### PR DESCRIPTION
The hide-org preference regression could reach the expected page under CI contention while Playwright kept waiting for the browser full load event. This exhausted the 30-second test budget before the visible label assertions could run, even though navigation had completed.

The persistence reloads now stop at DOM readiness. The existing repository-label assertions still prove that the preference applies before and after reload, while unrelated subresources no longer decide the test result.

<details>
<summary>Validation</summary>

- Frontend unit suite: 3,895 passed, 2 skipped.
- Mock Playwright Chromium lane: 205 passed, 4 skipped; one unrelated retry passed 3/3 in a focused rerun.
- Mock Playwright Firefox lane: 204 passed, 6 skipped.
- Frontend checks and non-mutating lint passed.
- Commit and push hooks passed.

</details>

<sup>generated by a clanker</sup>