### PR TITLE
Keep session launch visible in promoted workspace panes

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -591,6 +591,9 @@ Keyboard handlers must have one clear owner for each key press.
   Dock mode changes are pure local UI — never disable them behind mutation
   guards like `actionsBlocked`; only the modal-stack guard applies, and only
   to the expand direction.
+- Every pane belonging to a workspace keeps direct non-destructive actions such
+  as session launch; only destructive workspace actions are limited to the
+  workspace-owner leaf (`frontend/src/lib/components/terminal/WorkspacePaneControls.svelte`).
 - The workspace view renders by liveness, not cached presence: the previous
   workspace stays cached across an in-place A→B switch, and branching on
   `workspace` alone shows A's stale ready toolbar (with action guards

--- a/frontend/src/lib/components/terminal/WorkspacePaneControls.svelte
+++ b/frontend/src/lib/components/terminal/WorkspacePaneControls.svelte
@@ -13,12 +13,12 @@
 
   interface Props {
     /**
-     * Whether this instance renders the strip actions (Delete). One popover per
-     * related leaf is fine - it acts on the workspace wherever it opens - but the
-     * strip actions are visible destructive controls, and a workspace split across
-     * leaves (its pane in one, a promoted session in another) must not grow one
-     * Delete per leaf. The surface passes true only for the leaf holding the
-     * workspace pane itself.
+     * Whether this instance renders the owner-only strip actions (Delete). One
+     * popover per related leaf is fine - it acts on the workspace wherever it
+     * opens - but the owner-only actions are visible destructive controls, and a
+     * workspace split across leaves (its pane in one, a promoted session in
+     * another) must not grow one Delete per leaf. The surface passes true only for
+     * the leaf holding the workspace pane itself.
      */
     showStripActions?: boolean;
   }
@@ -147,6 +147,7 @@
 
 {#if controls}
   <div class="workspace-pane-controls">
+    {@render controls.paneActions?.()}
     {#if showStripActions}
       {@render controls.stripActions?.()}
     {/if}

--- a/frontend/src/lib/components/terminal/WorkspacePaneControls.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspacePaneControls.test.ts
@@ -65,20 +65,26 @@ describe("WorkspacePaneControls", () => {
     expect(button!.getAttribute("aria-expanded")).toBe("true");
   });
 
-  it("renders the strip actions only for the leaf that owns them", () => {
+  it("keeps shared pane actions visible when owner-only strip actions are suppressed", () => {
     // The popover follows the workspace to any leaf hosting one of its panes, but
-    // the strip actions carry Delete: a workspace split across leaves must not
-    // grow one visible Delete per leaf.
+    // owner-only strip actions carry Delete: a workspace split across leaves must
+    // not grow one visible Delete per leaf. Launch remains a direct action in every
+    // related pane, including a promoted session pane.
+    const paneActions = createRawSnippet(() => ({
+      render: () => `<button type="button">Launch session</button>`,
+    }));
     const stripActions = createRawSnippet(() => ({
       render: () => `<button type="button">Delete workspace main</button>`,
     }));
-    registerWorkspaceControls({ snippet, stripActions, workspaceKey: "ws-1" });
+    registerWorkspaceControls({ snippet, paneActions, stripActions, workspaceKey: "ws-1" });
 
     renderControls({ showStripActions: false });
+    expect(screen.getByRole("button", { name: "Launch session" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Delete workspace main" })).toBeNull();
     cleanup();
 
     renderControls();
+    expect(screen.getByRole("button", { name: "Launch session" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Delete workspace main" })).toBeTruthy();
   });
 

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -1224,6 +1224,7 @@
     untrack(() =>
       registerWorkspaceControls({
         snippet: workspaceControls,
+        paneActions: workspacePaneActions,
         stripActions: workspaceStripActions,
         dockRow: workspaceDockRow,
         workspacePaneRowOnly: rowOnly,
@@ -4633,15 +4634,12 @@
   {/if}
 {/snippet}
 
-<!-- Sits in the tab strip beside the controls trigger, not inside the popover.
-     Launching and deleting are the workspace actions a maintainer reaches for often
-     enough that opening a menu first is a click too many. Launch remains in the
-     popover as well because promoted session panes intentionally suppress these
-     workspace-level strip actions. -->
-{#snippet workspaceStripActions()}
+<!-- Sits in every related pane's tab strip. Launching is non-destructive and useful
+     from a promoted session too, so it must not disappear with owner-only actions. -->
+{#snippet workspacePaneActions()}
   <!-- Ready only. A workspace whose setup failed renders its own actions beside the
        Retry in the error panel, which is where the user is already looking, and one
-       still being created cannot launch or be deleted yet. -->
+       still being created cannot launch yet. -->
   {#if workspaceLive && workspace?.status === "ready"}
     <IconButton
       size="sm"
@@ -4653,6 +4651,13 @@
     >
       <PlayIcon size="13" strokeWidth="2" aria-hidden="true" />
     </IconButton>
+  {/if}
+{/snippet}
+
+<!-- The workspace pane alone owns destructive strip actions. A workspace split
+     across promoted session panes must still present exactly one Delete button. -->
+{#snippet workspaceStripActions()}
+  {#if workspaceLive && workspace?.status === "ready"}
     <IconButton
       size="sm"
       tone="danger"

--- a/frontend/src/lib/stores/workspace-host.svelte.ts
+++ b/frontend/src/lib/stores/workspace-host.svelte.ts
@@ -592,10 +592,15 @@ export function registerSessionPaneSnippet(snippet: Snippet<[{ paneKey: string; 
 export interface HostedWorkspaceControls {
   snippet: Snippet;
   /**
-   * The few controls that sit in the tab strip itself rather than behind the
-   * popover. Deleting a workspace is the one thing a maintainer does often enough
-   * that a click to open a menu first is a click too many, and it is the same
-   * action either way - so it lives here instead of in `snippet`, not in both.
+   * Non-destructive actions shown in every pane that belongs to the workspace.
+   * A promoted session pane still needs a direct route to launch another session,
+   * even though it is not the leaf that owns workspace-level destructive actions.
+   */
+  paneActions?: Snippet;
+  /**
+   * Owner-only controls that sit in the workspace pane's tab strip rather than
+   * behind the popover. Destructive actions must have one visible owner even when
+   * a workspace is split across several session panes.
    */
   stripActions?: Snippet;
   /**
@@ -627,6 +632,7 @@ export interface HostedWorkspaceControls {
 export function registerWorkspaceControls(controls: HostedWorkspaceControls | null): void {
   if (
     controls?.snippet === hostedControls?.snippet &&
+    controls?.paneActions === hostedControls?.paneActions &&
     controls?.stripActions === hostedControls?.stripActions &&
     controls?.dockRow === hostedControls?.dockRow &&
     controls?.workspacePaneRowOnly === hostedControls?.workspacePaneRowOnly &&


### PR DESCRIPTION
Promoted workspace sessions lost the top-bar Play action because pane ownership suppressed both launch and delete controls.

- Keep **Launch session** visible in every pane that belongs to the workspace.
- Keep **Delete workspace** limited to the workspace-owner pane so destructive actions are not duplicated.
- Apply the same behavior regardless of how the workspace was created, including issue-created workspaces.

<sup>generated by a clanker</sup>
