### PR TITLE
fix(archive): require complete GitHub merge metrics

### DIFF
--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -450,7 +450,7 @@ fallback repository listing.
 - Archive REST and GraphQL failures must preserve typed authentication and reset-aware rate-limit errors so scheduling defers rather than hot-looping generic retries. (`internal/github/pages.go::archiveTransportError`)
 - GitHub archive code owns historical identity inventory only; hydration must invoke ordinary item sync instead of adding archive-specific lookup, normalization, or persistence. (`internal/github/pages.go::ListIssuesPage`, `internal/github/sync.go::SyncArchiveItem`)
 - Archive item hydration bypasses persisted parent-detail ETags; an unchanged parent representation does not prove that legacy lifecycle timelines are complete. (`internal/github/sync.go::SyncArchiveItem`)
-- A merged GitHub archive lookup requires merge time, merge commit SHA, and files changed; fetched merged evidence survives rejection by newer local detail so hydration remains retryable. (`internal/github/sync.go::requireGitHubArchiveMergedMRMetrics`)
+- A merged GitHub archive lookup requires merge time and files changed plus fetched canonical head and merge SHAs that exactly match storage; absent or rejected canonical evidence keeps hydration retryable. (`internal/github/sync.go::requireGitHubArchiveMergedMRMetrics`)
 - Under repository, number, merged-row, and head-SHA guards, canonical merged detail replaces a stored pre-merge test SHA and fills other missing lifecycle fields without weakening snapshot ordering. (`internal/db/queries_merge_lifecycle.go::FillMissingMergedMRMetrics`)
 - Rejected canonical merged snapshots repair each available lifecycle field and
   the merger event under one route-fence lease; a rejected fenced repair stays

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -456,9 +456,9 @@ fallback repository listing.
   missing lifecycle fields when the head SHA matches; never weaken ordering.
   (`internal/github/sync.go::requireGitHubArchiveMergedMRMetrics`,
   `internal/db/queries_merge_lifecycle.go::FillMissingMergedMRMetrics`)
-- Rejected canonical merged snapshots persist the merger event even if metrics
-  are omitted; metric repair shares one route-fence lease, and stored
-  `merged_at` proves merge despite open legacy state. (`internal/github/sync.go::syncMRForRepoResolved`)
+- Rejected canonical merged snapshots repair each available lifecycle field and
+  the merger event under one route-fence lease; a rejected fenced repair stays
+  retryable. (`internal/github/sync.go::syncMRForRepoResolved`)
 - Post-hydration completeness queries the repository ID resolved by that sync;
   never re-resolve the caller's mutable route after reconciliation.
   (`internal/github/sync.go::SyncArchiveItem`)

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -450,7 +450,12 @@ fallback repository listing.
 - Archive REST and GraphQL failures must preserve typed authentication and reset-aware rate-limit errors so scheduling defers rather than hot-looping generic retries. (`internal/github/pages.go::archiveTransportError`)
 - GitHub archive code owns historical identity inventory only; hydration must invoke ordinary item sync instead of adding archive-specific lookup, normalization, or persistence. (`internal/github/pages.go::ListIssuesPage`, `internal/github/sync.go::SyncArchiveItem`)
 - Archive item hydration bypasses persisted parent-detail ETags; an unchanged parent representation does not prove that legacy lifecycle timelines are complete. (`internal/github/sync.go::SyncArchiveItem`)
-- A merged GitHub archive lookup requires merge time and files changed plus fetched canonical head and merge SHAs that exactly match storage; absent or rejected canonical evidence keeps hydration retryable. (`internal/github/sync.go::requireGitHubArchiveMergedMRMetrics`)
+- A merged GitHub archive lookup requires completed lifecycle persistence,
+  merge time, files changed, and fetched canonical SHAs that match storage;
+  interrupted or incomplete rounds stay retryable. (`internal/github/sync.go::requireGitHubArchiveMergedMRMetrics`)
+- An accepted merged snapshot preserves the stored immutable merge time when
+  the provider omits it; partial detail must not erase durable lifecycle data.
+  (`internal/github/sync.go::preserveMergedAtIfOmitted`)
 - Under repository, number, merged-row, and head-SHA guards, canonical merged detail replaces a stored pre-merge test SHA and fills other missing lifecycle fields without weakening snapshot ordering. (`internal/db/queries_merge_lifecycle.go::FillMissingMergedMRMetrics`)
 - Rejected canonical merged snapshots repair each available lifecycle field and
   the merger event under one route-fence lease; stored parent timing remains

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -456,9 +456,9 @@ fallback repository listing.
   missing lifecycle fields when the head SHA matches; never weaken ordering.
   (`internal/github/sync.go::requireGitHubArchiveMergedMRMetrics`,
   `internal/db/queries_merge_lifecycle.go::FillMissingMergedMRMetrics`)
