### PR TITLE
fix: explain incompatible Kata daemons

### DIFF
--- a/context/kata-mode.md
+++ b/context/kata-mode.md
@@ -65,6 +65,9 @@ in [`ui-interaction-contracts.md`](./ui-interaction-contracts.md).
 - Narrow reference, detail, and launch reads resolve the daemon from the route's
   daemon ID. Browser input never supplies daemon credentials or an ambient
   active-daemon fallback (`internal/server/kata/read_routes.go`).
+- Forge requires Kata v0.14.3 or newer with API schema `>=0.9.0 and <0.11.0`.
+  Mark other or missing schemas incompatible, fail narrow reads with a typed 503,
+  and surface upgrade guidance in the UI (`internal/server/kata/client.go::supportsKataAPISchema`).
 - Reference lists expose only open tasks, including empty-query autocomplete;
   completed tasks remain reachable through exact reference and issue-UID reads
   (`internal/server/kata/read_routes.go::Handler.listKataReferences`).

--- a/context/kata-mode.md
+++ b/context/kata-mode.md
@@ -65,9 +65,12 @@ in [`ui-interaction-contracts.md`](./ui-interaction-contracts.md).
 - Narrow reference, detail, and launch reads resolve the daemon from the route's
   daemon ID. Browser input never supplies daemon credentials or an ambient
   active-daemon fallback (`internal/server/kata/read_routes.go`).
-- Forge requires Kata v0.14.3 or newer with API schema `>=0.9.0 and <0.11.0`.
-  Mark other or missing schemas incompatible, fail narrow reads with a typed 503,
-  and surface upgrade guidance in the UI (`internal/server/kata/client.go::supportsKataAPISchema`).
+- Forge requires Kata v0.14.3 or newer with API schema `>=0.9.0 and <0.11.0`;
+  narrow reads require connected health and fail with a typed 503 otherwise
+  (`internal/server/kata/read_routes.go::Handler.kataClientForCompatibleDaemon`).
+- Surface schema guidance in the UI: upgrade Kata for old or missing schemas,
+  but upgrade Forge or select a supported Kata release for newer schemas
+  (`internal/server/kata/client.go::kataDaemonCompatibilityMessage`).
 - Reference lists expose only open tasks, including empty-query autocomplete;
   completed tasks remain reachable through exact reference and issue-UID reads
   (`internal/server/kata/read_routes.go::Handler.listKataReferences`).

--- a/frontend/src/lib/components/kata/KataLinkDialog.svelte
+++ b/frontend/src/lib/components/kata/KataLinkDialog.svelte
@@ -62,6 +62,12 @@
     selectedDaemon?.health === "connected" &&
       supportsKataAPISchema(selectedDaemon.api_schema_version ?? ""),
   );
