### PR TITLE
Remember review filters across reloads

### DIFF
--- a/docs/adr/0005-global-roborev-filter-persistence.md
+++ b/docs/adr/0005-global-roborev-filter-persistence.md
@@ -16,7 +16,7 @@ These choices describe how one browser should present Roborev jobs. They do not 
 
 Persist both boolean filters as browser-global preferences owned by the Roborev jobs store. Use the distinct `localStorage` keys `kenn-forge:roborev:hideClosed` and `kenn-forge:roborev:showAutoDesign`, with `"1"` for enabled and `"0"` for disabled.
 
-Every newly created Roborev jobs store restores the same two preferences, including stores used by workspace review sidebars. Existing stores retain their reactive values across navigation. Missing, unavailable, or unrecognized storage retains the current defaults: closed reviews remain visible and auto-design jobs remain hidden.
+Every Roborev jobs store shares the same two reactive preferences, including stores used by workspace review sidebars. A change in any mounted review surface refreshes every other live store immediately, and newly created stores restore the preferences from storage. Missing, unavailable, or unrecognized storage retains the current defaults: closed reviews remain visible and auto-design jobs remain hidden.
 
 Every mutation path writes the preference before refreshing the jobs query, so filter-bar actions and keyboard shortcuts behave consistently. Storage access is best-effort: read or write failures do not block in-memory filtering, request refreshes, or surface application errors.
 
@@ -25,6 +25,6 @@ Repository, branch, status, search, job type, and sort state remain transient.
 ## Consequences
 
 - The two choices follow the browser rather than a workspace or daemon.
-- Newly mounted main and sidebar review surfaces start with consistent filters.
+- Mounted main and sidebar review surfaces keep consistent filters, and newly mounted surfaces restore them.
 - Storage remains local to one browser and does not follow a user to another device.
-- Focused jobs-store tests must cover defaults, writes, restoration in a new store, and the resulting request query.
+- Focused jobs-store tests must cover defaults, writes, live-store synchronization, restoration in a new store, and the resulting request query. Full-stack browser coverage must verify both filters survive a reload.

--- a/docs/adr/0005-global-roborev-filter-persistence.md
+++ b/docs/adr/0005-global-roborev-filter-persistence.md
@@ -1,0 +1,30 @@
+# ADR 0005: Global Roborev Filter Persistence
+
+Date: 2026-08-10
+
+## Status
+
+Accepted
+
+## Context
+
+The Roborev review list resets **Hide closed** and **Show auto-design** to their defaults whenever its jobs store is recreated. This makes maintainers repeatedly restore the same view after a reload or after moving between the main Reviews view and a workspace review sidebar.
+
+These choices describe how one browser should present Roborev jobs. They do not describe a workspace, repository, branch, daemon, or server-side user setting.
+
+## Decision
+
+Persist both boolean filters as browser-global preferences owned by the Roborev jobs store. Use the distinct `localStorage` keys `kenn-forge:roborev:hideClosed` and `kenn-forge:roborev:showAutoDesign`, with `"1"` for enabled and `"0"` for disabled.
+
+Every newly created Roborev jobs store restores the same two preferences, including stores used by workspace review sidebars. Existing stores retain their reactive values across navigation. Missing, unavailable, or unrecognized storage retains the current defaults: closed reviews remain visible and auto-design jobs remain hidden.
+
+Every mutation path writes the preference before refreshing the jobs query, so filter-bar actions and keyboard shortcuts behave consistently. Storage access is best-effort: read or write failures do not block in-memory filtering, request refreshes, or surface application errors.
+
+Repository, branch, status, search, job type, and sort state remain transient.
+
+## Consequences
+
+- The two choices follow the browser rather than a workspace or daemon.
+- Newly mounted main and sidebar review surfaces start with consistent filters.
+- Storage remains local to one browser and does not follow a user to another device.
+- Focused jobs-store tests must cover defaults, writes, restoration in a new store, and the resulting request query.

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -659,6 +659,7 @@
   }
 
   onDestroy(() => {
+    stores?.roborevJobs?.dispose();
     stopFullAppShell();
     roborevPollingExecution?.interrupt();
   });

