### PR TITLE
fix: reconnect dev terminals after backend reloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,11 +265,13 @@ dev: ensure-embed-dir check-air
 	@echo "backend console log level: $${KENN_FORGE_LOG_STDERR_LEVEL:-info}"
 	@echo "tail with: tail -F $${KENN_FORGE_LOG_FILE:-$(DEV_BACKEND_LOG)}"
 	@if [ -n "$(KENN_FORGE_CONFIG)" ]; then \
+		KENN_FORGE_DEV_RESTART=1 \
 		KENN_FORGE_LOG_LEVEL="$${KENN_FORGE_LOG_LEVEL:-debug}" \
 		KENN_FORGE_LOG_FILE="$${KENN_FORGE_LOG_FILE:-$(DEV_BACKEND_LOG)}" \
 		KENN_FORGE_LOG_STDERR_LEVEL="$${KENN_FORGE_LOG_STDERR_LEVEL:-info}" \
 		"$(AIR_BIN)" -c .air.toml -- serve -config "$(KENN_FORGE_CONFIG)" $(ARGS); \
 	else \
+		KENN_FORGE_DEV_RESTART=1 \
 		KENN_FORGE_LOG_LEVEL="$${KENN_FORGE_LOG_LEVEL:-debug}" \
 		KENN_FORGE_LOG_FILE="$${KENN_FORGE_LOG_FILE:-$(DEV_BACKEND_LOG)}" \
 		KENN_FORGE_LOG_STDERR_LEVEL="$${KENN_FORGE_LOG_STDERR_LEVEL:-info}" \