+  const selectedDaemonProblem = $derived.by(() => {
+    if (!selectedDaemon || selectedDaemonUsable) return null;
+    if (selectedDaemon.hint) return selectedDaemon.hint;
+    if (selectedDaemon.health !== "connected") return `Kata daemon health: ${selectedDaemon.health}.`;
+    return `Kata API schema ${selectedDaemon.api_schema_version || "unknown"} is incompatible.`;
+  });
 
   function problemMessage(problem: unknown, fallback: string): string {
     if (typeof problem !== "object" || problem === null) return fallback;
@@ -224,6 +230,10 @@
         oninput={() => scheduleSearch()}
       />
     </div>
+
+    {#if selectedDaemonProblem}
+      <p class="error" role="alert">{selectedDaemonProblem}</p>
+    {/if}
 
     {#if error}
       <p class="error" role="alert">{error}</p>

--- a/frontend/src/lib/components/kata/KataLinkDialog.test.ts
+++ b/frontend/src/lib/components/kata/KataLinkDialog.test.ts
@@ -78,6 +78,30 @@ describe("KataLinkDialog", () => {
     expect(screen.queryByLabelText(/issue UID/i)).toBeNull();
   });
 
+  it("explains how to recover when the selected daemon is incompatible", async () => {
+    const get = vi.fn().mockResolvedValue({
+      data: {
+        daemons: [
+          {
+            id: "old",
+            url: "http://old",
+            health: "incompatible",
+            auth: "none",
+            default: true,
+            api_schema_version: "0.7.0",
+            hint: "Kata API schema 0.7.0 is incompatible; Forge requires >=0.9.0 and <0.11.0. Upgrade Kata.",
+          },
+        ],
+      },
+    });
+    renderDialog(clientWith(get));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Kata API schema 0.7.0 is incompatible");
+    expect(alert.textContent).toContain("Upgrade Kata");
+    expect((screen.getByRole("searchbox", { name: "Search Kata issues" }) as HTMLInputElement).disabled).toBe(true);
+  });
+
   it("debounces reference search and submits the selected canonical identity", async () => {
     const get = vi.fn().mockImplementation((path: string) => {
       if (path === "/kata/daemons") {

--- a/frontend/src/lib/components/terminal/NewWorkspaceDialog.svelte
+++ b/frontend/src/lib/components/terminal/NewWorkspaceDialog.svelte
@@ -297,6 +297,12 @@
     selectedDaemon?.health === "connected" &&
       supportsKataAPISchema(selectedDaemon.api_schema_version ?? ""),
   );
+  const selectedDaemonProblem = $derived.by(() => {
+    if (!selectedDaemon || selectedDaemonUsable) return null;
+    if (selectedDaemon.hint) return selectedDaemon.hint;
+    if (selectedDaemon.health !== "connected") return `Kata daemon health: ${selectedDaemon.health}.`;
+    return `Kata API schema ${selectedDaemon.api_schema_version || "unknown"} is incompatible.`;
+  });
   const selectedKataWorkspaceIdentity = $derived<KataWorkspaceIdentity | null>(
     source === "kata_issue" && selectedKataReference && selectedDaemonID
       ? { daemonID: selectedDaemonID, issueUID: selectedKataReference.uid }
@@ -632,6 +638,10 @@
           oninput={scheduleKataSearch}
         />
       </div>
+
+      {#if selectedDaemonProblem}
+        <p class="form-error" role="alert">{selectedDaemonProblem}</p>
+      {/if}
 
       {#if kataSearching}
         <p class="field-message" role="status">Searching…</p>

--- a/frontend/src/lib/components/terminal/NewWorkspaceDialog.test.ts
+++ b/frontend/src/lib/components/terminal/NewWorkspaceDialog.test.ts
@@ -296,6 +296,37 @@ describe("NewWorkspaceDialog", () => {
     });
   });
 
+  it("explains how to recover when the selected Kata daemon is incompatible", async () => {
+    mockGet.mockImplementation((path: string) => {
+      if (path === "/repos") return Promise.resolve({ data: [repoFixture("acme", "widget")] });
+      if (path === "/kata/daemons") {
+        return Promise.resolve({
+          data: {
+            daemons: [
+              {
+                id: "old",
+                url: "http://old",
+                health: "incompatible",
+                auth: "none",
+                default: true,
+                api_schema_version: "0.7.0",
+                hint: "Kata API schema 0.7.0 is incompatible; Forge requires >=0.9.0 and <0.11.0. Upgrade Kata.",
+              },
+            ],
+          },
+        });
+      }
+      throw new Error(`unexpected GET ${path}`);
+    });
+    await renderDialog();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Kata issue" }));
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Kata API schema 0.7.0 is incompatible");
+    expect(alert.textContent).toContain("Upgrade Kata");
+    expect((screen.getByRole("searchbox", { name: "Search Kata issues" }) as HTMLInputElement).disabled).toBe(true);
+  });
+
   it("routes non-default hosts through the host-scoped path", async () => {
     mockGet.mockResolvedValue({ data: [repoFixture("acme", "widget", "git.example.test", "forgejo")] });
     await renderDialog();

--- a/internal/server/kata/client.go
+++ b/internal/server/kata/client.go
@@ -18,6 +18,8 @@ const (
 	maxKataDaemonHealthBytes  = 1 << 20
 	defaultKataReferenceLimit = 100
 	maxKataReferenceLimit     = 200
+	kataMinimumVersion        = "v0.14.3"
+	kataSupportedAPISchemas   = ">=0.9.0 and <0.11.0"
 )
 
 type kataDaemonHealth struct {
@@ -91,10 +93,48 @@ func (c *kataDaemonClient) Health(ctx context.Context) (kataDaemonHealth, error)
 			"decode Kata daemon %q health response: %w", c.daemon.ID, err,
 		)
 	}
-	return kataDaemonHealth{
-		State:            "connected",
-		APISchemaVersion: payload.APISchemaVersion,
-	}, nil
+	state := "connected"
+	if !supportsKataAPISchema(payload.APISchemaVersion) {
+		state = "incompatible"
+	}
+	return kataDaemonHealth{State: state, APISchemaVersion: payload.APISchemaVersion}, nil
+}
+
+func supportsKataAPISchema(version string) bool {
+	parts := strings.Split(strings.TrimSpace(version), ".")
+	if len(parts) != 3 {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" || strings.IndexFunc(part, func(r rune) bool { return r < '0' || r > '9' }) >= 0 {
+			return false
+		}
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return false
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return false
+	}
+	if _, err := strconv.Atoi(parts[2]); err != nil {
+		return false
+	}
+	return major == 0 && (minor == 9 || minor == 10)
+}
+
+func kataDaemonCompatibilityMessage(version string) string {
+	detected := strings.TrimSpace(version)
+	if detected == "" {
+		detected = "unknown"
+	}
+	return fmt.Sprintf(
+		"Kata API schema %s is incompatible; Forge requires %s. Upgrade Kata to %s or newer with a supported API schema, then restart the daemon.",
+		detected,
+		kataSupportedAPISchemas,
+		kataMinimumVersion,
+	)
 }
 
 func (c *kataDaemonClient) References(

--- a/internal/server/kata/client.go
+++ b/internal/server/kata/client.go
@@ -101,27 +101,27 @@ func (c *kataDaemonClient) Health(ctx context.Context) (kataDaemonHealth, error)
 }
 
 func supportsKataAPISchema(version string) bool {
+	parsed, ok := parseKataAPISchema(version)
+	return ok && parsed[0] == 0 && (parsed[1] == 9 || parsed[1] == 10)
+}
+
+func parseKataAPISchema(version string) ([3]int, bool) {
+	var parsed [3]int
 	parts := strings.Split(strings.TrimSpace(version), ".")
 	if len(parts) != 3 {
-		return false
+		return parsed, false
 	}
-	for _, part := range parts {
+	for i, part := range parts {
 		if part == "" || strings.IndexFunc(part, func(r rune) bool { return r < '0' || r > '9' }) >= 0 {
-			return false
+			return parsed, false
 		}
+		value, err := strconv.Atoi(part)
+		if err != nil {
+			return parsed, false
+		}
+		parsed[i] = value
 	}
-	major, err := strconv.Atoi(parts[0])
-	if err != nil {
-		return false
-	}
-	minor, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return false
-	}
-	if _, err := strconv.Atoi(parts[2]); err != nil {
-		return false
-	}
-	return major == 0 && (minor == 9 || minor == 10)
+	return parsed, true
 }
 
 func kataDaemonCompatibilityMessage(version string) string {
@@ -129,12 +129,14 @@ func kataDaemonCompatibilityMessage(version string) string {
 	if detected == "" {
 		detected = "unknown"
 	}
-	return fmt.Sprintf(
-		"Kata API schema %s is incompatible; Forge requires %s. Upgrade Kata to %s or newer with a supported API schema, then restart the daemon.",
-		detected,
-		kataSupportedAPISchemas,
+	action := fmt.Sprintf(
+		"Upgrade Kata to %s or newer with a supported API schema, then restart the daemon.",
 		kataMinimumVersion,
 	)
+	if parsed, ok := parseKataAPISchema(detected); ok && (parsed[0] > 0 || parsed[1] >= 11) {
+		action = "Upgrade Forge or use a supported Kata release."
+	}
+	return fmt.Sprintf("Kata API schema %s is incompatible; Forge requires %s. %s", detected, kataSupportedAPISchemas, action)
 }
 
 func (c *kataDaemonClient) References(

--- a/internal/server/kata/client_test.go
+++ b/internal/server/kata/client_test.go
@@ -97,7 +97,43 @@ func TestKataDaemonClientHealthKeepsMissingSchemaVersionVisible(t *testing.T) {
 	}).Health(t.Context())
 
 	require.NoError(t, err)
-	assert.Equal(t, kataDaemonHealth{State: "connected"}, health)
+	assert.Equal(t, kataDaemonHealth{State: "incompatible"}, health)
+}
+
+func TestKataDaemonClientHealthMarksUnsupportedSchemaIncompatible(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.7.0"}`))
+	}))
+	defer upstream.Close()
+
+	health, err := newTestKataDaemonClient(t, katacatalog.Daemon{
+		ID: "example", URL: upstream.URL,
+	}).Health(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, kataDaemonHealth{State: "incompatible", APISchemaVersion: "0.7.0"}, health)
+}
+
+func TestSupportsKataAPISchema(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]bool{
+		"0.9.0":  true,
+		"0.10.7": true,
+		"0.8.9":  false,
+		"0.11.0": false,
+		"":       false,
+		"0.9":    false,
+		"0.9.-1": false,
+		"0.+9.0": false,
+	}
+	for version, want := range tests {
+		t.Run(version, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, want, supportsKataAPISchema(version))
+		})
+	}
 }
 
 func TestKataDaemonClientReferencesPinsFiltersAndCapsLimit(t *testing.T) {

--- a/internal/server/kata/client_test.go
+++ b/internal/server/kata/client_test.go
@@ -136,6 +136,36 @@ func TestSupportsKataAPISchema(t *testing.T) {
 	}
 }
 
+func TestKataDaemonCompatibilityMessagePointsToCompatibleProduct(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		version     string
+		want        string
+		doesNotWant string
+	}{
+		{name: "missing", version: "", want: "Upgrade Kata to v0.14.3 or newer"},
+		{name: "older", version: "0.8.9", want: "Upgrade Kata to v0.14.3 or newer"},
+		{
+			name:        "newer",
+			version:     "0.11.0",
+			want:        "Upgrade Forge or use a supported Kata release",
+			doesNotWant: "Upgrade Kata to v0.14.3 or newer",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			message := kataDaemonCompatibilityMessage(tt.version)
+			assert.Contains(t, message, tt.want)
+			if tt.doesNotWant != "" {
+				assert.NotContains(t, message, tt.doesNotWant)
+			}
+		})
+	}
+}
+
 func TestKataDaemonClientReferencesPinsFiltersAndCapsLimit(t *testing.T) {
 	assert := assert.New(t)
 	issueUIDs := []string{

--- a/internal/server/kata/effective_links.go
+++ b/internal/server/kata/effective_links.go
@@ -225,12 +225,20 @@ func (h *Handler) hydrateKataDaemonLinks(
 ) int {
 	client, problem := h.kataClientForDaemon(daemonID)
 	if problem != nil {
-		h.appendUnavailableKataLinks(ctx, response, links, "daemon unavailable", "")
+		reason := "daemon unavailable"
+		if problem.Detail != "" {
+			reason = problem.Detail
+		}
+		h.appendUnavailableKataLinks(ctx, response, links, reason, "")
 		return 0
 	}
 	health, err := client.Health(upstreamCtx)
 	if err != nil || health.State != "connected" {
-		h.appendUnavailableKataLinks(ctx, response, links, "daemon unavailable", health.State)
+		reason := "daemon unavailable"
+		if health.State == "incompatible" {
+			reason = kataDaemonCompatibilityMessage(health.APISchemaVersion)
+		}
+		h.appendUnavailableKataLinks(ctx, response, links, reason, health.State)
 		return 0
 	}
 	issueUIDs := make([]string, 0, len(links))

--- a/internal/server/kata/effective_links_test.go
+++ b/internal/server/kata/effective_links_test.go
@@ -207,6 +207,35 @@ func TestKataEffectiveLinkHydrationReportsOneDiagnosticPerDaemonFailure(t *testi
 	assert.Equal([]kataLinkDiagnostic{{DaemonID: "primary", Reason: "daemon unavailable"}}, response.Diagnostics)
 }
 
+func TestKataEffectiveLinkHydrationExplainsIncompatibleDaemon(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	old := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !assert.Equal("/api/v1/health", r.URL.Path, "unexpected incompatible daemon request") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.7.0"}`))
+	}))
+	t.Cleanup(old.Close)
+	configureKataLinkTestDaemon(t, old.URL)
+	srv, _ := setupTestServer(t)
+	candidates := make(map[string]*kataLinkCandidate)
+	mergeKataLinkCandidate(candidates, "primary", "project-a", "issue-a", kataLinkDirect)
+
+	response := srv.hydrateKataLinkCandidates(t.Context(), candidates)
+
+	assert.Equal("unavailable", response.State)
+	require.Len(response.Links, 1)
+	assert.Contains(response.Links[0].UnavailableReason, "Kata API schema 0.7.0 is incompatible")
+	assert.Contains(response.Links[0].UnavailableReason, "Upgrade Kata to v0.14.3 or newer")
+	assert.Equal([]kataLinkDiagnostic{{
+		DaemonID: "primary",
+		Reason:   response.Links[0].UnavailableReason,
+	}}, response.Diagnostics)
+}
+
 func TestKataEffectiveLinkHydrationKeepsExistingWorkspaceWhenDaemonUnavailable(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/kata/links.go
+++ b/internal/server/kata/links.go
@@ -208,7 +208,7 @@ func (h *Handler) validateKataLinkRequest(
 	}
 	health, healthErr := client.Health(ctx)
 	if healthErr != nil || health.State != "connected" {
-		return kataCreateLinkRequest{}, kataDaemonUnavailableProblem(request.DaemonID, health.State)
+		return kataCreateLinkRequest{}, kataDaemonUnavailableProblem(request.DaemonID, health)
 	}
 	detail, detailErr := client.IssueDetail(ctx, request.IssueUID)
 	if detailErr != nil {

--- a/internal/server/kata/read_routes.go
+++ b/internal/server/kata/read_routes.go
@@ -78,7 +78,7 @@ func (h *Handler) listKataReferences(
 ) (*kataReferencesOutput, error) {
 	ctx, cancel := context.WithTimeout(ctx, kataDaemonReadTimeout)
 	defer cancel()
-	client, problem := h.kataClientForDaemon(input.DaemonID)
+	client, problem := h.kataClientForCompatibleDaemon(input.DaemonID)
 	if problem != nil {
 		return nil, problem
 	}
@@ -102,7 +102,7 @@ func (h *Handler) resolveKataIssueReference(
 ) (*kataIssueReferenceResolveOutput, error) {
 	ctx, cancel := context.WithTimeout(ctx, kataDaemonReadTimeout)
 	defer cancel()
-	client, problem := h.kataClientForDaemon(input.DaemonID)
+	client, problem := h.kataClientForCompatibleDaemon(input.DaemonID)
 	if problem != nil {
 		return nil, problem
 	}
@@ -128,7 +128,7 @@ func (h *Handler) getKataIssueDetail(
 	}
 	health, err := client.Health(ctx)
 	if err != nil || health.State != "connected" {
-		return nil, kataDaemonUnavailableProblem(input.DaemonID, health.State)
+		return nil, kataDaemonUnavailableProblem(input.DaemonID, health)
 	}
 	detail, err := client.IssueDetail(ctx, input.IssueUID)
 	if err != nil {
@@ -145,7 +145,7 @@ func (h *Handler) getKataLaunchTarget(
 ) (*kataLaunchTargetOutput, error) {
 	ctx, cancel := context.WithTimeout(ctx, kataDaemonReadTimeout)
 	defer cancel()
-	client, problem := h.kataClientForDaemon(input.DaemonID)
+	client, problem := h.kataClientForCompatibleDaemon(input.DaemonID)
 	if problem != nil {
 		return nil, problem
 	}
@@ -181,10 +181,33 @@ func (h *Handler) kataClientForDaemon(daemonID string) (*kataDaemonClient, *http
 	return &kataDaemonClient{daemon: daemon, client: client, baseURL: baseURL}, nil
 }
 
-func kataDaemonUnavailableProblem(daemonID, health string) *httpapi.ProblemError {
+func (h *Handler) kataClientForCompatibleDaemon(daemonID string) (*kataDaemonClient, *httpapi.ProblemError) {
+	client, problem := h.kataClientForDaemon(daemonID)
+	if problem != nil {
+		return nil, problem
+	}
+	health := h.kataDaemonHealth(client.daemon.ID, client.daemon)
+	if health.State == "incompatible" {
+		return nil, kataDaemonUnavailableProblem(daemonID, health)
+	}
+	return client, nil
+}
+
+func kataDaemonUnavailableProblem(daemonID string, health kataDaemonHealth) *httpapi.ProblemError {
 	details := map[string]any{"daemon": daemonID}
-	if health != "" {
-		details["health"] = health
+	if health.State != "" {
+		details["health"] = health.State
+	}
+	if health.State == "incompatible" {
+		details["reason"] = "incompatible_api_schema"
+		details["api_schema_version"] = health.APISchemaVersion
+		details["supported_api_schema"] = kataSupportedAPISchemas
+		return httpapi.NewProblem(
+			http.StatusServiceUnavailable,
+			httpapi.CodeServiceUnavailable,
+			kataDaemonCompatibilityMessage(health.APISchemaVersion),
+			details,
+		)
 	}
 	return httpapi.NewProblem(
 		http.StatusServiceUnavailable,

--- a/internal/server/kata/read_routes.go
+++ b/internal/server/kata/read_routes.go
@@ -187,7 +187,7 @@ func (h *Handler) kataClientForCompatibleDaemon(daemonID string) (*kataDaemonCli
 		return nil, problem
 	}
 	health := h.kataDaemonHealth(client.daemon.ID, client.daemon)
-	if health.State == "incompatible" {
+	if health.State != "connected" {
 		return nil, kataDaemonUnavailableProblem(daemonID, health)
 	}
 	return client, nil

--- a/internal/server/kata/read_routes_test.go
+++ b/internal/server/kata/read_routes_test.go
@@ -258,7 +258,12 @@ url = "`+down.URL+`"
 
 func TestKataReferencesRouteReportsDaemonOnUpstreamFailure(t *testing.T) {
 	assert := assert.New(t)
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/health" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.10.0"}`))
+			return
+		}
 		http.Error(w, "unavailable", http.StatusInternalServerError)
 	}))
 	defer upstream.Close()
@@ -314,6 +319,57 @@ url = "`+upstream.URL+`"
 	assert.Equal(">=0.9.0 and <0.11.0", problem.Details["supported_api_schema"])
 	assert.Contains(problem.Detail, "Upgrade Kata")
 	assert.Zero(referenceCalls)
+}
+
+func TestKataReferencesRouteRequiresConnectedHealthBeforeNarrowRead(t *testing.T) {
+	tests := []struct {
+		name         string
+		healthStatus int
+		healthBody   string
+		wantHealth   string
+	}{
+		{name: "failed probe", healthStatus: http.StatusInternalServerError, wantHealth: "down"},
+		{name: "malformed probe", healthStatus: http.StatusOK, healthBody: "{", wantHealth: "down"},
+		{name: "authentication required", healthStatus: http.StatusUnauthorized, wantHealth: "auth_required"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			var referenceCalls int
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/api/v1/health" {
+					if tt.healthBody != "" {
+						_, _ = w.Write([]byte(tt.healthBody))
+						return
+					}
+					http.Error(w, "unavailable", tt.healthStatus)
+					return
+				}
+				referenceCalls++
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"issues":[]}`))
+			}))
+			defer upstream.Close()
+
+			home := t.TempDir()
+			t.Setenv("KATA_HOME", home)
+			writeKataServerCatalog(t, home, `
+[[daemon]]
+name = "unavailable"
+url = "`+upstream.URL+`"
+`)
+			srv, _ := setupTestServer(t)
+
+			rr := doJSON(t, srv, http.MethodGet,
+				"/api/v1/kata/daemons/unavailable/references?q=task", nil)
+			require.Equal(t, http.StatusServiceUnavailable, rr.Code, rr.Body.String())
+			problem := decodeProblem(t, rr)
+			assert.Equal(httpapi.CodeServiceUnavailable, problem.Code)
+			assert.Equal(tt.wantHealth, problem.Details["health"])
+			assert.NotContains(problem.Details, "reason")
+			assert.Zero(referenceCalls)
+		})
+	}
 }
 
 func TestKataReferencesRouteCollectsRequestedOpenResultsBeyondClosedMatches(t *testing.T) {

--- a/internal/server/kata/read_routes_test.go
+++ b/internal/server/kata/read_routes_test.go
@@ -208,6 +208,7 @@ url = "`+secondary.URL+`"
 	mu.Lock()
 	defer mu.Unlock()
 	assert.Equal([]string{
+		"/api/v1/health",
 		"/api/v1/ui/references?issue_uid=issue-a&issue_uid=issue-b&limit=200&project_uid=project-a&q=needle",
 		"/api/v1/ui/references?issue_uid=issue-closed&limit=2",
 		"/api/v1/ui/references?limit=200&project_uid=project-a",
@@ -280,9 +281,48 @@ url = "`+upstream.URL+`"
 	assert.NotContains(problem.Details, "platformHost")
 }
 
+func TestKataReferencesRouteExplainsIncompatibleDaemonBeforeNarrowRead(t *testing.T) {
+	assert := assert.New(t)
+	var referenceCalls int
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/health" {
+			_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.7.0"}`))
+			return
+		}
+		referenceCalls++
+		http.NotFound(w, r)
+	}))
+	defer upstream.Close()
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	writeKataServerCatalog(t, home, `
+[[daemon]]
+name = "old"
+url = "`+upstream.URL+`"
+`)
+	srv, _ := setupTestServer(t)
+
+	rr := doJSON(t, srv, http.MethodGet,
+		"/api/v1/kata/daemons/old/references?q=task", nil)
+	require.Equal(t, http.StatusServiceUnavailable, rr.Code, rr.Body.String())
+	problem := decodeProblem(t, rr)
+	assert.Equal(httpapi.CodeServiceUnavailable, problem.Code)
+	assert.Equal("incompatible_api_schema", problem.Details["reason"])
+	assert.Equal("0.7.0", problem.Details["api_schema_version"])
+	assert.Equal(">=0.9.0 and <0.11.0", problem.Details["supported_api_schema"])
+	assert.Contains(problem.Detail, "Upgrade Kata")
+	assert.Zero(referenceCalls)
+}
+
 func TestKataReferencesRouteCollectsRequestedOpenResultsBeyondClosedMatches(t *testing.T) {
 	assert := assert.New(t)
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/health" {
+			_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.10.0"}`))
+			return
+		}
 		assert.Equal("/api/v1/ui/references", r.URL.Path)
 		assert.Equal("task", r.URL.Query().Get("q"))
 		assert.Equal("200", r.URL.Query().Get("limit"))
