### PR TITLE
fix: support item numbers in Activity search

### DIFF
--- a/cmd/e2e-server/main_test.go
+++ b/cmd/e2e-server/main_test.go
@@ -290,7 +290,7 @@ esac
 	require.Eventually(func() bool {
 		_, statErr := os.Stat(started)
 		return statErr == nil
-	}, time.Second, 10*time.Millisecond)
+	}, 5*time.Second, 10*time.Millisecond)
 
 	stopDone := make(chan struct{})
 	go func() {
@@ -302,7 +302,7 @@ esac
 	require.Eventually(func() bool {
 		_, statErr := os.Stat(filepath.Join(gate.dir, "killing"))
 		return statErr == nil
-	}, time.Second, 10*time.Millisecond)
+	}, 5*time.Second, 10*time.Millisecond)
 
 	output, startErr := procutil.Command(
 		guarded[0], append(guarded[1:], "new-session")...,
@@ -313,7 +313,7 @@ esac
 	require.NoError(<-firstDone)
 	select {
 	case <-stopDone:
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		require.Fail("tmux stop did not acquire the creation gate")
 	}
 

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -27,3 +27,6 @@ fixtures, or changing shell-script coverage.
   must seed now-relative instants, not absolute calendar dates — pinned dates
   age out and the test starts failing on a later calendar day
   (`internal/server/e2etest/notifications_test.go::TestNotificationSyncReconcilesReusedRouteE2E`).
+- Build boundary-size Git histories through one fast-import stream, not a
+  subprocess per add/commit; parallel packages share process capacity
+  (`internal/testutil/gitfixture/history.go::AppendFileCommits`).

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -86,9 +86,9 @@ embedder protocol for arbitrary host state.
 - Threaded and Mobile Activity merge that snapshot after provider-event filters,
   so workspace recency can keep an event-less subject visible; Flat Activity
   remains provider-event-only (`frontend/src/lib/views/MobileActivityView.svelte::groups`).
-- Activity normalizes search once and keeps workspace recency for subjects with
-  matching provider events across incremental polls; metadata search filters only
-  eventless rows (`internal/server/huma_routes.go::Server.workspaceActivityResponse`).
+- Activity number search uses the same `#number` shape for provider events,
+  notifications, and eventless workspace subjects; matching provider events keep
+  workspace recency across incremental polls (`internal/server/huma_routes.go::Server.workspaceActivityResponse`).
 - Activity event references key that snapshot by stable repo ID: issues use
   own identity and PRs use resolved identity, so route reuse stays fail-closed
   (`internal/server/helpers.go::workspaceRefForActivityItem`).

--- a/internal/db/queries_activity.go
+++ b/internal/db/queries_activity.go
@@ -69,13 +69,14 @@ func (d *DB) ListActivity(
 	if opts.Search != "" {
 		pattern := "%" + strings.ToLower(opts.Search) + "%"
 		whereClauses = append(whereClauses,
-			"(LOWER(item_title) LIKE ? OR LOWER(body_preview) LIKE ? OR LOWER(branch_name) LIKE ? OR "+
+			"((item_type IN ('pr', 'issue') AND LOWER('#' || item_number || ' ' || item_title) LIKE ?) OR "+
+				"LOWER(item_title) LIKE ? OR LOWER(body_preview) LIKE ? OR LOWER(branch_name) LIKE ? OR "+
 				"LOWER(commit_sha) LIKE ? OR LOWER(before_sha) LIKE ? OR LOWER(after_sha) LIKE ? OR "+
 				"LOWER(author) LIKE ? OR LOWER(item_author) LIKE ? OR "+
 				"LOWER(author_name) LIKE ? OR LOWER(author_email) LIKE ? OR "+
 				"LOWER(committer_name) LIKE ? OR LOWER(committer_email) LIKE ?)")
 		args = append(args,
-			pattern, pattern, pattern, pattern, pattern, pattern,
+			pattern, pattern, pattern, pattern, pattern, pattern, pattern,
 			pattern, pattern, pattern, pattern, pattern, pattern)
 	}
 

--- a/internal/db/queries_activity_test.go
+++ b/internal/db/queries_activity_test.go
@@ -248,6 +248,24 @@ func TestListActivity(t *testing.T) {
 		}
 	})
 