-- Rejected canonical merged snapshots must persist the immutable merger event
-  under the same route fence; stored `merged_at` is sufficient evidence even
-  when legacy state remains open. (`internal/github/sync.go::syncMRForRepoResolved`,
+- Rejected canonical merged snapshots must repair fields and persist the merger
+  event under one route-fence lease; stored `merged_at` is sufficient evidence
+  even when legacy state remains open. (`internal/github/sync.go::syncMRForRepoResolved`,
   `internal/db/queries.go::UpsertMergedActorEvent`)
 - Post-hydration completeness queries the repository ID resolved by that sync;
   never re-resolve the caller's mutable route after reconciliation.

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -450,6 +450,11 @@ fallback repository listing.
 - Archive REST and GraphQL failures must preserve typed authentication and reset-aware rate-limit errors so scheduling defers rather than hot-looping generic retries. (`internal/github/pages.go::archiveTransportError`)
 - GitHub archive code owns historical identity inventory only; hydration must invoke ordinary item sync instead of adding archive-specific lookup, normalization, or persistence. (`internal/github/pages.go::ListIssuesPage`, `internal/github/sync.go::SyncArchiveItem`)
 - Archive item hydration bypasses persisted parent-detail ETags; an unchanged parent representation does not prove that legacy lifecycle timelines are complete. (`internal/github/sync.go::SyncArchiveItem`)
+- A merged GitHub archive lookup requires both merge commit SHA and files
+  changed. If an eager merge timestamp rejects older canonical detail, fill
+  only missing metrics when the head SHA matches; never weaken parent snapshot
+  ordering. (`internal/github/sync.go::requireGitHubArchiveMergedMRMetrics`,
+  `internal/db/queries_merge_lifecycle.go::FillMissingMergedMRMetrics`)
 - Archive issue hydration treats timeline failures as hard errors; ordinary issue refresh remains best-effort for that optional dataset. (`internal/github/sync.go::refreshIssueTimeline`)
 - GitHub archive admission with a known registry pacing window paces off
   provider quota alone: availability is the minimum across required resources

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -453,8 +453,8 @@ fallback repository listing.
 - A merged GitHub archive lookup requires merge time and files changed plus fetched canonical head and merge SHAs that exactly match storage; absent or rejected canonical evidence keeps hydration retryable. (`internal/github/sync.go::requireGitHubArchiveMergedMRMetrics`)
 - Under repository, number, merged-row, and head-SHA guards, canonical merged detail replaces a stored pre-merge test SHA and fills other missing lifecycle fields without weakening snapshot ordering. (`internal/db/queries_merge_lifecycle.go::FillMissingMergedMRMetrics`)
 - Rejected canonical merged snapshots repair each available lifecycle field and
-  the merger event under one route-fence lease; a rejected fenced repair stays
-  retryable. (`internal/github/sync.go::syncMRForRepoResolved`)
+  the merger event under one route-fence lease; stored parent timing remains
+  authoritative when GitHub omits it, and a rejected fence stays retryable. (`internal/github/sync.go::syncMRForRepoResolved`)
 - Post-hydration completeness queries the repository ID resolved by that sync;
   never re-resolve the caller's mutable route after reconciliation.
   (`internal/github/sync.go::SyncArchiveItem`)

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -453,9 +453,9 @@ fallback repository listing.
 - Every older-generation active merged GitHub lookup is requeued once; its new
   generation proves canonical merged detail passed the current verification.
   (`internal/db/queries_archive.go::RequeueArchiveLifecycleDetails`)
-- A merged GitHub archive lookup requires completed lifecycle persistence,
-  merge time, and fetched canonical SHAs and file count that match storage;
-  interrupted or incomplete rounds stay retryable. (`internal/github/sync.go::requireGitHubArchiveMergedMRMetrics`)
+- A GitHub archive lookup requires fetched and stored merge state to agree;
+  merged lookups also require completed lifecycle persistence, merge time, and
+  matching canonical SHAs and file count. (`internal/github/sync.go::requireGitHubArchiveMergedMRMetrics`)
 - An accepted merged snapshot preserves the stored immutable merge time when
   the provider omits it; partial detail must not erase durable lifecycle data.
   (`internal/github/sync.go::preserveMergedAtIfOmitted`)

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -450,13 +450,18 @@ fallback repository listing.
 - Archive REST and GraphQL failures must preserve typed authentication and reset-aware rate-limit errors so scheduling defers rather than hot-looping generic retries. (`internal/github/pages.go::archiveTransportError`)
 - GitHub archive code owns historical identity inventory only; hydration must invoke ordinary item sync instead of adding archive-specific lookup, normalization, or persistence. (`internal/github/pages.go::ListIssuesPage`, `internal/github/sync.go::SyncArchiveItem`)
 - Archive item hydration bypasses persisted parent-detail ETags; an unchanged parent representation does not prove that legacy lifecycle timelines are complete. (`internal/github/sync.go::SyncArchiveItem`)
+- Every older-generation active merged GitHub lookup is requeued once; its new
+  generation proves canonical merged detail passed the current verification.
+  (`internal/db/queries_archive.go::RequeueArchiveLifecycleDetails`)
 - A merged GitHub archive lookup requires completed lifecycle persistence,
-  merge time, files changed, and fetched canonical SHAs that match storage;
+  merge time, and fetched canonical SHAs and file count that match storage;
   interrupted or incomplete rounds stay retryable. (`internal/github/sync.go::requireGitHubArchiveMergedMRMetrics`)
 - An accepted merged snapshot preserves the stored immutable merge time when
   the provider omits it; partial detail must not erase durable lifecycle data.
   (`internal/github/sync.go::preserveMergedAtIfOmitted`)
-- Under repository, number, merged-row, and head-SHA guards, canonical merged detail replaces a stored pre-merge test SHA and fills other missing lifecycle fields without weakening snapshot ordering. (`internal/db/queries_merge_lifecycle.go::FillMissingMergedMRMetrics`)
+- Under repository, number, merged-row, and head-SHA guards, canonical merged
+  detail replaces stored merge SHA and file count while filling missing merge
+  time without weakening snapshot ordering. (`internal/db/queries_merge_lifecycle.go::FillMissingMergedMRMetrics`)
 - Rejected canonical merged snapshots repair each available lifecycle field and
   the merger event under one route-fence lease; stored parent timing remains
   authoritative when GitHub omits it, and a rejected fence stays retryable. (`internal/github/sync.go::syncMRForRepoResolved`)

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -451,10 +451,14 @@ fallback repository listing.
 - GitHub archive code owns historical identity inventory only; hydration must invoke ordinary item sync instead of adding archive-specific lookup, normalization, or persistence. (`internal/github/pages.go::ListIssuesPage`, `internal/github/sync.go::SyncArchiveItem`)
 - Archive item hydration bypasses persisted parent-detail ETags; an unchanged parent representation does not prove that legacy lifecycle timelines are complete. (`internal/github/sync.go::SyncArchiveItem`)
 - A merged GitHub archive lookup requires both merge commit SHA and files
-  changed. If an eager merge timestamp rejects older canonical detail, fill
-  only missing metrics when the head SHA matches; never weaken parent snapshot
-  ordering. (`internal/github/sync.go::requireGitHubArchiveMergedMRMetrics`,
+  changed. Treat either `merged` or `merged_at` as merged evidence. If an eager
+  merge timestamp rejects older canonical detail, fill only missing metrics
+  when the head SHA matches; never weaken parent snapshot ordering.
+  (`internal/github/sync.go::requireGitHubArchiveMergedMRMetrics`,
   `internal/db/queries_merge_lifecycle.go::FillMissingMergedMRMetrics`)
+- Post-hydration completeness queries the repository ID resolved by that sync;
+  never re-resolve the caller's mutable route after reconciliation.
+  (`internal/github/sync.go::SyncArchiveItem`)
 - Archive issue hydration treats timeline failures as hard errors; ordinary issue refresh remains best-effort for that optional dataset. (`internal/github/sync.go::refreshIssueTimeline`)
 - GitHub archive admission with a known registry pacing window paces off
   provider quota alone: availability is the minimum across required resources

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -456,10 +456,9 @@ fallback repository listing.
   missing lifecycle fields when the head SHA matches; never weaken ordering.
   (`internal/github/sync.go::requireGitHubArchiveMergedMRMetrics`,
   `internal/db/queries_merge_lifecycle.go::FillMissingMergedMRMetrics`)
-- Rejected canonical merged snapshots must repair fields and persist the merger
-  event under one route-fence lease; stored `merged_at` is sufficient evidence
-  even when legacy state remains open. (`internal/github/sync.go::syncMRForRepoResolved`,
-  `internal/db/queries.go::UpsertMergedActorEvent`)
+- Rejected canonical merged snapshots persist the merger event even if metrics
+  are omitted; metric repair shares one route-fence lease, and stored
+  `merged_at` proves merge despite open legacy state. (`internal/github/sync.go::syncMRForRepoResolved`)
 - Post-hydration completeness queries the repository ID resolved by that sync;
   never re-resolve the caller's mutable route after reconciliation.
   (`internal/github/sync.go::SyncArchiveItem`)

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -456,6 +456,9 @@ fallback repository listing.
 - A GitHub archive lookup requires fetched and stored merge state to agree;
   merged lookups also require completed lifecycle persistence, merge time, and
   matching canonical SHAs and file count. (`internal/github/sync.go::requireGitHubArchiveMergedMRMetrics`)
+- Archive completion atomically revalidates fetched merge evidence against the
+  transaction-current row; a mismatch remains retryable, never complete.
+  (`internal/db/queries_dataset_progress.go::validateArchiveMergeRequestEvidenceTx`)
 - An accepted merged snapshot preserves the stored immutable merge time when
   the provider omits it; partial detail must not erase durable lifecycle data.
   (`internal/github/sync.go::preserveMergedAtIfOmitted`)

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -450,12 +450,8 @@ fallback repository listing.
 - Archive REST and GraphQL failures must preserve typed authentication and reset-aware rate-limit errors so scheduling defers rather than hot-looping generic retries. (`internal/github/pages.go::archiveTransportError`)
 - GitHub archive code owns historical identity inventory only; hydration must invoke ordinary item sync instead of adding archive-specific lookup, normalization, or persistence. (`internal/github/pages.go::ListIssuesPage`, `internal/github/sync.go::SyncArchiveItem`)
 - Archive item hydration bypasses persisted parent-detail ETags; an unchanged parent representation does not prove that legacy lifecycle timelines are complete. (`internal/github/sync.go::SyncArchiveItem`)
-- A merged GitHub archive lookup requires merge time, merge commit SHA, and
-  files changed. Treat either `merged` state or `merged_at` as prior merge
-  evidence. If newer local detail rejects the canonical snapshot, fill only
-  missing lifecycle fields when the head SHA matches; never weaken ordering.
-  (`internal/github/sync.go::requireGitHubArchiveMergedMRMetrics`,
-  `internal/db/queries_merge_lifecycle.go::FillMissingMergedMRMetrics`)
+- A merged GitHub archive lookup requires merge time, merge commit SHA, and files changed; fetched merged evidence survives rejection by newer local detail so hydration remains retryable. (`internal/github/sync.go::requireGitHubArchiveMergedMRMetrics`)
+- Under repository, number, merged-row, and head-SHA guards, canonical merged detail replaces a stored pre-merge test SHA and fills other missing lifecycle fields without weakening snapshot ordering. (`internal/db/queries_merge_lifecycle.go::FillMissingMergedMRMetrics`)
 - Rejected canonical merged snapshots repair each available lifecycle field and
   the merger event under one route-fence lease; a rejected fenced repair stays
   retryable. (`internal/github/sync.go::syncMRForRepoResolved`)

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -456,6 +456,10 @@ fallback repository listing.
   missing lifecycle fields when the head SHA matches; never weaken ordering.
   (`internal/github/sync.go::requireGitHubArchiveMergedMRMetrics`,
   `internal/db/queries_merge_lifecycle.go::FillMissingMergedMRMetrics`)
+- Rejected canonical merged snapshots must persist the immutable merger event
+  under the same route fence; stored `merged_at` is sufficient evidence even
+  when legacy state remains open. (`internal/github/sync.go::syncMRForRepoResolved`,
+  `internal/db/queries.go::UpsertMergedActorEvent`)
 - Post-hydration completeness queries the repository ID resolved by that sync;
   never re-resolve the caller's mutable route after reconciliation.
   (`internal/github/sync.go::SyncArchiveItem`)

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -450,10 +450,10 @@ fallback repository listing.
 - Archive REST and GraphQL failures must preserve typed authentication and reset-aware rate-limit errors so scheduling defers rather than hot-looping generic retries. (`internal/github/pages.go::archiveTransportError`)
 - GitHub archive code owns historical identity inventory only; hydration must invoke ordinary item sync instead of adding archive-specific lookup, normalization, or persistence. (`internal/github/pages.go::ListIssuesPage`, `internal/github/sync.go::SyncArchiveItem`)
 - Archive item hydration bypasses persisted parent-detail ETags; an unchanged parent representation does not prove that legacy lifecycle timelines are complete. (`internal/github/sync.go::SyncArchiveItem`)
-- A merged GitHub archive lookup requires both merge commit SHA and files
-  changed. Treat either `merged` or `merged_at` as merged evidence. If an eager
-  merge timestamp rejects older canonical detail, fill only missing metrics
-  when the head SHA matches; never weaken parent snapshot ordering.
+- A merged GitHub archive lookup requires merge time, merge commit SHA, and
+  files changed. Treat either `merged` state or `merged_at` as prior merge
+  evidence. If newer local detail rejects the canonical snapshot, fill only
+  missing lifecycle fields when the head SHA matches; never weaken ordering.
   (`internal/github/sync.go::requireGitHubArchiveMergedMRMetrics`,
   `internal/db/queries_merge_lifecycle.go::FillMissingMergedMRMetrics`)
 - Post-hydration completeness queries the repository ID resolved by that sync;

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -256,7 +256,11 @@ registry helpers return typed errors for missing providers or capabilities.
   lifecycle details are missing, independent of historical inventory coverage;
   a close actor is current only when the latest authored close event matches
   `closed_at`. (`internal/db/queries_archive.go::RequeueArchiveLifecycleDetails`)
-- Successful canonical hydration durably marks lifecycle details checked even when a provider omits them, preventing repeated backfill reads. (`internal/db/queries_dataset_progress.go::CommitArchiveItemSync`)
+- Successful canonical hydration durably marks lifecycle details checked only
+  after provider-specific completeness gates pass; providers that define absent
+  fields as unavailable may still be checked once.
+  (`internal/archive/hydrate.go::hydrateItem`,
+  `internal/db/queries_dataset_progress.go::CommitArchiveItemSync`)
 - Authentication and repository-blocked errors defer every archive work class, including already-pending hydration, until an explicit retry clears the repository error. (`internal/archive/scheduler.go::archiveRepoDeferred`)
 - Archive admission is provider-host scoped. Normal index, notification, and active-detail work outrank archive requests; live work registers first, cancels the active archive request context, and waits for that request lease to release before provider I/O. Archive leases are released before SQLite commits. (`internal/github/sync.go::beginProviderWork`, `internal/github/sync.go::tryBeginArchiveProviderRequest`, `internal/github/sync.go::Admit`, `internal/archive/scheduler.go::admit`)
 - Split-auth live work holds every read/write credential identity it may spend, including identities selected after route reconciliation. Register work inside shared execution functions so no entry point bypasses admission. (`internal/github/notifications_sync.go::notificationProviderWork`)

--- a/context/testing.md
+++ b/context/testing.md
@@ -455,6 +455,10 @@ the fake or callback that observed the exact event, then await it with
 inherently observable only by polling, check immediately, then use a short ticker
 bounded by a context deadline. (`internal/github/syncertest/syncer_test.go::TestSyncerTriggerRunRunsRunOnce`)
 
+Async cache tests must observe the baseline through the consumer boundary
+before mutating inputs or advancing a fake clock; initial in-flight work can
+otherwise publish stale data at the new time. (`internal/server/workspacetest/workspace_enrichment_wire_test.go::TestWorkspaceListReportsCommitsAheadBehindE2E`)
+
 When server e2e tests chain `POST /api/v1/sync` with another ad-hoc sync
 trigger, treat the HTTP 202 and DB row timestamps as intermediate observations.
 `TriggerRun` is non-blocking and single-flight; wait for `/api/v1/sync/status`

--- a/internal/archive/hydrate.go
+++ b/internal/archive/hydrate.go
@@ -27,11 +27,11 @@ func (s *Service) hydrateItem(
 	if err != nil {
 		return err
 	}
-	providerAttempted, syncErr := s.items.SyncArchiveItem(
+	syncResult, syncErr := s.items.SyncArchiveItem(
 		requestCtx, repo.Ref, work.ItemType, work.ItemNumber,
 	)
 	preempted := archivePreempted(ctx, requestCtx)
-	deferred := complete(syncErr, providerAttempted)
+	deferred := complete(syncErr, syncResult.ProviderAttempted)
 	if preempted {
 		return errAdmissionDeferred
 	}
@@ -41,10 +41,17 @@ func (s *Service) hydrateItem(
 	commit := db.ArchiveItemSyncCommit{
 		RepoID: work.RepoID, ItemType: work.ItemType, ItemNumber: work.ItemNumber,
 		ScanGeneration: work.ScanGeneration, Now: s.now(),
+		MergeRequestEvidence: syncResult.MergeRequestEvidence,
 	}
 	if syncErr == nil {
 		commit.Outcome = db.ArchiveLookupPresent
-		return s.db.CommitArchiveItemSync(ctx, commit)
+		if err := s.db.CommitArchiveItemSync(ctx, commit); err != nil {
+			if errors.Is(err, db.ErrArchiveItemEvidenceChanged) {
+				return s.recordItemSyncFailure(ctx, commit, work.AttemptCount, err)
+			}
+			return err
+		}
+		return nil
 	}
 
 	outcome, destination, terminal := archiveTerminalSyncOutcome(syncErr)

--- a/internal/archive/service.go
+++ b/internal/archive/service.go
@@ -24,7 +24,14 @@ type ItemSyncer interface {
 	ArchiveItemSyncCost(platform.Kind, db.ArchiveItemType) int
 	SyncArchiveItem(
 		context.Context, platform.RepoRef, db.ArchiveItemType, int,
-	) (providerAttempted bool, err error)
+	) (ItemSyncResult, error)
+}
+
+// ItemSyncResult carries provider work accounting and any canonical evidence
+// that archive progress must revalidate atomically after domain persistence.
+type ItemSyncResult struct {
+	ProviderAttempted    bool
+	MergeRequestEvidence *db.ArchiveMergeRequestEvidence
 }
 
 type AdmissionResult struct {

--- a/internal/archive/service_test.go
+++ b/internal/archive/service_test.go
@@ -874,8 +874,8 @@ func (archiveFailingItemSource) SyncArchiveItem(
 	platform.RepoRef,
 	db.ArchiveItemType,
 	int,
-) (bool, error) {
-	return true, errors.New("transient provider failure")
+) (ItemSyncResult, error) {
+	return ItemSyncResult{ProviderAttempted: true}, errors.New("transient provider failure")
 }
 
 type archiveTestSource struct{ refs []platform.RepoRef }
@@ -891,8 +891,8 @@ func (archiveTestSource) SyncArchiveItem(
 	platform.RepoRef,
 	db.ArchiveItemType,
 	int,
-) (bool, error) {
-	return true, nil
+) (ItemSyncResult, error) {
+	return ItemSyncResult{ProviderAttempted: true}, nil
 }
 
 type archiveMutableSource struct{ refs []platform.RepoRef }

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -2247,19 +2247,20 @@ func (d *DB) UpsertMergedActorEvent(
 	canonicalizeMREventTimestamps(&event)
 	changed := false
 	err := d.Tx(ctx, func(tx *sql.Tx) error {
-		var parentState string
 		var parentMergedAt sql.NullString
 		err := tx.QueryRowContext(ctx, `
-			SELECT state, merged_at
+			SELECT merged_at
 			FROM forge_merge_requests
-			WHERE id = ?`, event.MergeRequestID).Scan(&parentState, &parentMergedAt)
+			WHERE id = ?`, event.MergeRequestID).Scan(&parentMergedAt)
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil
 		}
 		if err != nil {
-			return fmt.Errorf("read merged-event parent state: %w", err)
+			return fmt.Errorf("read merged-event parent timestamp: %w", err)
 		}
-		if parentState != string(MergeRequestStateMerged) || !parentMergedAt.Valid {
+		// A persisted merge timestamp is durable merge evidence even when a
+		// legacy row's state was not normalized to merged.
+		if !parentMergedAt.Valid {
 			return nil
 		}
 		currentMergedAt, err := parseDBTime(parentMergedAt.String)

--- a/internal/db/queries_archive.go
+++ b/internal/db/queries_archive.go
@@ -382,9 +382,9 @@ func (d *DB) RequeueArchiveLifecycleDetails(
 				(ai.item_type = 'merge_request' AND EXISTS (
 					SELECT 1 FROM forge_merge_requests mr
 					WHERE mr.repo_id = ai.repo_id AND mr.number = ai.item_number
-					  AND mr.merged_at IS NOT NULL
+					  AND (mr.state = 'merged' OR mr.merged_at IS NOT NULL)
 					  AND (
-						mr.files_changed IS NULL OR mr.merge_commit_sha = ''
+						mr.merged_at IS NULL OR mr.files_changed IS NULL OR mr.merge_commit_sha = ''
 						OR NOT EXISTS (
 							SELECT 1 FROM forge_mr_events e
 							WHERE e.merge_request_id = mr.id

--- a/internal/db/queries_archive.go
+++ b/internal/db/queries_archive.go
@@ -330,8 +330,8 @@ func requeueArchiveKnownItemLookupsTx(
 }
 
 // RequeueArchiveLifecycleDetails reopens completed provider lookups whose
-// persisted rows predate lifecycle actors or merge metrics. The normal archive
-// hydration path owns the provider read and persistence.
+// persisted rows predate the current lifecycle verification contract. The
+// normal archive hydration path owns the provider read and persistence.
 func (d *DB) RequeueArchiveLifecycleDetails(
 	ctx context.Context,
 	repoIDs []int64,
@@ -360,6 +360,7 @@ func (d *DB) RequeueArchiveLifecycleDetails(
 			SELECT 1
 			FROM forge_archive_items ai
 			JOIN forge_archive_repos ar ON ar.repo_id = ai.repo_id
+			JOIN forge_repos r ON r.id = ai.repo_id
 			WHERE ai.repo_id = forge_archive_dataset_progress.repo_id
 			  AND ai.item_type = forge_archive_dataset_progress.item_type
 			  AND ai.item_number = forge_archive_dataset_progress.item_number
@@ -383,14 +384,14 @@ func (d *DB) RequeueArchiveLifecycleDetails(
 					SELECT 1 FROM forge_merge_requests mr
 					WHERE mr.repo_id = ai.repo_id AND mr.number = ai.item_number
 					  AND (mr.state = 'merged' OR mr.merged_at IS NOT NULL)
-					  AND (
+					  AND (r.platform = 'github' OR (
 						mr.merged_at IS NULL OR mr.files_changed IS NULL OR mr.merge_commit_sha = ''
 						OR NOT EXISTS (
 							SELECT 1 FROM forge_mr_events e
 							WHERE e.merge_request_id = mr.id
 							  AND e.event_type = 'merged' AND e.author <> ''
 						)
-					  )
+					  ))
 				))
 			  )
 		  )`, sqlPlaceholders(len(repoIDs))), args...)

--- a/internal/db/queries_archive_test.go
+++ b/internal/db/queries_archive_test.go
@@ -674,6 +674,54 @@ func TestArchivePromptRediscoveryMakesTerminalItemClaimable(t *testing.T) {
 	assert.Equal(item.Number, claim.ItemNumber)
 }
 
+func TestCommitArchiveItemSyncRejectsMismatchedMergeEvidence(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := openTestDB(t)
+	ctx := t.Context()
+	now := archiveTestTime()
+	repoID := insertTestRepo(t, database, "acme", "verified-merge")
+	require.NoError(database.EnsureDiscoveryArchives(ctx, []int64{repoID}, now))
+	require.NoError(database.StartFullArchives(ctx, []int64{repoID}, now))
+	mergedAt := now.Add(-time.Hour)
+	_, err := database.UpsertMergeRequest(ctx, &MergeRequest{
+		RepoID: repoID, PlatformID: 7, Number: 7,
+		State: MergeRequestStateMerged, PlatformHeadSHA: "head-sha",
+		MergeCommitSHA: "replacement-merge-sha", FilesChanged: new(9),
+		CreatedAt: mergedAt.Add(-time.Hour), UpdatedAt: mergedAt,
+		LastActivityAt: mergedAt, MergedAt: &mergedAt, ClosedAt: &mergedAt,
+	})
+	require.NoError(err)
+	insertArchiveItemForTest(
+		t, database, repoID, ArchiveItemTypeMergeRequest, 7, mergedAt,
+	)
+	insertArchiveProgressForTest(
+		t, database, repoID, ArchiveItemTypeMergeRequest, 7,
+		ArchiveDatasetLookup, ArchiveDatasetProgressPending,
+	)
+	progress, err := database.GetDatasetProgress(
+		ctx, repoID, ArchiveItemTypeMergeRequest, 7, ArchiveDatasetLookup,
+	)
+	require.NoError(err)
+
+	err = database.CommitArchiveItemSync(ctx, ArchiveItemSyncCommit{
+		RepoID: repoID, ItemType: ArchiveItemTypeMergeRequest, ItemNumber: 7,
+		ScanGeneration: progress.ScanGeneration, Outcome: ArchiveLookupPresent,
+		MergeRequestEvidence: &ArchiveMergeRequestEvidence{
+			Merged: true, HeadSHA: "head-sha", MergeCommitSHA: "canonical-merge-sha",
+			FilesChanged: new(4),
+		},
+		Now: now,
+	})
+	require.ErrorIs(err, ErrArchiveItemEvidenceChanged)
+	assert.Equal(
+		ArchiveDatasetProgressPending,
+		archiveProgressStatusForTest(
+			t, database, repoID, ArchiveItemTypeMergeRequest, 7, ArchiveDatasetLookup,
+		),
+	)
+}
+
 func TestRequeueArchiveLifecycleDetailsOnlyReopensIncompleteGitHubRows(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/db/queries_archive_test.go
+++ b/internal/db/queries_archive_test.go
@@ -696,6 +696,12 @@ func TestRequeueArchiveLifecycleDetailsOnlyReopensIncompleteGitHubRows(t *testin
 		t, database, repoID, ArchiveItemTypeMergeRequest, 7,
 		ArchiveDatasetLookup, ArchiveDatasetProgressComplete,
 	)
+	_, err = database.WriteDB().ExecContext(ctx, `
+		UPDATE forge_archive_dataset_progress
+		SET scan_generation = ?
+		WHERE repo_id = ? AND item_type = 'merge_request'
+		  AND item_number = 7 AND dataset = 'lookup'`, int64(1<<32), repoID)
+	require.NoError(err)
 	issueID := insertArchiveReportIssue(
 		t, database, repoID, 8, "issue-8", "Closed issue", "author", mergedAt.Add(-time.Hour),
 	)

--- a/internal/db/queries_dataset_progress.go
+++ b/internal/db/queries_dataset_progress.go
@@ -9,7 +9,7 @@ import (
 )
 
 const nextEvenScanGenerationSQL = "scan_generation + 2 - (scan_generation % 2)"
-const archiveLifecycleDetailsGeneration int64 = 1 << 33
+const archiveLifecycleDetailsGeneration int64 = 1 << 34
 const maxScanPages = 10_000
 
 const (

--- a/internal/db/queries_dataset_progress.go
+++ b/internal/db/queries_dataset_progress.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -16,6 +17,8 @@ const (
 	datasetErrorCodePageBound     = "page_bound"
 	datasetErrorCodeInvalidCursor = "invalid_cursor"
 )
+
+var ErrArchiveItemEvidenceChanged = errors.New("archive item evidence changed")
 
 func formatDatasetProgressTime(t time.Time) string {
 	return t.UTC().Format(time.RFC3339Nano)
@@ -78,6 +81,10 @@ func (d *DB) CommitArchiveItemSync(ctx context.Context, commit ArchiveItemSyncCo
 	default:
 		return fmt.Errorf("commit archive item sync: invalid outcome %q", commit.Outcome)
 	}
+	if commit.MergeRequestEvidence != nil &&
+		(commit.ItemType != ArchiveItemTypeMergeRequest || commit.Outcome != ArchiveLookupPresent) {
+		return errors.New("commit archive item sync: merge request evidence requires a present merge request")
+	}
 	commit.Now = canonicalUTCTime(commit.Now)
 	var typedErr error
 	err := d.Tx(ctx, func(tx *sql.Tx) error {
@@ -110,6 +117,14 @@ func (d *DB) CommitArchiveItemSync(ctx context.Context, commit ArchiveItemSyncCo
 		if commit.Outcome == ArchiveLookupPresent {
 			if status == ArchiveDatasetProgressComplete {
 				return nil
+			}
+			if commit.MergeRequestEvidence != nil {
+				if err := validateArchiveMergeRequestEvidenceTx(
+					ctx, tx, commit.RepoID, commit.ItemNumber,
+					*commit.MergeRequestEvidence,
+				); err != nil {
+					return err
+				}
 			}
 			revision, err := lookupDomainRevisionTx(
 				ctx, tx, commit.RepoID, commit.ItemType, commit.ItemNumber,
@@ -176,6 +191,62 @@ func (d *DB) CommitArchiveItemSync(ctx context.Context, commit ArchiveItemSyncCo
 		return err
 	}
 	return typedErr
+}
+
+func validateArchiveMergeRequestEvidenceTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	repoID int64,
+	number int,
+	evidence ArchiveMergeRequestEvidence,
+) error {
+	var mr MergeRequest
+	err := tx.QueryRowContext(ctx, `
+		SELECT state, platform_head_sha, merge_commit_sha, files_changed, merged_at
+		FROM forge_merge_requests
+		WHERE repo_id = ? AND number = ?`, repoID, number,
+	).Scan(
+		&mr.State, &mr.PlatformHeadSHA, &mr.MergeCommitSHA,
+		&mr.FilesChanged, &mr.MergedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf(
+			"%w: repo %d merge request %d is not stored",
+			ErrArchiveItemEvidenceChanged, repoID, number,
+		)
+	}
+	if err != nil {
+		return fmt.Errorf("validate archive merge request evidence: %w", err)
+	}
+
+	storedMerged := mr.State == MergeRequestStateMerged || mr.MergedAt != nil
+	mismatched := make([]string, 0, 5)
+	if evidence.Merged != storedMerged {
+		mismatched = append(mismatched, "merge_state")
+	}
+	if evidence.Merged {
+		if mr.MergedAt == nil {
+			mismatched = append(mismatched, "merged_at")
+		}
+		if evidence.HeadSHA == "" || mr.PlatformHeadSHA != evidence.HeadSHA {
+			mismatched = append(mismatched, "platform_head_sha")
+		}
+		if evidence.MergeCommitSHA == "" || mr.MergeCommitSHA != evidence.MergeCommitSHA {
+			mismatched = append(mismatched, "merge_commit_sha")
+		}
+		if evidence.FilesChanged == nil || mr.FilesChanged == nil ||
+			*mr.FilesChanged != *evidence.FilesChanged {
+			mismatched = append(mismatched, "files_changed")
+		}
+	}
+	if len(mismatched) > 0 {
+		return fmt.Errorf(
+			"%w for repo %d merge request %d: %s",
+			ErrArchiveItemEvidenceChanged, repoID, number,
+			strings.Join(mismatched, ", "),
+		)
+	}
+	return nil
 }
 
 // FailArchiveItemSync applies one retry boundary to the item-level sync.

--- a/internal/db/queries_dataset_progress.go
+++ b/internal/db/queries_dataset_progress.go
@@ -9,7 +9,7 @@ import (
 )
 
 const nextEvenScanGenerationSQL = "scan_generation + 2 - (scan_generation % 2)"
-const archiveLifecycleDetailsGeneration int64 = 1 << 32
+const archiveLifecycleDetailsGeneration int64 = 1 << 33
 const maxScanPages = 10_000
 
 const (

--- a/internal/db/queries_merge_lifecycle.go
+++ b/internal/db/queries_merge_lifecycle.go
@@ -18,10 +18,9 @@ type MergeRequestMergeMetrics struct {
 	MergedAt       *time.Time
 }
 
-// FillMissingMergedMRMetrics repairs lifecycle fields omitted by an earlier
-// merged snapshot without weakening the parent snapshot timestamp guard. The
-// canonical merged response replaces merge_commit_sha because GitHub may have
-// stored a noncanonical test-merge SHA before the pull request merged.
+// FillMissingMergedMRMetrics repairs lifecycle fields from canonical merged
+// detail without weakening the parent snapshot timestamp guard. Canonical
+// merge_commit_sha and files_changed replace values from partial snapshots.
 func (d *DB) FillMissingMergedMRMetrics(
 	ctx context.Context,
 	metrics MergeRequestMergeMetrics,
@@ -40,9 +39,10 @@ func (d *DB) FillMissingMergedMRMetrics(
 		repairArgs = append(repairArgs, *metrics.MergeCommitSHA)
 	}
 	if metrics.FilesChanged != nil && *metrics.FilesChanged >= 0 {
-		setClauses = append(setClauses, "files_changed = COALESCE(files_changed, ?)")
-		missingClauses = append(missingClauses, "files_changed IS NULL")
+		setClauses = append(setClauses, "files_changed = ?")
+		missingClauses = append(missingClauses, "(files_changed IS NULL OR files_changed <> ?)")
 		setArgs = append(setArgs, *metrics.FilesChanged)
+		repairArgs = append(repairArgs, *metrics.FilesChanged)
 	}
 	var mergedAt any
 	if metrics.MergedAt != nil {

--- a/internal/db/queries_merge_lifecycle.go
+++ b/internal/db/queries_merge_lifecycle.go
@@ -32,7 +32,7 @@ func (d *DB) FillMissingMergedMRMetrics(
 			END,
 			files_changed = COALESCE(files_changed, ?)
 		WHERE repo_id = ? AND number = ?
-		  AND state = 'merged' AND merged_at IS NOT NULL
+		  AND (state = 'merged' OR merged_at IS NOT NULL)
 		  AND platform_head_sha = ? AND platform_head_sha <> ''
 		  AND (merge_commit_sha = '' OR files_changed IS NULL)`,
 		metrics.MergeCommitSHA, metrics.FilesChanged,

--- a/internal/db/queries_merge_lifecycle.go
+++ b/internal/db/queries_merge_lifecycle.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -12,8 +13,8 @@ type MergeRequestMergeMetrics struct {
 	RepoID         int64
 	Number         int
 	HeadSHA        string
-	MergeCommitSHA string
-	FilesChanged   int
+	MergeCommitSHA *string
+	FilesChanged   *int
 	MergedAt       *time.Time
 }
 
@@ -23,27 +24,44 @@ func (d *DB) FillMissingMergedMRMetrics(
 	ctx context.Context,
 	metrics MergeRequestMergeMetrics,
 ) (bool, error) {
-	if metrics.RepoID <= 0 || metrics.Number <= 0 || metrics.HeadSHA == "" ||
-		metrics.MergeCommitSHA == "" || metrics.FilesChanged < 0 {
+	if metrics.RepoID <= 0 || metrics.Number <= 0 || metrics.HeadSHA == "" {
 		return false, nil
+	}
+	setClauses := make([]string, 0, 3)
+	missingClauses := make([]string, 0, 3)
+	args := make([]any, 0, 6)
+	if metrics.MergeCommitSHA != nil && *metrics.MergeCommitSHA != "" {
+		setClauses = append(setClauses, `merge_commit_sha = CASE
+			WHEN merge_commit_sha = '' THEN ? ELSE merge_commit_sha
+		END`)
+		missingClauses = append(missingClauses, "merge_commit_sha = ''")
+		args = append(args, *metrics.MergeCommitSHA)
+	}
+	if metrics.FilesChanged != nil && *metrics.FilesChanged >= 0 {
+		setClauses = append(setClauses, "files_changed = COALESCE(files_changed, ?)")
+		missingClauses = append(missingClauses, "files_changed IS NULL")
+		args = append(args, *metrics.FilesChanged)
 	}
 	var mergedAt any
 	if metrics.MergedAt != nil {
 		mergedAt = canonicalUTCTime(*metrics.MergedAt)
+		setClauses = append(setClauses, "merged_at = COALESCE(merged_at, ?)")
+		missingClauses = append(missingClauses, "merged_at IS NULL")
+		args = append(args, mergedAt)
 	}
-	result, err := d.execContext(ctx, `
+	if len(setClauses) == 0 {
+		return false, nil
+	}
+	args = append(args, metrics.RepoID, metrics.Number, metrics.HeadSHA)
+	result, err := d.execContext(ctx, fmt.Sprintf(`
 		UPDATE forge_merge_requests
-		SET merge_commit_sha = CASE
-				WHEN merge_commit_sha = '' THEN ? ELSE merge_commit_sha
-			END,
-			files_changed = COALESCE(files_changed, ?),
-			merged_at = COALESCE(merged_at, ?)
+		SET %s
 		WHERE repo_id = ? AND number = ?
 		  AND (state = 'merged' OR merged_at IS NOT NULL)
 		  AND platform_head_sha = ? AND platform_head_sha <> ''
-		  AND (merge_commit_sha = '' OR files_changed IS NULL OR merged_at IS NULL)`,
-		metrics.MergeCommitSHA, metrics.FilesChanged, mergedAt,
-		metrics.RepoID, metrics.Number, metrics.HeadSHA,
+		  AND (%s)`, strings.Join(setClauses, ",\n\t\t\t"),
+		strings.Join(missingClauses, " OR ")),
+		args...,
 	)
 	if err != nil {
 		return false, fmt.Errorf("fill missing merged pull request metrics: %w", err)

--- a/internal/db/queries_merge_lifecycle.go
+++ b/internal/db/queries_merge_lifecycle.go
@@ -3,19 +3,21 @@ package db
 import (
 	"context"
 	"fmt"
+	"time"
 )
 
-// MergeRequestMergeMetrics identifies immutable metrics from a canonical
-// merged pull-request response.
+// MergeRequestMergeMetrics identifies immutable lifecycle fields from a
+// canonical merged pull-request response.
 type MergeRequestMergeMetrics struct {
 	RepoID         int64
 	Number         int
 	HeadSHA        string
 	MergeCommitSHA string
 	FilesChanged   int
+	MergedAt       *time.Time
 }
 
-// FillMissingMergedMRMetrics fills lifecycle metrics omitted by an earlier
+// FillMissingMergedMRMetrics fills lifecycle fields omitted by an earlier
 // merged snapshot without weakening the parent snapshot timestamp guard.
 func (d *DB) FillMissingMergedMRMetrics(
 	ctx context.Context,
@@ -25,17 +27,22 @@ func (d *DB) FillMissingMergedMRMetrics(
 		metrics.MergeCommitSHA == "" || metrics.FilesChanged < 0 {
 		return false, nil
 	}
+	var mergedAt any
+	if metrics.MergedAt != nil {
+		mergedAt = canonicalUTCTime(*metrics.MergedAt)
+	}
 	result, err := d.execContext(ctx, `
 		UPDATE forge_merge_requests
 		SET merge_commit_sha = CASE
 				WHEN merge_commit_sha = '' THEN ? ELSE merge_commit_sha
 			END,
-			files_changed = COALESCE(files_changed, ?)
+			files_changed = COALESCE(files_changed, ?),
+			merged_at = COALESCE(merged_at, ?)
 		WHERE repo_id = ? AND number = ?
 		  AND (state = 'merged' OR merged_at IS NOT NULL)
 		  AND platform_head_sha = ? AND platform_head_sha <> ''
-		  AND (merge_commit_sha = '' OR files_changed IS NULL)`,
-		metrics.MergeCommitSHA, metrics.FilesChanged,
+		  AND (merge_commit_sha = '' OR files_changed IS NULL OR merged_at IS NULL)`,
+		metrics.MergeCommitSHA, metrics.FilesChanged, mergedAt,
 		metrics.RepoID, metrics.Number, metrics.HeadSHA,
 	)
 	if err != nil {

--- a/internal/db/queries_merge_lifecycle.go
+++ b/internal/db/queries_merge_lifecycle.go
@@ -1,0 +1,49 @@
+package db
+
+import (
+	"context"
+	"fmt"
+)
+
+// MergeRequestMergeMetrics identifies immutable metrics from a canonical
+// merged pull-request response.
+type MergeRequestMergeMetrics struct {
+	RepoID         int64
+	Number         int
+	HeadSHA        string
+	MergeCommitSHA string
+	FilesChanged   int
+}
+
+// FillMissingMergedMRMetrics fills lifecycle metrics omitted by an earlier
+// merged snapshot without weakening the parent snapshot timestamp guard.
+func (d *DB) FillMissingMergedMRMetrics(
+	ctx context.Context,
+	metrics MergeRequestMergeMetrics,
+) (bool, error) {
+	if metrics.RepoID <= 0 || metrics.Number <= 0 || metrics.HeadSHA == "" ||
+		metrics.MergeCommitSHA == "" || metrics.FilesChanged < 0 {
+		return false, nil
+	}
+	result, err := d.execContext(ctx, `
+		UPDATE forge_merge_requests
+		SET merge_commit_sha = CASE
+				WHEN merge_commit_sha = '' THEN ? ELSE merge_commit_sha
+			END,
+			files_changed = COALESCE(files_changed, ?)
+		WHERE repo_id = ? AND number = ?
+		  AND state = 'merged' AND merged_at IS NOT NULL
+		  AND platform_head_sha = ? AND platform_head_sha <> ''
+		  AND (merge_commit_sha = '' OR files_changed IS NULL)`,
+		metrics.MergeCommitSHA, metrics.FilesChanged,
+		metrics.RepoID, metrics.Number, metrics.HeadSHA,
+	)
+	if err != nil {
+		return false, fmt.Errorf("fill missing merged pull request metrics: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("fill missing merged pull request metrics rows affected: %w", err)
+	}
+	return rows == 1, nil
+}

--- a/internal/db/queries_merge_lifecycle.go
+++ b/internal/db/queries_merge_lifecycle.go
@@ -18,8 +18,10 @@ type MergeRequestMergeMetrics struct {
 	MergedAt       *time.Time
 }
 
-// FillMissingMergedMRMetrics fills lifecycle fields omitted by an earlier
-// merged snapshot without weakening the parent snapshot timestamp guard.
+// FillMissingMergedMRMetrics repairs lifecycle fields omitted by an earlier
+// merged snapshot without weakening the parent snapshot timestamp guard. The
+// canonical merged response replaces merge_commit_sha because GitHub may have
+// stored a noncanonical test-merge SHA before the pull request merged.
 func (d *DB) FillMissingMergedMRMetrics(
 	ctx context.Context,
 	metrics MergeRequestMergeMetrics,
@@ -29,30 +31,31 @@ func (d *DB) FillMissingMergedMRMetrics(
 	}
 	setClauses := make([]string, 0, 3)
 	missingClauses := make([]string, 0, 3)
-	args := make([]any, 0, 6)
+	setArgs := make([]any, 0, 3)
+	repairArgs := make([]any, 0, 1)
 	if metrics.MergeCommitSHA != nil && *metrics.MergeCommitSHA != "" {
-		setClauses = append(setClauses, `merge_commit_sha = CASE
-			WHEN merge_commit_sha = '' THEN ? ELSE merge_commit_sha
-		END`)
-		missingClauses = append(missingClauses, "merge_commit_sha = ''")
-		args = append(args, *metrics.MergeCommitSHA)
+		setClauses = append(setClauses, "merge_commit_sha = ?")
+		missingClauses = append(missingClauses, "merge_commit_sha <> ?")
+		setArgs = append(setArgs, *metrics.MergeCommitSHA)
+		repairArgs = append(repairArgs, *metrics.MergeCommitSHA)
 	}
 	if metrics.FilesChanged != nil && *metrics.FilesChanged >= 0 {
 		setClauses = append(setClauses, "files_changed = COALESCE(files_changed, ?)")
 		missingClauses = append(missingClauses, "files_changed IS NULL")
-		args = append(args, *metrics.FilesChanged)
+		setArgs = append(setArgs, *metrics.FilesChanged)
 	}
 	var mergedAt any
 	if metrics.MergedAt != nil {
 		mergedAt = canonicalUTCTime(*metrics.MergedAt)
 		setClauses = append(setClauses, "merged_at = COALESCE(merged_at, ?)")
 		missingClauses = append(missingClauses, "merged_at IS NULL")
-		args = append(args, mergedAt)
+		setArgs = append(setArgs, mergedAt)
 	}
 	if len(setClauses) == 0 {
 		return false, nil
 	}
-	args = append(args, metrics.RepoID, metrics.Number, metrics.HeadSHA)
+	args := append(setArgs, metrics.RepoID, metrics.Number, metrics.HeadSHA)
+	args = append(args, repairArgs...)
 	result, err := d.execContext(ctx, fmt.Sprintf(`
 		UPDATE forge_merge_requests
 		SET %s

--- a/internal/db/queries_merge_lifecycle_test.go
+++ b/internal/db/queries_merge_lifecycle_test.go
@@ -77,7 +77,7 @@ func TestFillMissingMergedMRMetricsAcceptsEitherMergedIndicator(t *testing.T) {
 
 			changed, err := database.FillMissingMergedMRMetrics(ctx, MergeRequestMergeMetrics{
 				RepoID: repoID, Number: 7, HeadSHA: "head-sha",
-				MergeCommitSHA: "merge-sha", FilesChanged: 4,
+				MergeCommitSHA: "merge-sha", FilesChanged: 4, MergedAt: &mergedAt,
 			})
 			require.NoError(err)
 			require.True(changed)
@@ -88,6 +88,8 @@ func TestFillMissingMergedMRMetricsAcceptsEitherMergedIndicator(t *testing.T) {
 			require.Equal("merge-sha", after.MergeCommitSHA)
 			require.NotNil(after.FilesChanged)
 			require.Equal(4, *after.FilesChanged)
+			require.NotNil(after.MergedAt)
+			require.Equal(mergedAt, *after.MergedAt)
 		})
 	}
 }

--- a/internal/db/queries_merge_lifecycle_test.go
+++ b/internal/db/queries_merge_lifecycle_test.go
@@ -46,6 +46,52 @@ func TestFillMissingMergedMRMetricsFillsOnlyMissingFields(t *testing.T) {
 	assert.Equal(before.SnapshotRevision, after.SnapshotRevision)
 }
 
+func TestFillMissingMergedMRMetricsAcceptsEitherMergedIndicator(t *testing.T) {
+	tests := []struct {
+		name         string
+		state        MergeRequestState
+		mergedAtOnly bool
+	}{
+		{name: "merged state only", state: MergeRequestStateMerged},
+		{name: "merged timestamp only", state: MergeRequestStateOpen, mergedAtOnly: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			ctx := t.Context()
+			database := openTestDB(t)
+			repoID := insertTestRepo(t, database, "acme", "widget")
+			mergedAt := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+			var storedMergedAt *time.Time
+			if tt.mergedAtOnly {
+				storedMergedAt = &mergedAt
+			}
+			_, err := database.UpsertMergeRequest(ctx, &MergeRequest{
+				RepoID: repoID, PlatformID: 7, Number: 7, State: tt.state,
+				PlatformHeadSHA: "head-sha", MergedAt: storedMergedAt,
+				CreatedAt: mergedAt.Add(-time.Hour), UpdatedAt: mergedAt,
+				LastActivityAt: mergedAt,
+			})
+			require.NoError(err)
+
+			changed, err := database.FillMissingMergedMRMetrics(ctx, MergeRequestMergeMetrics{
+				RepoID: repoID, Number: 7, HeadSHA: "head-sha",
+				MergeCommitSHA: "merge-sha", FilesChanged: 4,
+			})
+			require.NoError(err)
+			require.True(changed)
+
+			after, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+			require.NoError(err)
+			require.NotNil(after)
+			require.Equal("merge-sha", after.MergeCommitSHA)
+			require.NotNil(after.FilesChanged)
+			require.Equal(4, *after.FilesChanged)
+		})
+	}
+}
+
 func TestFillMissingMergedMRMetricsPreservesExistingFields(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/db/queries_merge_lifecycle_test.go
+++ b/internal/db/queries_merge_lifecycle_test.go
@@ -124,7 +124,7 @@ func TestFillMissingMergedMRMetricsAcceptsEitherMergedIndicator(t *testing.T) {
 	}
 }
 
-func TestFillMissingMergedMRMetricsPreservesExistingFields(t *testing.T) {
+func TestFillMissingMergedMRMetricsReplacesPreMergeSHAAndPreservesFilledMetrics(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -135,7 +135,7 @@ func TestFillMissingMergedMRMetricsPreservesExistingFields(t *testing.T) {
 	_, err := database.UpsertMergeRequest(ctx, &MergeRequest{
 		RepoID: repoID, PlatformID: 7, Number: 7,
 		State: MergeRequestStateMerged, PlatformHeadSHA: "head-sha",
-		MergeCommitSHA: "stored-merge-sha",
+		MergeCommitSHA: "pre-merge-test-sha",
 		CreatedAt:      mergedAt.Add(-time.Hour), UpdatedAt: mergedAt,
 		LastActivityAt: mergedAt, MergedAt: &mergedAt,
 	})
@@ -150,7 +150,7 @@ func TestFillMissingMergedMRMetricsPreservesExistingFields(t *testing.T) {
 
 	changed, err = database.FillMissingMergedMRMetrics(ctx, MergeRequestMergeMetrics{
 		RepoID: repoID, Number: 7, HeadSHA: "head-sha",
-		MergeCommitSHA: new("later-merge-sha"), FilesChanged: new(9),
+		MergeCommitSHA: new("provider-merge-sha"), FilesChanged: new(9),
 	})
 	require.NoError(err)
 	assert.False(changed)
@@ -158,7 +158,7 @@ func TestFillMissingMergedMRMetricsPreservesExistingFields(t *testing.T) {
 	after, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
 	require.NoError(err)
 	require.NotNil(after)
-	assert.Equal("stored-merge-sha", after.MergeCommitSHA)
+	assert.Equal("provider-merge-sha", after.MergeCommitSHA)
 	require.NotNil(after.FilesChanged)
 	assert.Equal(4, *after.FilesChanged)
 }

--- a/internal/db/queries_merge_lifecycle_test.go
+++ b/internal/db/queries_merge_lifecycle_test.go
@@ -30,7 +30,7 @@ func TestFillMissingMergedMRMetricsFillsOnlyMissingFields(t *testing.T) {
 
 	changed, err := database.FillMissingMergedMRMetrics(ctx, MergeRequestMergeMetrics{
 		RepoID: repoID, Number: 7, HeadSHA: "head-sha",
-		MergeCommitSHA: "merge-sha", FilesChanged: 4,
+		MergeCommitSHA: new("merge-sha"), FilesChanged: new(4),
 	})
 	require.NoError(err)
 	assert.True(changed)
@@ -44,6 +44,36 @@ func TestFillMissingMergedMRMetricsFillsOnlyMissingFields(t *testing.T) {
 	assert.Equal("newer title", after.Title)
 	assert.Equal(before.UpdatedAt, after.UpdatedAt)
 	assert.Equal(before.SnapshotRevision, after.SnapshotRevision)
+}
+
+func TestFillMissingMergedMRMetricsUsesAvailableProviderFields(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	repoID := insertTestRepo(t, database, "acme", "widget")
+	mergedAt := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+
+	_, err := database.UpsertMergeRequest(ctx, &MergeRequest{
+		RepoID: repoID, PlatformID: 7, Number: 7,
+		State: MergeRequestStateMerged, PlatformHeadSHA: "head-sha",
+		MergeCommitSHA: "stored-merge-sha", FilesChanged: new(4),
+		CreatedAt: mergedAt.Add(-time.Hour), UpdatedAt: mergedAt,
+		LastActivityAt: mergedAt,
+	})
+	require.NoError(err)
+
+	changed, err := database.FillMissingMergedMRMetrics(ctx, MergeRequestMergeMetrics{
+		RepoID: repoID, Number: 7, HeadSHA: "head-sha", MergedAt: &mergedAt,
+	})
+	require.NoError(err)
+	require.True(changed)
+
+	after, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(after)
+	require.Equal("stored-merge-sha", after.MergeCommitSHA)
+	require.Equal(4, *after.FilesChanged)
+	require.Equal(mergedAt, *after.MergedAt)
 }
 
 func TestFillMissingMergedMRMetricsAcceptsEitherMergedIndicator(t *testing.T) {
@@ -77,7 +107,7 @@ func TestFillMissingMergedMRMetricsAcceptsEitherMergedIndicator(t *testing.T) {
 
 			changed, err := database.FillMissingMergedMRMetrics(ctx, MergeRequestMergeMetrics{
 				RepoID: repoID, Number: 7, HeadSHA: "head-sha",
-				MergeCommitSHA: "merge-sha", FilesChanged: 4, MergedAt: &mergedAt,
+				MergeCommitSHA: new("merge-sha"), FilesChanged: new(4), MergedAt: &mergedAt,
 			})
 			require.NoError(err)
 			require.True(changed)
@@ -113,14 +143,14 @@ func TestFillMissingMergedMRMetricsPreservesExistingFields(t *testing.T) {
 
 	changed, err := database.FillMissingMergedMRMetrics(ctx, MergeRequestMergeMetrics{
 		RepoID: repoID, Number: 7, HeadSHA: "head-sha",
-		MergeCommitSHA: "provider-merge-sha", FilesChanged: 4,
+		MergeCommitSHA: new("provider-merge-sha"), FilesChanged: new(4),
 	})
 	require.NoError(err)
 	assert.True(changed)
 
 	changed, err = database.FillMissingMergedMRMetrics(ctx, MergeRequestMergeMetrics{
 		RepoID: repoID, Number: 7, HeadSHA: "head-sha",
-		MergeCommitSHA: "later-merge-sha", FilesChanged: 9,
+		MergeCommitSHA: new("later-merge-sha"), FilesChanged: new(9),
 	})
 	require.NoError(err)
 	assert.False(changed)
@@ -171,10 +201,6 @@ func TestFillMissingMergedMRMetricsRejectsUnprovenIdentity(t *testing.T) {
 			name: "empty provider head", state: MergeRequestStateMerged,
 			storedHead: "head-sha", inputNumber: 7, mergeSHA: "merge-sha",
 		},
-		{
-			name: "empty provider merge SHA", state: MergeRequestStateMerged,
-			storedHead: "head-sha", inputNumber: 7, inputHead: "head-sha",
-		},
 	}
 
 	for _, tt := range tests {
@@ -202,7 +228,7 @@ func TestFillMissingMergedMRMetricsRejectsUnprovenIdentity(t *testing.T) {
 			}
 			changed, err := database.FillMissingMergedMRMetrics(ctx, MergeRequestMergeMetrics{
 				RepoID: inputRepoID, Number: tt.inputNumber, HeadSHA: tt.inputHead,
-				MergeCommitSHA: tt.mergeSHA, FilesChanged: 4,
+				MergeCommitSHA: new(tt.mergeSHA), FilesChanged: new(4),
 			})
 			require.NoError(err)
 			assert.False(changed)

--- a/internal/db/queries_merge_lifecycle_test.go
+++ b/internal/db/queries_merge_lifecycle_test.go
@@ -1,0 +1,169 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFillMissingMergedMRMetricsFillsOnlyMissingFields(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	repoID := insertTestRepo(t, database, "acme", "widget")
+	mergedAt := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	updatedAt := mergedAt.Add(time.Second + 500*time.Millisecond)
+
+	_, err := database.UpsertMergeRequest(ctx, &MergeRequest{
+		RepoID: repoID, PlatformID: 7, Number: 7, Title: "newer title",
+		State: MergeRequestStateMerged, PlatformHeadSHA: "head-sha",
+		CreatedAt: mergedAt.Add(-time.Hour), UpdatedAt: updatedAt,
+		LastActivityAt: updatedAt, MergedAt: &mergedAt,
+	})
+	require.NoError(err)
+	before, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(before)
+
+	changed, err := database.FillMissingMergedMRMetrics(ctx, MergeRequestMergeMetrics{
+		RepoID: repoID, Number: 7, HeadSHA: "head-sha",
+		MergeCommitSHA: "merge-sha", FilesChanged: 4,
+	})
+	require.NoError(err)
+	assert.True(changed)
+
+	after, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(after)
+	assert.Equal("merge-sha", after.MergeCommitSHA)
+	require.NotNil(after.FilesChanged)
+	assert.Equal(4, *after.FilesChanged)
+	assert.Equal("newer title", after.Title)
+	assert.Equal(before.UpdatedAt, after.UpdatedAt)
+	assert.Equal(before.SnapshotRevision, after.SnapshotRevision)
+}
+
+func TestFillMissingMergedMRMetricsPreservesExistingFields(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	repoID := insertTestRepo(t, database, "acme", "widget")
+	mergedAt := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+
+	_, err := database.UpsertMergeRequest(ctx, &MergeRequest{
+		RepoID: repoID, PlatformID: 7, Number: 7,
+		State: MergeRequestStateMerged, PlatformHeadSHA: "head-sha",
+		MergeCommitSHA: "stored-merge-sha",
+		CreatedAt:      mergedAt.Add(-time.Hour), UpdatedAt: mergedAt,
+		LastActivityAt: mergedAt, MergedAt: &mergedAt,
+	})
+	require.NoError(err)
+
+	changed, err := database.FillMissingMergedMRMetrics(ctx, MergeRequestMergeMetrics{
+		RepoID: repoID, Number: 7, HeadSHA: "head-sha",
+		MergeCommitSHA: "provider-merge-sha", FilesChanged: 4,
+	})
+	require.NoError(err)
+	assert.True(changed)
+
+	changed, err = database.FillMissingMergedMRMetrics(ctx, MergeRequestMergeMetrics{
+		RepoID: repoID, Number: 7, HeadSHA: "head-sha",
+		MergeCommitSHA: "later-merge-sha", FilesChanged: 9,
+	})
+	require.NoError(err)
+	assert.False(changed)
+
+	after, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(after)
+	assert.Equal("stored-merge-sha", after.MergeCommitSHA)
+	require.NotNil(after.FilesChanged)
+	assert.Equal(4, *after.FilesChanged)
+}
+
+func TestFillMissingMergedMRMetricsRejectsUnprovenIdentity(t *testing.T) {
+	tests := []struct {
+		name        string
+		state       MergeRequestState
+		storedHead  string
+		inputRepoID func(int64) int64
+		inputNumber int
+		inputHead   string
+		mergeSHA    string
+	}{
+		{
+			name: "open pull request", state: MergeRequestStateOpen,
+			storedHead: "head-sha", inputNumber: 7, inputHead: "head-sha",
+			mergeSHA: "merge-sha",
+		},
+		{
+			name: "different repository", state: MergeRequestStateMerged,
+			storedHead: "head-sha", inputRepoID: func(repoID int64) int64 { return repoID + 1 },
+			inputNumber: 7, inputHead: "head-sha", mergeSHA: "merge-sha",
+		},
+		{
+			name: "different number", state: MergeRequestStateMerged,
+			storedHead: "head-sha", inputNumber: 8, inputHead: "head-sha",
+			mergeSHA: "merge-sha",
+		},
+		{
+			name: "different head", state: MergeRequestStateMerged,
+			storedHead: "head-sha", inputNumber: 7, inputHead: "other-head",
+			mergeSHA: "merge-sha",
+		},
+		{
+			name: "empty stored head", state: MergeRequestStateMerged,
+			inputNumber: 7, inputHead: "head-sha", mergeSHA: "merge-sha",
+		},
+		{
+			name: "empty provider head", state: MergeRequestStateMerged,
+			storedHead: "head-sha", inputNumber: 7, mergeSHA: "merge-sha",
+		},
+		{
+			name: "empty provider merge SHA", state: MergeRequestStateMerged,
+			storedHead: "head-sha", inputNumber: 7, inputHead: "head-sha",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			ctx := t.Context()
+			database := openTestDB(t)
+			repoID := insertTestRepo(t, database, "acme", "widget")
+			mergedAt := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+			var storedMergedAt *time.Time
+			if tt.state == MergeRequestStateMerged {
+				storedMergedAt = &mergedAt
+			}
+			_, err := database.UpsertMergeRequest(ctx, &MergeRequest{
+				RepoID: repoID, PlatformID: 7, Number: 7, State: tt.state,
+				PlatformHeadSHA: tt.storedHead, CreatedAt: mergedAt.Add(-time.Hour),
+				UpdatedAt: mergedAt, LastActivityAt: mergedAt, MergedAt: storedMergedAt,
+			})
+			require.NoError(err)
+
+			inputRepoID := repoID
+			if tt.inputRepoID != nil {
+				inputRepoID = tt.inputRepoID(repoID)
+			}
+			changed, err := database.FillMissingMergedMRMetrics(ctx, MergeRequestMergeMetrics{
+				RepoID: inputRepoID, Number: tt.inputNumber, HeadSHA: tt.inputHead,
+				MergeCommitSHA: tt.mergeSHA, FilesChanged: 4,
+			})
+			require.NoError(err)
+			assert.False(changed)
+
+			after, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+			require.NoError(err)
+			require.NotNil(after)
+			assert.Empty(after.MergeCommitSHA)
+			assert.Nil(after.FilesChanged)
+		})
+	}
+}

--- a/internal/db/queries_merge_lifecycle_test.go
+++ b/internal/db/queries_merge_lifecycle_test.go
@@ -124,7 +124,7 @@ func TestFillMissingMergedMRMetricsAcceptsEitherMergedIndicator(t *testing.T) {
 	}
 }
 
-func TestFillMissingMergedMRMetricsReplacesPreMergeSHAAndPreservesFilledMetrics(t *testing.T) {
+func TestFillMissingMergedMRMetricsReplacesCanonicalMetrics(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -153,14 +153,14 @@ func TestFillMissingMergedMRMetricsReplacesPreMergeSHAAndPreservesFilledMetrics(
 		MergeCommitSHA: new("provider-merge-sha"), FilesChanged: new(9),
 	})
 	require.NoError(err)
-	assert.False(changed)
+	assert.True(changed)
 
 	after, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
 	require.NoError(err)
 	require.NotNil(after)
 	assert.Equal("provider-merge-sha", after.MergeCommitSHA)
 	require.NotNil(after.FilesChanged)
-	assert.Equal(4, *after.FilesChanged)
+	assert.Equal(9, *after.FilesChanged)
 }
 
 func TestFillMissingMergedMRMetricsRejectsUnprovenIdentity(t *testing.T) {

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -513,6 +513,34 @@ func TestUpsertMergedActorEventUsesCurrentParentMergedAt(t *testing.T) {
 	require.Equal(currentMergedAt, events[0].CreatedAt)
 }
 
+func TestUpsertMergedActorEventAcceptsLegacyParentWithMergedAt(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	repoID := insertTestRepo(t, d, "acme", "widget")
+	mergedAt := baseTime()
+	mrID := insertTestMRWithOptions(t, d, testMR(repoID, 1, func(mr *MergeRequest) {
+		mr.State = MergeRequestStateOpen
+		mr.MergedAt = &mergedAt
+	}))
+
+	changed, err := d.UpsertMergedActorEvent(ctx, MREvent{
+		MergeRequestID: mrID,
+		EventType:      "merged",
+		Author:         "merge-admin",
+		Summary:        "merged this",
+		CreatedAt:      mergedAt,
+		DedupeKey:      "legacy-merged-event",
+	})
+	require.NoError(err)
+	require.True(changed)
+	events, err := d.ListMREvents(ctx, mrID)
+	require.NoError(err)
+	require.Len(events, 1)
+	require.Equal("merge-admin", events[0].Author)
+	require.Equal(mergedAt, events[0].CreatedAt)
+}
+
 func TestUpsertMergedActorEventRejectsNonMergedParent(t *testing.T) {
 	require := require.New(t)
 	ctx := t.Context()

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -217,19 +217,29 @@ const (
 	ArchiveLookupInaccessible ArchiveLookupOutcome = "inaccessible"
 )
 
+// ArchiveMergeRequestEvidence is canonical provider evidence that must still
+// match storage when archive progress is committed.
+type ArchiveMergeRequestEvidence struct {
+	Merged         bool
+	HeadSHA        string
+	MergeCommitSHA string
+	FilesChanged   *int
+}
+
 // ArchiveItemSyncCommit records the outcome of running the existing full item
 // sync for archive hydration. Provider content is already persisted by the
 // syncer; this commit advances only archive progress and terminal lifecycle.
 type ArchiveItemSyncCommit struct {
-	RepoID         int64
-	ItemType       ArchiveItemType
-	ItemNumber     int
-	ScanGeneration int64
-	Outcome        ArchiveLookupOutcome
-	Destination    *RepoIdentity
-	ErrorCode      string
-	ErrorDetail    string
-	Now            time.Time
+	RepoID               int64
+	ItemType             ArchiveItemType
+	ItemNumber           int
+	ScanGeneration       int64
+	Outcome              ArchiveLookupOutcome
+	Destination          *RepoIdentity
+	ErrorCode            string
+	ErrorDetail          string
+	MergeRequestEvidence *ArchiveMergeRequestEvidence
+	Now                  time.Time
 }
 
 // ArchiveDatasetProgressKey addresses one dataset progress row.

--- a/internal/github/archive_lifecycle_test.go
+++ b/internal/github/archive_lifecycle_test.go
@@ -331,6 +331,78 @@ func TestArchiveHydrationPRShapedIssueBecomesTerminalInSQLite(t *testing.T) {
 		"terminal archive lookup must not hydrate the PR-shaped issue again")
 }
 
+func TestArchiveHydrationKeepsIncompleteMergedGitHubPRFailed(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	ref := platform.RepoRef{
+		Platform: platform.KindGitHub, Host: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	}
+	mergedAt := now.Add(-time.Hour)
+	item := buildOpenPR(7, mergedAt)
+	item.State = new("closed")
+	item.Merged = new(true)
+	item.MergedAt = makeTimestamp(mergedAt)
+	item.ClosedAt = makeTimestamp(mergedAt)
+	item.MergeCommitSHA = new("merge-sha")
+	item.ChangedFiles = nil
+	client := &archivePageMockClient{
+		mockClient: &mockClient{singlePR: item},
+		listInventoryIssuesPageFn: func(
+			context.Context, string, string, string, string, string,
+		) ([]*gh.Issue, string, bool, error) {
+			return nil, "", true, nil
+		},
+		listInventoryPullRequestsPageFn: func(
+			context.Context, string, string, string, int,
+		) ([]*gh.PullRequest, bool, error) {
+			return []*gh.PullRequest{item}, false, nil
+		},
+	}
+	tracker := NewPlatformRateTracker(database, "github", "github.com", "host", "rest")
+	tracker.UpdateFromRate(Rate{
+		Limit: 5000, Remaining: 4999, Reset: now.Add(time.Minute),
+	})
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, nil,
+		[]RepoRef{{
+			Platform: platform.KindGitHub, PlatformHost: "github.com",
+			Owner: ref.Owner, Name: ref.Name,
+		}},
+		time.Hour, map[string]*RateTracker{"github.com": tracker}, testBudget(5000),
+	)
+	syncer.now = func() time.Time { return now }
+	service, err := archive.NewService(
+		database, syncer.clients, syncer, syncer, nil,
+		archiveLifecycleClock{now: func() time.Time { return now }},
+	)
+	require.NoError(err)
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
+	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
+	require.NoError(err)
+
+	for range 2 {
+		require.NoError(service.RunEligible(t.Context()))
+	}
+	require.ErrorContains(service.RunEligible(t.Context()), "files_changed")
+
+	repo, err := database.GetRepoByIdentity(t.Context(), platform.DBRepoIdentity(ref))
+	require.NoError(err)
+	require.NotNil(repo)
+	progress, err := database.GetDatasetProgress(
+		t.Context(), repo.ID, db.ArchiveItemTypeMergeRequest, 7,
+		db.ArchiveDatasetLookup,
+	)
+	require.NoError(err)
+	assert.Equal(db.ArchiveDatasetProgressFailed, progress.Status)
+	assert.Equal(1, progress.AttemptCount)
+	assert.Nil(progress.CompletedAt)
+	require.NotNil(progress.LastErrorDetail)
+	assert.Contains(*progress.LastErrorDetail, "files_changed")
+}
+
 func TestArchivePreemptedItemRecordsNoFailureAndCompletesOnNextPass(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/github/archive_lifecycle_test.go
+++ b/internal/github/archive_lifecycle_test.go
@@ -1526,12 +1526,12 @@ func TestArchiveCompletionWithoutProviderAttemptAbandonsExpiredFeatureProbeReser
 	admission, err := syncer.Admit(t.Context(), ref, db.ArchiveItemTypeIssue, 1)
 	require.NoError(err)
 	require.True(admission.Allowed, admission.Detail)
-	providerAttempted, syncErr := syncer.SyncArchiveItem(
+	result, syncErr := syncer.SyncArchiveItem(
 		admission.Context, ref, db.ArchiveItemTypeIssue, 7,
 	)
 	require.Error(syncErr)
-	require.False(providerAttempted)
-	require.Nil(admission.Complete(syncErr, providerAttempted))
+	require.False(result.ProviderAttempted)
+	require.Nil(admission.Complete(syncErr, result.ProviderAttempted))
 
 	first, due := syncer.beginRepositoryFeatureProbe(
 		t.Context(), repo, platform.RepositoryFeatureIssues,

--- a/internal/github/merged_diff_test.go
+++ b/internal/github/merged_diff_test.go
@@ -657,6 +657,7 @@ func TestIntegrationSyncMRWrapsDiffFailureAsDiffSyncError(t *testing.T) {
 	baseRef := "main"
 	state := "closed"
 	merged := true
+	changedFiles := 1
 	now := time.Now().UTC()
 	mergedPR := &gh.PullRequest{
 		ID:             &ghID,
@@ -666,6 +667,7 @@ func TestIntegrationSyncMRWrapsDiffFailureAsDiffSyncError(t *testing.T) {
 		State:          &state,
 		Merged:         &merged,
 		MergeCommitSHA: &mergeCommit,
+		ChangedFiles:   &changedFiles,
 		UpdatedAt:      makeTimestamp(now),
 		CreatedAt:      makeTimestamp(now),
 		MergedAt:       makeTimestamp(now),

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -12441,6 +12441,7 @@ func (s *Syncer) syncMRForRepoResolved(
 					HeadSHA:        normalized.PlatformHeadSHA,
 					MergeCommitSHA: normalized.MergeCommitSHA,
 					FilesChanged:   *normalized.FilesChanged,
+					MergedAt:       normalized.MergedAt,
 				},
 			)
 			if errors.Is(repairErr, db.ErrRepositoryRouteFenceChanged) {
@@ -13024,7 +13025,10 @@ func (s *Syncer) requireGitHubArchiveMergedMRMetrics(
 	if mr.State != db.MergeRequestStateMerged && mr.MergedAt == nil {
 		return nil
 	}
-	missing := make([]string, 0, 2)
+	missing := make([]string, 0, 3)
+	if mr.MergedAt == nil {
+		missing = append(missing, "merged_at")
+	}
 	if mr.MergeCommitSHA == "" {
 		missing = append(missing, "merge_commit_sha")
 	}

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -12411,6 +12411,26 @@ func (s *Syncer) syncMRForRepo(
 		return fmt.Errorf("upsert MR #%d: %w", number, err)
 	}
 	if !accepted {
+		if ghPR != nil && ghPR.GetMerged() && normalized.FilesChanged != nil {
+			repairCtx := s.db.WithRepositoryRouteFence(
+				ctx, platform.DBRepoIdentity(platformRepoRef(repo)), routeFence,
+			)
+			_, repairErr := s.db.FillMissingMergedMRMetrics(
+				repairCtx,
+				db.MergeRequestMergeMetrics{
+					RepoID: repoID, Number: number,
+					HeadSHA:        normalized.PlatformHeadSHA,
+					MergeCommitSHA: normalized.MergeCommitSHA,
+					FilesChanged:   *normalized.FilesChanged,
+				},
+			)
+			if errors.Is(repairErr, db.ErrRepositoryRouteFenceChanged) {
+				return nil
+			}
+			if repairErr != nil {
+				return fmt.Errorf("repair merged MR #%d metrics: %w", number, repairErr)
+			}
+		}
 		return nil
 	}
 	ctx = s.db.WithRepositoryRouteFence(
@@ -12946,12 +12966,55 @@ func (s *Syncer) SyncArchiveItem(
 		providerAttempted := false
 		err := s.syncMRForRepo(ctx, repo, number, false, &providerAttempted)
 		if _, onlyDiffFailed := err.(*DiffSyncError); onlyDiffFailed { //nolint:errorlint // joined hard failures must propagate
-			return providerAttempted, nil
+			err = nil
+		}
+		if err == nil && repoPlatform(repo) == platform.KindGitHub {
+			err = s.requireGitHubArchiveMergedMRMetrics(ctx, repo, number)
 		}
 		return providerAttempted, err
 	default:
 		return false, fmt.Errorf("sync archive item: invalid item type %q", itemType)
 	}
+}
+
+func (s *Syncer) requireGitHubArchiveMergedMRMetrics(
+	ctx context.Context,
+	repo RepoRef,
+	number int,
+) error {
+	storedRepo, err := s.db.GetRepoByIdentity(
+		ctx, platform.DBRepoIdentity(platformRepoRef(repo)),
+	)
+	if err != nil {
+		return fmt.Errorf("verify GitHub archive MR #%d repository: %w", number, err)
+	}
+	if storedRepo == nil {
+		return fmt.Errorf("verify GitHub archive MR #%d: repository is not stored", number)
+	}
+	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, storedRepo.ID, number)
+	if err != nil {
+		return fmt.Errorf("verify GitHub archive MR #%d metrics: %w", number, err)
+	}
+	if mr == nil {
+		return fmt.Errorf("verify GitHub archive MR #%d metrics: pull request is not stored", number)
+	}
+	if mr.State != db.MergeRequestStateMerged && mr.MergedAt == nil {
+		return nil
+	}
+	missing := make([]string, 0, 2)
+	if mr.MergeCommitSHA == "" {
+		missing = append(missing, "merge_commit_sha")
+	}
+	if mr.FilesChanged == nil {
+		missing = append(missing, "files_changed")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf(
+			"verify GitHub archive MR %s/%s#%d metrics: missing %s",
+			repo.Owner, repo.Name, number, strings.Join(missing, ", "),
+		)
+	}
+	return nil
 }
 
 // SyncItemByNumber fetches an item by number from GitHub, determines

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -12487,8 +12487,18 @@ func (s *Syncer) syncMRForRepoResolved(
 			if s.afterMergedMRMetricsRepair != nil {
 				s.afterMergedMRMetricsRepair()
 			}
+			current, currentErr := s.db.GetMergeRequestByRepoIDAndNumber(
+				repairCtx, repoID, number,
+			)
+			if currentErr != nil {
+				return fmt.Errorf("read merged MR #%d after repair: %w", number, currentErr)
+			}
+			var currentMergedAt *time.Time
+			if current != nil {
+				currentMergedAt = current.MergedAt
+			}
 			if _, actorErr := s.persistMergedTransitionEvent(
-				repairCtx, mrID, revision, ghPR, normalized.MergedAt,
+				repairCtx, mrID, revision, ghPR, currentMergedAt,
 			); errors.Is(actorErr, db.ErrRepositoryRouteFenceChanged) {
 				abandonRepair()
 				return nil

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -918,6 +918,7 @@ type Syncer struct {
 	pendingIssueCommentSyncs []queuedIssueCommentSync
 
 	afterMergeRequestParentSnapshotCommit   func()
+	afterMergedMRMetricsRepair              func()
 	afterHeadRepoSnapshotRead               func()
 	afterNotificationRepoIdentityReconciled func()
 	beforeCloneRouteValidation              func()
@@ -12434,6 +12435,15 @@ func (s *Syncer) syncMRForRepoResolved(
 			repairCtx := s.db.WithRepositoryRouteFence(
 				ctx, platform.DBRepoIdentity(platformRepoRef(repo)), routeFence,
 			)
+			repairCtx, releaseRepair, lockErr :=
+				s.db.LockRepositoryReconciliationReadForWrite(repairCtx)
+			if errors.Is(lockErr, db.ErrRepositoryRouteFenceChanged) {
+				return nil
+			}
+			if lockErr != nil {
+				return fmt.Errorf("lock merged MR #%d repair: %w", number, lockErr)
+			}
+			defer releaseRepair()
 			_, repairErr := s.db.FillMissingMergedMRMetrics(
 				repairCtx,
 				db.MergeRequestMergeMetrics{
@@ -12449,6 +12459,9 @@ func (s *Syncer) syncMRForRepoResolved(
 			}
 			if repairErr != nil {
 				return fmt.Errorf("repair merged MR #%d metrics: %w", number, repairErr)
+			}
+			if s.afterMergedMRMetricsRepair != nil {
+				s.afterMergedMRMetricsRepair()
 			}
 			if _, actorErr := s.persistMergedTransitionEvent(
 				repairCtx, mrID, revision, ghPR, normalized.MergedAt,

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -13117,7 +13117,14 @@ func (s *Syncer) requireGitHubArchiveMergedMRMetrics(
 	if mr == nil {
 		return fmt.Errorf("verify GitHub archive MR #%d metrics: pull request is not stored", number)
 	}
-	if !fetched.merged && mr.State != db.MergeRequestStateMerged && mr.MergedAt == nil {
+	storedMerged := mr.State == db.MergeRequestStateMerged || mr.MergedAt != nil
+	if fetched.merged != storedMerged {
+		return fmt.Errorf(
+			"verify GitHub archive MR %s/%s#%d metrics: incomplete or mismatched merge_state",
+			storedRepo.Owner, storedRepo.Name, number,
+		)
+	}
+	if !fetched.merged {
 		return nil
 	}
 	incomplete := make([]string, 0, 4)

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -12268,6 +12268,7 @@ type mergeRequestFetchEvidence struct {
 	merged         bool
 	headSHA        string
 	mergeCommitSHA string
+	filesChanged   *int
 }
 
 func (s *Syncer) syncMRForRepoResolved(
@@ -12410,6 +12411,7 @@ func (s *Syncer) syncMRForRepoResolved(
 			merged:         normalized.State == db.MergeRequestStateMerged || normalized.MergedAt != nil,
 			headSHA:        normalized.PlatformHeadSHA,
 			mergeCommitSHA: normalized.MergeCommitSHA,
+			filesChanged:   normalized.FilesChanged,
 		}
 	}
 	headChanged := existing != nil &&
@@ -13129,11 +13131,17 @@ func (s *Syncer) requireGitHubArchiveMergedMRMetrics(
 		if fetched.mergeCommitSHA == "" || mr.MergeCommitSHA != fetched.mergeCommitSHA {
 			incomplete = append(incomplete, "merge_commit_sha")
 		}
-	} else if mr.MergeCommitSHA == "" {
-		incomplete = append(incomplete, "merge_commit_sha")
-	}
-	if mr.FilesChanged == nil {
-		incomplete = append(incomplete, "files_changed")
+		if fetched.filesChanged == nil || mr.FilesChanged == nil ||
+			*mr.FilesChanged != *fetched.filesChanged {
+			incomplete = append(incomplete, "files_changed")
+		}
+	} else {
+		if mr.MergeCommitSHA == "" {
+			incomplete = append(incomplete, "merge_commit_sha")
+		}
+		if mr.FilesChanged == nil {
+			incomplete = append(incomplete, "files_changed")
+		}
 	}
 	if len(incomplete) > 0 {
 		return fmt.Errorf(

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -12264,6 +12264,12 @@ func (s *Syncer) syncMRForRepo(
 	)
 }
 
+type mergeRequestFetchEvidence struct {
+	merged         bool
+	headSHA        string
+	mergeCommitSHA string
+}
+
 func (s *Syncer) syncMRForRepoResolved(
 	ctx context.Context,
 	repo RepoRef,
@@ -12271,13 +12277,13 @@ func (s *Syncer) syncMRForRepoResolved(
 	useConditionalPRDetail bool,
 	providerAttempted *bool,
 	resolvedRepoID *int64,
-	fetchedMerged *bool,
+	fetchedEvidence *mergeRequestFetchEvidence,
 ) error {
 	if resolvedRepoID != nil {
 		*resolvedRepoID = 0
 	}
-	if fetchedMerged != nil {
-		*fetchedMerged = false
+	if fetchedEvidence != nil {
+		*fetchedEvidence = mergeRequestFetchEvidence{}
 	}
 	if !IsArchiveSyncBudgetContext(ctx) {
 		bucket, err := s.bucketKeyForRepo(repo, false)
@@ -12395,8 +12401,12 @@ func (s *Syncer) syncMRForRepoResolved(
 	if normalized == nil {
 		return fmt.Errorf("get MR %s/%s#%d: provider returned no merge request", owner, name, number)
 	}
-	if fetchedMerged != nil {
-		*fetchedMerged = normalized.State == db.MergeRequestStateMerged || normalized.MergedAt != nil
+	if fetchedEvidence != nil {
+		*fetchedEvidence = mergeRequestFetchEvidence{
+			merged:         normalized.State == db.MergeRequestStateMerged || normalized.MergedAt != nil,
+			headSHA:        normalized.PlatformHeadSHA,
+			mergeCommitSHA: normalized.MergeCommitSHA,
+		}
 	}
 	headChanged := existing != nil &&
 		existing.PlatformHeadSHA != normalized.PlatformHeadSHA
@@ -13020,16 +13030,16 @@ func (s *Syncer) SyncArchiveItem(
 	case db.ArchiveItemTypeMergeRequest:
 		providerAttempted := false
 		var resolvedRepoID int64
-		var fetchedMerged bool
+		var fetchedEvidence mergeRequestFetchEvidence
 		err := s.syncMRForRepoResolved(
-			ctx, repo, number, false, &providerAttempted, &resolvedRepoID, &fetchedMerged,
+			ctx, repo, number, false, &providerAttempted, &resolvedRepoID, &fetchedEvidence,
 		)
 		if _, onlyDiffFailed := err.(*DiffSyncError); onlyDiffFailed { //nolint:errorlint // joined hard failures must propagate
 			err = nil
 		}
 		if err == nil && repoPlatform(repo) == platform.KindGitHub {
 			err = s.requireGitHubArchiveMergedMRMetrics(
-				ctx, resolvedRepoID, number, fetchedMerged,
+				ctx, resolvedRepoID, number, fetchedEvidence,
 			)
 		}
 		return providerAttempted, err
@@ -13042,7 +13052,7 @@ func (s *Syncer) requireGitHubArchiveMergedMRMetrics(
 	ctx context.Context,
 	repoID int64,
 	number int,
-	fetchedMerged bool,
+	fetched mergeRequestFetchEvidence,
 ) error {
 	if repoID == 0 {
 		return fmt.Errorf("verify GitHub archive MR #%d: repository was not resolved", number)
@@ -13061,23 +13071,30 @@ func (s *Syncer) requireGitHubArchiveMergedMRMetrics(
 	if mr == nil {
 		return fmt.Errorf("verify GitHub archive MR #%d metrics: pull request is not stored", number)
 	}
-	if !fetchedMerged && mr.State != db.MergeRequestStateMerged && mr.MergedAt == nil {
+	if !fetched.merged && mr.State != db.MergeRequestStateMerged && mr.MergedAt == nil {
 		return nil
 	}
-	missing := make([]string, 0, 3)
+	incomplete := make([]string, 0, 4)
 	if mr.MergedAt == nil {
-		missing = append(missing, "merged_at")
+		incomplete = append(incomplete, "merged_at")
 	}
-	if mr.MergeCommitSHA == "" {
-		missing = append(missing, "merge_commit_sha")
+	if fetched.merged {
+		if fetched.headSHA == "" || mr.PlatformHeadSHA != fetched.headSHA {
+			incomplete = append(incomplete, "platform_head_sha")
+		}
+		if fetched.mergeCommitSHA == "" || mr.MergeCommitSHA != fetched.mergeCommitSHA {
+			incomplete = append(incomplete, "merge_commit_sha")
+		}
+	} else if mr.MergeCommitSHA == "" {
+		incomplete = append(incomplete, "merge_commit_sha")
 	}
 	if mr.FilesChanged == nil {
-		missing = append(missing, "files_changed")
+		incomplete = append(incomplete, "files_changed")
 	}
-	if len(missing) > 0 {
+	if len(incomplete) > 0 {
 		return fmt.Errorf(
-			"verify GitHub archive MR %s/%s#%d metrics: missing %s",
-			storedRepo.Owner, storedRepo.Name, number, strings.Join(missing, ", "),
+			"verify GitHub archive MR %s/%s#%d metrics: incomplete or mismatched %s",
+			storedRepo.Owner, storedRepo.Name, number, strings.Join(incomplete, ", "),
 		)
 	}
 	return nil

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -12260,7 +12260,7 @@ func (s *Syncer) syncMRForRepo(
 	providerAttempted *bool,
 ) error {
 	return s.syncMRForRepoResolved(
-		ctx, repo, number, useConditionalPRDetail, providerAttempted, nil,
+		ctx, repo, number, useConditionalPRDetail, providerAttempted, nil, nil,
 	)
 }
 
@@ -12271,9 +12271,13 @@ func (s *Syncer) syncMRForRepoResolved(
 	useConditionalPRDetail bool,
 	providerAttempted *bool,
 	resolvedRepoID *int64,
+	fetchedMerged *bool,
 ) error {
 	if resolvedRepoID != nil {
 		*resolvedRepoID = 0
+	}
+	if fetchedMerged != nil {
+		*fetchedMerged = false
 	}
 	if !IsArchiveSyncBudgetContext(ctx) {
 		bucket, err := s.bucketKeyForRepo(repo, false)
@@ -12390,6 +12394,9 @@ func (s *Syncer) syncMRForRepoResolved(
 	}
 	if normalized == nil {
 		return fmt.Errorf("get MR %s/%s#%d: provider returned no merge request", owner, name, number)
+	}
+	if fetchedMerged != nil {
+		*fetchedMerged = normalized.State == db.MergeRequestStateMerged || normalized.MergedAt != nil
 	}
 	headChanged := existing != nil &&
 		existing.PlatformHeadSHA != normalized.PlatformHeadSHA
@@ -13013,14 +13020,17 @@ func (s *Syncer) SyncArchiveItem(
 	case db.ArchiveItemTypeMergeRequest:
 		providerAttempted := false
 		var resolvedRepoID int64
+		var fetchedMerged bool
 		err := s.syncMRForRepoResolved(
-			ctx, repo, number, false, &providerAttempted, &resolvedRepoID,
+			ctx, repo, number, false, &providerAttempted, &resolvedRepoID, &fetchedMerged,
 		)
 		if _, onlyDiffFailed := err.(*DiffSyncError); onlyDiffFailed { //nolint:errorlint // joined hard failures must propagate
 			err = nil
 		}
 		if err == nil && repoPlatform(repo) == platform.KindGitHub {
-			err = s.requireGitHubArchiveMergedMRMetrics(ctx, resolvedRepoID, number)
+			err = s.requireGitHubArchiveMergedMRMetrics(
+				ctx, resolvedRepoID, number, fetchedMerged,
+			)
 		}
 		return providerAttempted, err
 	default:
@@ -13032,6 +13042,7 @@ func (s *Syncer) requireGitHubArchiveMergedMRMetrics(
 	ctx context.Context,
 	repoID int64,
 	number int,
+	fetchedMerged bool,
 ) error {
 	if repoID == 0 {
 		return fmt.Errorf("verify GitHub archive MR #%d: repository was not resolved", number)
@@ -13050,7 +13061,7 @@ func (s *Syncer) requireGitHubArchiveMergedMRMetrics(
 	if mr == nil {
 		return fmt.Errorf("verify GitHub archive MR #%d metrics: pull request is not stored", number)
 	}
-	if mr.State != db.MergeRequestStateMerged && mr.MergedAt == nil {
+	if !fetchedMerged && mr.State != db.MergeRequestStateMerged && mr.MergedAt == nil {
 		return nil
 	}
 	missing := make([]string, 0, 3)

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -12432,42 +12432,48 @@ func (s *Syncer) syncMRForRepoResolved(
 	}
 	if !accepted {
 		if ghPR != nil && pullRequestWasMerged(ghPR) {
+			abandonRepair := func() {
+				if resolvedRepoID != nil {
+					*resolvedRepoID = 0
+				}
+			}
 			repairCtx := s.db.WithRepositoryRouteFence(
 				ctx, platform.DBRepoIdentity(platformRepoRef(repo)), routeFence,
 			)
 			repairCtx, releaseRepair, lockErr :=
 				s.db.LockRepositoryReconciliationReadForWrite(repairCtx)
 			if errors.Is(lockErr, db.ErrRepositoryRouteFenceChanged) {
+				abandonRepair()
 				return nil
 			}
 			if lockErr != nil {
 				return fmt.Errorf("lock merged MR #%d repair: %w", number, lockErr)
 			}
 			defer releaseRepair()
-			if normalized.FilesChanged != nil {
-				_, repairErr := s.db.FillMissingMergedMRMetrics(
-					repairCtx,
-					db.MergeRequestMergeMetrics{
-						RepoID: repoID, Number: number,
-						HeadSHA:        normalized.PlatformHeadSHA,
-						MergeCommitSHA: normalized.MergeCommitSHA,
-						FilesChanged:   *normalized.FilesChanged,
-						MergedAt:       normalized.MergedAt,
-					},
-				)
-				if errors.Is(repairErr, db.ErrRepositoryRouteFenceChanged) {
-					return nil
-				}
-				if repairErr != nil {
-					return fmt.Errorf("repair merged MR #%d metrics: %w", number, repairErr)
-				}
-				if s.afterMergedMRMetricsRepair != nil {
-					s.afterMergedMRMetricsRepair()
-				}
+			_, repairErr := s.db.FillMissingMergedMRMetrics(
+				repairCtx,
+				db.MergeRequestMergeMetrics{
+					RepoID: repoID, Number: number,
+					HeadSHA:        normalized.PlatformHeadSHA,
+					MergeCommitSHA: &normalized.MergeCommitSHA,
+					FilesChanged:   normalized.FilesChanged,
+					MergedAt:       normalized.MergedAt,
+				},
+			)
+			if errors.Is(repairErr, db.ErrRepositoryRouteFenceChanged) {
+				abandonRepair()
+				return nil
+			}
+			if repairErr != nil {
+				return fmt.Errorf("repair merged MR #%d metrics: %w", number, repairErr)
+			}
+			if s.afterMergedMRMetricsRepair != nil {
+				s.afterMergedMRMetricsRepair()
 			}
 			if _, actorErr := s.persistMergedTransitionEvent(
 				repairCtx, mrID, revision, ghPR, normalized.MergedAt,
 			); errors.Is(actorErr, db.ErrRepositoryRouteFenceChanged) {
+				abandonRepair()
 				return nil
 			} else if actorErr != nil {
 				return fmt.Errorf("repair merged MR #%d actor: %w", number, actorErr)

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -12258,6 +12258,22 @@ func (s *Syncer) syncMRForRepo(
 	useConditionalPRDetail bool,
 	providerAttempted *bool,
 ) error {
+	return s.syncMRForRepoResolved(
+		ctx, repo, number, useConditionalPRDetail, providerAttempted, nil,
+	)
+}
+
+func (s *Syncer) syncMRForRepoResolved(
+	ctx context.Context,
+	repo RepoRef,
+	number int,
+	useConditionalPRDetail bool,
+	providerAttempted *bool,
+	resolvedRepoID *int64,
+) error {
+	if resolvedRepoID != nil {
+		*resolvedRepoID = 0
+	}
 	if !IsArchiveSyncBudgetContext(ctx) {
 		bucket, err := s.bucketKeyForRepo(repo, false)
 		if err != nil {
@@ -12283,6 +12299,9 @@ func (s *Syncer) syncMRForRepo(
 	}
 	if !found {
 		return nil
+	}
+	if resolvedRepoID != nil {
+		*resolvedRepoID = repoID
 	}
 	repo = resolvedRef
 	if repo.Archived && !IsArchiveSyncBudgetContext(ctx) {
@@ -12411,7 +12430,7 @@ func (s *Syncer) syncMRForRepo(
 		return fmt.Errorf("upsert MR #%d: %w", number, err)
 	}
 	if !accepted {
-		if ghPR != nil && ghPR.GetMerged() && normalized.FilesChanged != nil {
+		if ghPR != nil && pullRequestWasMerged(ghPR) && normalized.FilesChanged != nil {
 			repairCtx := s.db.WithRepositoryRouteFence(
 				ctx, platform.DBRepoIdentity(platformRepoRef(repo)), routeFence,
 			)
@@ -12964,12 +12983,15 @@ func (s *Syncer) SyncArchiveItem(
 		return providerAttempted, err
 	case db.ArchiveItemTypeMergeRequest:
 		providerAttempted := false
-		err := s.syncMRForRepo(ctx, repo, number, false, &providerAttempted)
+		var resolvedRepoID int64
+		err := s.syncMRForRepoResolved(
+			ctx, repo, number, false, &providerAttempted, &resolvedRepoID,
+		)
 		if _, onlyDiffFailed := err.(*DiffSyncError); onlyDiffFailed { //nolint:errorlint // joined hard failures must propagate
 			err = nil
 		}
 		if err == nil && repoPlatform(repo) == platform.KindGitHub {
-			err = s.requireGitHubArchiveMergedMRMetrics(ctx, repo, number)
+			err = s.requireGitHubArchiveMergedMRMetrics(ctx, resolvedRepoID, number)
 		}
 		return providerAttempted, err
 	default:
@@ -12979,19 +13001,20 @@ func (s *Syncer) SyncArchiveItem(
 
 func (s *Syncer) requireGitHubArchiveMergedMRMetrics(
 	ctx context.Context,
-	repo RepoRef,
+	repoID int64,
 	number int,
 ) error {
-	storedRepo, err := s.db.GetRepoByIdentity(
-		ctx, platform.DBRepoIdentity(platformRepoRef(repo)),
-	)
+	if repoID == 0 {
+		return fmt.Errorf("verify GitHub archive MR #%d: repository was not resolved", number)
+	}
+	storedRepo, err := s.db.GetRepoByID(ctx, repoID)
 	if err != nil {
 		return fmt.Errorf("verify GitHub archive MR #%d repository: %w", number, err)
 	}
 	if storedRepo == nil {
 		return fmt.Errorf("verify GitHub archive MR #%d: repository is not stored", number)
 	}
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, storedRepo.ID, number)
+	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repoID, number)
 	if err != nil {
 		return fmt.Errorf("verify GitHub archive MR #%d metrics: %w", number, err)
 	}
@@ -13011,7 +13034,7 @@ func (s *Syncer) requireGitHubArchiveMergedMRMetrics(
 	if len(missing) > 0 {
 		return fmt.Errorf(
 			"verify GitHub archive MR %s/%s#%d metrics: missing %s",
-			repo.Owner, repo.Name, number, strings.Join(missing, ", "),
+			storedRepo.Owner, storedRepo.Name, number, strings.Join(missing, ", "),
 		)
 	}
 	return nil

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -12450,6 +12450,13 @@ func (s *Syncer) syncMRForRepoResolved(
 			if repairErr != nil {
 				return fmt.Errorf("repair merged MR #%d metrics: %w", number, repairErr)
 			}
+			if _, actorErr := s.persistMergedTransitionEvent(
+				repairCtx, mrID, revision, ghPR, normalized.MergedAt,
+			); errors.Is(actorErr, db.ErrRepositoryRouteFenceChanged) {
+				return nil
+			} else if actorErr != nil {
+				return fmt.Errorf("repair merged MR #%d actor: %w", number, actorErr)
+			}
 		}
 		return nil
 	}

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -13048,10 +13048,11 @@ func (s *Syncer) SyncArchiveItem(
 	ref platform.RepoRef,
 	itemType db.ArchiveItemType,
 	number int,
-) (bool, error) {
+) (archive.ItemSyncResult, error) {
+	result := archive.ItemSyncResult{}
 	repo, ok := s.trackedRepoByIdentity(ref.Platform, ref.Owner, ref.Name, ref.Host)
 	if !ok {
-		return false, fmt.Errorf(
+		return result, fmt.Errorf(
 			"repo %s/%s on %s/%s is not tracked",
 			ref.Owner, ref.Name, ref.Platform, ref.Host,
 		)
@@ -13063,7 +13064,8 @@ func (s *Syncer) SyncArchiveItem(
 	case db.ArchiveItemTypeIssue:
 		providerAttempted := false
 		err := s.syncIssueForRepo(ctx, repo, number, &providerAttempted)
-		return providerAttempted, err
+		result.ProviderAttempted = providerAttempted
+		return result, err
 	case db.ArchiveItemTypeMergeRequest:
 		providerAttempted := false
 		var resolvedRepoID int64
@@ -13080,10 +13082,23 @@ func (s *Syncer) SyncArchiveItem(
 			err = s.requireGitHubArchiveMergedMRMetrics(
 				ctx, resolvedRepoID, number, fetchedEvidence, lifecyclePersisted,
 			)
+			if err == nil {
+				var filesChanged *int
+				if fetchedEvidence.filesChanged != nil {
+					value := *fetchedEvidence.filesChanged
+					filesChanged = &value
+				}
+				result.MergeRequestEvidence = &db.ArchiveMergeRequestEvidence{
+					Merged: fetchedEvidence.merged, HeadSHA: fetchedEvidence.headSHA,
+					MergeCommitSHA: fetchedEvidence.mergeCommitSHA,
+					FilesChanged:   filesChanged,
+				}
+			}
 		}
-		return providerAttempted, err
+		result.ProviderAttempted = providerAttempted
+		return result, err
 	default:
-		return false, fmt.Errorf("sync archive item: invalid item type %q", itemType)
+		return result, fmt.Errorf("sync archive item: invalid item type %q", itemType)
 	}
 }
 

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -12260,7 +12260,7 @@ func (s *Syncer) syncMRForRepo(
 	providerAttempted *bool,
 ) error {
 	return s.syncMRForRepoResolved(
-		ctx, repo, number, useConditionalPRDetail, providerAttempted, nil, nil,
+		ctx, repo, number, useConditionalPRDetail, providerAttempted, nil, nil, nil,
 	)
 }
 
@@ -12278,12 +12278,16 @@ func (s *Syncer) syncMRForRepoResolved(
 	providerAttempted *bool,
 	resolvedRepoID *int64,
 	fetchedEvidence *mergeRequestFetchEvidence,
+	lifecyclePersisted *bool,
 ) error {
 	if resolvedRepoID != nil {
 		*resolvedRepoID = 0
 	}
 	if fetchedEvidence != nil {
 		*fetchedEvidence = mergeRequestFetchEvidence{}
+	}
+	if lifecyclePersisted != nil {
+		*lifecyclePersisted = false
 	}
 	if !IsArchiveSyncBudgetContext(ctx) {
 		bucket, err := s.bucketKeyForRepo(repo, false)
@@ -12414,6 +12418,7 @@ func (s *Syncer) syncMRForRepoResolved(
 		normalized.CommentCount = existing.CommentCount
 		normalized.ReviewDecision = existing.ReviewDecision
 		preserveMergeableStateIfOmitted(normalized, existing)
+		preserveMergedAtIfOmitted(normalized, existing)
 		// CI is tied to the head SHA. If the head moved we must clear the
 		// previous values; otherwise a failed CI refresh would leave stale
 		// checks attached to the new commit.
@@ -12505,6 +12510,9 @@ func (s *Syncer) syncMRForRepoResolved(
 			} else if actorErr != nil {
 				return fmt.Errorf("repair merged MR #%d actor: %w", number, actorErr)
 			}
+			if lifecyclePersisted != nil {
+				*lifecyclePersisted = true
+			}
 		}
 		return nil
 	}
@@ -12559,6 +12567,9 @@ func (s *Syncer) syncMRForRepoResolved(
 		}
 		if _, err := s.persistMergedTransitionEvent(ctx, mrID, revision, ghPR, normalized.MergedAt); err != nil {
 			return fmt.Errorf("persist merged lifecycle event for MR #%d: %w", number, err)
+		}
+		if lifecyclePersisted != nil {
+			*lifecyclePersisted = true
 		}
 
 		syncMRHeadSHA := ""
@@ -12629,6 +12640,9 @@ func (s *Syncer) syncMRForRepoResolved(
 		}
 		if _, err := s.persistMergedActorEvent(ctx, mrID, revision, platformMR.MergedBy, normalized.MergedAt); err != nil {
 			return fmt.Errorf("persist merged lifecycle event for MR #%d: %w", number, err)
+		}
+		if lifecyclePersisted != nil {
+			*lifecyclePersisted = true
 		}
 		detailApplied, err := s.markMergeRequestDetailFetchedIfRouteFence(
 			ctx, repo, routeFence, mrID, revision, pending, nil,
@@ -12722,6 +12736,17 @@ func preserveMergeableStateIfOmitted(
 	if normalized.MergeableState == "" ||
 		(normalized.MergeableState == "unknown" && existing.MergeableState != "") {
 		normalized.MergeableState = existing.MergeableState
+	}
+}
+
+func preserveMergedAtIfOmitted(
+	normalized *db.MergeRequest,
+	existing *db.MergeRequest,
+) {
+	if normalized.State == db.MergeRequestStateMerged &&
+		normalized.MergedAt == nil && existing.MergedAt != nil {
+		mergedAt := *existing.MergedAt
+		normalized.MergedAt = &mergedAt
 	}
 }
 
@@ -13041,15 +13066,17 @@ func (s *Syncer) SyncArchiveItem(
 		providerAttempted := false
 		var resolvedRepoID int64
 		var fetchedEvidence mergeRequestFetchEvidence
+		var lifecyclePersisted bool
 		err := s.syncMRForRepoResolved(
 			ctx, repo, number, false, &providerAttempted, &resolvedRepoID, &fetchedEvidence,
+			&lifecyclePersisted,
 		)
 		if _, onlyDiffFailed := err.(*DiffSyncError); onlyDiffFailed { //nolint:errorlint // joined hard failures must propagate
 			err = nil
 		}
 		if err == nil && repoPlatform(repo) == platform.KindGitHub {
 			err = s.requireGitHubArchiveMergedMRMetrics(
-				ctx, resolvedRepoID, number, fetchedEvidence,
+				ctx, resolvedRepoID, number, fetchedEvidence, lifecyclePersisted,
 			)
 		}
 		return providerAttempted, err
@@ -13063,6 +13090,7 @@ func (s *Syncer) requireGitHubArchiveMergedMRMetrics(
 	repoID int64,
 	number int,
 	fetched mergeRequestFetchEvidence,
+	lifecyclePersisted bool,
 ) error {
 	if repoID == 0 {
 		return fmt.Errorf("verify GitHub archive MR #%d: repository was not resolved", number)
@@ -13073,6 +13101,12 @@ func (s *Syncer) requireGitHubArchiveMergedMRMetrics(
 	}
 	if storedRepo == nil {
 		return fmt.Errorf("verify GitHub archive MR #%d: repository is not stored", number)
+	}
+	if fetched.merged && !lifecyclePersisted {
+		return fmt.Errorf(
+			"verify GitHub archive MR %s/%s#%d: lifecycle persistence incomplete",
+			storedRepo.Owner, storedRepo.Name, number,
+		)
 	}
 	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repoID, number)
 	if err != nil {

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -12431,7 +12431,7 @@ func (s *Syncer) syncMRForRepoResolved(
 		return fmt.Errorf("upsert MR #%d: %w", number, err)
 	}
 	if !accepted {
-		if ghPR != nil && pullRequestWasMerged(ghPR) && normalized.FilesChanged != nil {
+		if ghPR != nil && pullRequestWasMerged(ghPR) {
 			repairCtx := s.db.WithRepositoryRouteFence(
 				ctx, platform.DBRepoIdentity(platformRepoRef(repo)), routeFence,
 			)
@@ -12444,24 +12444,26 @@ func (s *Syncer) syncMRForRepoResolved(
 				return fmt.Errorf("lock merged MR #%d repair: %w", number, lockErr)
 			}
 			defer releaseRepair()
-			_, repairErr := s.db.FillMissingMergedMRMetrics(
-				repairCtx,
-				db.MergeRequestMergeMetrics{
-					RepoID: repoID, Number: number,
-					HeadSHA:        normalized.PlatformHeadSHA,
-					MergeCommitSHA: normalized.MergeCommitSHA,
-					FilesChanged:   *normalized.FilesChanged,
-					MergedAt:       normalized.MergedAt,
-				},
-			)
-			if errors.Is(repairErr, db.ErrRepositoryRouteFenceChanged) {
-				return nil
-			}
-			if repairErr != nil {
-				return fmt.Errorf("repair merged MR #%d metrics: %w", number, repairErr)
-			}
-			if s.afterMergedMRMetricsRepair != nil {
-				s.afterMergedMRMetricsRepair()
+			if normalized.FilesChanged != nil {
+				_, repairErr := s.db.FillMissingMergedMRMetrics(
+					repairCtx,
+					db.MergeRequestMergeMetrics{
+						RepoID: repoID, Number: number,
+						HeadSHA:        normalized.PlatformHeadSHA,
+						MergeCommitSHA: normalized.MergeCommitSHA,
+						FilesChanged:   *normalized.FilesChanged,
+						MergedAt:       normalized.MergedAt,
+					},
+				)
+				if errors.Is(repairErr, db.ErrRepositoryRouteFenceChanged) {
+					return nil
+				}
+				if repairErr != nil {
+					return fmt.Errorf("repair merged MR #%d metrics: %w", number, repairErr)
+				}
+				if s.afterMergedMRMetricsRepair != nil {
+					s.afterMergedMRMetricsRepair()
+				}
 			}
 			if _, actorErr := s.persistMergedTransitionEvent(
 				repairCtx, mrID, revision, ghPR, normalized.MergedAt,

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -13125,6 +13125,176 @@ func TestSyncArchiveIssueBypassesPersistedETagForLifecycleBackfill(t *testing.T)
 	assert.Equal("closer", events[0].Author)
 }
 
+func TestSyncArchiveMRRepairsMetricsFromRejectedCanonicalSnapshot(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	repo := RepoRef{
+		Platform: platform.KindGitHub, Owner: "owner", Name: "repo",
+		PlatformHost: "github.com",
+	}
+	repoID, err := database.UpsertRepo(
+		ctx, verifiedGitHubRepoIdentity("github.com", repo.Owner, repo.Name),
+	)
+	require.NoError(err)
+	canonicalUpdatedAt := time.Date(2026, 7, 28, 0, 41, 21, 0, time.UTC)
+	localUpdatedAt := canonicalUpdatedAt.Add(835 * time.Millisecond)
+	mergedAt := canonicalUpdatedAt.Add(-time.Second)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID: repoID, PlatformID: 7000, Number: 7, Title: "newer local title",
+		State: db.MergeRequestStateMerged, PlatformHeadSHA: "head-sha",
+		CreatedAt: canonicalUpdatedAt.Add(-time.Hour), UpdatedAt: localUpdatedAt,
+		LastActivityAt: localUpdatedAt, MergedAt: &mergedAt, ClosedAt: &mergedAt,
+	})
+	require.NoError(err)
+	before, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(before)
+
+	canonical := buildOpenPR(7, canonicalUpdatedAt)
+	closed := "closed"
+	merged := true
+	mergeSHA := "merge-sha"
+	filesChanged := 4
+	canonical.State = &closed
+	canonical.Merged = &merged
+	canonical.MergedAt = makeTimestamp(mergedAt)
+	canonical.ClosedAt = makeTimestamp(mergedAt)
+	canonical.MergeCommitSHA = &mergeSHA
+	canonical.ChangedFiles = &filesChanged
+	canonical.Head.SHA = new("head-sha")
+	client := &mockClient{singlePR: canonical}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, nil,
+		[]RepoRef{repo}, time.Minute, nil, testBudget(1000),
+	)
+
+	require.NoError(syncer.syncMRForRepo(
+		WithArchiveSyncBudget(ctx), repo, 7, false, nil,
+	))
+	after, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(after)
+	assert.Equal("merge-sha", after.MergeCommitSHA)
+	require.NotNil(after.FilesChanged)
+	assert.Equal(4, *after.FilesChanged)
+	assert.Equal("newer local title", after.Title)
+	assert.Equal(before.UpdatedAt, after.UpdatedAt)
+	assert.Equal(before.SnapshotRevision, after.SnapshotRevision)
+}
+
+func TestSyncArchiveMRRejectsMissingMergedMetrics(t *testing.T) {
+	tests := []struct {
+		name              string
+		storedMergeSHA    string
+		storedFiles       *int
+		providerMergeSHA  string
+		providerFiles     *int
+		missingFieldLabel string
+	}{
+		{
+			name: "merge commit SHA", storedFiles: new(4), providerFiles: new(4),
+			missingFieldLabel: "merge_commit_sha",
+		},
+		{
+			name: "files changed", storedMergeSHA: "merge-sha",
+			providerMergeSHA: "merge-sha", missingFieldLabel: "files_changed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			ctx := t.Context()
+			database := openTestDB(t)
+			repo := RepoRef{
+				Platform: platform.KindGitHub, Owner: "owner", Name: "repo",
+				PlatformHost: "github.com",
+			}
+			repoID, err := database.UpsertRepo(
+				ctx, verifiedGitHubRepoIdentity("github.com", repo.Owner, repo.Name),
+			)
+			require.NoError(err)
+			providerUpdatedAt := time.Date(2026, 7, 28, 0, 41, 21, 0, time.UTC)
+			localUpdatedAt := providerUpdatedAt.Add(835 * time.Millisecond)
+			mergedAt := providerUpdatedAt.Add(-time.Second)
+			_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+				RepoID: repoID, PlatformID: 7000, Number: 7,
+				State: db.MergeRequestStateMerged, PlatformHeadSHA: "head-sha",
+				MergeCommitSHA: tt.storedMergeSHA, FilesChanged: tt.storedFiles,
+				CreatedAt: providerUpdatedAt.Add(-time.Hour), UpdatedAt: localUpdatedAt,
+				LastActivityAt: localUpdatedAt, MergedAt: &mergedAt, ClosedAt: &mergedAt,
+			})
+			require.NoError(err)
+
+			canonical := buildOpenPR(7, providerUpdatedAt)
+			canonical.State = new("closed")
+			canonical.Merged = new(true)
+			canonical.MergedAt = makeTimestamp(mergedAt)
+			canonical.ClosedAt = makeTimestamp(mergedAt)
+			canonical.MergeCommitSHA = &tt.providerMergeSHA
+			canonical.ChangedFiles = tt.providerFiles
+			canonical.Head.SHA = new("head-sha")
+			syncer := NewSyncer(
+				map[string]Client{"github.com": &mockClient{singlePR: canonical}},
+				database, nil, []RepoRef{repo}, time.Minute, nil, testBudget(1000),
+			)
+
+			providerAttempted, err := syncer.SyncArchiveItem(
+				WithArchiveSyncBudget(ctx),
+				platform.RepoRef{
+					Platform: platform.KindGitHub, Host: "github.com",
+					Owner: repo.Owner, Name: repo.Name,
+				},
+				db.ArchiveItemTypeMergeRequest, 7,
+			)
+			require.ErrorContains(err, tt.missingFieldLabel)
+			require.True(providerAttempted)
+		})
+	}
+}
+
+func TestSyncArchiveMROpenPullRequestDoesNotRequireMergeMetrics(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	repo := RepoRef{
+		Platform: platform.KindGitHub, Owner: "owner", Name: "repo",
+		PlatformHost: "github.com",
+	}
+	repoID, err := database.UpsertRepo(
+		ctx, verifiedGitHubRepoIdentity("github.com", repo.Owner, repo.Name),
+	)
+	require.NoError(err)
+	providerUpdatedAt := time.Date(2026, 7, 28, 0, 41, 21, 0, time.UTC)
+	localUpdatedAt := providerUpdatedAt.Add(time.Second)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID: repoID, PlatformID: 7000, Number: 7,
+		State: db.MergeRequestStateOpen, PlatformHeadSHA: "head-sha",
+		CreatedAt: providerUpdatedAt.Add(-time.Hour), UpdatedAt: localUpdatedAt,
+		LastActivityAt: localUpdatedAt,
+	})
+	require.NoError(err)
+	canonical := buildOpenPR(7, providerUpdatedAt)
+	canonical.Head.SHA = new("head-sha")
+	syncer := NewSyncer(
+		map[string]Client{"github.com": &mockClient{singlePR: canonical}},
+		database, nil, []RepoRef{repo}, time.Minute, nil, testBudget(1000),
+	)
+
+	providerAttempted, err := syncer.SyncArchiveItem(
+		WithArchiveSyncBudget(ctx),
+		platform.RepoRef{
+			Platform: platform.KindGitHub, Host: "github.com",
+			Owner: repo.Owner, Name: repo.Name,
+		},
+		db.ArchiveItemTypeMergeRequest, 7,
+	)
+	require.NoError(err)
+	require.True(providerAttempted)
+}
+
 func TestSyncArchiveIssuePropagatesTimelineFailure(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -13694,6 +13694,33 @@ func TestSyncArchiveMRRejectsMissingMergedMetrics(t *testing.T) {
 	}
 }
 
+func TestRequireGitHubArchiveMergedMRMetricsRejectsMismatchedFilesChanged(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	repoID, err := database.UpsertRepo(
+		ctx, verifiedGitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+	mergedAt := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID: repoID, PlatformID: 7, Number: 7,
+		State: db.MergeRequestStateMerged, PlatformHeadSHA: "head-sha",
+		MergeCommitSHA: "merge-sha", FilesChanged: new(9),
+		CreatedAt: mergedAt.Add(-time.Hour), UpdatedAt: mergedAt,
+		LastActivityAt: mergedAt, MergedAt: &mergedAt, ClosedAt: &mergedAt,
+	})
+	require.NoError(err)
+
+	err = (&Syncer{db: database}).requireGitHubArchiveMergedMRMetrics(
+		ctx, repoID, 7, mergeRequestFetchEvidence{
+			merged: true, headSHA: "head-sha", mergeCommitSHA: "merge-sha",
+			filesChanged: new(4),
+		}, true,
+	)
+	require.ErrorContains(err, "files_changed")
+}
+
 func TestSyncArchiveMROpenPullRequestDoesNotRequireMergeMetrics(t *testing.T) {
 	require := require.New(t)
 	ctx := t.Context()

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -13331,6 +13331,181 @@ func TestSyncArchiveMRChecksMetricsByResolvedRepositoryIDAfterRename(t *testing.
 	require.Equal(4, *mr.FilesChanged)
 }
 
+func TestSyncArchiveMRPreservesStoredMergedAtWhenAcceptedResponseOmitsIt(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	repo := RepoRef{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		PlatformExternalID: "repo-a",
+	}
+	entry, accepted, err := database.ReconcileRepositoryObservation(
+		ctx,
+		db.RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformRepoID: "repo-a", Owner: "acme", Name: "widget",
+			RepoPath: "acme/widget",
+		},
+		time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC),
+	)
+	require.NoError(err)
+	require.True(accepted)
+
+	mergedAt := time.Date(2026, 8, 2, 11, 59, 59, 0, time.UTC)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID: entry.Repository.ID, PlatformID: 7, Number: 7,
+		State: db.MergeRequestStateMerged, PlatformHeadSHA: "head-sha",
+		MergeCommitSHA: "merge-sha", FilesChanged: new(4),
+		CreatedAt: mergedAt.Add(-time.Hour), UpdatedAt: mergedAt,
+		LastActivityAt: mergedAt, MergedAt: &mergedAt, ClosedAt: &mergedAt,
+	})
+	require.NoError(err)
+
+	providerUpdatedAt := mergedAt.Add(time.Minute)
+	canonical := buildOpenPR(7, providerUpdatedAt)
+	canonical.State = new("closed")
+	canonical.Merged = new(true)
+	canonical.MergedAt = nil
+	canonical.ClosedAt = makeTimestamp(mergedAt)
+	canonical.MergeCommitSHA = new("merge-sha")
+	canonical.ChangedFiles = new(4)
+	canonical.Head.SHA = new("head-sha")
+	canonical.MergedBy = &gh.User{Login: new("merge-admin")}
+	client := &mockClient{
+		singlePR: canonical,
+		getRepositoryFn: func(
+			context.Context, string, string,
+		) (*gh.Repository, error) {
+			return &gh.Repository{
+				ID: new(int64(1)), NodeID: new("repo-a"), Name: new("widget"),
+				Owner: &gh.User{Login: new("acme")}, Archived: new(false),
+			}, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client},
+		database, nil, []RepoRef{repo}, time.Minute, nil, testBudget(1000),
+	)
+
+	providerAttempted, err := syncer.SyncArchiveItem(
+		WithArchiveSyncBudget(ctx), platformRepoRef(repo),
+		db.ArchiveItemTypeMergeRequest, 7,
+	)
+	require.True(providerAttempted)
+	require.NoError(err)
+
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(ctx, entry.Repository.ID, 7)
+	require.NoError(err)
+	require.NotNil(mr)
+	require.NotNil(mr.MergedAt)
+	require.Equal(mergedAt, *mr.MergedAt)
+	events, err := database.ListMREvents(ctx, mr.ID)
+	require.NoError(err)
+	require.Len(events, 1)
+	require.Equal("merge-admin", events[0].Author)
+}
+
+func TestSyncArchiveMRRetriesWhenAcceptedSnapshotLosesRouteFenceBeforeActor(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	repo := RepoRef{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		PlatformExternalID: "repo-a",
+	}
+	entry, accepted, err := database.ReconcileRepositoryObservation(
+		ctx,
+		db.RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformRepoID: "repo-a", Owner: "acme", Name: "widget",
+			RepoPath: "acme/widget",
+		},
+		time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC),
+	)
+	require.NoError(err)
+	require.True(accepted)
+
+	mergedAt := time.Date(2026, 8, 2, 11, 59, 59, 0, time.UTC)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID: entry.Repository.ID, PlatformID: 7, Number: 7,
+		State: db.MergeRequestStateMerged, PlatformHeadSHA: "head-sha",
+		MergeCommitSHA: "merge-sha", FilesChanged: new(4),
+		CreatedAt: mergedAt.Add(-time.Hour), UpdatedAt: mergedAt,
+		LastActivityAt: mergedAt, MergedAt: &mergedAt, ClosedAt: &mergedAt,
+	})
+	require.NoError(err)
+
+	providerUpdatedAt := mergedAt.Add(time.Minute)
+	canonical := buildOpenPR(7, providerUpdatedAt)
+	canonical.State = new("closed")
+	canonical.Merged = new(true)
+	canonical.MergedAt = makeTimestamp(mergedAt)
+	canonical.ClosedAt = makeTimestamp(mergedAt)
+	canonical.MergeCommitSHA = new("merge-sha")
+	canonical.ChangedFiles = new(4)
+	canonical.Head.SHA = new("head-sha")
+	canonical.MergedBy = &gh.User{Login: new("merge-admin")}
+	client := &mockClient{
+		singlePR: canonical,
+		getRepositoryFn: func(
+			context.Context, string, string,
+		) (*gh.Repository, error) {
+			return &gh.Repository{
+				ID: new(int64(1)), NodeID: new("repo-a"), Name: new("widget"),
+				Owner: &gh.User{Login: new("acme")}, Archived: new(false),
+			}, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client},
+		database, nil, []RepoRef{repo}, time.Minute, nil, testBudget(1000),
+	)
+
+	var raceStarted atomic.Bool
+	writeLockAttempted := make(chan struct{})
+	var writeLockAttemptedOnce sync.Once
+	restoreWriteLockHook := database.SetBeforeRepositoryReconciliationWriteLockForTest(func() {
+		if raceStarted.Load() {
+			writeLockAttemptedOnce.Do(func() { close(writeLockAttempted) })
+		}
+	})
+	t.Cleanup(restoreWriteLockHook)
+	reconciliationDone := make(chan error, 1)
+	syncer.afterMergeRequestParentSnapshotCommit = func() {
+		raceStarted.Store(true)
+		go func() {
+			_, _, reconcileErr := database.ReconcileRepositoryObservation(
+				ctx,
+				db.RepoIdentity{
+					Platform: "github", PlatformHost: "github.com",
+					PlatformRepoID: "repo-a", Owner: "acme", Name: "renamed",
+					RepoPath: "acme/renamed",
+				},
+				time.Now().UTC().Add(time.Hour),
+			)
+			reconciliationDone <- reconcileErr
+		}()
+		<-writeLockAttempted
+	}
+
+	providerAttempted, err := syncer.SyncArchiveItem(
+		WithArchiveSyncBudget(ctx), platformRepoRef(repo),
+		db.ArchiveItemTypeMergeRequest, 7,
+	)
+	require.True(providerAttempted)
+	require.ErrorContains(err, "lifecycle persistence")
+	require.NoError(<-reconciliationDone)
+
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(ctx, entry.Repository.ID, 7)
+	require.NoError(err)
+	require.NotNil(mr)
+	events, err := database.ListMREvents(ctx, mr.ID)
+	require.NoError(err)
+	require.Empty(events)
+}
+
 func TestSyncArchiveMRRetriesWhenRejectedRepairLosesRouteFence(t *testing.T) {
 	require := require.New(t)
 	ctx := t.Context()

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -13250,6 +13250,7 @@ func TestSyncArchiveMRRejectsMissingMergedMetrics(t *testing.T) {
 		storedFiles       *int
 		providerMergeSHA  string
 		providerFiles     *int
+		missingMergedAt   bool
 		missingFieldLabel string
 	}{
 		{
@@ -13259,6 +13260,11 @@ func TestSyncArchiveMRRejectsMissingMergedMetrics(t *testing.T) {
 		{
 			name: "files changed", storedMergeSHA: "merge-sha",
 			providerMergeSHA: "merge-sha", missingFieldLabel: "files_changed",
+		},
+		{
+			name: "merged timestamp", storedMergeSHA: "merge-sha", storedFiles: new(4),
+			providerMergeSHA: "merge-sha", providerFiles: new(4), missingMergedAt: true,
+			missingFieldLabel: "merged_at",
 		},
 	}
 
@@ -13278,19 +13284,25 @@ func TestSyncArchiveMRRejectsMissingMergedMetrics(t *testing.T) {
 			providerUpdatedAt := time.Date(2026, 7, 28, 0, 41, 21, 0, time.UTC)
 			localUpdatedAt := providerUpdatedAt.Add(835 * time.Millisecond)
 			mergedAt := providerUpdatedAt.Add(-time.Second)
+			var storedMergedAt *time.Time
+			if !tt.missingMergedAt {
+				storedMergedAt = &mergedAt
+			}
 			_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
 				RepoID: repoID, PlatformID: 7000, Number: 7,
 				State: db.MergeRequestStateMerged, PlatformHeadSHA: "head-sha",
 				MergeCommitSHA: tt.storedMergeSHA, FilesChanged: tt.storedFiles,
 				CreatedAt: providerUpdatedAt.Add(-time.Hour), UpdatedAt: localUpdatedAt,
-				LastActivityAt: localUpdatedAt, MergedAt: &mergedAt, ClosedAt: &mergedAt,
+				LastActivityAt: localUpdatedAt, MergedAt: storedMergedAt, ClosedAt: &mergedAt,
 			})
 			require.NoError(err)
 
 			canonical := buildOpenPR(7, providerUpdatedAt)
 			canonical.State = new("closed")
 			canonical.Merged = new(true)
-			canonical.MergedAt = makeTimestamp(mergedAt)
+			if !tt.missingMergedAt {
+				canonical.MergedAt = makeTimestamp(mergedAt)
+			}
 			canonical.ClosedAt = makeTimestamp(mergedAt)
 			canonical.MergeCommitSHA = &tt.providerMergeSHA
 			canonical.ChangedFiles = tt.providerFiles

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -13424,13 +13424,16 @@ func TestSyncArchiveMRRejectsMissingMergedMetrics(t *testing.T) {
 		name              string
 		storedMergeSHA    string
 		storedFiles       *int
+		storedHeadSHA     string
 		providerMergeSHA  string
 		providerFiles     *int
+		providerHeadSHA   string
 		missingMergedAt   bool
 		missingFieldLabel string
 	}{
 		{
-			name: "merge commit SHA", storedFiles: new(4), providerFiles: new(4),
+			name: "canonical merge commit SHA", storedMergeSHA: "pre-merge-test-sha",
+			storedFiles: new(4), providerFiles: new(4),
 			missingFieldLabel: "merge_commit_sha",
 		},
 		{
@@ -13441,6 +13444,12 @@ func TestSyncArchiveMRRejectsMissingMergedMetrics(t *testing.T) {
 			name: "merged timestamp", storedMergeSHA: "merge-sha", storedFiles: new(4),
 			providerMergeSHA: "merge-sha", providerFiles: new(4), missingMergedAt: true,
 			missingFieldLabel: "merged_at",
+		},
+		{
+			name: "canonical head SHA", storedMergeSHA: "pre-merge-test-sha",
+			storedFiles: new(4), storedHeadSHA: "newer-head-sha",
+			providerMergeSHA: "merge-sha", providerFiles: new(4),
+			providerHeadSHA: "canonical-head-sha", missingFieldLabel: "platform_head_sha",
 		},
 	}
 
@@ -13464,9 +13473,13 @@ func TestSyncArchiveMRRejectsMissingMergedMetrics(t *testing.T) {
 			if !tt.missingMergedAt {
 				storedMergedAt = &mergedAt
 			}
+			storedHeadSHA := tt.storedHeadSHA
+			if storedHeadSHA == "" {
+				storedHeadSHA = "head-sha"
+			}
 			_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
 				RepoID: repoID, PlatformID: 7000, Number: 7,
-				State: db.MergeRequestStateMerged, PlatformHeadSHA: "head-sha",
+				State: db.MergeRequestStateMerged, PlatformHeadSHA: storedHeadSHA,
 				MergeCommitSHA: tt.storedMergeSHA, FilesChanged: tt.storedFiles,
 				CreatedAt: providerUpdatedAt.Add(-time.Hour), UpdatedAt: localUpdatedAt,
 				LastActivityAt: localUpdatedAt, MergedAt: storedMergedAt, ClosedAt: &mergedAt,
@@ -13482,7 +13495,11 @@ func TestSyncArchiveMRRejectsMissingMergedMetrics(t *testing.T) {
 			canonical.ClosedAt = makeTimestamp(mergedAt)
 			canonical.MergeCommitSHA = &tt.providerMergeSHA
 			canonical.ChangedFiles = tt.providerFiles
-			canonical.Head.SHA = new("head-sha")
+			providerHeadSHA := tt.providerHeadSHA
+			if providerHeadSHA == "" {
+				providerHeadSHA = "head-sha"
+			}
+			canonical.Head.SHA = &providerHeadSHA
 			syncer := NewSyncer(
 				map[string]Client{"github.com": &mockClient{singlePR: canonical}},
 				database, nil, []RepoRef{repo}, time.Minute, nil, testBudget(1000),

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -13125,7 +13125,7 @@ func TestSyncArchiveIssueBypassesPersistedETagForLifecycleBackfill(t *testing.T)
 	assert.Equal("closer", events[0].Author)
 }
 
-func TestSyncArchiveMRRepairsMetricsFromRejectedCanonicalSnapshot(t *testing.T) {
+func TestSyncArchiveMRRepairsMetricsFromMergedAtOnlyRejectedSnapshot(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -13154,11 +13154,10 @@ func TestSyncArchiveMRRepairsMetricsFromRejectedCanonicalSnapshot(t *testing.T) 
 
 	canonical := buildOpenPR(7, canonicalUpdatedAt)
 	closed := "closed"
-	merged := true
 	mergeSHA := "merge-sha"
 	filesChanged := 4
 	canonical.State = &closed
-	canonical.Merged = &merged
+	canonical.Merged = nil
 	canonical.MergedAt = makeTimestamp(mergedAt)
 	canonical.ClosedAt = makeTimestamp(mergedAt)
 	canonical.MergeCommitSHA = &mergeSHA
@@ -13182,6 +13181,66 @@ func TestSyncArchiveMRRepairsMetricsFromRejectedCanonicalSnapshot(t *testing.T) 
 	assert.Equal("newer local title", after.Title)
 	assert.Equal(before.UpdatedAt, after.UpdatedAt)
 	assert.Equal(before.SnapshotRevision, after.SnapshotRevision)
+}
+
+func TestSyncArchiveMRChecksMetricsByResolvedRepositoryIDAfterRename(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	repo := RepoRef{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		PlatformExternalID: "repo-a",
+	}
+	entry, accepted, err := database.ReconcileRepositoryObservation(
+		ctx,
+		db.RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformRepoID: "repo-a", Owner: "acme", Name: "widget",
+			RepoPath: "acme/widget",
+		},
+		time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC),
+	)
+	require.NoError(err)
+	require.True(accepted)
+
+	now := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	canonical := buildOpenPR(7, now)
+	canonical.State = new("closed")
+	canonical.Merged = new(true)
+	canonical.MergedAt = makeTimestamp(now)
+	canonical.ClosedAt = makeTimestamp(now)
+	canonical.MergeCommitSHA = new("merge-sha")
+	canonical.ChangedFiles = new(4)
+	client := &mockClient{
+		singlePR: canonical,
+		getRepositoryFn: func(
+			context.Context, string, string,
+		) (*gh.Repository, error) {
+			return &gh.Repository{
+				ID: new(int64(1)), NodeID: new("repo-a"), Name: new("renamed"),
+				Owner: &gh.User{Login: new("acme")}, Archived: new(false),
+			}, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, nil,
+		[]RepoRef{repo}, time.Minute, nil, testBudget(1000),
+	)
+
+	_, err = syncer.SyncArchiveItem(
+		WithArchiveSyncBudget(ctx), platformRepoRef(repo),
+		db.ArchiveItemTypeMergeRequest, 7,
+	)
+	require.NoError(err)
+
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(
+		ctx, entry.Repository.ID, 7,
+	)
+	require.NoError(err)
+	require.NotNil(mr)
+	require.Equal("merge-sha", mr.MergeCommitSHA)
+	require.Equal(4, *mr.FilesChanged)
 }
 
 func TestSyncArchiveMRRejectsMissingMergedMetrics(t *testing.T) {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -13101,7 +13101,7 @@ func TestSyncArchiveIssueBypassesPersistedETagForLifecycleBackfill(t *testing.T)
 		[]RepoRef{repo}, time.Minute, nil, testBudget(1000),
 	)
 
-	providerAttempted, err := syncer.SyncArchiveItem(
+	result, err := syncer.SyncArchiveItem(
 		WithArchiveSyncBudget(ctx),
 		platform.RepoRef{
 			Platform: platform.KindGitHub, Host: "github.com",
@@ -13110,7 +13110,7 @@ func TestSyncArchiveIssueBypassesPersistedETagForLifecycleBackfill(t *testing.T)
 		db.ArchiveItemTypeIssue, 7,
 	)
 	require.NoError(err)
-	assert.True(providerAttempted)
+	assert.True(result.ProviderAttempted)
 	assert.Zero(int(client.conditionalCalls.Load()))
 	assert.Equal(int32(1), client.unconditionalCalls.Load())
 	assert.Equal(int32(1), client.timelineCalls.Load())
@@ -13250,13 +13250,13 @@ func TestSyncArchiveMRRetriesWhenMergedResponseCannotRepairNewerOpenSnapshot(t *
 		database, nil, []RepoRef{repo}, time.Minute, nil, testBudget(1000),
 	)
 
-	providerAttempted, err := syncer.SyncArchiveItem(
+	result, err := syncer.SyncArchiveItem(
 		WithArchiveSyncBudget(ctx), platform.RepoRef{
 			Platform: platform.KindGitHub, Host: "github.com",
 			Owner: repo.Owner, Name: repo.Name,
 		}, db.ArchiveItemTypeMergeRequest, 7,
 	)
-	require.True(providerAttempted)
+	require.True(result.ProviderAttempted)
 	require.ErrorContains(err, "merge_state")
 
 	after, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
@@ -13388,11 +13388,11 @@ func TestSyncArchiveMRPreservesStoredMergedAtWhenAcceptedResponseOmitsIt(t *test
 		database, nil, []RepoRef{repo}, time.Minute, nil, testBudget(1000),
 	)
 
-	providerAttempted, err := syncer.SyncArchiveItem(
+	result, err := syncer.SyncArchiveItem(
 		WithArchiveSyncBudget(ctx), platformRepoRef(repo),
 		db.ArchiveItemTypeMergeRequest, 7,
 	)
-	require.True(providerAttempted)
+	require.True(result.ProviderAttempted)
 	require.NoError(err)
 
 	mr, err := database.GetMergeRequestByRepoIDAndNumber(ctx, entry.Repository.ID, 7)
@@ -13490,11 +13490,11 @@ func TestSyncArchiveMRRetriesWhenAcceptedSnapshotLosesRouteFenceBeforeActor(t *t
 		<-writeLockAttempted
 	}
 
-	providerAttempted, err := syncer.SyncArchiveItem(
+	result, err := syncer.SyncArchiveItem(
 		WithArchiveSyncBudget(ctx), platformRepoRef(repo),
 		db.ArchiveItemTypeMergeRequest, 7,
 	)
-	require.True(providerAttempted)
+	require.True(result.ProviderAttempted)
 	require.ErrorContains(err, "lifecycle persistence")
 	require.NoError(<-reconciliationDone)
 
@@ -13579,11 +13579,11 @@ func TestSyncArchiveMRRetriesWhenRejectedRepairLosesRouteFence(t *testing.T) {
 		[]RepoRef{repo}, time.Minute, nil, testBudget(1000),
 	)
 
-	providerAttempted, err := syncer.SyncArchiveItem(
+	result, err := syncer.SyncArchiveItem(
 		WithArchiveSyncBudget(ctx), platformRepoRef(repo),
 		db.ArchiveItemTypeMergeRequest, 7,
 	)
-	require.True(providerAttempted)
+	require.True(result.ProviderAttempted)
 	require.ErrorContains(err, "repository was not resolved")
 
 	mr, err := database.GetMergeRequestByRepoIDAndNumber(ctx, entry.Repository.ID, 7)
@@ -13680,7 +13680,7 @@ func TestSyncArchiveMRRejectsMissingMergedMetrics(t *testing.T) {
 				database, nil, []RepoRef{repo}, time.Minute, nil, testBudget(1000),
 			)
 
-			providerAttempted, err := syncer.SyncArchiveItem(
+			result, err := syncer.SyncArchiveItem(
 				WithArchiveSyncBudget(ctx),
 				platform.RepoRef{
 					Platform: platform.KindGitHub, Host: "github.com",
@@ -13689,7 +13689,7 @@ func TestSyncArchiveMRRejectsMissingMergedMetrics(t *testing.T) {
 				db.ArchiveItemTypeMergeRequest, 7,
 			)
 			require.ErrorContains(err, tt.missingFieldLabel)
-			require.True(providerAttempted)
+			require.True(result.ProviderAttempted)
 		})
 	}
 }
@@ -13730,7 +13730,7 @@ func TestSyncArchiveMRRejectsCanonicalUnmergedStoredMergedDisagreement(t *testin
 		database, nil, []RepoRef{repo}, time.Minute, nil, testBudget(1000),
 	)
 
-	providerAttempted, err := syncer.SyncArchiveItem(
+	result, err := syncer.SyncArchiveItem(
 		WithArchiveSyncBudget(ctx),
 		platform.RepoRef{
 			Platform: platform.KindGitHub, Host: "github.com",
@@ -13739,7 +13739,7 @@ func TestSyncArchiveMRRejectsCanonicalUnmergedStoredMergedDisagreement(t *testin
 		db.ArchiveItemTypeMergeRequest, 7,
 	)
 	require.ErrorContains(err, "merge_state")
-	require.True(providerAttempted)
+	require.True(result.ProviderAttempted)
 
 	stored, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
 	require.NoError(err)
@@ -13807,7 +13807,7 @@ func TestSyncArchiveMROpenPullRequestDoesNotRequireMergeMetrics(t *testing.T) {
 		database, nil, []RepoRef{repo}, time.Minute, nil, testBudget(1000),
 	)
 
-	providerAttempted, err := syncer.SyncArchiveItem(
+	result, err := syncer.SyncArchiveItem(
 		WithArchiveSyncBudget(ctx),
 		platform.RepoRef{
 			Platform: platform.KindGitHub, Host: "github.com",
@@ -13816,7 +13816,7 @@ func TestSyncArchiveMROpenPullRequestDoesNotRequireMergeMetrics(t *testing.T) {
 		db.ArchiveItemTypeMergeRequest, 7,
 	)
 	require.NoError(err)
-	require.True(providerAttempted)
+	require.True(result.ProviderAttempted)
 }
 
 func TestSyncArchiveIssuePropagatesTimelineFailure(t *testing.T) {
@@ -13841,7 +13841,7 @@ func TestSyncArchiveIssuePropagatesTimelineFailure(t *testing.T) {
 		[]RepoRef{repo}, time.Minute, nil, testBudget(1000),
 	)
 
-	providerAttempted, err := syncer.SyncArchiveItem(
+	result, err := syncer.SyncArchiveItem(
 		WithArchiveSyncBudget(ctx),
 		platform.RepoRef{
 			Platform: platform.KindGitHub, Host: "github.com",
@@ -13851,7 +13851,7 @@ func TestSyncArchiveIssuePropagatesTimelineFailure(t *testing.T) {
 	)
 
 	require.ErrorIs(err, timelineErr)
-	assert.True(providerAttempted)
+	assert.True(result.ProviderAttempted)
 	assert.Equal(int32(1), client.issueTimelineCalls.Load())
 }
 

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -13257,7 +13257,7 @@ func TestSyncArchiveMRRetriesWhenMergedResponseCannotRepairNewerOpenSnapshot(t *
 		}, db.ArchiveItemTypeMergeRequest, 7,
 	)
 	require.True(providerAttempted)
-	require.ErrorContains(err, "merged_at")
+	require.ErrorContains(err, "merge_state")
 
 	after, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
 	require.NoError(err)
@@ -13692,6 +13692,64 @@ func TestSyncArchiveMRRejectsMissingMergedMetrics(t *testing.T) {
 			require.True(providerAttempted)
 		})
 	}
+}
+
+func TestSyncArchiveMRRejectsCanonicalUnmergedStoredMergedDisagreement(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	repo := RepoRef{
+		Platform: platform.KindGitHub, Owner: "owner", Name: "repo",
+		PlatformHost: "github.com",
+	}
+	repoID, err := database.UpsertRepo(
+		ctx, verifiedGitHubRepoIdentity("github.com", repo.Owner, repo.Name),
+	)
+	require.NoError(err)
+	providerUpdatedAt := time.Date(2026, 7, 28, 0, 41, 21, 0, time.UTC)
+	localUpdatedAt := providerUpdatedAt.Add(time.Second)
+	mergedAt := providerUpdatedAt.Add(-time.Minute)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID: repoID, PlatformID: 7000, Number: 7,
+		State: db.MergeRequestStateMerged, PlatformHeadSHA: "head-sha",
+		MergeCommitSHA: "merge-sha", FilesChanged: new(4),
+		CreatedAt: providerUpdatedAt.Add(-time.Hour), UpdatedAt: localUpdatedAt,
+		LastActivityAt: localUpdatedAt, MergedAt: &mergedAt, ClosedAt: &mergedAt,
+	})
+	require.NoError(err)
+
+	canonical := buildOpenPR(7, providerUpdatedAt)
+	canonical.State = new("closed")
+	canonical.Merged = new(false)
+	canonical.MergedAt = nil
+	canonical.ClosedAt = makeTimestamp(providerUpdatedAt.Add(-time.Minute))
+	canonical.MergeCommitSHA = nil
+	canonical.Head.SHA = new("head-sha")
+	syncer := NewSyncer(
+		map[string]Client{"github.com": &mockClient{singlePR: canonical}},
+		database, nil, []RepoRef{repo}, time.Minute, nil, testBudget(1000),
+	)
+
+	providerAttempted, err := syncer.SyncArchiveItem(
+		WithArchiveSyncBudget(ctx),
+		platform.RepoRef{
+			Platform: platform.KindGitHub, Host: "github.com",
+			Owner: repo.Owner, Name: repo.Name,
+		},
+		db.ArchiveItemTypeMergeRequest, 7,
+	)
+	require.ErrorContains(err, "merge_state")
+	require.True(providerAttempted)
+
+	stored, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(stored)
+	require.Equal(db.MergeRequestStateMerged, stored.State)
+	require.NotNil(stored.MergedAt)
+	require.Equal(mergedAt, *stored.MergedAt)
+	require.Equal("merge-sha", stored.MergeCommitSHA)
+	require.NotNil(stored.FilesChanged)
+	require.Equal(4, *stored.FilesChanged)
 }
 
 func TestRequireGitHubArchiveMergedMRMetricsRejectsMismatchedFilesChanged(t *testing.T) {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -13144,7 +13144,8 @@ func TestSyncArchiveMRRepairsMetricsFromMergedAtOnlyRejectedSnapshot(t *testing.
 	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
 		RepoID: repoID, PlatformID: 7000, Number: 7, Title: "newer local title",
 		State: db.MergeRequestStateMerged, PlatformHeadSHA: "head-sha",
-		CreatedAt: canonicalUpdatedAt.Add(-time.Hour), UpdatedAt: localUpdatedAt,
+		MergeCommitSHA: "pre-merge-test-sha",
+		CreatedAt:      canonicalUpdatedAt.Add(-time.Hour), UpdatedAt: localUpdatedAt,
 		LastActivityAt: localUpdatedAt, MergedAt: &mergedAt, ClosedAt: &mergedAt,
 	})
 	require.NoError(err)
@@ -13209,6 +13210,65 @@ func TestSyncArchiveMRRepairsMetricsFromMergedAtOnlyRejectedSnapshot(t *testing.
 	require.NoError(err)
 	require.Len(events, 1)
 	assert.Equal("merge-admin", events[0].Author)
+}
+
+func TestSyncArchiveMRRetriesWhenMergedResponseCannotRepairNewerOpenSnapshot(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	repo := RepoRef{
+		Platform: platform.KindGitHub, Owner: "owner", Name: "repo",
+		PlatformHost: "github.com",
+	}
+	repoID, err := database.UpsertRepo(
+		ctx, verifiedGitHubRepoIdentity("github.com", repo.Owner, repo.Name),
+	)
+	require.NoError(err)
+	providerUpdatedAt := time.Date(2026, 7, 28, 0, 41, 21, 0, time.UTC)
+	localUpdatedAt := providerUpdatedAt.Add(835 * time.Millisecond)
+	mergedAt := providerUpdatedAt.Add(-time.Second)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID: repoID, PlatformID: 7000, Number: 7,
+		State: db.MergeRequestStateOpen, PlatformHeadSHA: "head-sha",
+		MergeCommitSHA: "pre-merge-test-sha",
+		CreatedAt:      providerUpdatedAt.Add(-time.Hour), UpdatedAt: localUpdatedAt,
+		LastActivityAt: localUpdatedAt,
+	})
+	require.NoError(err)
+
+	canonical := buildOpenPR(7, providerUpdatedAt)
+	canonical.State = new("closed")
+	canonical.Merged = new(true)
+	canonical.MergedAt = makeTimestamp(mergedAt)
+	canonical.ClosedAt = makeTimestamp(mergedAt)
+	canonical.MergeCommitSHA = new("merge-sha")
+	canonical.ChangedFiles = new(4)
+	canonical.Head.SHA = new("head-sha")
+	syncer := NewSyncer(
+		map[string]Client{"github.com": &mockClient{singlePR: canonical}},
+		database, nil, []RepoRef{repo}, time.Minute, nil, testBudget(1000),
+	)
+
+	providerAttempted, err := syncer.SyncArchiveItem(
+		WithArchiveSyncBudget(ctx), platform.RepoRef{
+			Platform: platform.KindGitHub, Host: "github.com",
+			Owner: repo.Owner, Name: repo.Name,
+		}, db.ArchiveItemTypeMergeRequest, 7,
+	)
+	require.True(providerAttempted)
+	require.ErrorContains(err, "merged_at")
+
+	after, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(after)
+	assert.Equal(db.MergeRequestStateOpen, after.State)
+	assert.Nil(after.MergedAt)
+	assert.Equal("pre-merge-test-sha", after.MergeCommitSHA)
+	assert.Nil(after.FilesChanged)
+	events, err := database.ListMREvents(ctx, after.ID)
+	require.NoError(err)
+	assert.Empty(events)
 }
 
 func TestSyncArchiveMRChecksMetricsByResolvedRepositoryIDAfterRename(t *testing.T) {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -13163,15 +13163,39 @@ func TestSyncArchiveMRRepairsMetricsFromMergedAtOnlyRejectedSnapshot(t *testing.
 	canonical.MergeCommitSHA = &mergeSHA
 	canonical.ChangedFiles = &filesChanged
 	canonical.Head.SHA = new("head-sha")
+	canonical.MergedBy = &gh.User{Login: new("merge-admin")}
 	client := &mockClient{singlePR: canonical}
 	syncer := NewSyncer(
 		map[string]Client{"github.com": client}, database, nil,
 		[]RepoRef{repo}, time.Minute, nil, testBudget(1000),
 	)
+	var raceStarted atomic.Bool
+	writeLockAttempted := make(chan struct{})
+	var writeLockAttemptedOnce sync.Once
+	restoreWriteLockHook := database.SetBeforeRepositoryReconciliationWriteLockForTest(func() {
+		if raceStarted.Load() {
+			writeLockAttemptedOnce.Do(func() { close(writeLockAttempted) })
+		}
+	})
+	t.Cleanup(restoreWriteLockHook)
+	reconciliationDone := make(chan error, 1)
+	syncer.afterMergedMRMetricsRepair = func() {
+		raceStarted.Store(true)
+		go func() {
+			_, _, reconcileErr := database.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+				Platform: "github", PlatformHost: "github.com",
+				PlatformRepoID: "repo-owner-repo", Owner: "owner", Name: "renamed",
+				RepoPath: "owner/renamed",
+			}, time.Now().UTC().Add(time.Hour))
+			reconciliationDone <- reconcileErr
+		}()
+		<-writeLockAttempted
+	}
 
 	require.NoError(syncer.syncMRForRepo(
 		WithArchiveSyncBudget(ctx), repo, 7, false, nil,
 	))
+	require.NoError(<-reconciliationDone)
 	after, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
 	require.NoError(err)
 	require.NotNil(after)
@@ -13181,6 +13205,10 @@ func TestSyncArchiveMRRepairsMetricsFromMergedAtOnlyRejectedSnapshot(t *testing.
 	assert.Equal("newer local title", after.Title)
 	assert.Equal(before.UpdatedAt, after.UpdatedAt)
 	assert.Equal(before.SnapshotRevision, after.SnapshotRevision)
+	events, err := database.ListMREvents(ctx, after.ID)
+	require.NoError(err)
+	require.Len(events, 1)
+	assert.Equal("merge-admin", events[0].Author)
 }
 
 func TestSyncArchiveMRChecksMetricsByResolvedRepositoryIDAfterRename(t *testing.T) {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -13271,6 +13271,94 @@ func TestSyncArchiveMRChecksMetricsByResolvedRepositoryIDAfterRename(t *testing.
 	require.Equal(4, *mr.FilesChanged)
 }
 
+func TestSyncArchiveMRRetriesWhenRejectedRepairLosesRouteFence(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	repo := RepoRef{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		PlatformExternalID: "repo-a",
+	}
+	entry, accepted, err := database.ReconcileRepositoryObservation(
+		ctx,
+		db.RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformRepoID: "repo-a", Owner: "acme", Name: "widget",
+			RepoPath: "acme/widget",
+		},
+		time.Now().UTC().Add(-time.Hour),
+	)
+	require.NoError(err)
+	require.True(accepted)
+
+	providerUpdatedAt := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	localUpdatedAt := providerUpdatedAt.Add(835 * time.Millisecond)
+	mergedAt := providerUpdatedAt.Add(-time.Second)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID: entry.Repository.ID, PlatformID: 7, Number: 7,
+		State: db.MergeRequestStateMerged, PlatformHeadSHA: "head-sha",
+		MergeCommitSHA: "merge-sha", FilesChanged: new(4),
+		CreatedAt: providerUpdatedAt.Add(-time.Hour), UpdatedAt: localUpdatedAt,
+		LastActivityAt: localUpdatedAt, MergedAt: &mergedAt, ClosedAt: &mergedAt,
+	})
+	require.NoError(err)
+
+	canonical := buildOpenPR(7, providerUpdatedAt)
+	canonical.State = new("closed")
+	canonical.Merged = new(true)
+	canonical.MergedAt = makeTimestamp(mergedAt)
+	canonical.ClosedAt = makeTimestamp(mergedAt)
+	canonical.MergeCommitSHA = new("merge-sha")
+	canonical.ChangedFiles = nil
+	canonical.Head.SHA = new("head-sha")
+	canonical.MergedBy = &gh.User{Login: new("merge-admin")}
+	client := &mockClient{
+		getRepositoryFn: func(
+			context.Context, string, string,
+		) (*gh.Repository, error) {
+			return &gh.Repository{
+				ID: new(int64(1)), NodeID: new("repo-a"), Name: new("widget"),
+				Owner: &gh.User{Login: new("acme")}, Archived: new(false),
+			}, nil
+		},
+		getPullRequestFn: func(
+			context.Context, string, string, int,
+		) (*gh.PullRequest, error) {
+			_, accepted, reconcileErr := database.ReconcileRepositoryObservation(
+				ctx,
+				db.RepoIdentity{
+					Platform: "github", PlatformHost: "github.com",
+					PlatformRepoID: "repo-a", Owner: "acme", Name: "renamed",
+					RepoPath: "acme/renamed",
+				},
+				time.Now().UTC().Add(time.Hour),
+			)
+			require.NoError(reconcileErr)
+			require.True(accepted)
+			return canonical, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, nil,
+		[]RepoRef{repo}, time.Minute, nil, testBudget(1000),
+	)
+
+	providerAttempted, err := syncer.SyncArchiveItem(
+		WithArchiveSyncBudget(ctx), platformRepoRef(repo),
+		db.ArchiveItemTypeMergeRequest, 7,
+	)
+	require.True(providerAttempted)
+	require.ErrorContains(err, "repository was not resolved")
+
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(ctx, entry.Repository.ID, 7)
+	require.NoError(err)
+	require.NotNil(mr)
+	events, err := database.ListMREvents(ctx, mr.ID)
+	require.NoError(err)
+	require.Empty(events)
+}
+
 func TestSyncArchiveMRRejectsMissingMergedMetrics(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/internal/github/syncertest/gitlab_sync_test.go
+++ b/internal/github/syncertest/gitlab_sync_test.go
@@ -347,7 +347,7 @@ func TestGitLabArchiveIssueLifecyclePersistsCloseActorInReport(t *testing.T) {
 		time.Minute, nil, nil,
 	)
 
-	providerAttempted, err := syncer.SyncArchiveItem(
+	result, err := syncer.SyncArchiveItem(
 		ghclient.WithArchiveSyncBudget(ctx),
 		platform.RepoRef{
 			Platform: platform.KindGitLab, Host: "gitlab.example.com",
@@ -357,7 +357,7 @@ func TestGitLabArchiveIssueLifecyclePersistsCloseActorInReport(t *testing.T) {
 		db.ArchiveItemTypeIssue, 7,
 	)
 	require.NoError(err)
-	assert.True(providerAttempted)
+	assert.True(result.ProviderAttempted)
 
 	issue, err := database.GetIssue(
 		ctx, "gitlab", "gitlab.example.com", "group", "project", 7,

--- a/internal/server/e2etest/archive_merge_metrics_test.go
+++ b/internal/server/e2etest/archive_merge_metrics_test.go
@@ -32,6 +32,7 @@ type archiveMergeMetricsCase struct {
 	storeMergedTime      bool
 	storeMergeMetrics    bool
 	providerFilesChanged bool
+	omitProviderMergedAt bool
 }
 
 func TestArchiveReportRepairsMergedMetricsAcrossRepositoryRenameE2E(t *testing.T) {
@@ -51,6 +52,10 @@ func TestArchiveReportRepairsMergedMetricsAcrossRepositoryRenameE2E(t *testing.T
 		{
 			name: "state only with stored metrics", state: db.MergeRequestStateMerged,
 			storeMergeMetrics: true,
+		},
+		{
+			name: "stored timestamp with provider actor", state: db.MergeRequestStateMerged,
+			storeMergedTime: true, storeMergeMetrics: true, omitProviderMergedAt: true,
 		},
 	}
 	for _, tt := range tests {
@@ -75,6 +80,10 @@ func testArchiveReportRepairsMergedMetricsAcrossRepositoryRename(
 	if tt.providerFilesChanged {
 		changedFilesField = `,"changed_files":4`
 	}
+	mergedAtField := `"merged_at":"2026-08-02T11:59:59Z",`
+	if tt.omitProviderMergedAt {
+		mergedAtField = ""
+	}
 	var renamed atomic.Bool
 
 	providerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -94,12 +103,12 @@ func testArchiveReportRepairsMergedMetricsAcrossRepositoryRename(
 				"created_at":"2026-08-02T10:00:00Z",
 				"updated_at":"2026-08-02T12:00:00Z",
 				"closed_at":"2026-08-02T11:59:59Z",
-				"merged_at":"2026-08-02T11:59:59Z",
+				"merged":true,%s
 				"merged_by":{"login":"merge-admin"},
 				"merge_commit_sha":"merge-sha"%s,
 				"head":{"ref":"feature","sha":"head-sha","repo":{"id":1,"node_id":"R_widget","name":"renamed","full_name":"acme/renamed","owner":{"login":"acme"}}},
 				"base":{"ref":"main","sha":"base-sha","repo":{"id":1,"node_id":"R_widget","name":"renamed","full_name":"acme/renamed","owner":{"login":"acme"}}}
-			}`, changedFilesField)
+			}`, mergedAtField, changedFilesField)
 		default:
 			http.NotFound(w, r)
 		}

--- a/internal/server/e2etest/archive_merge_metrics_test.go
+++ b/internal/server/e2etest/archive_merge_metrics_test.go
@@ -1,6 +1,7 @@
 package e2etest
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -26,15 +27,27 @@ type archiveMergeMetricsClock struct{ now time.Time }
 func (c archiveMergeMetricsClock) Now() time.Time { return c.now }
 
 type archiveMergeMetricsCase struct {
-	name            string
-	state           db.MergeRequestState
-	storeMergedTime bool
+	name                 string
+	state                db.MergeRequestState
+	storeMergedTime      bool
+	storeMergeMetrics    bool
+	providerFilesChanged bool
 }
 
 func TestArchiveReportRepairsMergedMetricsAcrossRepositoryRenameE2E(t *testing.T) {
 	tests := []archiveMergeMetricsCase{
-		{name: "merged timestamp only", state: db.MergeRequestStateOpen, storeMergedTime: true},
-		{name: "merged state only", state: db.MergeRequestStateMerged},
+		{
+			name: "merged timestamp only", state: db.MergeRequestStateOpen,
+			storeMergedTime: true, providerFilesChanged: true,
+		},
+		{
+			name: "merged state only", state: db.MergeRequestStateMerged,
+			providerFilesChanged: true,
+		},
+		{
+			name: "complete metrics missing actor", state: db.MergeRequestStateMerged,
+			storeMergedTime: true, storeMergeMetrics: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -54,6 +67,10 @@ func testArchiveReportRepairsMergedMetricsAcrossRepositoryRename(
 	canonicalUpdatedAt := now.Add(-time.Hour)
 	localUpdatedAt := canonicalUpdatedAt.Add(835 * time.Millisecond)
 	mergedAt := canonicalUpdatedAt.Add(-time.Second)
+	changedFilesField := ""
+	if tt.providerFilesChanged {
+		changedFilesField = `,"changed_files":4`
+	}
 	var renamed atomic.Bool
 
 	providerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -66,7 +83,7 @@ func testArchiveReportRepairsMergedMetricsAcrossRepositoryRename(
 			}
 			_, _ = w.Write([]byte(`{"id":1,"node_id":"R_widget","name":"widget","full_name":"acme/widget","owner":{"login":"acme"}}`))
 		case "/api/v3/repos/acme/renamed/pulls/7":
-			_, _ = w.Write([]byte(`{
+			_, _ = fmt.Fprintf(w, `{
 				"id":7,"node_id":"PR_7","number":7,
 				"html_url":"https://github.com/acme/renamed/pull/7",
 				"title":"canonical title","state":"closed",
@@ -75,10 +92,10 @@ func testArchiveReportRepairsMergedMetricsAcrossRepositoryRename(
 				"closed_at":"2026-08-02T11:59:59Z",
 				"merged_at":"2026-08-02T11:59:59Z",
 				"merged_by":{"login":"merge-admin"},
-				"merge_commit_sha":"merge-sha","changed_files":4,
+				"merge_commit_sha":"merge-sha"%s,
 				"head":{"ref":"feature","sha":"head-sha","repo":{"id":1,"node_id":"R_widget","name":"renamed","full_name":"acme/renamed","owner":{"login":"acme"}}},
 				"base":{"ref":"main","sha":"base-sha","repo":{"id":1,"node_id":"R_widget","name":"renamed","full_name":"acme/renamed","owner":{"login":"acme"}}}
-			}`))
+			}`, changedFilesField)
 		default:
 			http.NotFound(w, r)
 		}
@@ -141,12 +158,19 @@ func testArchiveReportRepairsMergedMetricsAcrossRepositoryRename(
 	if tt.storeMergedTime {
 		storedMergedAt = &mergedAt
 	}
+	var storedFilesChanged *int
+	storedMergeCommitSHA := ""
+	if tt.storeMergeMetrics {
+		storedFilesChanged = new(4)
+		storedMergeCommitSHA = "merge-sha"
+	}
 	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
 		RepoID: repo.ID, PlatformID: 7, PlatformExternalID: "PR_7", Number: 7,
 		URL: "https://github.com/acme/widget/pull/7", Title: "newer local title",
 		State: tt.state, PlatformHeadSHA: "head-sha",
 		CreatedAt: canonicalUpdatedAt.Add(-2 * time.Hour), UpdatedAt: localUpdatedAt,
 		LastActivityAt: localUpdatedAt, MergedAt: storedMergedAt, ClosedAt: &mergedAt,
+		FilesChanged: storedFilesChanged, MergeCommitSHA: storedMergeCommitSHA,
 	})
 	require.NoError(err)
 	require.NoError(database.CommitArchiveInventoryPage(ctx, db.ArchiveInventoryCommit{

--- a/internal/server/e2etest/archive_merge_metrics_test.go
+++ b/internal/server/e2etest/archive_merge_metrics_test.go
@@ -1,6 +1,7 @@
 package e2etest
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -25,6 +26,36 @@ import (
 type archiveMergeMetricsClock struct{ now time.Time }
 
 func (c archiveMergeMetricsClock) Now() time.Time { return c.now }
+
+type interveningMergeSnapshotSyncer struct {
+	*ghclient.Syncer
+	database *db.DB
+	repoID   int64
+	now      time.Time
+}
+
+func (s *interveningMergeSnapshotSyncer) SyncArchiveItem(
+	ctx context.Context,
+	ref platform.RepoRef,
+	itemType db.ArchiveItemType,
+	number int,
+) (archive.ItemSyncResult, error) {
+	result, err := s.Syncer.SyncArchiveItem(ctx, ref, itemType, number)
+	if err != nil || itemType != db.ArchiveItemTypeMergeRequest {
+		return result, err
+	}
+	current, err := s.database.GetMergeRequestByRepoIDAndNumber(ctx, s.repoID, number)
+	if err != nil || current == nil {
+		return result, err
+	}
+	intervening := *current
+	intervening.MergeCommitSHA = "intervening-merge-sha"
+	intervening.FilesChanged = new(9)
+	intervening.UpdatedAt = s.now.Add(time.Minute)
+	intervening.LastActivityAt = intervening.UpdatedAt
+	_, err = s.database.UpsertMergeRequest(ctx, &intervening)
+	return result, err
+}
 
 type archiveMergeMetricsCase struct {
 	name                 string
@@ -74,6 +105,115 @@ func TestArchiveReportRepairsMergedMetricsAcrossRepositoryRenameE2E(t *testing.T
 			testArchiveReportRepairsMergedMetricsAcrossRepositoryRename(t, tt)
 		})
 	}
+}
+
+func TestArchiveHydrationRejectsInterveningMergeRequestSnapshotE2E(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Date(2026, 8, 2, 13, 0, 0, 0, time.UTC)
+	mergedAt := now.Add(-time.Hour)
+
+	providerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v3/repos/acme/widget":
+			_, _ = w.Write([]byte(`{"id":1,"node_id":"R_widget","name":"widget","full_name":"acme/widget","owner":{"login":"acme"}}`))
+		case "/api/v3/repos/acme/widget/pulls/7":
+			_, _ = w.Write([]byte(`{
+				"id":7,"node_id":"PR_7","number":7,
+				"html_url":"https://github.com/acme/widget/pull/7",
+				"title":"canonical title","state":"closed","merged":true,
+				"created_at":"2026-08-02T10:00:00Z",
+				"updated_at":"2026-08-02T12:00:00Z",
+				"closed_at":"2026-08-02T12:00:00Z",
+				"merged_at":"2026-08-02T12:00:00Z",
+				"merged_by":{"login":"merge-admin"},
+				"merge_commit_sha":"merge-sha","changed_files":4,
+				"head":{"ref":"feature","sha":"head-sha","repo":{"id":1,"node_id":"R_widget","name":"widget","full_name":"acme/widget","owner":{"login":"acme"}}},
+				"base":{"ref":"main","sha":"base-sha","repo":{"id":1,"node_id":"R_widget","name":"widget","full_name":"acme/widget","owner":{"login":"acme"}}}
+			}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(providerServer.Close)
+
+	providerClient, err := ghclient.NewClient(
+		staticTokenSource("archive-token"), "github.com", nil, nil,
+		ghclient.WithBaseURLForTesting(providerServer.URL),
+	)
+	require.NoError(err)
+	registry, err := ghclient.NewProviderRegistry(map[string]ghclient.Client{
+		"github.com": providerClient,
+	})
+	require.NoError(err)
+	database := dbtest.Open(t)
+	ref := platform.RepoRef{
+		Platform: platform.KindGitHub, Host: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	}
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry, database, nil,
+		[]ghclient.RepoRef{{
+			Platform: ref.Platform, PlatformHost: ref.Host,
+			Owner: ref.Owner, Name: ref.Name, RepoPath: ref.RepoPath,
+		}},
+		time.Hour, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	wrapped := &interveningMergeSnapshotSyncer{
+		Syncer: syncer, database: database, now: now,
+	}
+	archiveService, err := archive.NewService(
+		database, registry, nil, wrapped, nil, archiveMergeMetricsClock{now: now},
+	)
+	require.NoError(err)
+	requireEnsureConfigured(t, archiveService, []platform.RepoRef{ref})
+	repo, err := database.GetRepoByIdentity(ctx, platform.DBRepoIdentity(ref))
+	require.NoError(err)
+	require.NotNil(repo)
+	wrapped.repoID = repo.ID
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID: repo.ID, PlatformID: 7, PlatformExternalID: "PR_7", Number: 7,
+		URL: "https://github.com/acme/widget/pull/7", Title: "stored title",
+		State: db.MergeRequestStateMerged, PlatformHeadSHA: "head-sha",
+		CreatedAt: now.Add(-3 * time.Hour), UpdatedAt: now, LastActivityAt: now,
+		MergedAt: &mergedAt, ClosedAt: &mergedAt,
+		FilesChanged: new(4), MergeCommitSHA: "merge-sha",
+	})
+	require.NoError(err)
+	require.NoError(database.StartFullArchives(ctx, []int64{repo.ID}, now))
+	require.NoError(database.CommitArchiveInventoryPage(ctx, db.ArchiveInventoryCommit{
+		RepoID: repo.ID, ItemType: db.ArchiveItemTypeIssue,
+		ScanGeneration: 1, Exhausted: true, Coverage: db.ArchiveCoverageSupported,
+		Now: now,
+	}))
+	require.NoError(database.CommitArchiveInventoryPage(ctx, db.ArchiveInventoryCommit{
+		RepoID: repo.ID, ItemType: db.ArchiveItemTypeMergeRequest,
+		Items: []db.ArchiveInventoryItem{{
+			Number: 7, ProviderItemID: "PR_7",
+			ProviderCreatedAt: now.Add(-3 * time.Hour), ProviderUpdatedAt: mergedAt,
+		}},
+		ScanGeneration: 1, Exhausted: true, Coverage: db.ArchiveCoverageSupported,
+		Now: now,
+	}))
+
+	runErr := archiveService.RunEligible(ctx)
+	require.ErrorIs(runErr, db.ErrArchiveItemEvidenceChanged)
+	progress, err := database.GetDatasetProgress(
+		ctx, repo.ID, db.ArchiveItemTypeMergeRequest, 7, db.ArchiveDatasetLookup,
+	)
+	require.NoError(err)
+	assert.Equal(db.ArchiveDatasetProgressFailed, progress.Status)
+	require.NotNil(progress.LastErrorCode)
+	assert.Equal(string(db.ArchiveErrorCodeTransient), *progress.LastErrorCode)
+	stored, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, 7)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal("intervening-merge-sha", stored.MergeCommitSHA)
+	require.NotNil(stored.FilesChanged)
+	assert.Equal(9, *stored.FilesChanged)
 }
 
 func testArchiveReportRepairsMergedMetricsAcrossRepositoryRename(

--- a/internal/server/e2etest/archive_merge_metrics_test.go
+++ b/internal/server/e2etest/archive_merge_metrics_test.go
@@ -1,0 +1,202 @@
+package e2etest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/forge/internal/apiclient"
+	"go.kenn.io/forge/internal/apiclient/generated"
+	"go.kenn.io/forge/internal/archive"
+	"go.kenn.io/forge/internal/db"
+	ghclient "go.kenn.io/forge/internal/github"
+	"go.kenn.io/forge/internal/platform"
+	"go.kenn.io/forge/internal/server"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+	"go.kenn.io/forge/internal/testutil/servertest"
+)
+
+type archiveMergeMetricsClock struct{ now time.Time }
+
+func (c archiveMergeMetricsClock) Now() time.Time { return c.now }
+
+func TestArchiveReportRepairsMergedMetricsAcrossRepositoryRenameE2E(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Date(2026, 8, 2, 13, 0, 0, 0, time.UTC)
+	canonicalUpdatedAt := now.Add(-time.Hour)
+	localUpdatedAt := canonicalUpdatedAt.Add(835 * time.Millisecond)
+	mergedAt := canonicalUpdatedAt.Add(-time.Second)
+	var renamed atomic.Bool
+
+	providerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v3/repos/acme/widget":
+			if renamed.Load() {
+				_, _ = w.Write([]byte(`{"id":1,"node_id":"R_widget","name":"renamed","full_name":"acme/renamed","owner":{"login":"acme"}}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"id":1,"node_id":"R_widget","name":"widget","full_name":"acme/widget","owner":{"login":"acme"}}`))
+		case "/api/v3/repos/acme/renamed/pulls/7":
+			_, _ = w.Write([]byte(`{
+				"id":7,"node_id":"PR_7","number":7,
+				"html_url":"https://github.com/acme/renamed/pull/7",
+				"title":"canonical title","state":"closed",
+				"created_at":"2026-08-02T10:00:00Z",
+				"updated_at":"2026-08-02T12:00:00Z",
+				"closed_at":"2026-08-02T11:59:59Z",
+				"merged_at":"2026-08-02T11:59:59Z",
+				"merge_commit_sha":"merge-sha","changed_files":4,
+				"head":{"ref":"feature","sha":"head-sha","repo":{"id":1,"node_id":"R_widget","name":"renamed","full_name":"acme/renamed","owner":{"login":"acme"}}},
+				"base":{"ref":"main","sha":"base-sha","repo":{"id":1,"node_id":"R_widget","name":"renamed","full_name":"acme/renamed","owner":{"login":"acme"}}}
+			}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(providerServer.Close)
+
+	providerClient, err := ghclient.NewClient(
+		staticTokenSource("archive-token"), "github.com", nil, nil,
+		ghclient.WithBaseURLForTesting(providerServer.URL),
+	)
+	require.NoError(err)
+	registry, err := ghclient.NewProviderRegistry(map[string]ghclient.Client{
+		"github.com": providerClient,
+	})
+	require.NoError(err)
+	database := dbtest.Open(t)
+	ref := platform.RepoRef{
+		Platform: platform.KindGitHub, Host: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	}
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry, database, nil,
+		[]ghclient.RepoRef{{
+			Platform: ref.Platform, PlatformHost: ref.Host,
+			Owner: ref.Owner, Name: ref.Name, RepoPath: ref.RepoPath,
+		}},
+		time.Hour, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	clock := archiveMergeMetricsClock{now: now}
+	archiveService, err := archive.NewService(
+		database, registry, nil, syncer, nil, clock,
+	)
+	require.NoError(err)
+	requireEnsureConfigured(t, archiveService, []platform.RepoRef{ref})
+
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{
+		Archive:                       archiveService,
+		HostCheckAllowLoopbackAnyPort: true,
+	})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	forgeServer := httptest.NewServer(srv)
+	t.Cleanup(forgeServer.Close)
+	api, err := apiclient.NewWithHTTPClient(forgeServer.URL, forgeServer.Client())
+	require.NoError(err)
+	repositories := []generated.ArchiveRepositoryRef{{
+		Provider: "github", PlatformHost: "github.com",
+		Owner: ref.Owner, Name: ref.Name, RepoPath: ref.RepoPath,
+	}}
+	started, err := api.HTTP.StartArchivesWithResponse(
+		ctx, generated.ArchiveMutationBody{Repositories: &repositories},
+	)
+	require.NoError(err)
+	require.NotNil(started.JSON200)
+
+	repo, err := database.GetRepoByIdentity(ctx, platform.DBRepoIdentity(ref))
+	require.NoError(err)
+	require.NotNil(repo)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID: repo.ID, PlatformID: 7, PlatformExternalID: "PR_7", Number: 7,
+		URL: "https://github.com/acme/widget/pull/7", Title: "newer local title",
+		State: db.MergeRequestStateOpen, PlatformHeadSHA: "head-sha",
+		CreatedAt: canonicalUpdatedAt.Add(-2 * time.Hour), UpdatedAt: localUpdatedAt,
+		LastActivityAt: localUpdatedAt, MergedAt: &mergedAt, ClosedAt: &mergedAt,
+	})
+	require.NoError(err)
+	require.NoError(database.CommitArchiveInventoryPage(ctx, db.ArchiveInventoryCommit{
+		RepoID: repo.ID, ItemType: db.ArchiveItemTypeIssue,
+		ScanGeneration: 1, Exhausted: true, Coverage: db.ArchiveCoverageSupported,
+		Now: now,
+	}))
+	require.NoError(database.CommitArchiveInventoryPage(ctx, db.ArchiveInventoryCommit{
+		RepoID: repo.ID, ItemType: db.ArchiveItemTypeMergeRequest,
+		Items: []db.ArchiveInventoryItem{{
+			Number: 7, ProviderItemID: "PR_7",
+			ProviderCreatedAt: canonicalUpdatedAt.Add(-2 * time.Hour),
+			ProviderUpdatedAt: canonicalUpdatedAt,
+		}},
+		ScanGeneration: 1, Exhausted: true, Coverage: db.ArchiveCoverageSupported,
+		Now: now,
+	}))
+	progress, err := database.GetDatasetProgress(
+		ctx, repo.ID, db.ArchiveItemTypeMergeRequest, 7, db.ArchiveDatasetLookup,
+	)
+	require.NoError(err)
+	require.NoError(database.CommitArchiveItemSync(ctx, db.ArchiveItemSyncCommit{
+		RepoID: repo.ID, ItemType: db.ArchiveItemTypeMergeRequest, ItemNumber: 7,
+		ScanGeneration: progress.ScanGeneration, Outcome: db.ArchiveLookupPresent,
+		Now: now,
+	}))
+	_, err = database.WriteDB().ExecContext(ctx, `
+		UPDATE forge_archive_dataset_progress
+		SET scan_generation = ?
+		WHERE repo_id = ? AND item_type = 'merge_request'
+		  AND item_number = 7 AND dataset = 'lookup'`, int64(1<<32), repo.ID)
+	require.NoError(err)
+
+	requireEnsureConfigured(t, archiveService, []platform.RepoRef{ref})
+	progress, err = database.GetDatasetProgress(
+		ctx, repo.ID, db.ArchiveItemTypeMergeRequest, 7, db.ArchiveDatasetLookup,
+	)
+	require.NoError(err)
+	assert.Equal(db.ArchiveDatasetProgressPending, progress.Status)
+
+	renamed.Store(true)
+	require.NoError(archiveService.RunEligible(ctx))
+	progress, err = database.GetDatasetProgress(
+		ctx, repo.ID, db.ArchiveItemTypeMergeRequest, 7, db.ArchiveDatasetLookup,
+	)
+	require.NoError(err)
+	assert.Equal(db.ArchiveDatasetProgressComplete, progress.Status)
+
+	storedRepo, err := database.GetRepoByID(ctx, repo.ID)
+	require.NoError(err)
+	require.NotNil(storedRepo)
+	assert.Equal("renamed", storedRepo.Name)
+	storedMR, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, 7)
+	require.NoError(err)
+	require.NotNil(storedMR)
+	assert.Equal("merge-sha", storedMR.MergeCommitSHA)
+	require.NotNil(storedMR.FilesChanged)
+	assert.Equal(4, *storedMR.FilesChanged)
+	assert.Equal("newer local title", storedMR.Title)
+
+	verbose := true
+	reportResponse, err := api.HTTP.GetArchiveReportWithResponse(ctx, &generated.GetArchiveReportParams{
+		Start: mergedAt.Add(-time.Minute).Format(time.RFC3339),
+		End:   mergedAt.Add(time.Minute).Format(time.RFC3339), Verbose: &verbose,
+	})
+	require.NoError(err)
+	require.NotNil(reportResponse.JSON200)
+	require.NotNil(reportResponse.JSON200.Activity)
+	require.Len(*reportResponse.JSON200.Activity, 1)
+	merged := (*reportResponse.JSON200.Activity)[0]
+	assert.Equal(generated.ArchiveReportActivityResponseKindMergeRequestMerged, merged.Kind)
+	require.NotNil(merged.MergeCommitSha)
+	assert.Equal("merge-sha", *merged.MergeCommitSha)
+	require.NotNil(merged.FilesChanged)
+	assert.Equal(int64(4), *merged.FilesChanged)
+	require.NotNil(reportResponse.JSON200.Repositories)
+	require.Len(*reportResponse.JSON200.Repositories, 1)
+	assert.Equal("renamed", (*reportResponse.JSON200.Repositories)[0].Repository.Name)
+}

--- a/internal/server/e2etest/archive_merge_metrics_test.go
+++ b/internal/server/e2etest/archive_merge_metrics_test.go
@@ -25,7 +25,28 @@ type archiveMergeMetricsClock struct{ now time.Time }
 
 func (c archiveMergeMetricsClock) Now() time.Time { return c.now }
 
+type archiveMergeMetricsCase struct {
+	name            string
+	state           db.MergeRequestState
+	storeMergedTime bool
+}
+
 func TestArchiveReportRepairsMergedMetricsAcrossRepositoryRenameE2E(t *testing.T) {
+	tests := []archiveMergeMetricsCase{
+		{name: "merged timestamp only", state: db.MergeRequestStateOpen, storeMergedTime: true},
+		{name: "merged state only", state: db.MergeRequestStateMerged},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testArchiveReportRepairsMergedMetricsAcrossRepositoryRename(t, tt)
+		})
+	}
+}
+
+func testArchiveReportRepairsMergedMetricsAcrossRepositoryRename(
+	t *testing.T,
+	tt archiveMergeMetricsCase,
+) {
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -115,12 +136,16 @@ func TestArchiveReportRepairsMergedMetricsAcrossRepositoryRenameE2E(t *testing.T
 	repo, err := database.GetRepoByIdentity(ctx, platform.DBRepoIdentity(ref))
 	require.NoError(err)
 	require.NotNil(repo)
+	var storedMergedAt *time.Time
+	if tt.storeMergedTime {
+		storedMergedAt = &mergedAt
+	}
 	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
 		RepoID: repo.ID, PlatformID: 7, PlatformExternalID: "PR_7", Number: 7,
 		URL: "https://github.com/acme/widget/pull/7", Title: "newer local title",
-		State: db.MergeRequestStateOpen, PlatformHeadSHA: "head-sha",
+		State: tt.state, PlatformHeadSHA: "head-sha",
 		CreatedAt: canonicalUpdatedAt.Add(-2 * time.Hour), UpdatedAt: localUpdatedAt,
-		LastActivityAt: localUpdatedAt, MergedAt: &mergedAt, ClosedAt: &mergedAt,
+		LastActivityAt: localUpdatedAt, MergedAt: storedMergedAt, ClosedAt: &mergedAt,
 	})
 	require.NoError(err)
 	require.NoError(database.CommitArchiveInventoryPage(ctx, db.ArchiveInventoryCommit{
@@ -179,6 +204,8 @@ func TestArchiveReportRepairsMergedMetricsAcrossRepositoryRenameE2E(t *testing.T
 	assert.Equal("merge-sha", storedMR.MergeCommitSHA)
 	require.NotNil(storedMR.FilesChanged)
 	assert.Equal(4, *storedMR.FilesChanged)
+	require.NotNil(storedMR.MergedAt)
+	assert.Equal(mergedAt, *storedMR.MergedAt)
 	assert.Equal("newer local title", storedMR.Title)
 
 	verbose := true

--- a/internal/server/e2etest/archive_merge_metrics_test.go
+++ b/internal/server/e2etest/archive_merge_metrics_test.go
@@ -31,8 +31,12 @@ type archiveMergeMetricsCase struct {
 	state                db.MergeRequestState
 	storeMergedTime      bool
 	storeMergeMetrics    bool
+	storeMergeActor      bool
+	storedMergeSHA       string
+	storedFilesChanged   int
 	providerFilesChanged bool
 	omitProviderMergedAt bool
+	expectMissingFiles   bool
 }
 
 func TestArchiveReportRepairsMergedMetricsAcrossRepositoryRenameE2E(t *testing.T) {
@@ -47,15 +51,22 @@ func TestArchiveReportRepairsMergedMetricsAcrossRepositoryRenameE2E(t *testing.T
 		},
 		{
 			name: "complete metrics missing actor", state: db.MergeRequestStateMerged,
-			storeMergedTime: true, storeMergeMetrics: true,
+			storeMergedTime: true, storeMergeMetrics: true, expectMissingFiles: true,
 		},
 		{
 			name: "state only with stored metrics", state: db.MergeRequestStateMerged,
-			storeMergeMetrics: true,
+			storeMergeMetrics: true, providerFilesChanged: true,
 		},
 		{
 			name: "stored timestamp with provider actor", state: db.MergeRequestStateMerged,
-			storeMergedTime: true, storeMergeMetrics: true, omitProviderMergedAt: true,
+			storeMergedTime: true, storeMergeMetrics: true, providerFilesChanged: true,
+			omitProviderMergedAt: true,
+		},
+		{
+			name: "old generation with stale canonical metrics", state: db.MergeRequestStateMerged,
+			storeMergedTime: true, storeMergeMetrics: true, storeMergeActor: true,
+			storedMergeSHA: "pre-merge-test-sha", storedFilesChanged: 9,
+			providerFilesChanged: true,
 		},
 	}
 	for _, tt := range tests {
@@ -174,10 +185,16 @@ func testArchiveReportRepairsMergedMetricsAcrossRepositoryRename(
 	var storedFilesChanged *int
 	storedMergeCommitSHA := ""
 	if tt.storeMergeMetrics {
-		storedFilesChanged = new(4)
-		storedMergeCommitSHA = "merge-sha"
+		storedFilesChanged = new(tt.storedFilesChanged)
+		if tt.storedFilesChanged == 0 {
+			storedFilesChanged = new(4)
+		}
+		storedMergeCommitSHA = tt.storedMergeSHA
+		if storedMergeCommitSHA == "" {
+			storedMergeCommitSHA = "merge-sha"
+		}
 	}
-	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+	mrID, err := database.UpsertMergeRequest(ctx, &db.MergeRequest{
 		RepoID: repo.ID, PlatformID: 7, PlatformExternalID: "PR_7", Number: 7,
 		URL: "https://github.com/acme/widget/pull/7", Title: "newer local title",
 		State: tt.state, PlatformHeadSHA: "head-sha",
@@ -186,6 +203,13 @@ func testArchiveReportRepairsMergedMetricsAcrossRepositoryRename(
 		FilesChanged: storedFilesChanged, MergeCommitSHA: storedMergeCommitSHA,
 	})
 	require.NoError(err)
+	if tt.storeMergeActor {
+		require.NoError(database.UpsertMREvents(ctx, []db.MREvent{{
+			MergeRequestID: mrID, EventType: "merged", Author: "merge-admin",
+			Summary: "merged this", CreatedAt: mergedAt,
+			DedupeKey: "merged-existing",
+		}}))
+	}
 	require.NoError(database.CommitArchiveInventoryPage(ctx, db.ArchiveInventoryCommit{
 		RepoID: repo.ID, ItemType: db.ArchiveItemTypeIssue,
 		ScanGeneration: 1, Exhausted: true, Coverage: db.ArchiveCoverageSupported,
@@ -225,11 +249,24 @@ func testArchiveReportRepairsMergedMetricsAcrossRepositoryRename(
 	assert.Equal(db.ArchiveDatasetProgressPending, progress.Status)
 
 	renamed.Store(true)
-	require.NoError(archiveService.RunEligible(ctx))
+	runErr := archiveService.RunEligible(ctx)
 	progress, err = database.GetDatasetProgress(
 		ctx, repo.ID, db.ArchiveItemTypeMergeRequest, 7, db.ArchiveDatasetLookup,
 	)
 	require.NoError(err)
+	if tt.expectMissingFiles {
+		require.ErrorContains(runErr, "files_changed")
+		assert.NotEqual(db.ArchiveDatasetProgressComplete, progress.Status)
+		storedMR, readErr := database.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, 7)
+		require.NoError(readErr)
+		require.NotNil(storedMR)
+		events, eventsErr := database.ListMREvents(ctx, storedMR.ID)
+		require.NoError(eventsErr)
+		require.Len(events, 1)
+		assert.Equal("merge-admin", events[0].Author)
+		return
+	}
+	require.NoError(runErr)
 	assert.Equal(db.ArchiveDatasetProgressComplete, progress.Status)
 
 	storedRepo, err := database.GetRepoByID(ctx, repo.ID)

--- a/internal/server/e2etest/archive_merge_metrics_test.go
+++ b/internal/server/e2etest/archive_merge_metrics_test.go
@@ -48,6 +48,10 @@ func TestArchiveReportRepairsMergedMetricsAcrossRepositoryRenameE2E(t *testing.T
 			name: "complete metrics missing actor", state: db.MergeRequestStateMerged,
 			storeMergedTime: true, storeMergeMetrics: true,
 		},
+		{
+			name: "state only with stored metrics", state: db.MergeRequestStateMerged,
+			storeMergeMetrics: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/server/e2etest/archive_merge_metrics_test.go
+++ b/internal/server/e2etest/archive_merge_metrics_test.go
@@ -74,6 +74,7 @@ func testArchiveReportRepairsMergedMetricsAcrossRepositoryRename(
 				"updated_at":"2026-08-02T12:00:00Z",
 				"closed_at":"2026-08-02T11:59:59Z",
 				"merged_at":"2026-08-02T11:59:59Z",
+				"merged_by":{"login":"merge-admin"},
 				"merge_commit_sha":"merge-sha","changed_files":4,
 				"head":{"ref":"feature","sha":"head-sha","repo":{"id":1,"node_id":"R_widget","name":"renamed","full_name":"acme/renamed","owner":{"login":"acme"}}},
 				"base":{"ref":"main","sha":"base-sha","repo":{"id":1,"node_id":"R_widget","name":"renamed","full_name":"acme/renamed","owner":{"login":"acme"}}}
@@ -219,6 +220,8 @@ func testArchiveReportRepairsMergedMetricsAcrossRepositoryRename(
 	require.Len(*reportResponse.JSON200.Activity, 1)
 	merged := (*reportResponse.JSON200.Activity)[0]
 	assert.Equal(generated.ArchiveReportActivityResponseKindMergeRequestMerged, merged.Kind)
+	require.NotNil(merged.Actor)
+	assert.Equal("merge-admin", *merged.Actor)
 	require.NotNil(merged.MergeCommitSha)
 	assert.Equal("merge-sha", *merged.MergeCommitSha)
 	require.NotNil(merged.FilesChanged)

--- a/internal/server/e2etest/archive_quota_test.go
+++ b/internal/server/e2etest/archive_quota_test.go
@@ -39,16 +39,16 @@ func (s archiveQuotaBurstSource) SyncArchiveItem(
 	ref platform.RepoRef,
 	_ db.ArchiveItemType,
 	number int,
-) (bool, error) {
+) (archive.ItemSyncResult, error) {
 	attempted := false
 	for range 10 {
 		_, err := s.client.GetIssue(ctx, ref.Owner, ref.Name, number)
 		if err != nil {
-			return attempted, err
+			return archive.ItemSyncResult{ProviderAttempted: attempted}, err
 		}
 		attempted = true
 	}
-	return attempted, nil
+	return archive.ItemSyncResult{ProviderAttempted: attempted}, nil
 }
 
 func TestArchiveAPIStopsProviderBurstAtObservedQuotaHeadroomE2E(t *testing.T) {

--- a/internal/server/workspacetest/workspace_enrichment_wire_test.go
+++ b/internal/server/workspacetest/workspace_enrichment_wire_test.go
@@ -32,6 +32,24 @@ func TestWorkspaceListReportsCommitsAheadBehindE2E(t *testing.T) {
 		},
 	})
 	ws := createReadyWorkspace(t, context.Background(), fixture.client)
+	workspaceByID := func() *generated.WorkspaceResponse {
+		resp, err := fixture.client.HTTP.ListWorkspacesWithResponse(t.Context())
+		if err != nil || resp.JSON200 == nil || resp.JSON200.Workspaces == nil {
+			return nil
+		}
+		for i := range *resp.JSON200.Workspaces {
+			candidate := &(*resp.JSON200.Workspaces)[i]
+			if candidate.Id == ws.Id {
+				return candidate
+			}
+		}
+		return nil
+	}
+	require.Eventually(func() bool {
+		initial := workspaceByID()
+		return initial != nil && initial.CommitsAhead != nil && initial.CommitsBehind != nil &&
+			*initial.CommitsAhead == 0 && *initial.CommitsBehind == 0
+	}, 10*time.Second, 10*time.Millisecond)
 
 	runGit(t, ws.WorktreePath, "config", "user.email", "test@test.com")
 	runGit(t, ws.WorktreePath, "config", "user.name", "Test")
@@ -44,20 +62,10 @@ func TestWorkspaceListReportsCommitsAheadBehindE2E(t *testing.T) {
 
 	var found *generated.WorkspaceResponse
 	require.Eventually(func() bool {
-		resp, err := fixture.client.HTTP.ListWorkspacesWithResponse(t.Context())
-		if err != nil || resp.JSON200 == nil || resp.JSON200.Workspaces == nil {
-			return false
-		}
-		for i := range *resp.JSON200.Workspaces {
-			candidate := &(*resp.JSON200.Workspaces)[i]
-			if candidate.Id == ws.Id {
-				found = candidate
-				break
-			}
-		}
+		found = workspaceByID()
 		return found != nil && found.CommitsAhead != nil && found.CommitsBehind != nil &&
 			*found.CommitsAhead == 2 && *found.CommitsBehind == 0
-	}, 2*time.Second, 10*time.Millisecond)
+	}, 10*time.Second, 10*time.Millisecond)
 	require.NotNil(found)
 	assert.Equal(int64(2), *found.CommitsAhead)
 	assert.Equal(int64(0), *found.CommitsBehind)


### PR DESCRIPTION
Archive lifecycle hydration could report a merged GitHub pull request as complete with missing or stale canonical merge evidence. GitHub may expose a test merge commit before merge, while a newer local snapshot can also reject the later canonical merged detail through normal timestamp ordering.

- Require merge time and files-changed count plus fetched canonical head and merge SHAs that exactly match storage before merged GitHub hydration completes.
- Replace a pre-merge test SHA only when repository, pull request, merged-row, and head-SHA identity guards match.
- Preserve merger attribution from canonical detail by using the transaction-current stored merge time when GitHub omits that timestamp.
- Keep hydration retryable when canonical merged evidence is absent or snapshot ordering prevents it from being persisted.
- Reopen rows completed by the prior lifecycle generation so existing incomplete archives repair automatically.

This does not change the database schema or API, and other providers retain their current completeness rules.