@@ -323,7 +363,11 @@ url = "`+upstream.URL+`"
 }
 
 func TestKataReferencesRouteFailsClosedWhenOpenResultsExceedDaemonWindow(t *testing.T) {
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/health" {
+			_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.10.0"}`))
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		issues := make([]kataIssueReference, 200)
 		for i := range issues {

--- a/internal/server/kata/routes.go
+++ b/internal/server/kata/routes.go
@@ -94,6 +94,8 @@ func (h *Handler) listKataDaemons(context.Context, *struct{}) (*listKataDaemonsO
 		hint := ""
 		if d.Local && d.URL == "" {
 			hint = "local daemon not running; run `kata daemon start`"
+		} else if health[i].State == "incompatible" {
+			hint = kataDaemonCompatibilityMessage(health[i].APISchemaVersion)
 		}
 
 		out.Daemons = append(out.Daemons, kataDaemonResponse{

--- a/internal/server/kata/routes_test.go
+++ b/internal/server/kata/routes_test.go
@@ -150,6 +150,32 @@ url = "`+authRequired.URL+`"
 	assert.Equal("auth_required", body.Daemons[1].Health)
 }
 
+func TestKataDaemonsEndpointSurfacesIncompatibleSchema(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.7.0"}`))
+	}))
+	defer upstream.Close()
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	writeKataServerCatalog(t, home, `
+[[daemon]]
+name = "old"
+url = "`+upstream.URL+`"
+`)
+	srv, _ := setupTestServer(t)
+
+	daemons := requestKataDaemons(t, srv)
+	require.Len(daemons, 1)
+	assert.Equal("incompatible", daemons[0].Health)
+	assert.Equal("0.7.0", daemons[0].APISchemaVersion)
+	assert.Contains(daemons[0].Hint, "Forge requires >=0.9.0 and <0.11.0")
+	assert.Contains(daemons[0].Hint, "Upgrade Kata")
+}
+
 func TestKataDaemonsEndpointRejectsUnsetTokenEnv(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -774,7 +800,7 @@ func requestKataDaemons(t *testing.T, srv *Server) []kataDaemonWire {
 
 func writeKataHealthOK(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
-	_, _ = w.Write([]byte(`{"ok":true}`))
+	_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.10.0"}`))
 }
 
 func writeKataServerCatalog(t *testing.T, home string, body string) {

--- a/internal/server/kata/unix_transport_test.go
+++ b/internal/server/kata/unix_transport_test.go
@@ -66,6 +66,10 @@ func TestKataProjectMappingsClosesUnixConnections(t *testing.T) {
 
 	upstream := startTrackedKataUnixServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/health" {
+			_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.10.0"}`))
+			return
+		}
 		if r.URL.Path != "/api/v1/projects" {
 			http.NotFound(w, r)
 			return

--- a/internal/server/kata/workspace.go
+++ b/internal/server/kata/workspace.go
@@ -321,7 +321,7 @@ func (h *Handler) canonicalKataWorkspaceMetadata(
 	ctx context.Context,
 	requested db.WorkspaceKataMetadata,
 ) (db.WorkspaceKataMetadata, error) {
-	client, problem := h.kataClientForDaemon(requested.DaemonID)
+	client, problem := h.kataClientForCompatibleDaemon(requested.DaemonID)
 	if problem != nil {
 		return db.WorkspaceKataMetadata{}, problem
 	}
@@ -805,6 +805,10 @@ func (h *Handler) getKataProjectMappings(
 	daemon, problem := h.selectKataDaemonForID(input.DaemonID)
 	if problem != nil {
 		return nil, problem
+	}
+	health := h.kataDaemonHealth(daemon.ID, daemon)
+	if health.State == "incompatible" {
+		return nil, kataDaemonUnavailableProblem(daemon.ID, health)
 	}
 	client, baseURL, err := h.kataDaemonHTTPClient(daemon)
 	if err != nil {

--- a/internal/server/kata/workspace.go
+++ b/internal/server/kata/workspace.go
@@ -807,7 +807,7 @@ func (h *Handler) getKataProjectMappings(
 		return nil, problem
 	}
 	health := h.kataDaemonHealth(daemon.ID, daemon)
-	if health.State == "incompatible" {
+	if health.State != "connected" {
 		return nil, kataDaemonUnavailableProblem(daemon.ID, health)
 	}
 	client, baseURL, err := h.kataDaemonHTTPClient(daemon)

--- a/internal/server/kata/workspace_test.go
+++ b/internal/server/kata/workspace_test.go
@@ -49,6 +49,11 @@ func setupWorkspaceTestServerWithConfigContent(
 func setupKataWorkspaceReferenceDaemon(t *testing.T, reference kataIssueReference) {
 	t.Helper()
 	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/health" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.10.0"}`))
+			return
+		}
 		assert.Equal(t, "/api/v1/ui/references", r.URL.Path)
 		assert.Equal(t, []string{reference.UID}, r.URL.Query()["issue_uid"])
 		w.Header().Set("Content-Type", "application/json")
@@ -1343,6 +1348,11 @@ func TestCreateKataWorkspaceUsesCanonicalMovedTaskMetadata(t *testing.T) {
 
 	daemonCalls := 0
 	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/health" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.10.0"}`))
+			return
+		}
 		daemonCalls++
 		assert.Equal("/api/v1/ui/references", r.URL.Path)
 		assert.Equal([]string{"issue-moved"}, r.URL.Query()["issue_uid"])
@@ -1422,6 +1432,11 @@ func TestCreateKataWorkspaceRejectsDeletedTask(t *testing.T) {
 	require := require.New(t)
 
 	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/health" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.10.0"}`))
+			return
+		}
 		assert.Equal("/api/v1/ui/references", r.URL.Path)
 		assert.Equal([]string{"issue-deleted"}, r.URL.Query()["issue_uid"])
 		http.NotFound(w, r)

--- a/internal/server/kata/workspace_test.go
+++ b/internal/server/kata/workspace_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/procutil"
+	"go.kenn.io/forge/internal/server/httpapi"
 	"go.kenn.io/forge/internal/server/workspaceapi"
 )
 
@@ -568,6 +569,10 @@ func TestKataProjectMappingsReportsManualRegisteredProjectTarget(t *testing.T) {
 
 	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/health" {
+			_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.10.0"}`))
+			return
+		}
 		if r.URL.Path != "/api/v1/projects" {
 			http.NotFound(w, r)
 			return
@@ -621,6 +626,36 @@ repo_path = "acme/kenn-forge"
 	require.Len(resp.Targets, 1)
 	assert.Equal("Kenn Forge", resp.Targets[0].DisplayName)
 	assert.Equal("acme/kenn-forge", resp.Targets[0].Repo.RepoPath)
+}
+
+func TestKataProjectMappingsRequiresConnectedHealthBeforeProjectsRead(t *testing.T) {
+	assert := assert.New(t)
+	var projectCalls int
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/health" {
+			http.Error(w, "unavailable", http.StatusInternalServerError)
+			return
+		}
+		projectCalls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"projects":[]}`))
+	}))
+	t.Cleanup(daemon.Close)
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	writeKataProxyCatalog(t, home, `
+[[daemon]]
+name = "desktop"
+url = "`+daemon.URL+`"
+`)
+	srv, _ := setupTestServer(t)
+
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/kata/project-mappings", nil)
+	require.Equal(t, http.StatusServiceUnavailable, rr.Code, rr.Body.String())
+	problem := decodeProblem(t, rr)
+	assert.Equal(httpapi.CodeServiceUnavailable, problem.Code)
+	assert.Equal("down", problem.Details["health"])
+	assert.Zero(projectCalls)
 }
 
 func TestKataWorkspaceTargetTrackedRepoNameFallbackRequiresOneMatch(t *testing.T) {


### PR DESCRIPTION
Forge's retained Kata surfaces require daemon routes introduced in Kata v0.14.3. Older daemons still appeared connected because Forge accepted any successful health response, then failed searches and workspace actions with generic upstream errors. Maintainers could not tell that the Kata version was the cause.

This change requires a connected health response with a supported schema before Forge calls schema-dependent Kata routes. Failed, malformed, unauthorized, missing, and unsupported health results now stop with a typed service-unavailable response. Older or missing schemas direct users to upgrade Kata; newer unsupported schemas direct them to upgrade Forge or use a supported Kata release. Forge supports API schemas `>=0.9.0 and <0.11.0`.

<details>
<summary>Validation</summary>

- The hook-enforced short Go suite passed.
- Kata server and catalog package tests passed.
- Focused Kata dialog tests passed: 28 tests.
- Frontend formatting, lint, Svelte, type, and Effect checks passed.
- API generation reproduced without drift.
- Non-mutating Go lint and push hooks passed.

</details>