--- a/cmd/kenn-forge/main.go
+++ b/cmd/kenn-forge/main.go
@@ -618,12 +618,13 @@ func run(opts serve.Options) error {
 	srv = server.NewWithConfig(
 		database, syncer, cloneMgr, assets,
 		cfg, configPath, server.ServerOptions{
-			DaemonAccess:        daemonAccess,
-			WorktreeDir:         filepath.Join(cfg.DataDir, "worktrees"),
-			PtyOwnerManagerPath: os.Getenv("KENN_FORGE_PTY_MANAGER"),
-			Telemetry:           telemetryReporter,
-			TokenSources:        tokenSources,
-			Archive:             archiveService,
+			DaemonAccess:                    daemonAccess,
+			WorktreeDir:                     filepath.Join(cfg.DataDir, "worktrees"),
+			PtyOwnerManagerPath:             os.Getenv("KENN_FORGE_PTY_MANAGER"),
+			Telemetry:                       telemetryReporter,
+			TokenSources:                    tokenSources,
+			Archive:                         archiveService,
+			DetachRuntimeSessionsForRestart: os.Getenv("KENN_FORGE_DEV_RESTART") == "1",
 		},
 	)
 	srv.AttachHTTPServer(httpSrv, ln)

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -120,6 +120,12 @@ still exists.
 - During kenn-forge shutdown, detach/restart behavior is different: do not treat
   normal server shutdown as a natural user exit that should erase recoverable
   base runtime state.
+- Air-based development launchers opt into restart-detach classification via
+  `KENN_FORGE_DEV_RESTART`; terminal bridges close without an `exited` frame so
+  the browser reconnects to the surviving tmux or ptyowner session. Genuine
+  process exits and non-development shutdown behavior remain unchanged
+  (`scripts/dev-stack-backend.sh`, `docker/backend-dev-entrypoint.sh`,
+  `internal/workspace/localruntime/manager.go::Manager.Shutdown`).
 - New tmux sessions use the `forge-` prefix; persisted `middleman-` session
   names remain valid and must not be rewritten (`internal/workspace/`).
 - Every tmux client attach must force UTF-8; service launchers may omit locale

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -124,7 +124,8 @@ still exists.
   `KENN_FORGE_DEV_RESTART`; terminal bridges close without an `exited` frame so
   the browser reconnects to the surviving tmux or ptyowner session. Genuine
   process exits and non-development shutdown behavior remain unchanged
-  (`scripts/dev-stack-backend.sh`, `docker/backend-dev-entrypoint.sh`,
+  (`Makefile::dev`, `scripts/dev-stack-backend.sh`,
+  `docker/backend-dev-entrypoint.sh`,
   `internal/workspace/localruntime/manager.go::Manager.Shutdown`).
 - New tmux sessions use the `forge-` prefix; persisted `middleman-` session
   names remain valid and must not be rewritten (`internal/workspace/`).

--- a/docker/backend-dev-entrypoint.sh
+++ b/docker/backend-dev-entrypoint.sh
@@ -31,6 +31,7 @@ trap 'cleanup' EXIT
 
 air_bin="${AIR_BIN:-/go/bin/air}"
 go_bin="${GO_BIN:-go}"
+export KENN_FORGE_DEV_RESTART=1
 config_path="${KENN_FORGE_CONFIG_PATH:-/data/config.toml}"
 backend_port="$($go_bin run ./cmd/kenn-forge config read -config "$config_path" port 2>/dev/null || true)"
 case "$backend_port" in

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -91,7 +91,11 @@ type ServerOptions struct {
 	// port matching after HostCheck/cfg options have been selected.
 	// Use this for httptest-style listeners on ephemeral ports.
 	HostCheckAllowLoopbackAnyPort bool
-	deferredMergeMaxWait          time.Duration
+	// DetachRuntimeSessionsForRestart makes shutdown-driven terminal
+	// attachment loss reconnectable. Development reloaders use this because
+	// the durable tmux/ptyowner process outlives the server process.
+	DetachRuntimeSessionsForRestart bool
+	deferredMergeMaxWait            time.Duration
 }
 
 type shutdownDeadline struct {
@@ -930,15 +934,16 @@ func newServer(
 			Targets: localruntime.ResolveLaunchTargets(
 				agents, tmuxCmd, nil,
 			),
-			TmuxCommand:              tmuxCmd,
-			TmuxOwnerMarker:          s.workspaces.TmuxOwnerMarker(),
-			WrapAgentSessionsInTmux:  cfg.TmuxAgentSessionsEnabled(),
-			HideTmuxStatus:           hideTmuxStatus,
-			StripEnvVars:             s.runtimeStripEnvVars,
-			ShellCommand:             cfg.ShellCommand(),
-			OnSessionExit:            s.handleRuntimeSessionExit,
-			PtyOwnerRuntime:          runtimePtyOwner,
-			KnownPtyOwnerSessionKeys: s.workspaces.RuntimeSessionKeysForWorkspace,
+			TmuxCommand:                    tmuxCmd,
+			TmuxOwnerMarker:                s.workspaces.TmuxOwnerMarker(),
+			WrapAgentSessionsInTmux:        cfg.TmuxAgentSessionsEnabled(),
+			HideTmuxStatus:                 hideTmuxStatus,
+			StripEnvVars:                   s.runtimeStripEnvVars,
+			ShellCommand:                   cfg.ShellCommand(),
+			OnSessionExit:                  s.handleRuntimeSessionExit,
+			PtyOwnerRuntime:                runtimePtyOwner,
+			KnownPtyOwnerSessionKeys:       s.workspaces.RuntimeSessionKeysForWorkspace,
+			DetachSessionsForServerRestart: options.DetachRuntimeSessionsForRestart,
 		})
 	}
 	s.workspaceAPI = workspaceapi.New(workspaceapi.Deps{

--- a/internal/server/workspaceapi/workspace_runtime_terminal.go
+++ b/internal/server/workspaceapi/workspace_runtime_terminal.go
@@ -367,9 +367,12 @@ func bridgeRuntimeAttachment(
 		// Write the frame BEFORE cancel: coder/websocket tears down
 		// the underlying connection when the input goroutine's
 		// Read context is canceled, which races our Write.
-		writeRuntimeExit(conn, attachment.Info())
+		detachedForRestart := attachment.DetachedForServerRestart()
+		if !detachedForRestart {
+			writeRuntimeExit(conn, attachment.Info())
+		}
 		cancel()
-		return true
+		return !detachedForRestart
 	case <-inputDone:
 		cancel()
 		return false
@@ -401,11 +404,12 @@ func bridgeRuntimeAttachment(
 		// against socket teardown — the Write loses ~25 % of the
 		// time and the frame never reaches the client.
 		closed := attachment.SessionOutputClosed()
-		if closed {
+		exited := closed && !attachment.DetachedForServerRestart()
+		if exited {
 			writeRuntimeExit(conn, attachment.Info())
 		}
 		cancel()
-		return closed
+		return exited
 	case <-ctx.Done():
 		return false
 	}

--- a/internal/server/workspaceapi/workspace_runtime_terminal_test.go
+++ b/internal/server/workspaceapi/workspace_runtime_terminal_test.go
@@ -217,6 +217,62 @@ func TestServeRuntimeTerminalClosedOutputStillReportsSessionExit(t *testing.T) {
 	}
 }
 
+func TestServeRuntimeTerminalRestartDetachDoesNotReportSessionExit(t *testing.T) {
+	tests := []struct {
+		name   string
+		output func() <-chan []byte
+		done   func() <-chan struct{}
+	}{
+		{
+			name: "pty eof arrives first",
+			output: func() <-chan []byte {
+				output := make(chan []byte)
+				close(output)
+				return output
+			},
+			done: func() <-chan struct{} { return make(chan struct{}) },
+		},
+		{
+			name:   "process done arrives first",
+			output: func() <-chan []byte { return make(chan []byte) },
+			done: func() <-chan struct{} {
+				done := make(chan struct{})
+				close(done)
+				return done
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			attachment := localruntime.NewAttachmentForTesting(
+				localruntime.AttachmentForTestingOptions{
+					Output:                   tt.output(),
+					Done:                     tt.done(),
+					SessionOutputClosed:      func() bool { return true },
+					DetachedForServerRestart: func() bool { return true },
+				},
+			)
+			wsURL, handlerDone := runtimeTerminalTestServer(t, attachment)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			conn, _, err := websocket.Dial(ctx, wsURL, nil)
+			require.NoError(err)
+			defer conn.Close(websocket.StatusNormalClosure, "done")
+
+			_, _, err = conn.Read(ctx)
+			require.Error(err)
+			select {
+			case <-handlerDone:
+			case <-ctx.Done():
+				require.Fail("terminal handler did not return after restart detach")
+			}
+		})
+	}
+}
+
 func TestServeRuntimeTerminalDrainsDelayedFinalOutputBeforeSessionExit(t *testing.T) {
 	require := require.New(t)
 	output := make(chan []byte, 1)

--- a/internal/workspace/localruntime/attachment_testing.go
+++ b/internal/workspace/localruntime/attachment_testing.go
@@ -9,12 +9,13 @@ import "context"
 // fields default to no-ops; tests that exercise resize / refresh /
 // write callbacks should set them explicitly.
 type AttachmentForTestingOptions struct {
-	Output              <-chan []byte
-	Done                <-chan struct{}
-	Info                func() SessionInfo
-	Resize              func(cols, rows int) error
-	Refresh             func(context.Context) error
-	SessionOutputClosed func() bool
+	Output                   <-chan []byte
+	Done                     <-chan struct{}
+	Info                     func() SessionInfo
+	Resize                   func(cols, rows int) error
+	Refresh                  func(context.Context) error
+	SessionOutputClosed      func() bool
+	DetachedForServerRestart func() bool
 }
 
 // NewAttachmentForTesting constructs an Attachment with caller-
@@ -32,6 +33,10 @@ func NewAttachmentForTesting(opts AttachmentForTestingOptions) *Attachment {
 	if sessionOutputClosed == nil {
 		sessionOutputClosed = func() bool { return false }
 	}
+	detachedForRestart := opts.DetachedForServerRestart
+	if detachedForRestart == nil {
+		detachedForRestart = func() bool { return false }
+	}
 	return &Attachment{
 		Output:              opts.Output,
 		Done:                opts.Done,
@@ -39,5 +44,6 @@ func NewAttachmentForTesting(opts AttachmentForTestingOptions) *Attachment {
 		resize:              opts.Resize,
 		refresh:             opts.Refresh,
 		sessionOutputClosed: sessionOutputClosed,
+		detachedForRestart:  detachedForRestart,
 	}
 }

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -117,6 +117,10 @@ type Options struct {
 	// KnownPtyOwnerSessionKeys returns durable session keys that may no longer
 	// have an in-memory attachment after a server restart.
 	KnownPtyOwnerSessionKeys func(context.Context, string) ([]string, error)
+	// DetachSessionsForServerRestart marks shutdown-driven attachment loss as
+	// recoverable so terminal bridges do not report a natural process exit.
+	// Normal shutdown behavior is unchanged unless the caller opts in.
+	DetachSessionsForServerRestart bool
 }
 
 type Manager struct {
@@ -134,6 +138,7 @@ type Manager struct {
 	onSessionExit     func(SessionInfo)
 	ptyOwnerRuntime   ptyownerruntime.Owner
 	knownSessionKeys  func(context.Context, string) ([]string, error)
+	detachForRestart  bool
 	startLocks        map[string]*sync.Mutex
 	stoppingWS        map[string]int
 	inflightWS        map[string]int
@@ -194,6 +199,7 @@ type session struct {
 	lifecycleMu               sync.Mutex
 	lifecycleClosed           bool
 	stopRequested             bool
+	detachedForServerRestart  bool
 	nextAttachmentID          uint64
 	resizeOwnerID             uint64
 	resizeOwnerPriority       ResizePriority
@@ -236,6 +242,7 @@ type Attachment struct {
 	// this subscriber for falling behind; that is not a session exit
 	// and bridges must not propagate it as one.
 	sessionOutputClosed func() bool
+	detachedForRestart  func() bool
 }
 
 func NewManager(options Options) *Manager {
@@ -260,6 +267,7 @@ func NewManager(options Options) *Manager {
 		onSessionExit:     options.OnSessionExit,
 		ptyOwnerRuntime:   options.PtyOwnerRuntime,
 		knownSessionKeys:  options.KnownPtyOwnerSessionKeys,
+		detachForRestart:  options.DetachSessionsForServerRestart,
 		startLocks:        make(map[string]*sync.Mutex),
 		stoppingWS:        make(map[string]int),
 		inflightWS:        make(map[string]int),
@@ -1336,6 +1344,16 @@ func (a *Attachment) SessionOutputClosed() bool {
 	return a.sessionOutputClosed()
 }
 
+// DetachedForServerRestart reports whether the server deliberately detached
+// this recoverable session during shutdown. That is a connection interruption,
+// not a process exit.
+func (a *Attachment) DetachedForServerRestart() bool {
+	if a == nil || a.detachedForRestart == nil {
+		return false
+	}
+	return a.detachedForRestart()
+}
+
 func fallbackSessionLabel(label string, fallback string) string {
 	label = strings.TrimSpace(label)
 	if label != "" {
@@ -1488,6 +1506,9 @@ func (m *Manager) Shutdown() {
 	m.mu.Unlock()
 
 	for _, s := range sessions {
+		if m.detachForRestart {
+			s.markDetachedForServerRestart()
+		}
 		s.detach()
 	}
 	for _, s := range sessions {
@@ -2316,6 +2337,12 @@ func (s *session) wasStopRequested() bool {
 	return s.stopRequested
 }
 
+func (s *session) markDetachedForServerRestart() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.detachedForServerRestart = true
+}
+
 func (s *session) detach() {
 	s.lifecycleMu.Lock()
 	defer s.lifecycleMu.Unlock()
@@ -2577,6 +2604,11 @@ func attachToSession(
 			s.mu.Lock()
 			defer s.mu.Unlock()
 			return s.outputClosed
+		},
+		detachedForRestart: func() bool {
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			return s.detachedForServerRestart
 		},
 	}, nil
 }

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -1350,7 +1350,10 @@ func TestManagerShutdownLeavesTmuxSessionsRunning(t *testing.T) {
 		0o755,
 	))
 	t.Setenv("TMUX_RECORD", record)
-	mgr := NewManager(Options{TmuxCommand: []string{tmuxPath}})
+	mgr := NewManager(Options{
+		TmuxCommand:                    []string{tmuxPath},
+		DetachSessionsForServerRestart: true,
+	})
 	info := SessionInfo{
 		Key:         "ws-1_codex",
 		WorkspaceID: "ws-1",
@@ -1376,9 +1379,13 @@ func TestManagerShutdownLeavesTmuxSessionsRunning(t *testing.T) {
 	mgr.mu.Lock()
 	mgr.sessions[info.Key] = s
 	mgr.mu.Unlock()
+	attachment, err := mgr.AttachSession(info.WorkspaceID, info.Key)
+	require.NoError(err)
+	defer attachment.Close()
 
 	mgr.Shutdown()
 
+	assert.True(attachment.DetachedForServerRestart())
 	_, statErr := os.Stat(record)
 	assert.True(os.IsNotExist(statErr), "shutdown should not invoke tmux cleanup")
 	assert.Eventually(func() bool {

--- a/scripts/dev-stack-backend.sh
+++ b/scripts/dev-stack-backend.sh
@@ -19,6 +19,7 @@ printf 'tail with: tail -F %s\n' "${KENN_FORGE_LOG_FILE:-tmp/logs/backend-dev.lo
 export KENN_FORGE_LOG_LEVEL="${KENN_FORGE_LOG_LEVEL:-debug}"
 export KENN_FORGE_LOG_FILE="${KENN_FORGE_LOG_FILE:-tmp/logs/backend-dev.log}"
 export KENN_FORGE_LOG_STDERR_LEVEL="${KENN_FORGE_LOG_STDERR_LEVEL:-info}"
+export KENN_FORGE_DEV_RESTART=1
 
 air_bin="${AIR_BIN:-}"
 if [ -z "$air_bin" ]; then


### PR DESCRIPTION
- Prevent workspace terminals from disappearing when the Air backend reloads during local development.
- Let Firefox and other browsers reconnect to the surviving terminal session without reloading or restarting the browser.
- Preserve real terminal exits and non-development behavior.

<sup>generated by a clanker</sup>