--- a/frontend/src/lib/components/workspace/WorkspaceRightSidebar.svelte
+++ b/frontend/src/lib/components/workspace/WorkspaceRightSidebar.svelte
@@ -320,6 +320,7 @@
   });
 
   onDestroy(() => {
+    sidebarJobs.dispose();
     appRuntime.runCommand(
       Effect.gen(function* () {
         const workflow = yield* RoborevWorkflow;

--- a/frontend/src/lib/stores/roborev-jobs.test.ts
+++ b/frontend/src/lib/stores/roborev-jobs.test.ts
@@ -73,55 +73,24 @@ function makeJob(id: number, startedAt?: string, finishedAt?: string): ReviewJob
 }
 
 describe("createJobsStore filter preferences", () => {
-  it("uses existing defaults for missing or unrecognized preferences", () => {
-    const store = createJobsStore({ client: {} as never, navigate: vi.fn() });
-
-    expect(store.getFilterHideClosed()).toBe(false);
-    expect(store.getFilterShowAutoDesign()).toBe(false);
-
-    localStorage.setItem("kenn-forge:roborev:hideClosed", "unknown");
-    localStorage.setItem("kenn-forge:roborev:showAutoDesign", "unknown");
-    const restored = createJobsStore({ client: {} as never, navigate: vi.fn() });
-
-    expect(restored.getFilterHideClosed()).toBe(false);
-    expect(restored.getFilterShowAutoDesign()).toBe(false);
-  });
-
-  it("writes both filter choices to global browser storage", () => {
+  it("restores filter choices in a new store and applies them to the jobs query", async () => {
     const client = {
       GET: vi.fn().mockResolvedValue({
         data: { jobs: [], has_more: false, stats: { done: 0, closed: 0, open: 0 } },
         error: undefined,
       }),
     };
-    const store = createJobsStore({ client: client as never, navigate: vi.fn() });
+    const firstStore = createJobsStore({ client: client as never, navigate: vi.fn() });
 
-    store.setFilter("hideClosed", true);
-    store.setFilter("showAutoDesign", true);
-    expect(localStorage.getItem("kenn-forge:roborev:hideClosed")).toBe("1");
-    expect(localStorage.getItem("kenn-forge:roborev:showAutoDesign")).toBe("1");
+    firstStore.setFilter("hideClosed", true);
+    firstStore.setFilter("showAutoDesign", true);
+    firstStore.dispose();
 
-    store.setFilter("hideClosed", false);
-    store.setFilter("showAutoDesign", false);
-    expect(localStorage.getItem("kenn-forge:roborev:hideClosed")).toBe("0");
-    expect(localStorage.getItem("kenn-forge:roborev:showAutoDesign")).toBe("0");
-  });
+    const restoredStore = createJobsStore({ client: client as never, navigate: vi.fn() });
+    await loadJobs(restoredStore);
 
-  it("restores enabled preferences and applies them to the jobs query", async () => {
-    localStorage.setItem("kenn-forge:roborev:hideClosed", "1");
-    localStorage.setItem("kenn-forge:roborev:showAutoDesign", "1");
-    const client = {
-      GET: vi.fn().mockResolvedValue({
-        data: { jobs: [], has_more: false, stats: { done: 0, closed: 0, open: 0 } },
-        error: undefined,
-      }),
-    };
-    const store = createJobsStore({ client: client as never, navigate: vi.fn() });
-
-    await loadJobs(store);
-
-    expect(store.getFilterHideClosed()).toBe(true);
-    expect(store.getFilterShowAutoDesign()).toBe(true);
+    expect(restoredStore.getFilterHideClosed()).toBe(true);
+    expect(restoredStore.getFilterShowAutoDesign()).toBe(true);
     expect(client.GET).toHaveBeenCalledWith(
       "/api/jobs",
       expect.objectContaining({ params: { query: { closed: "false", limit: 50 } } }),
@@ -157,65 +126,44 @@ describe("createJobsStore filter preferences", () => {
     );
   });
 
-  it("keeps shared preferences when storage is unavailable to a later live store", () => {
-    const client = {
+  it("keeps filtering when browser storage is unavailable", async () => {
+    const getItem = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("storage unavailable");
+    });
+    const firstClient = {
       GET: vi.fn().mockResolvedValue({
         data: { jobs: [], has_more: false, stats: { done: 0, closed: 0, open: 0 } },
         error: undefined,
       }),
     };
-    const firstStore = createJobsStore({ client: client as never, navigate: vi.fn() });
-    firstStore.setFilter("hideClosed", true);
-    firstStore.setFilter("showAutoDesign", true);
-    const getItem = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
-      throw new Error("storage unavailable");
-    });
-
-    try {
-      const secondStore = createJobsStore({ client: client as never, navigate: vi.fn() });
-
-      expect(secondStore.getFilterHideClosed()).toBe(true);
-      expect(secondStore.getFilterShowAutoDesign()).toBe(true);
-    } finally {
-      getItem.mockRestore();
-    }
-  });
-
-  it("falls back to defaults when browser storage reads fail", () => {
-    const getItem = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
-      throw new Error("storage unavailable");
-    });
-
-    try {
-      const store = createJobsStore({ client: {} as never, navigate: vi.fn() });
-
-      expect(store.getFilterHideClosed()).toBe(false);
-      expect(store.getFilterShowAutoDesign()).toBe(false);
-    } finally {
-      getItem.mockRestore();
-    }
-  });
-
-  it("keeps filtering and refreshes jobs when browser storage writes fail", async () => {
-    const client = {
+    const secondClient = {
       GET: vi.fn().mockResolvedValue({
         data: { jobs: [], has_more: false, stats: { done: 0, closed: 0, open: 0 } },
         error: undefined,
       }),
     };
-    const store = createJobsStore({ client: client as never, navigate: vi.fn() });
     const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
       throw new Error("storage unavailable");
     });
 
     try {
-      store.setFilter("hideClosed", true);
-      store.setFilter("showAutoDesign", true);
+      const firstStore = createJobsStore({ client: firstClient as never, navigate: vi.fn() });
+      expect(firstStore.getFilterHideClosed()).toBe(false);
+      expect(firstStore.getFilterShowAutoDesign()).toBe(false);
 
-      expect(store.getFilterHideClosed()).toBe(true);
-      expect(store.getFilterShowAutoDesign()).toBe(true);
-      await vi.waitFor(() => expect(client.GET).toHaveBeenCalled());
+      firstStore.setFilter("hideClosed", true);
+      firstStore.setFilter("showAutoDesign", true);
+      const secondStore = createJobsStore({ client: secondClient as never, navigate: vi.fn() });
+      await loadJobs(secondStore);
+
+      expect(secondStore.getFilterHideClosed()).toBe(true);
+      expect(secondStore.getFilterShowAutoDesign()).toBe(true);
+      expect(secondClient.GET).toHaveBeenCalledWith(
+        "/api/jobs",
+        expect.objectContaining({ params: { query: { closed: "false", limit: 50 } } }),
+      );
     } finally {
+      getItem.mockRestore();
       setItem.mockRestore();
     }
   });

--- a/frontend/src/lib/stores/roborev-jobs.test.ts
+++ b/frontend/src/lib/stores/roborev-jobs.test.ts
@@ -41,9 +41,14 @@ async function loadJobs(store: JobsStore): Promise<void> {
   expect(exit._tag).toBe("Success");
 }
 
+beforeEach(() => {
+  localStorage.clear();
+});
+
 afterEach(async () => {
   await Promise.all(Array.from(runtimes, (runtime) => Effect.runPromise(runtime.disposeEffect)));
   runtimes.clear();
+  localStorage.clear();
 });
 
 function makeJob(id: number, startedAt?: string, finishedAt?: string): ReviewJob {
@@ -62,6 +67,102 @@ function makeJob(id: number, startedAt?: string, finishedAt?: string): ReviewJob
     ...(finishedAt ? { finished_at: finishedAt } : {}),
   };
 }
+
+describe("createJobsStore filter preferences", () => {
+  it("uses existing defaults for missing or unrecognized preferences", () => {
+    const store = createJobsStore({ client: {} as never, navigate: vi.fn() });
+
+    expect(store.getFilterHideClosed()).toBe(false);
+    expect(store.getFilterShowAutoDesign()).toBe(false);
+
+    localStorage.setItem("kenn-forge:roborev:hideClosed", "unknown");
+    localStorage.setItem("kenn-forge:roborev:showAutoDesign", "unknown");
+    const restored = createJobsStore({ client: {} as never, navigate: vi.fn() });
+
+    expect(restored.getFilterHideClosed()).toBe(false);
+    expect(restored.getFilterShowAutoDesign()).toBe(false);
+  });
+
+  it("writes both filter choices to global browser storage", () => {
+    const client = {
+      GET: vi.fn().mockResolvedValue({
+        data: { jobs: [], has_more: false, stats: { done: 0, closed: 0, open: 0 } },
+        error: undefined,
+      }),
+    };
+    const store = createJobsStore({ client: client as never, navigate: vi.fn() });
+
+    store.setFilter("hideClosed", true);
+    store.setFilter("showAutoDesign", true);
+    expect(localStorage.getItem("kenn-forge:roborev:hideClosed")).toBe("1");
+    expect(localStorage.getItem("kenn-forge:roborev:showAutoDesign")).toBe("1");
+
+    store.setFilter("hideClosed", false);
+    store.setFilter("showAutoDesign", false);
+    expect(localStorage.getItem("kenn-forge:roborev:hideClosed")).toBe("0");
+    expect(localStorage.getItem("kenn-forge:roborev:showAutoDesign")).toBe("0");
+  });
+
+  it("restores enabled preferences and applies them to the jobs query", async () => {
+    localStorage.setItem("kenn-forge:roborev:hideClosed", "1");
+    localStorage.setItem("kenn-forge:roborev:showAutoDesign", "1");
+    const client = {
+      GET: vi.fn().mockResolvedValue({
+        data: { jobs: [], has_more: false, stats: { done: 0, closed: 0, open: 0 } },
+        error: undefined,
+      }),
+    };
+    const store = createJobsStore({ client: client as never, navigate: vi.fn() });
+
+    await loadJobs(store);
+
+    expect(store.getFilterHideClosed()).toBe(true);
+    expect(store.getFilterShowAutoDesign()).toBe(true);
+    expect(client.GET).toHaveBeenCalledWith(
+      "/api/jobs",
+      expect.objectContaining({ params: { query: { closed: "false", limit: 50 } } }),
+    );
+  });
+
+  it("falls back to defaults when browser storage reads fail", () => {
+    const getItem = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("storage unavailable");
+    });
+
+    try {
+      const store = createJobsStore({ client: {} as never, navigate: vi.fn() });
+
+      expect(store.getFilterHideClosed()).toBe(false);
+      expect(store.getFilterShowAutoDesign()).toBe(false);
+    } finally {
+      getItem.mockRestore();
+    }
+  });
+
+  it("keeps filtering and refreshes jobs when browser storage writes fail", async () => {
+    const client = {
+      GET: vi.fn().mockResolvedValue({
+        data: { jobs: [], has_more: false, stats: { done: 0, closed: 0, open: 0 } },
+        error: undefined,
+      }),
+    };
+    const store = createJobsStore({ client: client as never, navigate: vi.fn() });
+    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("storage unavailable");
+    });
+
+    try {
+      store.setFilter("hideClosed", true);
+      store.setFilter("showAutoDesign", true);
+
+      expect(store.getFilterHideClosed()).toBe(true);
+      expect(store.getFilterShowAutoDesign()).toBe(true);
+      await vi.waitFor(() => expect(client.GET).toHaveBeenCalled());
+    } finally {
+      setItem.mockRestore();
+    }
+  });
+});
 
 describe("createJobsStore cost sorting", () => {
   function makeCostJob(id: number, tokenUsage?: string): ReviewJob {

--- a/frontend/src/lib/stores/roborev-jobs.test.ts
+++ b/frontend/src/lib/stores/roborev-jobs.test.ts
@@ -13,6 +13,7 @@ type ReviewJob = components["schemas"]["ReviewJob"];
 
 const originalFetch = globalThis.fetch;
 const runtimes = new Set<OwnedAppRuntime>();
+const stores = new Set<JobsStore>();
 const storeRuntimes = new WeakMap<JobsStore, OwnedAppRuntime>();
 let ownerSequence = 0;
 
@@ -25,6 +26,7 @@ function createJobsStore(options: Omit<JobsStoreOptions, "runtime" | "owner">) {
   runtimes.add(runtime);
   ownerSequence += 1;
   const store = createRuntimeJobsStore({ ...options, runtime, owner: `jobs-test:${ownerSequence}` });
+  stores.add(store);
   storeRuntimes.set(store, runtime);
   return store;
 }
@@ -46,6 +48,8 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
+  for (const store of stores) store.dispose();
+  stores.clear();
   await Promise.all(Array.from(runtimes, (runtime) => Effect.runPromise(runtime.disposeEffect)));
   runtimes.clear();
   localStorage.clear();
@@ -122,6 +126,59 @@ describe("createJobsStore filter preferences", () => {
       "/api/jobs",
       expect.objectContaining({ params: { query: { closed: "false", limit: 50 } } }),
     );
+  });
+
+  it("synchronizes filter changes across live jobs stores", async () => {
+    const firstClient = {
+      GET: vi.fn().mockResolvedValue({
+        data: { jobs: [], has_more: false, stats: { done: 0, closed: 0, open: 0 } },
+        error: undefined,
+      }),
+    };
+    const secondClient = {
+      GET: vi.fn().mockResolvedValue({
+        data: { jobs: [], has_more: false, stats: { done: 0, closed: 0, open: 0 } },
+        error: undefined,
+      }),
+    };
+    const firstStore = createJobsStore({ client: firstClient as never, navigate: vi.fn() });
+    const secondStore = createJobsStore({ client: secondClient as never, navigate: vi.fn() });
+
+    firstStore.setFilter("hideClosed", true);
+    firstStore.setFilter("showAutoDesign", true);
+
+    expect(secondStore.getFilterHideClosed()).toBe(true);
+    expect(secondStore.getFilterShowAutoDesign()).toBe(true);
+    await vi.waitFor(() =>
+      expect(secondClient.GET).toHaveBeenCalledWith(
+        "/api/jobs",
+        expect.objectContaining({ params: { query: { closed: "false", limit: 50 } } }),
+      ),
+    );
+  });
+
+  it("keeps shared preferences when storage is unavailable to a later live store", () => {
+    const client = {
+      GET: vi.fn().mockResolvedValue({
+        data: { jobs: [], has_more: false, stats: { done: 0, closed: 0, open: 0 } },
+        error: undefined,
+      }),
+    };
+    const firstStore = createJobsStore({ client: client as never, navigate: vi.fn() });
+    firstStore.setFilter("hideClosed", true);
+    firstStore.setFilter("showAutoDesign", true);
+    const getItem = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("storage unavailable");
+    });
+
+    try {
+      const secondStore = createJobsStore({ client: client as never, navigate: vi.fn() });
+
+      expect(secondStore.getFilterHideClosed()).toBe(true);
+      expect(secondStore.getFilterShowAutoDesign()).toBe(true);
+    } finally {
+      getItem.mockRestore();
+    }
   });
 
   it("falls back to defaults when browser storage reads fail", () => {

--- a/frontend/src/lib/stores/roborev/jobs.svelte.ts
+++ b/frontend/src/lib/stores/roborev/jobs.svelte.ts
@@ -47,6 +47,25 @@ type StringFilterKey = "repo" | "branch" | "status" | "search" | "jobType";
 type BooleanFilterKey = "hideClosed" | "showAutoDesign";
 type FilterKey = StringFilterKey | BooleanFilterKey;
 
+const HIDE_CLOSED_STORAGE_KEY = "kenn-forge:roborev:hideClosed";
+const SHOW_AUTO_DESIGN_STORAGE_KEY = "kenn-forge:roborev:showAutoDesign";
+
+function readBooleanPreference(key: string): boolean {
+  try {
+    return localStorage.getItem(key) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writeBooleanPreference(key: string, value: boolean): void {
+  try {
+    localStorage.setItem(key, value ? "1" : "0");
+  } catch {
+    // Storage is best-effort; reactive state still owns this store instance.
+  }
+}
+
 export function createJobsStore(opts: JobsStoreOptions) {
   const client = opts.client;
 
@@ -66,9 +85,9 @@ export function createJobsStore(opts: JobsStoreOptions) {
   let filterBranch = $state<string | undefined>(undefined);
   let filterStatus = $state<string | undefined>(undefined);
   let filterSearch = $state<string | undefined>(undefined);
-  let filterHideClosed = $state(false);
+  let filterHideClosed = $state(readBooleanPreference(HIDE_CLOSED_STORAGE_KEY));
   let filterJobType = $state<string | undefined>(undefined);
-  let filterShowAutoDesign = $state(false);
+  let filterShowAutoDesign = $state(readBooleanPreference(SHOW_AUTO_DESIGN_STORAGE_KEY));
 
   // Sorting (client-side)
   let sortColumn = $state<SortColumn>("id");
@@ -392,6 +411,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
       case "hideClosed":
         if (typeof value !== "boolean") return;
         filterHideClosed = value;
+        writeBooleanPreference(HIDE_CLOSED_STORAGE_KEY, value);
         break;
       case "jobType":
         if (typeof value === "boolean") return;
@@ -400,6 +420,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
       case "showAutoDesign":
         if (typeof value !== "boolean") return;
         filterShowAutoDesign = value;
+        writeBooleanPreference(SHOW_AUTO_DESIGN_STORAGE_KEY, value);
         break;
     }
     loadJobs();

--- a/frontend/src/lib/stores/roborev/jobs.svelte.ts
+++ b/frontend/src/lib/stores/roborev/jobs.svelte.ts
@@ -49,6 +49,11 @@ type FilterKey = StringFilterKey | BooleanFilterKey;
 
 const HIDE_CLOSED_STORAGE_KEY = "kenn-forge:roborev:hideClosed";
 const SHOW_AUTO_DESIGN_STORAGE_KEY = "kenn-forge:roborev:showAutoDesign";
+const booleanFilterPreferences = $state<Record<BooleanFilterKey, boolean>>({
+  hideClosed: false,
+  showAutoDesign: false,
+});
+const booleanFilterSubscribers = new Map<symbol, () => void>();
 
 function readBooleanPreference(key: string): boolean {
   try {
@@ -66,8 +71,38 @@ function writeBooleanPreference(key: string, value: boolean): void {
   }
 }
 
+function notifyBooleanFilterSubscribers(origin?: symbol): void {
+  for (const [owner, refresh] of booleanFilterSubscribers) {
+    if (owner !== origin) refresh();
+  }
+}
+
+function hydrateBooleanFilterPreferences(): void {
+  const hideClosed = readBooleanPreference(HIDE_CLOSED_STORAGE_KEY);
+  const showAutoDesign = readBooleanPreference(SHOW_AUTO_DESIGN_STORAGE_KEY);
+  if (
+    hideClosed === booleanFilterPreferences.hideClosed &&
+    showAutoDesign === booleanFilterPreferences.showAutoDesign
+  ) {
+    return;
+  }
+  booleanFilterPreferences.hideClosed = hideClosed;
+  booleanFilterPreferences.showAutoDesign = showAutoDesign;
+  notifyBooleanFilterSubscribers();
+}
+
+function setBooleanFilterPreference(key: BooleanFilterKey, value: boolean, origin: symbol): void {
+  booleanFilterPreferences[key] = value;
+  writeBooleanPreference(key === "hideClosed" ? HIDE_CLOSED_STORAGE_KEY : SHOW_AUTO_DESIGN_STORAGE_KEY, value);
+  notifyBooleanFilterSubscribers(origin);
+}
+
 export function createJobsStore(opts: JobsStoreOptions) {
   const client = opts.client;
+  const filterOwner = Symbol(opts.owner);
+  let disposed = false;
+
+  if (booleanFilterSubscribers.size === 0) hydrateBooleanFilterPreferences();
 
   // State
   let jobs = $state<ReviewJob[]>([]);
@@ -85,9 +120,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
   let filterBranch = $state<string | undefined>(undefined);
   let filterStatus = $state<string | undefined>(undefined);
   let filterSearch = $state<string | undefined>(undefined);
-  let filterHideClosed = $state(readBooleanPreference(HIDE_CLOSED_STORAGE_KEY));
   let filterJobType = $state<string | undefined>(undefined);
-  let filterShowAutoDesign = $state(readBooleanPreference(SHOW_AUTO_DESIGN_STORAGE_KEY));
 
   // Sorting (client-side)
   let sortColumn = $state<SortColumn>("id");
@@ -112,9 +145,9 @@ export function createJobsStore(opts: JobsStoreOptions) {
     if (filterBranch) q.branch = filterBranch;
     if (filterStatus) q.status = filterStatus;
     if (filterSearch) q.git_ref = filterSearch;
-    if (filterHideClosed) q.closed = "false";
+    if (booleanFilterPreferences.hideClosed) q.closed = "false";
     if (filterJobType) q.job_type = filterJobType;
-    if (!filterShowAutoDesign) q.hide_classify_jobs = "true";
+    if (!booleanFilterPreferences.showAutoDesign) q.hide_classify_jobs = "true";
     return q;
   }
 
@@ -410,8 +443,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
         break;
       case "hideClosed":
         if (typeof value !== "boolean") return;
-        filterHideClosed = value;
-        writeBooleanPreference(HIDE_CLOSED_STORAGE_KEY, value);
+        setBooleanFilterPreference(key, value, filterOwner);
         break;
       case "jobType":
         if (typeof value === "boolean") return;
@@ -419,8 +451,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
         break;
       case "showAutoDesign":
         if (typeof value !== "boolean") return;
-        filterShowAutoDesign = value;
-        writeBooleanPreference(SHOW_AUTO_DESIGN_STORAGE_KEY, value);
+        setBooleanFilterPreference(key, value, filterOwner);
         break;
     }
     loadJobs();
@@ -909,13 +940,13 @@ export function createJobsStore(opts: JobsStoreOptions) {
     return filterSearch;
   }
   function getFilterHideClosed(): boolean {
-    return filterHideClosed;
+    return booleanFilterPreferences.hideClosed;
   }
   function getFilterJobType(): string | undefined {
     return filterJobType;
   }
   function getFilterShowAutoDesign(): boolean {
-    return filterShowAutoDesign;
+    return booleanFilterPreferences.showAutoDesign;
   }
   function getSortColumn(): SortColumn {
     return sortColumn;
@@ -926,6 +957,16 @@ export function createJobsStore(opts: JobsStoreOptions) {
   function isEventStreamConnected(): boolean {
     return eventStreamConnected;
   }
+
+  function dispose(): void {
+    if (disposed) return;
+    disposed = true;
+    booleanFilterSubscribers.delete(filterOwner);
+  }
+
+  booleanFilterSubscribers.set(filterOwner, () => {
+    if (!disposed) loadJobs();
+  });
 
   return {
     getJobs,
@@ -948,6 +989,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
     getSortColumn,
     getSortDirection,
     isEventStreamConnected,
+    dispose,
     togglePanel,
     ensurePanelMembers,
     setPanelMemberInterest,

--- a/frontend/tests/e2e-full/roborev-e2e.spec.ts
+++ b/frontend/tests/e2e-full/roborev-e2e.spec.ts
@@ -640,6 +640,34 @@ test.describe.serial("Roborev", () => {
       await expect(autoDesignClassifyRow.locator(".col-type")).toHaveText("classify");
     });
 
+    test("review visibility filters survive a reload", async ({ page }) => {
+      await waitForReviewsReady(page);
+      await waitForJobRows(page, 10);
+
+      await page.getByLabel("Hide closed").check();
+      await page.getByLabel("Show auto-design").check();
+      await expect(page.locator(".git-ref[title='auto-design-classify']")).toBeVisible();
+      expect(await page.evaluate(() => localStorage.getItem("kenn-forge:roborev:hideClosed"))).toBe("1");
+      expect(await page.evaluate(() => localStorage.getItem("kenn-forge:roborev:showAutoDesign"))).toBe("1");
+
+      const restoredJobs = page.waitForResponse((response) => {
+        const url = new URL(response.url());
+        return (
+          response.ok() &&
+          url.pathname.endsWith("/api/roborev/api/jobs") &&
+          url.searchParams.get("limit") === "50" &&
+          url.searchParams.get("closed") === "false" &&
+          url.searchParams.get("hide_classify_jobs") === null
+        );
+      });
+      await page.reload();
+      await restoredJobs;
+
+      await expect(page.getByLabel("Hide closed")).toBeChecked();
+      await expect(page.getByLabel("Show auto-design")).toBeChecked();
+      await expect(page.locator(".git-ref[title='auto-design-classify']")).toBeVisible();
+    });
+
     test("status counts follow the default auto-design visibility", async ({ page }) => {
       await page.route("**/api/roborev/api/stream/events", (route) => route.abort());
       await waitForReviewsReady(page);

--- a/frontend/tests/e2e-full/roborev-e2e.spec.ts
+++ b/frontend/tests/e2e-full/roborev-e2e.spec.ts
@@ -646,9 +646,6 @@ test.describe.serial("Roborev", () => {
 
       await page.getByLabel("Hide closed").check();
       await page.getByLabel("Show auto-design").check();
-      await expect(page.locator(".git-ref[title='auto-design-classify']")).toBeVisible();
-      expect(await page.evaluate(() => localStorage.getItem("kenn-forge:roborev:hideClosed"))).toBe("1");
-      expect(await page.evaluate(() => localStorage.getItem("kenn-forge:roborev:showAutoDesign"))).toBe("1");
 
       const restoredJobs = page.waitForResponse((response) => {
         const url = new URL(response.url());


### PR DESCRIPTION
The Reviews view reset **Hide closed** and **Show auto-design** whenever its jobs store was recreated. Maintainers had to restore the same view after browser reloads and when moving between the main list and workspace review sidebars.

Both choices now follow the browser instead of a workspace or daemon. If browser storage is unavailable, the current view still filters and refreshes normally.

<details>
<summary>Validation</summary>

- Frontend unit suite: 3,900 passed, 2 skipped.
- Focused review-store suite: 31 passed.
- Frontend formatting, lint, Svelte checks, Effect diagnostics, and push hooks passed.
- Gitleaks scanned both commits and all introduced blobs.

</details>

<sup>generated by a clanker</sup>