+	t.Run("search matches item numbers", func(t *testing.T) {
+		for _, search := range []string{"10", "#10"} {
+			t.Run(search, func(t *testing.T) {
+				assert := assert.New(t)
+				require := require.New(t)
+				items, err := d.ListActivity(ctx, ListActivityOpts{
+					Search: search, Limit: 50,
+				})
+				require.NoError(err)
+				require.Len(items, 2)
+				for _, item := range items {
+					assert.Equal("issue", item.ItemType)
+					assert.Equal(10, item.ItemNumber)
+				}
+			})
+		}
+	})
+
 	t.Run("search matches activity actor and item author", func(t *testing.T) {
 		assert := assert.New(t)
 		require := require.New(t)

--- a/internal/gitclone/repo_browser_test.go
+++ b/internal/gitclone/repo_browser_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 	"go.kenn.io/forge/internal/tokenauth"
 )
 
@@ -981,11 +982,7 @@ func TestRepoBrowserLastChangedFallsBackPastBatchLogLimit(t *testing.T) {
 	mgr, repo, work := setupRepoBrowserTestRepo(t)
 	readmeSHA := gitSHA(t, work, "HEAD")
 
-	for i := range RepoBrowserLastChangedLogLimit + 1 {
-		require.NoError(os.WriteFile(filepath.Join(work, "churn.txt"), fmt.Appendf(nil, "%d\n", i), 0o644))
-		commitTestRun(t, work, "git", "add", ".")
-		commitTestRun(t, work, "git", "commit", "-m", fmt.Sprintf("churn %03d", i))
-	}
+	gitfixture.AppendFileCommits(t, work, "main", "churn.txt", RepoBrowserLastChangedLogLimit+1)
 	commitTestRun(t, work, "git", "push", "origin", "main")
 	require.NoError(mgr.RefreshRepoBrowserClone(t.Context(), repo))
 	ref := repoBrowserMainRef(t, mgr, repo)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -23660,40 +23660,6 @@ func TestWorkspaceActivitySearchKeepsSubjectsWithMatchingProviderEvents(t *testi
 	assert.Equal("ws-41", got[0].Workspace.ID)
 }
 
-func TestWorkspaceActivitySearchMatchesItemNumber(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
-	key := db.WorkspaceSubjectKey{
-		RepoID: 7, ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: 41,
-	}
-	snapshot := workspaceapi.WorkspaceSubjectSnapshot{
-		OwnReferences: map[db.WorkspaceSubjectKey]workspaceapi.WorkspaceRef{},
-		Subjects: map[db.WorkspaceSubjectKey]workspaceapi.SubjectActivity{
-			key: {
-				Subject: db.WorkspaceSubjectMetadata{
-					Key: key, Platform: "github", PlatformHost: "github.com",
-					RepoOwner: "acme", RepoName: "widget", RepoPath: "acme/widget",
-					Title: "Unrelated title", Author: "alice", State: "open",
-				},
-				Workspace:  workspaceapi.WorkspaceRef{ID: "ws-41", Status: "ready"},
-				ActivityAt: &now,
-			},
-		},
-	}
-	srv := &Server{repoResolver: httpapi.NewRepositoryResolver(httpapi.RepositoryResolverDeps{})}
-
-	got := srv.workspaceActivityResponse(
-		&listActivityInput{},
-		db.ListActivityOpts{Search: "#41"},
-		snapshot,
-		nil,
-	)
-
-	require.Len(got, 1)
-	assert.Equal(41, got[0].ItemNumber)
-}
-
 func TestAPIListActivityIncludesNotificationSyncedBeforeRepo(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -23588,6 +23588,19 @@ func TestAPIListActivity(t *testing.T) {
 	assert.Equal("comment", (*filtered.JSON200.Items)[0].ActivityType)
 	assert.Equal("reviewer", (*filtered.JSON200.Items)[0].Author)
 
+	itemNumber := "#1"
+	byNumber, err := client.HTTP.ListActivityWithResponse(
+		ctx, &generated.ListActivityParams{Since: &since, Search: &itemNumber},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, byNumber.StatusCode())
+	require.NotNil(byNumber.JSON200)
+	require.NotNil(byNumber.JSON200.Items)
+	require.Len(*byNumber.JSON200.Items, 2)
+	for _, item := range *byNumber.JSON200.Items {
+		assert.Equal(int64(1), item.ItemNumber)
+	}
+
 	whitespace := " \t "
 	unfiltered, err := client.HTTP.ListActivityWithResponse(
 		ctx, &generated.ListActivityParams{Since: &since, Search: &whitespace},
@@ -23645,6 +23658,40 @@ func TestWorkspaceActivitySearchKeepsSubjectsWithMatchingProviderEvents(t *testi
 	assert.Equal(matchedKey.ItemNumber, got[0].ItemNumber)
 	require.NotNil(got[0].Workspace)
 	assert.Equal("ws-41", got[0].Workspace.ID)
+}
+
+func TestWorkspaceActivitySearchMatchesItemNumber(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	key := db.WorkspaceSubjectKey{
+		RepoID: 7, ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: 41,
+	}
+	snapshot := workspaceapi.WorkspaceSubjectSnapshot{
+		OwnReferences: map[db.WorkspaceSubjectKey]workspaceapi.WorkspaceRef{},
+		Subjects: map[db.WorkspaceSubjectKey]workspaceapi.SubjectActivity{
+			key: {
+				Subject: db.WorkspaceSubjectMetadata{
+					Key: key, Platform: "github", PlatformHost: "github.com",
+					RepoOwner: "acme", RepoName: "widget", RepoPath: "acme/widget",
+					Title: "Unrelated title", Author: "alice", State: "open",
+				},
+				Workspace:  workspaceapi.WorkspaceRef{ID: "ws-41", Status: "ready"},
+				ActivityAt: &now,
+			},
+		},
+	}
+	srv := &Server{repoResolver: httpapi.NewRepositoryResolver(httpapi.RepositoryResolverDeps{})}
+
+	got := srv.workspaceActivityResponse(
+		&listActivityInput{},
+		db.ListActivityOpts{Search: "#41"},
+		snapshot,
+		nil,
+	)
+
+	require.Len(got, 1)
+	assert.Equal(41, got[0].ItemNumber)
 }
 
 func TestAPIListActivityIncludesNotificationSyncedBeforeRepo(t *testing.T) {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1470,7 +1470,7 @@ func (s *Server) workspaceActivityResponse(
 		if opts.Search != "" {
 			haystack := strings.ToLower(strings.Join([]string{
 				subject.Title, subject.Author, subject.RepoOwner + "/" + subject.RepoName,
-				subject.RepoPath, strconv.Itoa(key.ItemNumber),
+				subject.RepoPath, "#" + strconv.Itoa(key.ItemNumber),
 			}, " "))
 			if _, matchedProviderEvent := matchedSubjects[key]; !matchedProviderEvent && !strings.Contains(haystack, opts.Search) {
 				continue

--- a/internal/server/repobrowserapi/handler_test.go
+++ b/internal/server/repobrowserapi/handler_test.go
@@ -23,6 +23,7 @@ import (
 	"go.kenn.io/forge/internal/server/httpapi"
 	"go.kenn.io/forge/internal/server/repobrowserapi"
 	"go.kenn.io/forge/internal/testutil/dbtest"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 	"go.kenn.io/forge/internal/tokenauth"
 	gitcmd "go.kenn.io/kit/git/cmd"
 	"golang.org/x/sync/semaphore"
@@ -593,11 +594,7 @@ func TestRepoBrowserLastChangedFallsBackPastBatchLogLimit(t *testing.T) {
 	srv, work := setupRepoBrowserServer(t, "github", "github.com", "acme/widgets")
 	readmeSHA := testGitSHA(t, work, "HEAD")
 
-	for i := range gitclone.RepoBrowserLastChangedLogLimit + 1 {
-		require.NoError(os.WriteFile(filepath.Join(work, "churn.txt"), fmt.Appendf(nil, "%d\n", i), 0o644))
-		serverRepoBrowserGit(t, work, "add", ".")
-		serverRepoBrowserGit(t, work, "commit", "-m", fmt.Sprintf("churn %03d", i))
-	}
+	gitfixture.AppendFileCommits(t, work, "main", "churn.txt", gitclone.RepoBrowserLastChangedLogLimit+1)
 	churnSHA := testGitSHA(t, work, "HEAD")
 	serverRepoBrowserGit(t, work, "push", "origin", "main")
 
@@ -605,7 +602,7 @@ func TestRepoBrowserLastChangedFallsBackPastBatchLogLimit(t *testing.T) {
 		"/api/v1/repo/github/acme/widgets/browser/last-changed?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&path=README.md&path=churn.txt",
 	)
 
-	require.Equal(http.StatusOK, rr.Code)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	var body repobrowserapi.RepoBrowserLastChangedResponse
 	require.NoError(json.Unmarshal(rr.Body.Bytes(), &body))
 	assert.Equal(readmeSHA, body.Commits["README.md"].SHA)

--- a/internal/server/tmux_wrapper_test.go
+++ b/internal/server/tmux_wrapper_test.go
@@ -520,6 +520,72 @@ func TestSearchedActivityIncrementalPollRetainsWorkspaceSubject(t *testing.T) {
 	assert.Equal(workspaceID, incrementalWorkspace.Workspace.Id)
 }
 
+func TestWorkspaceActivityNumberSearchIncludesEventlessSubject(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	t.Setenv("TMUX_PANE_OUTPUT", "baseline output")
+	script, _ := writeTmuxRecorder(t)
+	client, _, database, _ := setupWrapperServerWithScriptAndDBAndServer(t, script)
+	ctx := t.Context()
+
+	repo, err := database.GetRepoByIdentity(
+		ctx, verifiedGitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+	require.NotNil(repo)
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, 1)
+	require.NoError(err)
+	require.NotNil(mr)
+	mr.Title = "Unrelated title"
+	_, err = database.UpsertMergeRequest(ctx, mr)
+	require.NoError(err)
+
+	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			Provider: "github", PlatformHost: "github.com",
+			Owner: "acme", Name: "widget", MrNumber: 1,
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(createResp.JSON202)
+	workspaceID := createResp.JSON202.Id
+	waitForWorkspaceReady(t, ctx, client, workspaceID)
+
+	require.Eventually(func() bool {
+		activity := getRawWorkspaceActivity(t, client, ctx, workspaceID)
+		return activity.TmuxActivitySource == "none" && activity.TmuxLastOutputAt == nil
+	}, 3*time.Second, 50*time.Millisecond, "tmux baseline was not observed")
+	since := time.Now().UTC().Format(time.RFC3339Nano)
+	t.Setenv("TMUX_PANE_OUTPUT", "changed output")
+
+	for _, search := range []string{"1", "#1"} {
+		var response *generated.ListActivityResponse
+		require.Eventually(func() bool {
+			got, requestErr := client.HTTP.ListActivityWithResponse(
+				ctx, &generated.ListActivityParams{Search: &search, Since: &since},
+			)
+			if requestErr != nil || got.JSON200 == nil || got.JSON200.WorkspaceActivity == nil {
+				return false
+			}
+			response = got
+			return len(*got.JSON200.WorkspaceActivity) == 1
+		}, 8*time.Second, 100*time.Millisecond, "workspace activity did not match %q", search)
+		require.NotNil(response)
+		require.NotNil(response.JSON200)
+		require.NotNil(response.JSON200.Items)
+		assert.Empty(*response.JSON200.Items, "provider Activity must remain outside the window")
+		require.NotNil(response.JSON200.WorkspaceActivity)
+		require.Len(*response.JSON200.WorkspaceActivity, 1)
+		workspaceSubject := (*response.JSON200.WorkspaceActivity)[0]
+		assert.EqualValues(1, workspaceSubject.ItemNumber)
+		assert.Equal("Unrelated title", workspaceSubject.ItemTitle)
+		require.NotNil(workspaceSubject.Workspace)
+		assert.Equal(workspaceID, workspaceSubject.Workspace.Id)
+	}
+}
+
 func getRawWorkspaceActivity(
 	t *testing.T,
 	client *apiclient.Client,

--- a/internal/testutil/gitfixture/history.go
+++ b/internal/testutil/gitfixture/history.go
@@ -1,0 +1,59 @@
+// Package gitfixture builds synthetic Git histories for tests.
+package gitfixture
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	gitcmd "go.kenn.io/kit/git/cmd"
+)
+
+// AppendFileCommits adds count commits that successively replace path on ref.
+// It uses one fast-import process so boundary-size histories do not exhaust
+// shared subprocess capacity when Go packages run concurrently.
+func AppendFileCommits(t *testing.T, dir, ref, path string, count int) {
+	t.Helper()
+	require := require.New(t)
+	runner := gitcmd.New().WithConfig("gc.auto", "0").WithConfig("maintenance.auto", "false")
+	base, err := runner.Output(t.Context(), dir, "rev-parse", ref)
+	require.NoError(err)
+
+	var stream bytes.Buffer
+	parent := strings.TrimSpace(string(base))
+	mark := 1
+	startedAt := time.Now().UTC().Unix()
+	for i := range count {
+		content := fmt.Appendf(nil, "%d\n", i)
+		fmt.Fprintf(&stream, "blob\nmark :%d\ndata %d\n", mark, len(content))
+		stream.Write(content)
+		stream.WriteByte('\n')
+		blobMark := mark
+		mark++
+
+		message := fmt.Sprintf("churn %03d", i)
+		fmt.Fprintf(
+			&stream,
+			"commit refs/heads/%s\nmark :%d\nauthor Alice <alice@example.com> %d +0000\ncommitter Alice <alice@example.com> %d +0000\ndata %d\n%s\nfrom %s\nM 100644 :%d %s\n\n",
+			ref,
+			mark,
+			startedAt+int64(i),
+			startedAt+int64(i),
+			len(message),
+			message,
+			parent,
+			blobMark,
+			path,
+		)
+		parent = fmt.Sprintf(":%d", mark)
+		mark++
+	}
+
+	out, stderr, err := runner.Run(t.Context(), dir, &stream, "fast-import", "--quiet")
+	require.NoError(err, "git fast-import failed: %s%s", out, stderr)
+	out, stderr, err = runner.Run(t.Context(), dir, nil, "reset", "--hard", ref)
+	require.NoError(err, "git reset failed: %s%s", out, stderr)
+}


### PR DESCRIPTION
Activity search did not match pull request or issue numbers even though the dedicated list views did.

- Make bare (`10`) and hash-prefixed (`#10`) queries match every Activity row for that item.
- Keep notifications and eventless workspace subjects under the same search contract.
- Preserve the existing title, author, body, branch, and commit search behavior.
- Keep boundary-size repository history checks within CI process capacity and give the tmux shutdown probe enough scheduler headroom under the full test suite.

<sup>generated by a clanker</sup>
