### PR TITLE
Prevent private test tmux servers from leaking

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 version: "2"
 run:
   tests: true
+  allow-parallel-runners: true
 linters:
   default: none
   enable:

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -23,9 +23,9 @@ fixtures, or changing shell-script coverage.
 - Shell-script tests must execute the script against controlled inputs and
   assert observable output, side effects, or exit status. Do not grep scripts,
   workflows, config, or docs for expected implementation text.
-- Real private tmux tests use `testtmux`: publish gates before runs, remove them only
-  after their runs, and retain startup markers on gate, read, validation, or identity
-  errors; share one stale-owner deadline and never address the default server. (`internal/testutil/testtmux/owner.go::Owner`)
+- Private tmux tests retain markers on gate, read, validation, or identity errors;
+  one deadline covers gate closure and startup draining, and cleanup never addresses
+  the default server. (`internal/testutil/testtmux/owner.go::Owner`)
 - Tmux recovery reaps only definitely absent identities and preserves state when
   lookup is indeterminate; real tmux ownership is supported only on Darwin and
   Linux, which provide high-resolution process starts. (`internal/testutil/testtmux/process_identity.go::processIdentityStatus`)

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -24,8 +24,8 @@ fixtures, or changing shell-script coverage.
   assert observable output, side effects, or exit status. Do not grep scripts,
   workflows, config, or docs for expected implementation text.
 - Real private tmux tests use `testtmux`: gate server creation under stable
-  PID-plus-start ownership and drain admitted startups before cleanup; never
-  address the default server. (`internal/testutil/testtmux/owner.go::Owner`)
+  PID-plus-start ownership, bound draining, and terminate matching stalls;
+  never address the default server. (`internal/testutil/testtmux/owner.go::Owner`)
 - Use provider live or container fixtures only when fake transports cannot
   catch endpoint or authentication drift. GitHub GraphQL validation is gated by
   `KENN_FORGE_LIVE_GITHUB_TESTS=1`.

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -23,9 +23,9 @@ fixtures, or changing shell-script coverage.
 - Shell-script tests must execute the script against controlled inputs and
   assert observable output, side effects, or exit status. Do not grep scripts,
   workflows, config, or docs for expected implementation text.
-- Real private tmux tests use `testtmux`: publish admission gates before runs and
-  remove paired gates only after runs; retain PID-plus-start state on gate errors,
-  share one stale-owner drain deadline, and never address the default server. (`internal/testutil/testtmux/owner.go::Owner`)
+- Real private tmux tests use `testtmux`: publish gates before runs, remove them only
+  after their runs, and retain startup markers on gate, read, validation, or identity
+  errors; share one stale-owner deadline and never address the default server. (`internal/testutil/testtmux/owner.go::Owner`)
 - Tmux recovery reaps only definitely absent identities and preserves state when
   lookup is indeterminate; real tmux ownership is supported only on Darwin and
   Linux, which provide high-resolution process starts. (`internal/testutil/testtmux/process_identity.go::processIdentityStatus`)

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -23,9 +23,9 @@ fixtures, or changing shell-script coverage.
 - Shell-script tests must execute the script against controlled inputs and
   assert observable output, side effects, or exit status. Do not grep scripts,
   workflows, config, or docs for expected implementation text.
-- Real private tmux tests must use `testtmux` with PID-plus-start ownership and
-  an explicit private socket; never address the user's default server.
-  (`internal/testutil/testtmux/owner.go::Owner`)
+- Real private tmux tests use `testtmux` with atomic PID-plus-start ownership and
+  private sockets; skip unsupported platforms and never address the default
+  server. (`internal/testutil/testtmux/owner.go::Owner`)
 - Use provider live or container fixtures only when fake transports cannot
   catch endpoint or authentication drift. GitHub GraphQL validation is gated by
   `KENN_FORGE_LIVE_GITHUB_TESTS=1`.

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -23,9 +23,9 @@ fixtures, or changing shell-script coverage.
 - Shell-script tests must execute the script against controlled inputs and
   assert observable output, side effects, or exit status. Do not grep scripts,
   workflows, config, or docs for expected implementation text.
-- Real private tmux tests use `testtmux`: retain PID-plus-start ownership state
-  on gate errors and share one drain deadline across stale owners; never address
-  the default server. (`internal/testutil/testtmux/owner.go::Owner`)
+- Real private tmux tests use `testtmux`: publish admission gates before runs and
+  remove paired gates only after runs; retain PID-plus-start state on gate errors,
+  share one stale-owner drain deadline, and never address the default server. (`internal/testutil/testtmux/owner.go::Owner`)
 - Orphan recovery accepts explicit or exact server-title socket paths only when
   contained by the dedicated root. (`internal/testutil/testtmux/owner.go::reapStaleProcesses`)
 - Use provider live or container fixtures only when fake transports cannot

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -24,8 +24,9 @@ fixtures, or changing shell-script coverage.
   assert observable output, side effects, or exit status. Do not grep scripts,
   workflows, config, or docs for expected implementation text.
 - Real private tmux tests use `testtmux`: gate server creation under stable
-  PID-plus-start ownership, bound draining, and terminate matching stalls;
-  never address the default server. (`internal/testutil/testtmux/owner.go::Owner`)
+  PID-plus-start ownership, share one drain deadline across stale owners, and
+  terminate matching stalls; never address the default server.
+  (`internal/testutil/testtmux/owner.go::Owner`)
 - Use provider live or container fixtures only when fake transports cannot
   catch endpoint or authentication drift. GitHub GraphQL validation is gated by
   `KENN_FORGE_LIVE_GITHUB_TESTS=1`.

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -23,9 +23,9 @@ fixtures, or changing shell-script coverage.
 - Shell-script tests must execute the script against controlled inputs and
   assert observable output, side effects, or exit status. Do not grep scripts,
   workflows, config, or docs for expected implementation text.
-- Real private tmux tests use `testtmux` with atomic PID-plus-start ownership and
-  private sockets; skip unsupported platforms and never address the default
-  server. (`internal/testutil/testtmux/owner.go::Owner`)
+- Real private tmux tests use `testtmux`: serialize PID-plus-start ownership
+  under a stable per-user root, remove only per-run state, and never address
+  the default server; skip unsupported platforms. (`internal/testutil/testtmux/owner.go::Owner`)
 - Use provider live or container fixtures only when fake transports cannot
   catch endpoint or authentication drift. GitHub GraphQL validation is gated by
   `KENN_FORGE_LIVE_GITHUB_TESTS=1`.

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -23,10 +23,11 @@ fixtures, or changing shell-script coverage.
 - Shell-script tests must execute the script against controlled inputs and
   assert observable output, side effects, or exit status. Do not grep scripts,
   workflows, config, or docs for expected implementation text.
-- Real private tmux tests use `testtmux`: gate server creation under stable
-  PID-plus-start ownership, share one drain deadline across stale owners, and
-  terminate matching stalls; never address the default server.
-  (`internal/testutil/testtmux/owner.go::Owner`)
+- Real private tmux tests use `testtmux`: retain PID-plus-start ownership state
+  on gate errors and share one drain deadline across stale owners; never address
+  the default server. (`internal/testutil/testtmux/owner.go::Owner`)
+- Orphan recovery accepts explicit or exact server-title socket paths only when
+  contained by the dedicated root. (`internal/testutil/testtmux/owner.go::reapStaleProcesses`)
 - Use provider live or container fixtures only when fake transports cannot
   catch endpoint or authentication drift. GitHub GraphQL validation is gated by
   `KENN_FORGE_LIVE_GITHUB_TESTS=1`.

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -23,6 +23,9 @@ fixtures, or changing shell-script coverage.
 - Shell-script tests must execute the script against controlled inputs and
   assert observable output, side effects, or exit status. Do not grep scripts,
   workflows, config, or docs for expected implementation text.
+- Real private tmux tests must use `testtmux` with PID-plus-start ownership and
+  an explicit private socket; never address the user's default server.
+  (`internal/testutil/testtmux/owner.go::Owner`)
 - Use provider live or container fixtures only when fake transports cannot
   catch endpoint or authentication drift. GitHub GraphQL validation is gated by
   `KENN_FORGE_LIVE_GITHUB_TESTS=1`.

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -23,9 +23,9 @@ fixtures, or changing shell-script coverage.
 - Shell-script tests must execute the script against controlled inputs and
   assert observable output, side effects, or exit status. Do not grep scripts,
   workflows, config, or docs for expected implementation text.
-- Real private tmux tests use `testtmux`: serialize PID-plus-start ownership
-  under a stable per-user root, remove only per-run state, and never address
-  the default server; skip unsupported platforms. (`internal/testutil/testtmux/owner.go::Owner`)
+- Real private tmux tests use `testtmux`: gate server creation under stable
+  PID-plus-start ownership and drain admitted startups before cleanup; never
+  address the default server. (`internal/testutil/testtmux/owner.go::Owner`)
 - Use provider live or container fixtures only when fake transports cannot
   catch endpoint or authentication drift. GitHub GraphQL validation is gated by
   `KENN_FORGE_LIVE_GITHUB_TESTS=1`.

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -26,6 +26,9 @@ fixtures, or changing shell-script coverage.
 - Real private tmux tests use `testtmux`: publish admission gates before runs and
   remove paired gates only after runs; retain PID-plus-start state on gate errors,
   share one stale-owner drain deadline, and never address the default server. (`internal/testutil/testtmux/owner.go::Owner`)
+- Tmux recovery reaps only definitely absent identities and preserves state when
+  lookup is indeterminate; real tmux ownership is supported only on Darwin and
+  Linux, which provide high-resolution process starts. (`internal/testutil/testtmux/process_identity.go::processIdentityStatus`)
 - Orphan recovery accepts explicit or exact server-title socket paths only when
   contained by the dedicated root. (`internal/testutil/testtmux/owner.go::reapStaleProcesses`)
 - Use provider live or container fixtures only when fake transports cannot

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -25680,7 +25680,9 @@ func setupWorkspaceServerFixtureWithMockHostAndOptions(
 		}
 	}
 	srv := New(database, syncer, nil, basePath, cfg, options)
-	t.Cleanup(func() { cleanupWorkspaceServerFixtureTmuxSessions(t, dir) })
+	t.Cleanup(func() {
+		cleanupWorkspaceServerFixtureTmuxSessions(t, cfg.Tmux.Command, dir)
+	})
 	// Cleanup callbacks run LIFO. Drain the server first so async
 	// workspace setup cannot create a tmux session after fixture
 	// artifact cleanup has listed workspaces. The DB cleanup was
@@ -25763,25 +25765,29 @@ func cleanupWorkspaceServerFixtureArtifactsWithContext(
 	return errors.Join(errs...)
 }
 
-func cleanupWorkspaceServerFixtureTmuxSessions(t *testing.T, root string) {
+func cleanupWorkspaceServerFixtureTmuxSessions(
+	t *testing.T,
+	tmuxCommand []string,
+	root string,
+) {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	require.NoError(t, cleanupWorkspaceServerFixtureTmuxSessionsWithContext(
-		ctx, root,
+		ctx, tmuxCommand, root,
 	))
 }
 
 func cleanupWorkspaceServerFixtureTmuxSessionsWithContext(
 	ctx context.Context,
+	tmuxCommand []string,
 	root string,
 ) error {
-	tmuxPath, err := exec.LookPath("tmux")
-	if err != nil {
+	if len(tmuxCommand) == 0 {
 		return nil
 	}
-	sessions, err := forgeTmuxSessions(ctx, tmuxPath, func(path string) bool {
+	sessions, err := forgeTmuxSessions(ctx, tmuxCommand, func(path string) bool {
 		return pathIsWithin(root, path)
 	})
 	if err != nil {
@@ -25789,8 +25795,8 @@ func cleanupWorkspaceServerFixtureTmuxSessionsWithContext(
 	}
 	var errs []error
 	for _, session := range sessions {
-		cmd := procutil.CommandContext(
-			ctx, tmuxPath, "kill-session", "-t", session,
+		cmd := configuredTmuxCommandContext(
+			ctx, tmuxCommand, "kill-session", "-t", session,
 		)
 		var stderr bytes.Buffer
 		cmd.Stderr = &stderr
@@ -25804,7 +25810,7 @@ func cleanupWorkspaceServerFixtureTmuxSessionsWithContext(
 			)
 		}
 	}
-	remaining, err := forgeTmuxSessions(ctx, tmuxPath, func(path string) bool {
+	remaining, err := forgeTmuxSessions(ctx, tmuxCommand, func(path string) bool {
 		return pathIsWithin(root, path)
 	})
 	if err != nil {
@@ -25828,21 +25834,25 @@ func cleanupServerTestTmux(owner *testtmux.Owner) error {
 
 func forgeTmuxSessions(
 	ctx context.Context,
-	tmuxPath string,
+	tmuxCommand []string,
 	includePath func(string) bool,
 ) ([]string, error) {
 	// Colon-separated because tmux 3.6+ sanitizes control characters in
 	// -F output (a tab prints as "_"). Session names cannot contain ":"
 	// (tmux replaces it with "_"), so cutting at the first colon is
 	// unambiguous even when the session path contains colons.
-	cmd := procutil.CommandContext(
-		ctx, tmuxPath, "list-sessions", "-F", "#{session_name}:#{session_path}",
+	cmd := configuredTmuxCommandContext(
+		ctx, tmuxCommand,
+		"list-sessions", "-F", "#{session_name}:#{session_path}",
 	)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := procutil.Run(ctx, cmd, "test tmux cleanup list"); err != nil {
+		if errors.Is(err, exec.ErrNotFound) || errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
 		msg := strings.TrimSpace(stderr.String())
 		if isTmuxServerAbsentMessage(msg) {
 			return nil, nil
@@ -25863,6 +25873,15 @@ func forgeTmuxSessions(
 	}
 	slices.Sort(sessions)
 	return sessions, nil
+}
+
+func configuredTmuxCommandContext(
+	ctx context.Context,
+	tmuxCommand []string,
+	args ...string,
+) *exec.Cmd {
+	commandArgs := append(slices.Clone(tmuxCommand[1:]), args...)
+	return procutil.CommandContext(ctx, tmuxCommand[0], commandArgs...)
 }
 
 func isTmuxServerAbsentMessage(msg string) bool {
@@ -26259,11 +26278,81 @@ func TestForgeTmuxSessionsTreatsMissingTmuxSocketAsEmpty(t *testing.T) {
 	require.NoError(os.WriteFile(script, []byte(body), 0o755))
 
 	sessions, err := forgeTmuxSessions(
-		context.Background(), script, pathIsGoTestTempPath,
+		context.Background(), []string{script}, pathIsGoTestTempPath,
 	)
 
 	require.NoError(err)
 	require.Empty(sessions)
+}
+
+func TestForgeTmuxSessionsTreatsMissingConfiguredCommandAsEmpty(t *testing.T) {
+	require := require.New(t)
+	sessions, err := forgeTmuxSessions(
+		context.Background(),
+		[]string{filepath.Join(t.TempDir(), "missing-tmux")},
+		pathIsGoTestTempPath,
+	)
+
+	require.NoError(err)
+	require.Empty(sessions)
+}
+
+func TestWorkspaceFixtureTmuxCleanupUsesConfiguredCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake tmux fixture uses Unix shell semantics")
+	}
+	require := require.New(t)
+	dir := t.TempDir()
+	defaultCalled := filepath.Join(dir, "default-called")
+	defaultTmux := filepath.Join(dir, "tmux")
+	require.NoError(os.WriteFile(
+		defaultTmux,
+		[]byte("#!/bin/sh\n: > \"$DEFAULT_TMUX_CALLED\"\nexit 99\n"),
+		0o755,
+	))
+	t.Setenv("DEFAULT_TMUX_CALLED", defaultCalled)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	privateRecord := filepath.Join(dir, "private-record")
+	privateKilled := filepath.Join(dir, "private-killed")
+	privateTmux := filepath.Join(dir, "private-tmux")
+	privateRoot := filepath.Join(dir, "fixture")
+	privateSocket := filepath.Join(dir, "private.sock")
+	privateBody := `#!/bin/sh
+printf '%s\n' "$*" >> "$PRIVATE_TMUX_RECORD"
+case "$*" in
+  *list-sessions*)
+    if [ ! -f "$PRIVATE_TMUX_KILLED" ]; then
+      printf 'kenn-forge-fixture:%s\n' "$PRIVATE_TMUX_ROOT"
+    fi
+    ;;
+  *kill-session*)
+    : > "$PRIVATE_TMUX_KILLED"
+    ;;
+esac
+`
+	require.NoError(os.WriteFile(privateTmux, []byte(privateBody), 0o755))
+	t.Setenv("PRIVATE_TMUX_RECORD", privateRecord)
+	t.Setenv("PRIVATE_TMUX_KILLED", privateKilled)
+	t.Setenv("PRIVATE_TMUX_ROOT", privateRoot)
+
+	err := cleanupWorkspaceServerFixtureTmuxSessionsWithContext(
+		context.Background(),
+		[]string{privateTmux, "-S", privateSocket},
+		privateRoot,
+	)
+	require.NoError(err)
+	_, err = os.Stat(defaultCalled)
+	require.ErrorIs(err, os.ErrNotExist)
+	require.FileExists(privateKilled)
+	record, err := os.ReadFile(privateRecord)
+	require.NoError(err)
+	for line := range strings.SplitSeq(strings.TrimSpace(string(record)), "\n") {
+		require.True(
+			strings.HasPrefix(line, "-S "+privateSocket+" "),
+			"fixture cleanup lost private tmux prefix: %s", line,
+		)
+	}
 }
 
 func TestServerTestCleanupDoesNotInvokeDefaultTmux(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -62,6 +62,7 @@ import (
 	"go.kenn.io/forge/internal/testutil/gitsafe"
 	"go.kenn.io/forge/internal/testutil/processjob"
 	"go.kenn.io/forge/internal/testutil/testsignal"
+	"go.kenn.io/forge/internal/testutil/testtmux"
 	"go.kenn.io/forge/internal/tokenauth"
 	"go.kenn.io/forge/internal/workspace"
 	"go.kenn.io/forge/internal/workspace/localruntime"
@@ -72,7 +73,8 @@ import (
 const serverRuntimeHelperMarker = "kenn-forge-runtime-helper"
 
 var (
-	ptyE2ESemaphore = semaphore.NewWeighted(1)
+	privateTmuxOwner *testtmux.Owner
+	ptyE2ESemaphore  = semaphore.NewWeighted(1)
 	// Root keeps only Workspace tests that cross provider, config, Kata,
 	// runtime, terminal, Fleet, or agent-context composition boundaries.
 	// Bound their Git setup independently from the workspacetest binary.
@@ -87,6 +89,12 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "contain server test process tree: %v\n", err)
 		os.Exit(1)
 	}
+	var ownerErr error
+	privateTmuxOwner, ownerErr = testtmux.New()
+	if ownerErr != nil {
+		fmt.Fprintf(os.Stderr, "initialize private test tmux owner: %v\n", ownerErr)
+		os.Exit(1)
+	}
 	envDir, envDirErr := os.MkdirTemp("", "kenn-forge-server-tmux-env-*")
 	if envDirErr == nil {
 		_ = os.Setenv("KENN_FORGE_TMUX_ENV_DIR", envDir)
@@ -94,7 +102,10 @@ func TestMain(m *testing.M) {
 	runCleanup, stopSignalCleanup := testsignal.Install(func() error {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		return cleanupForgeTestTmuxSessionsWithContext(ctx)
+		return errors.Join(
+			cleanupForgeTestTmuxSessionsWithContext(ctx),
+			privateTmuxOwner.Cleanup(),
+		)
 	}, func(err error) {
 		fmt.Fprintf(os.Stderr, "cleanup kenn-forge test tmux sessions: %v\n", err)
 	})
@@ -30349,17 +30360,7 @@ func isolatedRealTmuxCommandIfAvailable(t *testing.T) []string {
 
 func isolatedRealTmuxCommand(t *testing.T, tmuxPath string) []string {
 	t.Helper()
-	require := require.New(t)
-	tmuxDir, err := os.MkdirTemp("/tmp", "kenn-forge-test-tmux-*")
-	require.NoError(err)
-	socket := filepath.Join(tmuxDir, "tmux.sock")
-	t.Cleanup(func() {
-		_ = procutil.Command(
-			tmuxPath, "-f", "/dev/null", "-S", socket, "kill-server",
-		).Run()
-		_ = os.RemoveAll(tmuxDir)
-	})
-	return []string{tmuxPath, "-f", "/dev/null", "-S", socket}
+	return privateTmuxOwner.Command(t, tmuxPath)
 }
 
 func serverRuntimeHelperCommand(mode string) []string {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -82,6 +82,9 @@ var (
 )
 
 func TestMain(m *testing.M) {
+	if code, ok := testtmux.CommandWrapperExitCode(); ok {
+		os.Exit(code)
+	}
 	if isServerHelperProcess() {
 		os.Exit(m.Run())
 	}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -89,23 +89,20 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "contain server test process tree: %v\n", err)
 		os.Exit(1)
 	}
-	var ownerErr error
-	privateTmuxOwner, ownerErr = testtmux.New()
-	if ownerErr != nil {
-		fmt.Fprintf(os.Stderr, "initialize private test tmux owner: %v\n", ownerErr)
-		os.Exit(1)
+	if testtmux.Supported() {
+		var ownerErr error
+		privateTmuxOwner, ownerErr = testtmux.New()
+		if ownerErr != nil {
+			fmt.Fprintf(os.Stderr, "initialize private test tmux owner: %v\n", ownerErr)
+			os.Exit(1)
+		}
 	}
 	envDir, envDirErr := os.MkdirTemp("", "kenn-forge-server-tmux-env-*")
 	if envDirErr == nil {
 		_ = os.Setenv("KENN_FORGE_TMUX_ENV_DIR", envDir)
 	}
 	runCleanup, stopSignalCleanup := testsignal.Install(func() error {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		return errors.Join(
-			cleanupForgeTestTmuxSessionsWithContext(ctx),
-			privateTmuxOwner.Cleanup(),
-		)
+		return cleanupServerTestTmux(privateTmuxOwner)
 	}, func(err error) {
 		fmt.Fprintf(os.Stderr, "cleanup kenn-forge test tmux sessions: %v\n", err)
 	})
@@ -25822,52 +25819,11 @@ func cleanupWorkspaceServerFixtureTmuxSessionsWithContext(
 	return errors.Join(errs...)
 }
 
-func cleanupForgeTestTmuxSessionsWithContext(ctx context.Context) error {
-	tmuxPath, err := exec.LookPath("tmux")
-	if err != nil {
+func cleanupServerTestTmux(owner *testtmux.Owner) error {
+	if owner == nil {
 		return nil
 	}
-	sessions, err := forgeTmuxSessions(
-		ctx, tmuxPath, pathIsGoTestTempPath,
-	)
-	if err != nil {
-		return err
-	}
-	var errs []error
-	for _, session := range sessions {
-		cmd := procutil.CommandContext(
-			ctx, tmuxPath, "kill-session", "-t", session,
-		)
-		var stderr bytes.Buffer
-		cmd.Stderr = &stderr
-		if err := procutil.Run(ctx, cmd, "test tmux cleanup"); err != nil {
-			msg := strings.TrimSpace(stderr.String())
-			if strings.Contains(msg, "can't find session") ||
-				isTmuxServerAbsentMessage(msg) {
-				continue
-			}
-			errs = append(
-				errs,
-				fmt.Errorf(
-					"kill leaked tmux session %s: %w: %s",
-					session, err, msg,
-				),
-			)
-		}
-	}
-	remaining, err := forgeTmuxSessions(
-		ctx, tmuxPath, pathIsGoTestTempPath,
-	)
-	if err != nil {
-		errs = append(errs, err)
-	}
-	if len(remaining) > 0 {
-		errs = append(errs, fmt.Errorf(
-			"server tests leaked tmux sessions: %s",
-			strings.Join(remaining, ", "),
-		))
-	}
-	return errors.Join(errs...)
+	return owner.Cleanup()
 }
 
 func forgeTmuxSessions(
@@ -26310,35 +26266,30 @@ func TestForgeTmuxSessionsTreatsMissingTmuxSocketAsEmpty(t *testing.T) {
 	require.Empty(sessions)
 }
 
-func TestCleanupForgeTestTmuxSessionsIgnoresConcurrentRemoval(t *testing.T) {
+func TestServerTestCleanupDoesNotInvokeDefaultTmux(t *testing.T) {
 	require := require.New(t)
+	var owner *testtmux.Owner
+	if testtmux.Supported() {
+		var err error
+		owner, err = testtmux.New()
+		require.NoError(err)
+		t.Cleanup(func() { _ = owner.Cleanup() })
+	}
+
 	dir := t.TempDir()
-	statePath := filepath.Join(dir, "removed")
+	logPath := filepath.Join(dir, "tmux-called")
 	tmuxPath := filepath.Join(dir, "tmux")
-	body := `#!/bin/sh
-if [ "$1" = "list-sessions" ]; then
-  if [ ! -f "$TMUX_REMOVED_STATE" ]; then
-    echo "kenn-forge-concurrent:$TMUX_SESSION_PATH"
-  fi
-  exit 0
-fi
-if [ "$1" = "kill-session" ]; then
-  : > "$TMUX_REMOVED_STATE"
-  echo "can't find session: $3" >&2
-  exit 1
-fi
-exit 2
-`
-	require.NoError(os.WriteFile(tmuxPath, []byte(body), 0o755))
-	t.Setenv("PATH", dir)
-	t.Setenv("TMUX_REMOVED_STATE", statePath)
-	t.Setenv("TMUX_SESSION_PATH", dir)
+	require.NoError(os.WriteFile(
+		tmuxPath,
+		[]byte("#!/bin/sh\n: > \"$TMUX_CALLED\"\nexit 1\n"),
+		0o755,
+	))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("TMUX_CALLED", logPath)
 
-	err := cleanupForgeTestTmuxSessionsWithContext(
-		context.Background(),
-	)
-
-	require.NoError(err)
+	require.NoError(cleanupServerTestTmux(owner))
+	_, err := os.Stat(logPath)
+	require.ErrorIs(err, os.ErrNotExist)
 }
 
 func TestWorkspaceRuntimeTargetsRefreshAfterSettingsUpdateE2E(t *testing.T) {
@@ -30351,6 +30302,9 @@ esac
 
 func isolatedRealTmuxCommandIfAvailable(t *testing.T) []string {
 	t.Helper()
+	if !testtmux.Supported() {
+		return nil
+	}
 	tmuxPath, err := exec.LookPath("tmux")
 	if err != nil {
 		return nil
@@ -30360,6 +30314,9 @@ func isolatedRealTmuxCommandIfAvailable(t *testing.T) []string {
 
 func isolatedRealTmuxCommand(t *testing.T, tmuxPath string) []string {
 	t.Helper()
+	if !testtmux.Supported() {
+		t.Skip("real tmux tests require Unix")
+	}
 	return privateTmuxOwner.Command(t, tmuxPath)
 }
 

--- a/internal/testutil/testtmux/owner.go
+++ b/internal/testutil/testtmux/owner.go
@@ -417,6 +417,13 @@ func waitForAdmittedCreations(ctx context.Context, admissionDirs []string) error
 }
 
 func admittedCreations(admissionDirs []string) ([]tmuxProcess, error) {
+	return admittedCreationsWithLookup(admissionDirs, processStart)
+}
+
+func admittedCreationsWithLookup(
+	admissionDirs []string,
+	lookupStart processStartLookup,
+) ([]tmuxProcess, error) {
 	seen := make(map[tmuxProcess]bool)
 	for _, admissionDir := range admissionDirs {
 		markers, err := filepath.Glob(filepath.Join(admissionDir, "starting.*"))
@@ -432,8 +439,19 @@ func admittedCreations(admissionDirs []string) ([]tmuxProcess, error) {
 			pid, parseErr := strconv.Atoi(parts[1])
 			start, readErr := os.ReadFile(marker)
 			if parseErr != nil || readErr != nil ||
-				tokenForStart(string(start)) != parts[2] ||
-				!processStillMatches(pid, string(start), processStart) {
+				tokenForStart(string(start)) != parts[2] {
+				_ = os.Remove(marker)
+				continue
+			}
+			status, statusErr := exactProcessIdentityState(
+				pid, string(start), lookupStart,
+			)
+			if statusErr != nil {
+				return nil, fmt.Errorf(
+					"inspect admitted private tmux startup %s: %w", marker, statusErr,
+				)
+			}
+			if status == processIdentityAbsent {
 				_ = os.Remove(marker)
 				continue
 			}
@@ -515,7 +533,7 @@ func reapStale(root string) error {
 
 func reapStaleWithLookup(
 	root string,
-	lookupStart func(int) (string, error),
+	lookupStart processStartLookup,
 ) error {
 	entries, err := os.ReadDir(root)
 	if err != nil {
@@ -540,7 +558,13 @@ func reapStaleWithLookup(
 			continue
 		}
 		runName := strings.TrimPrefix(entry.Name(), admissionPrefix)
-		if runIsLive(identity, lookupStart) {
+		ownerStatus, ownerErr := runProcessIdentityState(identity, lookupStart)
+		if ownerErr != nil {
+			gateStates[runName] = gateFailed
+			cleanupErrors = append(cleanupErrors, ownerErr)
+			continue
+		}
+		if ownerStatus == processIdentityLive {
 			gateStates[runName] = gateDeferred
 			continue
 		}
@@ -594,7 +618,12 @@ func reapStaleWithLookup(
 			continue
 		case gateSafe:
 		default:
-			if runIsLive(identity, lookupStart) {
+			ownerStatus, ownerErr := runProcessIdentityState(identity, lookupStart)
+			if ownerErr != nil {
+				cleanupErrors = append(cleanupErrors, ownerErr)
+				continue
+			}
+			if ownerStatus == processIdentityLive {
 				continue
 			}
 			runDir := filepath.Join(root, entry.Name())
@@ -722,7 +751,15 @@ func reapStaleProcesses(root string) error {
 			continue
 		}
 		identity, runDir, ok := runForSocket(root, socket)
-		if !ok || runIsLive(identity, processStart) {
+		if !ok {
+			continue
+		}
+		ownerStatus, ownerErr := runProcessIdentityState(identity, processStart)
+		if ownerErr != nil {
+			cleanupErrors = append(cleanupErrors, ownerErr)
+			continue
+		}
+		if ownerStatus == processIdentityLive {
 			continue
 		}
 		if _, statErr := os.Lstat(runDir); statErr == nil ||
@@ -810,14 +847,6 @@ func parseAdmissionName(name string) (processIdentity, bool) {
 		return processIdentity{}, false
 	}
 	return parseRunName(strings.TrimPrefix(name, admissionPrefix))
-}
-
-func runIsLive(
-	identity processIdentity,
-	lookupStart func(int) (string, error),
-) bool {
-	start, err := lookupStart(identity.pid)
-	return err == nil && tokenForStart(start) == identity.startToken
 }
 
 func identityForSocket(root, socket string) (processIdentity, bool) {

--- a/internal/testutil/testtmux/owner.go
+++ b/internal/testutil/testtmux/owner.go
@@ -15,6 +15,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -27,9 +28,14 @@ import (
 )
 
 const (
-	startTokenLength = 12
-	cleanupTimeout   = 2 * time.Second
-	rootLockName     = ".owner.lock"
+	startTokenLength      = 12
+	cleanupTimeout        = 2 * time.Second
+	rootLockName          = ".owner.lock"
+	admissionPrefix       = "admission."
+	admissionLockName     = "lock"
+	admissionClosedName   = "closed"
+	wrapperExecutableName = "tmux-wrapper"
+	wrapperMetadataName   = "wrapper.json"
 )
 
 var runNamePattern = regexp.MustCompile(
@@ -50,18 +56,25 @@ type registeredServer struct {
 
 // Owner tracks private tmux servers for one test binary.
 type Owner struct {
-	root       string
-	runDir     string
-	mu         sync.Mutex
-	servers    map[string]registeredServer
-	cleanup    sync.Once
-	cleanupErr error
+	root         string
+	runDir       string
+	admissionDir string
+	mu           sync.Mutex
+	servers      map[string]registeredServer
+	closed       bool
+	cleanup      sync.Once
+	cleanupErr   error
 }
 
 type ownerMarker struct {
 	PID          int    `json:"pid"`
 	ProcessStart string `json:"process_start"`
 	StartToken   string `json:"start_token"`
+}
+
+type wrapperMetadata struct {
+	TmuxPath     string `json:"tmux_path"`
+	AdmissionDir string `json:"admission_dir"`
 }
 
 // New creates an owner beneath a stable, per-user temporary root. It reaps
@@ -123,10 +136,16 @@ func newAt(root string) (*Owner, error) {
 		if err != nil {
 			return err
 		}
+		admissionDir := filepath.Join(root, admissionPrefix+runName)
+		if err := os.Mkdir(admissionDir, 0o700); err != nil {
+			_ = os.RemoveAll(runDir)
+			return fmt.Errorf("create private tmux admission directory: %w", err)
+		}
 		owner = &Owner{
-			root:    root,
-			runDir:  runDir,
-			servers: make(map[string]registeredServer),
+			root:         root,
+			runDir:       runDir,
+			admissionDir: admissionDir,
+			servers:      make(map[string]registeredServer),
 		}
 		return nil
 	})
@@ -187,24 +206,118 @@ func publishRun(
 // Command registers a private socket before returning a tmux command prefix.
 func (o *Owner) Command(t testing.TB, tmuxPath string) []string {
 	t.Helper()
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	require.False(t, o.closed, "private tmux owner is cleaning up")
+
 	nonce, err := randomToken(6)
 	require.NoError(t, err)
 	serverDir := filepath.Join(o.runDir, "server-"+nonce)
 	require.NoError(t, os.Mkdir(serverDir, 0o700))
 	socket := filepath.Join(serverDir, "tmux.sock")
+	executable, err := os.Executable()
+	require.NoError(t, err)
+	metadata, err := json.Marshal(wrapperMetadata{
+		TmuxPath:     tmuxPath,
+		AdmissionDir: o.admissionDir,
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(serverDir, wrapperMetadataName), metadata, 0o600,
+	))
+	wrapperPath := filepath.Join(serverDir, wrapperExecutableName)
+	require.NoError(t, os.Symlink(executable, wrapperPath))
 	server := registeredServer{tmuxPath: tmuxPath, socket: socket}
-	o.mu.Lock()
 	o.servers[socket] = server
-	o.mu.Unlock()
 	t.Cleanup(func() {
 		require.NoError(t, o.release(server))
 	})
-	return []string{tmuxPath, "-f", "/dev/null", "-S", socket}
+	return []string{wrapperPath, "-f", "/dev/null", "-S", socket}
+}
+
+// CommandWrapperExitCode runs a private tmux command when the current test
+// binary was invoked through an Owner command wrapper.
+func CommandWrapperExitCode() (int, bool) {
+	if filepath.Base(os.Args[0]) != wrapperExecutableName {
+		return 0, false
+	}
+	metadataPath := filepath.Join(filepath.Dir(os.Args[0]), wrapperMetadataName)
+	content, err := os.ReadFile(metadataPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read private tmux wrapper metadata: %v\n", err)
+		return 1, true
+	}
+	var metadata wrapperMetadata
+	if err := json.Unmarshal(content, &metadata); err != nil {
+		fmt.Fprintf(os.Stderr, "decode private tmux wrapper metadata: %v\n", err)
+		return 1, true
+	}
+	return runWrappedTmux(metadata, os.Args[1:]), true
+}
+
+func runWrappedTmux(metadata wrapperMetadata, args []string) int {
+	var activePath string
+	if slices.Contains(args, "new-session") {
+		lock := flock.New(filepath.Join(metadata.AdmissionDir, admissionLockName))
+		if err := lock.Lock(); err != nil {
+			fmt.Fprintf(os.Stderr, "acquire private tmux admission lock: %v\n", err)
+			return 1
+		}
+		if _, err := os.Stat(filepath.Join(metadata.AdmissionDir, admissionClosedName)); err == nil {
+			_ = lock.Unlock()
+			fmt.Fprintln(os.Stderr, "private tmux owner is cleaning up")
+			return 1
+		} else if !errors.Is(err, os.ErrNotExist) {
+			_ = lock.Unlock()
+			fmt.Fprintf(os.Stderr, "inspect private tmux admission gate: %v\n", err)
+			return 1
+		}
+		start, err := processStart(os.Getpid())
+		if err != nil {
+			_ = lock.Unlock()
+			fmt.Fprintf(os.Stderr, "identify private tmux wrapper: %v\n", err)
+			return 1
+		}
+		activePath = filepath.Join(metadata.AdmissionDir, fmt.Sprintf(
+			"starting.%d.%s", os.Getpid(), tokenForStart(start),
+		))
+		if err := os.WriteFile(activePath, []byte(start), 0o600); err != nil {
+			_ = lock.Unlock()
+			fmt.Fprintf(os.Stderr, "record private tmux startup: %v\n", err)
+			return 1
+		}
+		if err := lock.Unlock(); err != nil {
+			_ = os.Remove(activePath)
+			fmt.Fprintf(os.Stderr, "release private tmux admission lock: %v\n", err)
+			return 1
+		}
+		defer func() { _ = os.Remove(activePath) }()
+	}
+
+	if err := replaceWithTmux(metadata.TmuxPath, args); err != nil {
+		if activePath != "" {
+			_ = os.Remove(activePath)
+		}
+		fmt.Fprintf(os.Stderr, "run private tmux command: %v\n", err)
+		return 1
+	}
+	return 0
 }
 
 // Cleanup stops every registered server and removes this owner's run.
 func (o *Owner) Cleanup() error {
 	o.cleanup.Do(func() {
+		o.mu.Lock()
+		o.closed = true
+		o.mu.Unlock()
+
+		var cleanupErrors []error
+		if err := closeAdmission(o.admissionDir); err != nil {
+			cleanupErrors = append(cleanupErrors, err)
+		} else if err := waitForAdmittedCreations(o.admissionDir); err != nil {
+			cleanupErrors = append(cleanupErrors, err)
+		}
+
 		o.mu.Lock()
 		servers := make([]registeredServer, 0, len(o.servers))
 		for _, server := range o.servers {
@@ -212,7 +325,6 @@ func (o *Owner) Cleanup() error {
 		}
 		o.mu.Unlock()
 
-		var cleanupErrors []error
 		for _, server := range servers {
 			if err := o.release(server); err != nil {
 				cleanupErrors = append(cleanupErrors, err)
@@ -224,9 +336,62 @@ func (o *Owner) Cleanup() error {
 		} else if err := os.RemoveAll(o.runDir); err != nil {
 			cleanupErrors = append(cleanupErrors, err)
 		}
+		if err := os.RemoveAll(o.admissionDir); err != nil {
+			cleanupErrors = append(cleanupErrors, err)
+		}
 		o.cleanupErr = errors.Join(cleanupErrors...)
 	})
 	return o.cleanupErr
+}
+
+func closeAdmission(admissionDir string) (err error) {
+	lock := flock.New(filepath.Join(admissionDir, admissionLockName))
+	if err := lock.Lock(); err != nil {
+		return fmt.Errorf("close private tmux admission gate: %w", err)
+	}
+	defer func() {
+		if unlockErr := lock.Unlock(); unlockErr != nil {
+			err = errors.Join(err, fmt.Errorf(
+				"release private tmux admission gate: %w", unlockErr,
+			))
+		}
+	}()
+	if err := os.WriteFile(
+		filepath.Join(admissionDir, admissionClosedName), []byte("closed\n"), 0o600,
+	); err != nil {
+		return fmt.Errorf("close private tmux admission gate: %w", err)
+	}
+	return nil
+}
+
+func waitForAdmittedCreations(admissionDir string) error {
+	for {
+		markers, err := filepath.Glob(filepath.Join(admissionDir, "starting.*"))
+		if err != nil {
+			return fmt.Errorf("list admitted private tmux startups: %w", err)
+		}
+		live := false
+		for _, marker := range markers {
+			name := filepath.Base(marker)
+			parts := strings.Split(name, ".")
+			if len(parts) != 3 || parts[0] != "starting" {
+				continue
+			}
+			pid, parseErr := strconv.Atoi(parts[1])
+			start, readErr := os.ReadFile(marker)
+			if parseErr != nil || readErr != nil ||
+				tokenForStart(string(start)) != parts[2] ||
+				!processStillMatches(pid, string(start), processStart) {
+				_ = os.Remove(marker)
+				continue
+			}
+			live = true
+		}
+		if !live {
+			return nil
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 func (o *Owner) release(server registeredServer) error {
@@ -278,6 +443,38 @@ func reapStale(root string) error {
 		return fmt.Errorf("list tmux test root: %w", err)
 	}
 	var cleanupErrors []error
+	staleAdmissions := make(map[string]bool)
+	for _, entry := range entries {
+		identity, ok := parseAdmissionName(entry.Name())
+		if !ok || runIsLive(identity, processStart) {
+			continue
+		}
+		admissionDir := filepath.Join(root, entry.Name())
+		info, statErr := os.Lstat(admissionDir)
+		if statErr != nil {
+			if !errors.Is(statErr, fs.ErrNotExist) {
+				cleanupErrors = append(cleanupErrors, statErr)
+			}
+			continue
+		}
+		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 ||
+			info.Mode().Perm() != 0o700 || validateDirectoryOwner(info) != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf(
+				"refusing insecure stale tmux admission directory: %s",
+				admissionDir,
+			))
+			continue
+		}
+		if err := closeAdmission(admissionDir); err != nil {
+			cleanupErrors = append(cleanupErrors, err)
+			continue
+		}
+		if err := waitForAdmittedCreations(admissionDir); err != nil {
+			cleanupErrors = append(cleanupErrors, err)
+			continue
+		}
+		staleAdmissions[admissionDir] = true
+	}
 	for _, entry := range entries {
 		identity, ok := parseRunName(entry.Name())
 		if !ok || runIsLive(identity, processStart) {
@@ -316,6 +513,11 @@ func reapStale(root string) error {
 	}
 	if err := reapStaleProcesses(root); err != nil {
 		cleanupErrors = append(cleanupErrors, err)
+	}
+	for admissionDir := range staleAdmissions {
+		if err := os.RemoveAll(admissionDir); err != nil {
+			cleanupErrors = append(cleanupErrors, err)
+		}
 	}
 	return errors.Join(cleanupErrors...)
 }
@@ -449,6 +651,13 @@ func parseRunName(name string) (processIdentity, bool) {
 		return processIdentity{}, false
 	}
 	return processIdentity{pid: pid, startToken: match[2]}, true
+}
+
+func parseAdmissionName(name string) (processIdentity, bool) {
+	if !strings.HasPrefix(name, admissionPrefix) {
+		return processIdentity{}, false
+	}
+	return parseRunName(strings.TrimPrefix(name, admissionPrefix))
 }
 
 func runIsLive(

--- a/internal/testutil/testtmux/owner.go
+++ b/internal/testutil/testtmux/owner.go
@@ -434,14 +434,30 @@ func admittedCreationsWithLookup(
 			name := filepath.Base(marker)
 			parts := strings.Split(name, ".")
 			if len(parts) != 3 || parts[0] != "starting" {
-				continue
+				return nil, fmt.Errorf(
+					"invalid admitted private tmux startup marker %s", marker,
+				)
 			}
 			pid, parseErr := strconv.Atoi(parts[1])
 			start, readErr := os.ReadFile(marker)
-			if parseErr != nil || readErr != nil ||
+			if readErr != nil {
+				_, statErr := os.Lstat(marker)
+				if errors.Is(statErr, os.ErrNotExist) {
+					continue
+				}
+				if statErr != nil {
+					readErr = errors.Join(readErr, statErr)
+				}
+				return nil, fmt.Errorf(
+					"read admitted private tmux startup marker %s: %w",
+					marker, readErr,
+				)
+			}
+			if parseErr != nil || pid <= 0 || len(start) == 0 ||
 				tokenForStart(string(start)) != parts[2] {
-				_ = os.Remove(marker)
-				continue
+				return nil, fmt.Errorf(
+					"invalid admitted private tmux startup marker %s", marker,
+				)
 			}
 			status, statusErr := exactProcessIdentityState(
 				pid, string(start), lookupStart,

--- a/internal/testutil/testtmux/owner.go
+++ b/internal/testutil/testtmux/owner.go
@@ -63,6 +63,9 @@ type ownerMarker struct {
 // New creates an owner beneath a stable, per-user temporary root. It reaps
 // stale owners before publishing the new run.
 func New() (*Owner, error) {
+	if !Supported() {
+		return nil, errors.New("private test tmux servers are unsupported on Windows")
+	}
 	current, err := user.Current()
 	if err != nil {
 		return nil, fmt.Errorf("resolve current user: %w", err)
@@ -97,31 +100,54 @@ func newAt(root string) (*Owner, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create tmux test run nonce: %w", err)
 	}
-	runDir := filepath.Join(root, fmt.Sprintf(
+	runName := fmt.Sprintf(
 		"run.%d.%s.%s", identity.pid, identity.startToken, nonce,
-	))
-	if err := os.Mkdir(runDir, 0o700); err != nil {
-		return nil, fmt.Errorf("create tmux test run: %w", err)
-	}
+	)
 	marker := ownerMarker{
 		PID:          identity.pid,
 		ProcessStart: start,
 		StartToken:   identity.startToken,
 	}
-	content, err := json.Marshal(marker)
+	runDir, err := publishRun(root, runName, marker, os.Rename)
 	if err != nil {
-		_ = os.Remove(runDir)
-		return nil, fmt.Errorf("encode tmux test owner: %w", err)
-	}
-	if err := os.WriteFile(filepath.Join(runDir, "owner.json"), content, 0o600); err != nil {
-		_ = os.Remove(runDir)
-		return nil, fmt.Errorf("write tmux test owner: %w", err)
+		return nil, err
 	}
 	return &Owner{
 		root:    root,
 		runDir:  runDir,
 		servers: make(map[string]registeredServer),
 	}, nil
+}
+
+func publishRun(
+	root string,
+	runName string,
+	marker ownerMarker,
+	rename func(string, string) error,
+) (string, error) {
+	stagingDir := filepath.Join(root, "stage."+runName)
+	finalDir := filepath.Join(root, runName)
+	if err := os.Mkdir(stagingDir, 0o700); err != nil {
+		return "", fmt.Errorf("create staged tmux test run: %w", err)
+	}
+	removeStaging := true
+	defer func() {
+		if removeStaging {
+			_ = os.RemoveAll(stagingDir)
+		}
+	}()
+	content, err := json.Marshal(marker)
+	if err != nil {
+		return "", fmt.Errorf("encode tmux test owner: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(stagingDir, "owner.json"), content, 0o600); err != nil {
+		return "", fmt.Errorf("write tmux test owner: %w", err)
+	}
+	if err := rename(stagingDir, finalDir); err != nil {
+		return "", fmt.Errorf("publish tmux test run: %w", err)
+	}
+	removeStaging = false
+	return finalDir, nil
 }
 
 // Command registers a private socket before returning a tmux command prefix.

--- a/internal/testutil/testtmux/owner.go
+++ b/internal/testutil/testtmux/owner.go
@@ -364,17 +364,17 @@ func closeAdmission(admissionDir string) (err error) {
 	return nil
 }
 
-func drainAdmittedCreations(admissionDir string) error {
+func drainAdmittedCreations(admissionDirs ...string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
 	defer cancel()
-	return waitForAdmittedCreations(ctx, admissionDir)
+	return waitForAdmittedCreations(ctx, admissionDirs)
 }
 
-func waitForAdmittedCreations(ctx context.Context, admissionDir string) error {
+func waitForAdmittedCreations(ctx context.Context, admissionDirs []string) error {
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
 	for {
-		startups, err := admittedCreations(admissionDir)
+		startups, err := admittedCreations(admissionDirs)
 		if err != nil {
 			return err
 		}
@@ -389,27 +389,33 @@ func waitForAdmittedCreations(ctx context.Context, admissionDir string) error {
 	}
 }
 
-func admittedCreations(admissionDir string) ([]tmuxProcess, error) {
-	markers, err := filepath.Glob(filepath.Join(admissionDir, "starting.*"))
-	if err != nil {
-		return nil, fmt.Errorf("list admitted private tmux startups: %w", err)
+func admittedCreations(admissionDirs []string) ([]tmuxProcess, error) {
+	seen := make(map[tmuxProcess]bool)
+	for _, admissionDir := range admissionDirs {
+		markers, err := filepath.Glob(filepath.Join(admissionDir, "starting.*"))
+		if err != nil {
+			return nil, fmt.Errorf("list admitted private tmux startups: %w", err)
+		}
+		for _, marker := range markers {
+			name := filepath.Base(marker)
+			parts := strings.Split(name, ".")
+			if len(parts) != 3 || parts[0] != "starting" {
+				continue
+			}
+			pid, parseErr := strconv.Atoi(parts[1])
+			start, readErr := os.ReadFile(marker)
+			if parseErr != nil || readErr != nil ||
+				tokenForStart(string(start)) != parts[2] ||
+				!processStillMatches(pid, string(start), processStart) {
+				_ = os.Remove(marker)
+				continue
+			}
+			seen[tmuxProcess{pid: pid, start: string(start)}] = true
+		}
 	}
-	startups := make([]tmuxProcess, 0, len(markers))
-	for _, marker := range markers {
-		name := filepath.Base(marker)
-		parts := strings.Split(name, ".")
-		if len(parts) != 3 || parts[0] != "starting" {
-			continue
-		}
-		pid, parseErr := strconv.Atoi(parts[1])
-		start, readErr := os.ReadFile(marker)
-		if parseErr != nil || readErr != nil ||
-			tokenForStart(string(start)) != parts[2] ||
-			!processStillMatches(pid, string(start), processStart) {
-			_ = os.Remove(marker)
-			continue
-		}
-		startups = append(startups, tmuxProcess{pid: pid, start: string(start)})
+	startups := make([]tmuxProcess, 0, len(seen))
+	for startup := range seen {
+		startups = append(startups, startup)
 	}
 	return startups, nil
 }
@@ -482,7 +488,7 @@ func reapStale(root string) error {
 		return fmt.Errorf("list tmux test root: %w", err)
 	}
 	var cleanupErrors []error
-	staleAdmissions := make(map[string]bool)
+	var staleAdmissions []string
 	for _, entry := range entries {
 		identity, ok := parseAdmissionName(entry.Name())
 		if !ok || runIsLive(identity, processStart) {
@@ -508,11 +514,13 @@ func reapStale(root string) error {
 			cleanupErrors = append(cleanupErrors, err)
 			continue
 		}
-		if err := drainAdmittedCreations(admissionDir); err != nil {
+		staleAdmissions = append(staleAdmissions, admissionDir)
+	}
+	if len(staleAdmissions) > 0 {
+		if err := drainAdmittedCreations(staleAdmissions...); err != nil {
 			cleanupErrors = append(cleanupErrors, err)
-			continue
+			staleAdmissions = nil
 		}
-		staleAdmissions[admissionDir] = true
 	}
 	for _, entry := range entries {
 		identity, ok := parseRunName(entry.Name())
@@ -553,7 +561,7 @@ func reapStale(root string) error {
 	if err := reapStaleProcesses(root); err != nil {
 		cleanupErrors = append(cleanupErrors, err)
 	}
-	for admissionDir := range staleAdmissions {
+	for _, admissionDir := range staleAdmissions {
 		if err := os.RemoveAll(admissionDir); err != nil {
 			cleanupErrors = append(cleanupErrors, err)
 		}

--- a/internal/testutil/testtmux/owner.go
+++ b/internal/testutil/testtmux/owner.go
@@ -331,9 +331,11 @@ func (o *Owner) Cleanup() error {
 		o.mu.Unlock()
 
 		var cleanupErrors []error
-		gateErr := closeAdmission(o.admissionDir)
+		ctx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
+		defer cancel()
+		gateErr := closeAdmission(ctx, o.admissionDir)
 		if gateErr == nil {
-			gateErr = drainAdmittedCreations(o.admissionDir)
+			gateErr = waitForAdmittedCreations(ctx, []string{o.admissionDir})
 		}
 		if gateErr != nil {
 			o.cleanupErr = gateErr
@@ -371,10 +373,14 @@ func (o *Owner) Cleanup() error {
 	return o.cleanupErr
 }
 
-func closeAdmission(admissionDir string) (err error) {
+func closeAdmission(ctx context.Context, admissionDir string) (err error) {
 	lock := flock.New(filepath.Join(admissionDir, admissionLockName))
-	if err := lock.Lock(); err != nil {
-		return fmt.Errorf("close private tmux admission gate: %w", err)
+	locked, lockErr := lock.TryLockContext(ctx, 10*time.Millisecond)
+	if lockErr != nil {
+		return fmt.Errorf("close private tmux admission gate: %w", lockErr)
+	}
+	if !locked {
+		return errors.New("close private tmux admission gate: lock unavailable")
 	}
 	defer func() {
 		if unlockErr := lock.Unlock(); unlockErr != nil {
@@ -389,12 +395,6 @@ func closeAdmission(admissionDir string) (err error) {
 		return fmt.Errorf("close private tmux admission gate: %w", err)
 	}
 	return nil
-}
-
-func drainAdmittedCreations(admissionDirs ...string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
-	defer cancel()
-	return waitForAdmittedCreations(ctx, admissionDirs)
 }
 
 func waitForAdmittedCreations(ctx context.Context, admissionDirs []string) error {
@@ -555,6 +555,8 @@ func reapStaleWithLookup(
 	if err != nil {
 		return fmt.Errorf("list tmux test root: %w", err)
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
+	defer cancel()
 	var cleanupErrors []error
 	type staleAdmission struct {
 		runName string
@@ -601,7 +603,7 @@ func reapStaleWithLookup(
 			))
 			continue
 		}
-		if err := closeAdmission(admissionDir); err != nil {
+		if err := closeAdmission(ctx, admissionDir); err != nil {
 			cleanupErrors = append(cleanupErrors, err)
 			continue
 		}
@@ -615,7 +617,7 @@ func reapStaleWithLookup(
 		for _, admission := range staleAdmissions {
 			admissionDirs = append(admissionDirs, admission.dir)
 		}
-		if err := drainAdmittedCreations(admissionDirs...); err != nil {
+		if err := waitForAdmittedCreations(ctx, admissionDirs); err != nil {
 			cleanupErrors = append(cleanupErrors, err)
 			staleAdmissions = nil
 		} else {

--- a/internal/testutil/testtmux/owner.go
+++ b/internal/testutil/testtmux/owner.go
@@ -312,10 +312,13 @@ func (o *Owner) Cleanup() error {
 		o.mu.Unlock()
 
 		var cleanupErrors []error
-		if err := closeAdmission(o.admissionDir); err != nil {
-			cleanupErrors = append(cleanupErrors, err)
-		} else if err := drainAdmittedCreations(o.admissionDir); err != nil {
-			cleanupErrors = append(cleanupErrors, err)
+		gateErr := closeAdmission(o.admissionDir)
+		if gateErr == nil {
+			gateErr = drainAdmittedCreations(o.admissionDir)
+		}
+		if gateErr != nil {
+			o.cleanupErr = gateErr
+			return
 		}
 
 		o.mu.Lock()
@@ -483,17 +486,41 @@ func prepareRoot(root string) error {
 }
 
 func reapStale(root string) error {
+	return reapStaleWithLookup(root, processStart)
+}
+
+func reapStaleWithLookup(
+	root string,
+	lookupStart func(int) (string, error),
+) error {
 	entries, err := os.ReadDir(root)
 	if err != nil {
 		return fmt.Errorf("list tmux test root: %w", err)
 	}
 	var cleanupErrors []error
-	var staleAdmissions []string
+	type staleAdmission struct {
+		runName string
+		dir     string
+	}
+	type gateState uint8
+	const (
+		gateDeferred gateState = iota + 1
+		gateFailed
+		gateSafe
+	)
+	var staleAdmissions []staleAdmission
+	gateStates := make(map[string]gateState)
 	for _, entry := range entries {
 		identity, ok := parseAdmissionName(entry.Name())
-		if !ok || runIsLive(identity, processStart) {
+		if !ok {
 			continue
 		}
+		runName := strings.TrimPrefix(entry.Name(), admissionPrefix)
+		if runIsLive(identity, lookupStart) {
+			gateStates[runName] = gateDeferred
+			continue
+		}
+		gateStates[runName] = gateFailed
 		admissionDir := filepath.Join(root, entry.Name())
 		info, statErr := os.Lstat(admissionDir)
 		if statErr != nil {
@@ -514,17 +541,47 @@ func reapStale(root string) error {
 			cleanupErrors = append(cleanupErrors, err)
 			continue
 		}
-		staleAdmissions = append(staleAdmissions, admissionDir)
+		staleAdmissions = append(staleAdmissions, staleAdmission{
+			runName: runName,
+			dir:     admissionDir,
+		})
 	}
 	if len(staleAdmissions) > 0 {
-		if err := drainAdmittedCreations(staleAdmissions...); err != nil {
+		admissionDirs := make([]string, 0, len(staleAdmissions))
+		for _, admission := range staleAdmissions {
+			admissionDirs = append(admissionDirs, admission.dir)
+		}
+		if err := drainAdmittedCreations(admissionDirs...); err != nil {
 			cleanupErrors = append(cleanupErrors, err)
 			staleAdmissions = nil
+		} else {
+			for _, admission := range staleAdmissions {
+				gateStates[admission.runName] = gateSafe
+			}
 		}
 	}
 	for _, entry := range entries {
 		identity, ok := parseRunName(entry.Name())
-		if !ok || runIsLive(identity, processStart) {
+		if !ok {
+			continue
+		}
+		switch gateStates[entry.Name()] {
+		case gateDeferred, gateFailed:
+			continue
+		case gateSafe:
+		default:
+			if runIsLive(identity, lookupStart) {
+				continue
+			}
+			runDir := filepath.Join(root, entry.Name())
+			if err := validateRunMarker(runDir, identity); err != nil {
+				cleanupErrors = append(cleanupErrors, err)
+			} else {
+				cleanupErrors = append(cleanupErrors, fmt.Errorf(
+					"refusing stale tmux test run without admission gate: %s",
+					runDir,
+				))
+			}
 			continue
 		}
 		runDir := filepath.Join(root, entry.Name())
@@ -561,8 +618,8 @@ func reapStale(root string) error {
 	if err := reapStaleProcesses(root); err != nil {
 		cleanupErrors = append(cleanupErrors, err)
 	}
-	for _, admissionDir := range staleAdmissions {
-		if err := os.RemoveAll(admissionDir); err != nil {
+	for _, admission := range staleAdmissions {
+		if err := os.RemoveAll(admission.dir); err != nil {
 			cleanupErrors = append(cleanupErrors, err)
 		}
 	}
@@ -666,6 +723,9 @@ func killRunProcesses(runDir string) error {
 }
 
 func explicitSocket(command string) (string, bool) {
+	if socket, ok := tmuxServerTitleSocket(command); ok {
+		return socket, true
+	}
 	fields := strings.Fields(command)
 	for index := 0; index+1 < len(fields); index++ {
 		if fields[index] == "-S" && filepath.IsAbs(fields[index+1]) {
@@ -673,6 +733,18 @@ func explicitSocket(command string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func tmuxServerTitleSocket(command string) (string, bool) {
+	const prefix = "tmux: server ("
+	if !strings.HasPrefix(command, prefix) || !strings.HasSuffix(command, ")") {
+		return "", false
+	}
+	socket := strings.TrimSuffix(strings.TrimPrefix(command, prefix), ")")
+	if !filepath.IsAbs(socket) || strings.ContainsAny(socket, " \t\r\n()") {
+		return "", false
+	}
+	return filepath.Clean(socket), true
 }
 
 func randomToken(bytes int) (string, error) {

--- a/internal/testutil/testtmux/owner.go
+++ b/internal/testutil/testtmux/owner.go
@@ -1,0 +1,438 @@
+// Package testtmux owns private tmux servers started by Go tests.
+package testtmux
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/procutil"
+)
+
+const (
+	startTokenLength = 12
+	cleanupTimeout   = 2 * time.Second
+)
+
+var runNamePattern = regexp.MustCompile(
+	`^run\.([1-9][0-9]*)\.([0-9a-f]{12})\.([A-Za-z0-9]{6,32})$`,
+)
+
+type processIdentity struct {
+	pid        int
+	startToken string
+}
+
+type registeredServer struct {
+	tmuxPath string
+	socket   string
+}
+
+// Owner tracks private tmux servers for one test binary.
+type Owner struct {
+	root       string
+	runDir     string
+	mu         sync.Mutex
+	servers    map[string]registeredServer
+	cleanup    sync.Once
+	cleanupErr error
+}
+
+type ownerMarker struct {
+	PID          int    `json:"pid"`
+	ProcessStart string `json:"process_start"`
+	StartToken   string `json:"start_token"`
+}
+
+// New creates an owner beneath a stable, per-user temporary root. It reaps
+// stale owners before publishing the new run.
+func New() (*Owner, error) {
+	current, err := user.Current()
+	if err != nil {
+		return nil, fmt.Errorf("resolve current user: %w", err)
+	}
+	uid := current.Uid
+	if uid == "" || strings.ContainsAny(uid, `/\\`) {
+		return nil, fmt.Errorf("invalid current user ID %q", uid)
+	}
+	return newAt(filepath.Join(tmuxRootBase(), "kenn-forge-tmux-"+uid))
+}
+
+func newAt(root string) (*Owner, error) {
+	if !filepath.IsAbs(root) {
+		return nil, fmt.Errorf("tmux test root must be absolute: %s", root)
+	}
+	root = filepath.Clean(root)
+	if err := prepareRoot(root); err != nil {
+		return nil, err
+	}
+	if err := reapStale(root); err != nil {
+		return nil, err
+	}
+	start, err := processStart(os.Getpid())
+	if err != nil {
+		return nil, fmt.Errorf("identify tmux test owner: %w", err)
+	}
+	identity := processIdentity{
+		pid:        os.Getpid(),
+		startToken: tokenForStart(start),
+	}
+	nonce, err := randomToken(6)
+	if err != nil {
+		return nil, fmt.Errorf("create tmux test run nonce: %w", err)
+	}
+	runDir := filepath.Join(root, fmt.Sprintf(
+		"run.%d.%s.%s", identity.pid, identity.startToken, nonce,
+	))
+	if err := os.Mkdir(runDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create tmux test run: %w", err)
+	}
+	marker := ownerMarker{
+		PID:          identity.pid,
+		ProcessStart: start,
+		StartToken:   identity.startToken,
+	}
+	content, err := json.Marshal(marker)
+	if err != nil {
+		_ = os.Remove(runDir)
+		return nil, fmt.Errorf("encode tmux test owner: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "owner.json"), content, 0o600); err != nil {
+		_ = os.Remove(runDir)
+		return nil, fmt.Errorf("write tmux test owner: %w", err)
+	}
+	return &Owner{
+		root:    root,
+		runDir:  runDir,
+		servers: make(map[string]registeredServer),
+	}, nil
+}
+
+// Command registers a private socket before returning a tmux command prefix.
+func (o *Owner) Command(t testing.TB, tmuxPath string) []string {
+	t.Helper()
+	nonce, err := randomToken(6)
+	require.NoError(t, err)
+	serverDir := filepath.Join(o.runDir, "server-"+nonce)
+	require.NoError(t, os.Mkdir(serverDir, 0o700))
+	socket := filepath.Join(serverDir, "tmux.sock")
+	server := registeredServer{tmuxPath: tmuxPath, socket: socket}
+	o.mu.Lock()
+	o.servers[socket] = server
+	o.mu.Unlock()
+	t.Cleanup(func() {
+		require.NoError(t, o.release(server))
+	})
+	return []string{tmuxPath, "-f", "/dev/null", "-S", socket}
+}
+
+// Cleanup stops every registered server and removes this owner's run.
+func (o *Owner) Cleanup() error {
+	o.cleanup.Do(func() {
+		o.mu.Lock()
+		servers := make([]registeredServer, 0, len(o.servers))
+		for _, server := range o.servers {
+			servers = append(servers, server)
+		}
+		o.mu.Unlock()
+
+		var cleanupErrors []error
+		for _, server := range servers {
+			if err := o.release(server); err != nil {
+				cleanupErrors = append(cleanupErrors, err)
+			}
+		}
+		processErr := killRunProcesses(o.runDir)
+		if processErr != nil {
+			cleanupErrors = append(cleanupErrors, processErr)
+		} else if err := os.RemoveAll(o.runDir); err != nil {
+			cleanupErrors = append(cleanupErrors, err)
+		}
+		_ = os.Remove(o.root)
+		o.cleanupErr = errors.Join(cleanupErrors...)
+	})
+	return o.cleanupErr
+}
+
+func (o *Owner) release(server registeredServer) error {
+	o.mu.Lock()
+	_, registered := o.servers[server.socket]
+	o.mu.Unlock()
+	if !registered {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
+	defer cancel()
+	command := procutil.CommandContext(
+		ctx, server.tmuxPath, "-f", "/dev/null", "-S", server.socket,
+		"kill-server",
+	)
+	_ = command.Run()
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return fmt.Errorf("stop tmux test server %s: %w", server.socket, ctx.Err())
+	}
+	if err := os.RemoveAll(filepath.Dir(server.socket)); err != nil {
+		return fmt.Errorf("remove tmux test server directory: %w", err)
+	}
+	o.mu.Lock()
+	delete(o.servers, server.socket)
+	o.mu.Unlock()
+	return nil
+}
+
+func prepareRoot(root string) error {
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return fmt.Errorf("create tmux test root: %w", err)
+	}
+	info, err := os.Lstat(root)
+	if err != nil {
+		return fmt.Errorf("inspect tmux test root: %w", err)
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm() != 0o700 {
+		return fmt.Errorf("refusing insecure tmux test root: %s", root)
+	}
+	if err := validateDirectoryOwner(info); err != nil {
+		return fmt.Errorf("refusing tmux test root ownership: %w", err)
+	}
+	return nil
+}
+
+func reapStale(root string) error {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return fmt.Errorf("list tmux test root: %w", err)
+	}
+	var cleanupErrors []error
+	for _, entry := range entries {
+		identity, ok := parseRunName(entry.Name())
+		if !ok || runIsLive(identity, processStart) {
+			continue
+		}
+		runDir := filepath.Join(root, entry.Name())
+		info, statErr := os.Lstat(runDir)
+		if statErr != nil {
+			if !errors.Is(statErr, fs.ErrNotExist) {
+				cleanupErrors = append(cleanupErrors, statErr)
+			}
+			continue
+		}
+		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 ||
+			info.Mode().Perm() != 0o700 || validateDirectoryOwner(info) != nil {
+			cleanupErrors = append(cleanupErrors,
+				fmt.Errorf("refusing insecure stale tmux test run: %s", runDir),
+			)
+			continue
+		}
+		if err := validateRunMarker(runDir, identity); err != nil {
+			cleanupErrors = append(cleanupErrors, err)
+			continue
+		}
+		if err := killSocketsIn(runDir); err != nil {
+			cleanupErrors = append(cleanupErrors, err)
+			continue
+		}
+		if err := killRunProcesses(runDir); err != nil {
+			cleanupErrors = append(cleanupErrors, err)
+			continue
+		}
+		if err := os.RemoveAll(runDir); err != nil {
+			cleanupErrors = append(cleanupErrors, err)
+		}
+	}
+	if err := reapStaleProcesses(root); err != nil {
+		cleanupErrors = append(cleanupErrors, err)
+	}
+	return errors.Join(cleanupErrors...)
+}
+
+func validateRunMarker(runDir string, identity processIdentity) error {
+	path := filepath.Join(runDir, "owner.json")
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("inspect stale tmux test owner %s: %w", path, err)
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 ||
+		validateDirectoryOwner(info) != nil {
+		return fmt.Errorf("refusing insecure stale tmux test owner: %s", path)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read stale tmux test owner %s: %w", path, err)
+	}
+	var marker ownerMarker
+	if err := json.Unmarshal(content, &marker); err != nil {
+		return fmt.Errorf("decode stale tmux test owner %s: %w", path, err)
+	}
+	if marker.PID != identity.pid || marker.StartToken != identity.startToken ||
+		tokenForStart(marker.ProcessStart) != identity.startToken {
+		return fmt.Errorf("refusing mismatched stale tmux test owner: %s", path)
+	}
+	return nil
+}
+
+func killSocketsIn(runDir string) error {
+	tmuxPath, err := exec.LookPath("tmux")
+	if err != nil {
+		return nil
+	}
+	return filepath.WalkDir(runDir, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSocket == 0 {
+			return nil
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
+		defer cancel()
+		_ = procutil.CommandContext(ctx, tmuxPath, "-S", path, "kill-server").Run()
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("stop stale tmux test server %s: %w", path, ctx.Err())
+		}
+		return nil
+	})
+}
+
+func reapStaleProcesses(root string) error {
+	processes, err := tmuxProcesses()
+	if err != nil {
+		return err
+	}
+	var cleanupErrors []error
+	for _, process := range processes {
+		socket, ok := explicitSocket(process.command)
+		if !ok {
+			continue
+		}
+		identity, runDir, ok := runForSocket(root, socket)
+		if !ok || runIsLive(identity, processStart) {
+			continue
+		}
+		if _, statErr := os.Lstat(runDir); statErr == nil ||
+			!errors.Is(statErr, fs.ErrNotExist) {
+			continue
+		}
+		if err := stopProcess(process.pid, process.start); err != nil {
+			cleanupErrors = append(cleanupErrors, err)
+		}
+	}
+	return errors.Join(cleanupErrors...)
+}
+
+func killRunProcesses(runDir string) error {
+	processes, err := tmuxProcesses()
+	if err != nil {
+		return err
+	}
+	runPrefix := filepath.Clean(runDir) + string(filepath.Separator)
+	var cleanupErrors []error
+	for _, process := range processes {
+		socket, ok := explicitSocket(process.command)
+		if !ok || !strings.HasPrefix(filepath.Clean(socket), runPrefix) {
+			continue
+		}
+		if err := stopProcess(process.pid, process.start); err != nil {
+			cleanupErrors = append(cleanupErrors, err)
+		}
+	}
+	return errors.Join(cleanupErrors...)
+}
+
+func explicitSocket(command string) (string, bool) {
+	fields := strings.Fields(command)
+	for index := 0; index+1 < len(fields); index++ {
+		if fields[index] == "-S" && filepath.IsAbs(fields[index+1]) {
+			return filepath.Clean(fields[index+1]), true
+		}
+	}
+	return "", false
+}
+
+func randomToken(bytes int) (string, error) {
+	buffer := make([]byte, bytes)
+	if _, err := rand.Read(buffer); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buffer), nil
+}
+
+func tokenForStart(start string) string {
+	sum := sha256.Sum256([]byte(start))
+	return hex.EncodeToString(sum[:])[:startTokenLength]
+}
+
+func parseRunName(name string) (processIdentity, bool) {
+	match := runNamePattern.FindStringSubmatch(name)
+	if match == nil {
+		return processIdentity{}, false
+	}
+	pid, err := strconv.Atoi(match[1])
+	if err != nil || pid <= 0 {
+		return processIdentity{}, false
+	}
+	return processIdentity{pid: pid, startToken: match[2]}, true
+}
+
+func runIsLive(
+	identity processIdentity,
+	lookupStart func(int) (string, error),
+) bool {
+	start, err := lookupStart(identity.pid)
+	return err == nil && tokenForStart(start) == identity.startToken
+}
+
+func identityForSocket(root, socket string) (processIdentity, bool) {
+	identity, _, ok := runForSocket(root, socket)
+	return identity, ok
+}
+
+func runForSocket(root, socket string) (processIdentity, string, bool) {
+	if !filepath.IsAbs(root) || !filepath.IsAbs(socket) {
+		return processIdentity{}, "", false
+	}
+	root = filepath.Clean(root)
+	socket = filepath.Clean(socket)
+	relative, err := filepath.Rel(root, socket)
+	if err != nil || relative == "." || relative == ".." ||
+		filepath.IsAbs(relative) {
+		return processIdentity{}, "", false
+	}
+	parts := splitPath(relative)
+	if len(parts) < 3 || parts[len(parts)-1] != "tmux.sock" {
+		return processIdentity{}, "", false
+	}
+	identity, ok := parseRunName(parts[0])
+	return identity, filepath.Join(root, parts[0]), ok
+}
+
+func splitPath(path string) []string {
+	var parts []string
+	for path != "." && path != string(filepath.Separator) && path != "" {
+		dir, base := filepath.Split(path)
+		if base == "" || base == "." || base == ".." {
+			return nil
+		}
+		parts = append([]string{base}, parts...)
+		path = filepath.Clean(dir)
+	}
+	return parts
+}

--- a/internal/testutil/testtmux/owner.go
+++ b/internal/testutil/testtmux/owner.go
@@ -314,7 +314,7 @@ func (o *Owner) Cleanup() error {
 		var cleanupErrors []error
 		if err := closeAdmission(o.admissionDir); err != nil {
 			cleanupErrors = append(cleanupErrors, err)
-		} else if err := waitForAdmittedCreations(o.admissionDir); err != nil {
+		} else if err := drainAdmittedCreations(o.admissionDir); err != nil {
 			cleanupErrors = append(cleanupErrors, err)
 		}
 
@@ -364,34 +364,73 @@ func closeAdmission(admissionDir string) (err error) {
 	return nil
 }
 
-func waitForAdmittedCreations(admissionDir string) error {
+func drainAdmittedCreations(admissionDir string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
+	defer cancel()
+	return waitForAdmittedCreations(ctx, admissionDir)
+}
+
+func waitForAdmittedCreations(ctx context.Context, admissionDir string) error {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
 	for {
-		markers, err := filepath.Glob(filepath.Join(admissionDir, "starting.*"))
+		startups, err := admittedCreations(admissionDir)
 		if err != nil {
-			return fmt.Errorf("list admitted private tmux startups: %w", err)
+			return err
 		}
-		live := false
-		for _, marker := range markers {
-			name := filepath.Base(marker)
-			parts := strings.Split(name, ".")
-			if len(parts) != 3 || parts[0] != "starting" {
-				continue
-			}
-			pid, parseErr := strconv.Atoi(parts[1])
-			start, readErr := os.ReadFile(marker)
-			if parseErr != nil || readErr != nil ||
-				tokenForStart(string(start)) != parts[2] ||
-				!processStillMatches(pid, string(start), processStart) {
-				_ = os.Remove(marker)
-				continue
-			}
-			live = true
-		}
-		if !live {
+		if len(startups) == 0 {
 			return nil
 		}
-		time.Sleep(10 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			return stopAdmittedCreations(startups)
+		case <-ticker.C:
+		}
 	}
+}
+
+func admittedCreations(admissionDir string) ([]tmuxProcess, error) {
+	markers, err := filepath.Glob(filepath.Join(admissionDir, "starting.*"))
+	if err != nil {
+		return nil, fmt.Errorf("list admitted private tmux startups: %w", err)
+	}
+	startups := make([]tmuxProcess, 0, len(markers))
+	for _, marker := range markers {
+		name := filepath.Base(marker)
+		parts := strings.Split(name, ".")
+		if len(parts) != 3 || parts[0] != "starting" {
+			continue
+		}
+		pid, parseErr := strconv.Atoi(parts[1])
+		start, readErr := os.ReadFile(marker)
+		if parseErr != nil || readErr != nil ||
+			tokenForStart(string(start)) != parts[2] ||
+			!processStillMatches(pid, string(start), processStart) {
+			_ = os.Remove(marker)
+			continue
+		}
+		startups = append(startups, tmuxProcess{pid: pid, start: string(start)})
+	}
+	return startups, nil
+}
+
+func stopAdmittedCreations(startups []tmuxProcess) error {
+	errorsByProcess := make(chan error, len(startups))
+	var wait sync.WaitGroup
+	for _, startup := range startups {
+		wait.Go(func() {
+			errorsByProcess <- stopProcess(startup.pid, startup.start)
+		})
+	}
+	wait.Wait()
+	close(errorsByProcess)
+	var cleanupErrors []error
+	for err := range errorsByProcess {
+		if err != nil {
+			cleanupErrors = append(cleanupErrors, err)
+		}
+	}
+	return errors.Join(cleanupErrors...)
 }
 
 func (o *Owner) release(server registeredServer) error {
@@ -469,7 +508,7 @@ func reapStale(root string) error {
 			cleanupErrors = append(cleanupErrors, err)
 			continue
 		}
-		if err := waitForAdmittedCreations(admissionDir); err != nil {
+		if err := drainAdmittedCreations(admissionDir); err != nil {
 			cleanupErrors = append(cleanupErrors, err)
 			continue
 		}

--- a/internal/testutil/testtmux/owner.go
+++ b/internal/testutil/testtmux/owner.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofrs/flock"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/procutil"
 )
@@ -28,11 +29,14 @@ import (
 const (
 	startTokenLength = 12
 	cleanupTimeout   = 2 * time.Second
+	rootLockName     = ".owner.lock"
 )
 
 var runNamePattern = regexp.MustCompile(
 	`^run\.([1-9][0-9]*)\.([0-9a-f]{12})\.([A-Za-z0-9]{6,32})$`,
 )
+
+var rootLockMu sync.Mutex
 
 type processIdentity struct {
 	pid        int
@@ -82,41 +86,71 @@ func newAt(root string) (*Owner, error) {
 		return nil, fmt.Errorf("tmux test root must be absolute: %s", root)
 	}
 	root = filepath.Clean(root)
+	// Bootstrap the directory so it can contain its stable lock file. The
+	// validated initialization is repeated while holding the lock below.
 	if err := prepareRoot(root); err != nil {
 		return nil, err
 	}
-	if err := reapStale(root); err != nil {
-		return nil, err
+	var owner *Owner
+	err := withRootLock(root, func() error {
+		if err := prepareRoot(root); err != nil {
+			return err
+		}
+		if err := reapStale(root); err != nil {
+			return err
+		}
+		start, err := processStart(os.Getpid())
+		if err != nil {
+			return fmt.Errorf("identify tmux test owner: %w", err)
+		}
+		identity := processIdentity{
+			pid:        os.Getpid(),
+			startToken: tokenForStart(start),
+		}
+		nonce, err := randomToken(6)
+		if err != nil {
+			return fmt.Errorf("create tmux test run nonce: %w", err)
+		}
+		runName := fmt.Sprintf(
+			"run.%d.%s.%s", identity.pid, identity.startToken, nonce,
+		)
+		marker := ownerMarker{
+			PID:          identity.pid,
+			ProcessStart: start,
+			StartToken:   identity.startToken,
+		}
+		runDir, err := publishRun(root, runName, marker, os.Rename)
+		if err != nil {
+			return err
+		}
+		owner = &Owner{
+			root:    root,
+			runDir:  runDir,
+			servers: make(map[string]registeredServer),
+		}
+		return nil
+	})
+	return owner, err
+}
+
+func withRootLock(root string, fn func() error) (err error) {
+	// flock does not serialize fresh lock handles within every supported Unix
+	// process, so pair it with a package mutex for goroutines in this binary.
+	rootLockMu.Lock()
+	defer rootLockMu.Unlock()
+
+	lock := flock.New(filepath.Join(root, rootLockName))
+	if err := lock.Lock(); err != nil {
+		return fmt.Errorf("acquire tmux test root lock: %w", err)
 	}
-	start, err := processStart(os.Getpid())
-	if err != nil {
-		return nil, fmt.Errorf("identify tmux test owner: %w", err)
-	}
-	identity := processIdentity{
-		pid:        os.Getpid(),
-		startToken: tokenForStart(start),
-	}
-	nonce, err := randomToken(6)
-	if err != nil {
-		return nil, fmt.Errorf("create tmux test run nonce: %w", err)
-	}
-	runName := fmt.Sprintf(
-		"run.%d.%s.%s", identity.pid, identity.startToken, nonce,
-	)
-	marker := ownerMarker{
-		PID:          identity.pid,
-		ProcessStart: start,
-		StartToken:   identity.startToken,
-	}
-	runDir, err := publishRun(root, runName, marker, os.Rename)
-	if err != nil {
-		return nil, err
-	}
-	return &Owner{
-		root:    root,
-		runDir:  runDir,
-		servers: make(map[string]registeredServer),
-	}, nil
+	defer func() {
+		if unlockErr := lock.Unlock(); unlockErr != nil {
+			err = errors.Join(err, fmt.Errorf(
+				"release tmux test root lock: %w", unlockErr,
+			))
+		}
+	}()
+	return fn()
 }
 
 func publishRun(
@@ -190,7 +224,6 @@ func (o *Owner) Cleanup() error {
 		} else if err := os.RemoveAll(o.runDir); err != nil {
 			cleanupErrors = append(cleanupErrors, err)
 		}
-		_ = os.Remove(o.root)
 		o.cleanupErr = errors.Join(cleanupErrors...)
 	})
 	return o.cleanupErr

--- a/internal/testutil/testtmux/owner.go
+++ b/internal/testutil/testtmux/owner.go
@@ -132,14 +132,11 @@ func newAt(root string) (*Owner, error) {
 			ProcessStart: start,
 			StartToken:   identity.startToken,
 		}
-		runDir, err := publishRun(root, runName, marker, os.Rename)
+		runDir, admissionDir, err := publishOwnerState(
+			root, runName, marker, os.Rename,
+		)
 		if err != nil {
 			return err
-		}
-		admissionDir := filepath.Join(root, admissionPrefix+runName)
-		if err := os.Mkdir(admissionDir, 0o700); err != nil {
-			_ = os.RemoveAll(runDir)
-			return fmt.Errorf("create private tmux admission directory: %w", err)
 		}
 		owner = &Owner{
 			root:         root,
@@ -201,6 +198,28 @@ func publishRun(
 	}
 	removeStaging = false
 	return finalDir, nil
+}
+
+func publishOwnerState(
+	root string,
+	runName string,
+	marker ownerMarker,
+	rename func(string, string) error,
+) (string, string, error) {
+	admissionDir := filepath.Join(root, admissionPrefix+runName)
+	if err := os.Mkdir(admissionDir, 0o700); err != nil {
+		return "", "", fmt.Errorf("create private tmux admission directory: %w", err)
+	}
+	runDir, err := publishRun(root, runName, marker, rename)
+	if err != nil {
+		if removeErr := os.RemoveAll(admissionDir); removeErr != nil {
+			err = errors.Join(err, fmt.Errorf(
+				"remove private tmux admission directory: %w", removeErr,
+			))
+		}
+		return "", "", err
+	}
+	return runDir, admissionDir, nil
 }
 
 // Command registers a private socket before returning a tmux command prefix.
@@ -334,13 +353,18 @@ func (o *Owner) Cleanup() error {
 			}
 		}
 		processErr := killRunProcesses(o.runDir)
+		runRemoved := false
 		if processErr != nil {
 			cleanupErrors = append(cleanupErrors, processErr)
 		} else if err := os.RemoveAll(o.runDir); err != nil {
 			cleanupErrors = append(cleanupErrors, err)
+		} else {
+			runRemoved = true
 		}
-		if err := os.RemoveAll(o.admissionDir); err != nil {
-			cleanupErrors = append(cleanupErrors, err)
+		if runRemoved {
+			if err := os.RemoveAll(o.admissionDir); err != nil {
+				cleanupErrors = append(cleanupErrors, err)
+			}
 		}
 		o.cleanupErr = errors.Join(cleanupErrors...)
 	})
@@ -613,12 +637,21 @@ func reapStaleWithLookup(
 		}
 		if err := os.RemoveAll(runDir); err != nil {
 			cleanupErrors = append(cleanupErrors, err)
+			continue
 		}
 	}
 	if err := reapStaleProcesses(root); err != nil {
 		cleanupErrors = append(cleanupErrors, err)
 	}
 	for _, admission := range staleAdmissions {
+		_, statErr := os.Lstat(filepath.Join(root, admission.runName))
+		if statErr == nil {
+			continue
+		}
+		if !errors.Is(statErr, fs.ErrNotExist) {
+			cleanupErrors = append(cleanupErrors, statErr)
+			continue
+		}
 		if err := os.RemoveAll(admission.dir); err != nil {
 			cleanupErrors = append(cleanupErrors, err)
 		}

--- a/internal/testutil/testtmux/owner_test.go
+++ b/internal/testutil/testtmux/owner_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -466,6 +467,103 @@ esac
 	}
 	require.Error(<-startupDone)
 	requireProcessGone(t, startup.Process.Pid)
+}
+
+func TestNewAtDrainsMultipleStaleAdmissionsWithinOneDeadline(t *testing.T) {
+	if os.Getenv("KENN_FORGE_TEST_TMUX_STALLED_STARTUP") == "1" {
+		term := make(chan os.Signal, 1)
+		signal.Notify(term, syscall.SIGTERM)
+		require.NoError(t, os.WriteFile(
+			os.Getenv("KENN_FORGE_TEST_TMUX_STALLED_READY"),
+			[]byte("ready\n"),
+			0o600,
+		))
+		for range term {
+		}
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("stale startup recovery requires Unix signals")
+	}
+	require := require.New(t)
+	root := filepath.Join(t.TempDir(), "root")
+	require.NoError(prepareRoot(root))
+
+	type startupProcess struct {
+		command *exec.Cmd
+		done    chan error
+	}
+	startups := make([]startupProcess, 0, 2)
+	for index := range 2 {
+		ready := filepath.Join(root, fmt.Sprintf("ready-%d", index))
+		command := procutil.Command(
+			os.Args[0],
+			"-test.run=^TestNewAtDrainsMultipleStaleAdmissionsWithinOneDeadline$",
+		)
+		command.Env = append(os.Environ(),
+			"KENN_FORGE_TEST_TMUX_STALLED_STARTUP=1",
+			"KENN_FORGE_TEST_TMUX_STALLED_READY="+ready,
+		)
+		require.NoError(command.Start())
+		done := make(chan error, 1)
+		go func() { done <- command.Wait() }()
+		startups = append(startups, startupProcess{command: command, done: done})
+		t.Cleanup(func() {
+			if !processGone(command.Process.Pid) {
+				_ = command.Process.Kill()
+			}
+			select {
+			case <-done:
+			default:
+			}
+		})
+		require.Eventually(func() bool {
+			_, statErr := os.Stat(ready)
+			return statErr == nil
+		}, 5*time.Second, 10*time.Millisecond)
+
+		start, err := processStart(command.Process.Pid)
+		require.NoError(err)
+		runName := fmt.Sprintf(
+			"run.%d.%s.%06d",
+			999_999-index,
+			tokenForStart(fmt.Sprintf("dead-owner-%d", index)),
+			index,
+		)
+		admissionDir := filepath.Join(root, admissionPrefix+runName)
+		require.NoError(os.Mkdir(admissionDir, 0o700))
+		marker := filepath.Join(admissionDir, fmt.Sprintf(
+			"starting.%d.%s", command.Process.Pid, tokenForStart(start),
+		))
+		require.NoError(os.WriteFile(marker, []byte(start), 0o600))
+	}
+
+	type newResult struct {
+		owner *Owner
+		err   error
+	}
+	result := make(chan newResult, 1)
+	go func() {
+		owner, err := newAt(root)
+		result <- newResult{owner: owner, err: err}
+	}()
+	select {
+	case created := <-result:
+		require.NoError(created.err)
+		t.Cleanup(func() { _ = created.owner.Cleanup() })
+	case <-time.After(2*cleanupTimeout + time.Second):
+		for _, startup := range startups {
+			_ = startup.command.Process.Kill()
+		}
+		created := <-result
+		if created.owner != nil {
+			t.Cleanup(func() { _ = created.owner.Cleanup() })
+		}
+		require.Fail("stale admissions did not share one cleanup deadline")
+	}
+	for _, startup := range startups {
+		require.Error(<-startup.done)
+		requireProcessGone(t, startup.command.Process.Pid)
+	}
 }
 
 func TestNewAtReapsServerAfterRunDirectoryDisappears(t *testing.T) {

--- a/internal/testutil/testtmux/owner_test.go
+++ b/internal/testutil/testtmux/owner_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -19,6 +20,13 @@ import (
 	"go.kenn.io/forge/internal/procutil"
 	"go.kenn.io/forge/internal/testutil/testsignal"
 )
+
+func TestMain(m *testing.M) {
+	if code, ok := CommandWrapperExitCode(); ok {
+		os.Exit(code)
+	}
+	os.Exit(m.Run())
+}
 
 func requireTmux(t *testing.T) string {
 	t.Helper()
@@ -339,6 +347,67 @@ func TestOwnerCleanupStopsRegisteredServerAfterDirectoryDisappears(t *testing.T)
 
 	require.NoError(t, owner.Cleanup())
 	requireProcessGone(t, serverPID)
+}
+
+func TestOwnerCleanupWaitsForAdmittedStartup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake tmux fixture uses Unix shell semantics")
+	}
+	require := require.New(t)
+	directory := t.TempDir()
+	root := filepath.Join(directory, "root")
+	owner, err := newAt(root)
+	require.NoError(err)
+	t.Cleanup(func() { _ = owner.Cleanup() })
+
+	entered := filepath.Join(directory, "entered")
+	release := filepath.Join(directory, "release")
+	record := filepath.Join(directory, "record")
+	tmuxPath := filepath.Join(directory, "fake-tmux")
+	body := `#!/bin/sh
+case "$*" in
+  *new-session*)
+    : > "$TEST_TMUX_ENTERED"
+    while [ ! -f "$TEST_TMUX_RELEASE" ]; do sleep 0.01; done
+    printf 'created\n' >> "$TEST_TMUX_RECORD"
+    ;;
+  *kill-server*)
+    printf 'killed\n' >> "$TEST_TMUX_RECORD"
+    ;;
+esac
+`
+	require.NoError(os.WriteFile(tmuxPath, []byte(body), 0o755))
+	t.Setenv("TEST_TMUX_ENTERED", entered)
+	t.Setenv("TEST_TMUX_RELEASE", release)
+	t.Setenv("TEST_TMUX_RECORD", record)
+
+	tmuxCommand := owner.Command(t, tmuxPath)
+	startupDone := make(chan error, 1)
+	go func() {
+		args := append(slices.Clone(tmuxCommand[1:]), "new-session", "-d")
+		startupDone <- procutil.Command(tmuxCommand[0], args...).Run()
+	}()
+	require.Eventually(func() bool {
+		_, statErr := os.Stat(entered)
+		return statErr == nil
+	}, 5*time.Second, 10*time.Millisecond)
+	require.NoError(os.RemoveAll(owner.runDir))
+
+	cleanupDone := make(chan error, 1)
+	go func() { cleanupDone <- owner.Cleanup() }()
+	select {
+	case cleanupErr := <-cleanupDone:
+		require.NoError(cleanupErr)
+		require.Fail("cleanup returned while admitted tmux startup was blocked")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	require.NoError(os.WriteFile(release, []byte("release\n"), 0o600))
+	require.NoError(<-startupDone)
+	require.NoError(<-cleanupDone)
+	content, err := os.ReadFile(record)
+	require.NoError(err)
+	require.Equal("created\nkilled\n", string(content))
 }
 
 func TestNewAtReapsServerAfterRunDirectoryDisappears(t *testing.T) {

--- a/internal/testutil/testtmux/owner_test.go
+++ b/internal/testutil/testtmux/owner_test.go
@@ -119,7 +119,7 @@ func TestParseRunName(t *testing.T) {
 func TestSupportedMatchesPlatform(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, runtime.GOOS != "windows", Supported())
+	assert.Equal(t, runtime.GOOS == "darwin" || runtime.GOOS == "linux", Supported())
 }
 
 func TestPublishRunDoesNotExposeUnmarkedFinalDirectory(t *testing.T) {
@@ -297,8 +297,28 @@ func TestOwnerCleanupPreservesAdmissionWhenRunRemovalFails(t *testing.T) {
 	require.DirExists(admissionDir)
 }
 
-func TestRunIsLiveRequiresMatchingProcessStart(t *testing.T) {
+func TestAdmittedCreationsPreservesMarkerWhenLookupIsIndeterminate(t *testing.T) {
+	require := require.New(t)
+	admissionDir := t.TempDir()
+	start := "startup-identity"
+	marker := filepath.Join(admissionDir, fmt.Sprintf(
+		"starting.%d.%s", 31415, tokenForStart(start),
+	))
+	require.NoError(os.WriteFile(marker, []byte(start), 0o600))
+
+	_, err := admittedCreationsWithLookup(
+		[]string{admissionDir},
+		func(int) (string, error) {
+			return "", errors.New("transient identity lookup failure")
+		},
+	)
+	require.Error(err)
+	require.FileExists(marker)
+}
+
+func TestRunProcessIdentityStateRequiresMatchingStart(t *testing.T) {
 	t.Parallel()
+	require := require.New(t)
 
 	lookup := func(pid int) (string, error) {
 		switch pid {
@@ -307,29 +327,37 @@ func TestRunIsLiveRequiresMatchingProcessStart(t *testing.T) {
 		case 202:
 			return "reused-start", nil
 		default:
-			return "", errors.New("process not found")
+			return "", errProcessAbsent
 		}
 	}
 
-	assert.True(t, runIsLive(
+	status, err := runProcessIdentityState(
 		processIdentity{pid: 101, startToken: tokenForStart("same-start")},
 		lookup,
-	))
-	assert.False(t, runIsLive(
+	)
+	require.NoError(err)
+	require.Equal(processIdentityLive, status)
+
+	status, err = runProcessIdentityState(
 		processIdentity{pid: 202, startToken: tokenForStart("original-start")},
 		lookup,
-	), "a reused PID must not pin a dead run")
-	assert.False(t, runIsLive(
+	)
+	require.NoError(err)
+	require.Equal(processIdentityAbsent, status, "a reused PID must not pin a dead run")
+
+	status, err = runProcessIdentityState(
 		processIdentity{pid: 303, startToken: tokenForStart("gone")},
 		lookup,
-	))
+	)
+	require.NoError(err)
+	require.Equal(processIdentityAbsent, status)
 }
 
 func TestProcessStartIsStableForLiveProcess(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	if runtime.GOOS == "windows" {
-		t.Skip("the Windows identity implementation is cross-compiled here")
+	if !Supported() {
+		t.Skip("high-resolution process identity is unavailable")
 	}
 	first, err := processStart(os.Getpid())
 	require.NoError(err)
@@ -340,19 +368,34 @@ func TestProcessStartIsStableForLiveProcess(t *testing.T) {
 	assert.Equal(first, second)
 }
 
-func TestProcessStillMatchesRequiresOriginalStart(t *testing.T) {
+func TestProcessStartReportsDefiniteAbsence(t *testing.T) {
+	if !Supported() {
+		t.Skip("high-resolution process identity is unavailable")
+	}
+
+	_, err := processStart(2_000_000_000)
+	require.ErrorIs(t, err, errProcessAbsent)
+}
+
+func TestExactProcessIdentityStateRequiresOriginalStart(t *testing.T) {
 	t.Parallel()
-	assert := assert.New(t)
+	require := require.New(t)
 
 	lookup := func(pid int) (string, error) {
 		if pid == 101 {
 			return "current-start", nil
 		}
-		return "", errors.New("process not found")
+		return "", errProcessAbsent
 	}
-	assert.True(processStillMatches(101, "current-start", lookup))
-	assert.False(processStillMatches(101, "prior-start", lookup))
-	assert.False(processStillMatches(202, "gone", lookup))
+	status, err := exactProcessIdentityState(101, "current-start", lookup)
+	require.NoError(err)
+	require.Equal(processIdentityLive, status)
+	status, err = exactProcessIdentityState(101, "prior-start", lookup)
+	require.NoError(err)
+	require.Equal(processIdentityAbsent, status)
+	status, err = exactProcessIdentityState(202, "gone", lookup)
+	require.NoError(err)
+	require.Equal(processIdentityAbsent, status)
 }
 
 func TestIdentityForSocketRequiresContainedRunPath(t *testing.T) {
@@ -704,7 +747,7 @@ func TestReapStaleRemovesAdmissionWithoutRun(t *testing.T) {
 	require.NoError(os.Mkdir(admissionDir, 0o700))
 
 	require.NoError(reapStaleWithLookup(root, func(int) (string, error) {
-		return "", errors.New("owner exited")
+		return "", errProcessAbsent
 	}))
 	require.NoDirExists(admissionDir)
 }
@@ -730,7 +773,7 @@ func TestReapStalePreservesAdmissionWhenRunValidationFails(t *testing.T) {
 	require.NoError(os.Mkdir(admissionDir, 0o700))
 
 	require.Error(reapStaleWithLookup(root, func(int) (string, error) {
-		return "", errors.New("owner exited")
+		return "", errProcessAbsent
 	}))
 	require.DirExists(runDir)
 	require.DirExists(admissionDir)
@@ -764,13 +807,42 @@ func TestReapStaleDefersOwnerThatDiesAfterAdmissionSnapshot(t *testing.T) {
 		if lookups == 1 {
 			return start, nil
 		}
-		return "", errors.New("owner exited")
+		return "", errProcessAbsent
 	}
 
 	require.NoError(reapStaleWithLookup(root, lookupStart))
 	require.Equal(1, lookups)
 	require.DirExists(runDir)
 	require.DirExists(admissionDir)
+}
+
+func TestReapStalePreservesOwnerWhenLookupIsIndeterminate(t *testing.T) {
+	require := require.New(t)
+	root := filepath.Join(t.TempDir(), "root")
+	require.NoError(prepareRoot(root))
+	start := "live-owner"
+	identity := processIdentity{
+		pid:        31415,
+		startToken: tokenForStart(start),
+	}
+	runName := fmt.Sprintf(
+		"run.%d.%s.abcdef", identity.pid, identity.startToken,
+	)
+	runDir, err := publishRun(root, runName, ownerMarker{
+		PID:          identity.pid,
+		ProcessStart: start,
+		StartToken:   identity.startToken,
+	}, os.Rename)
+	require.NoError(err)
+	admissionDir := filepath.Join(root, admissionPrefix+runName)
+	require.NoError(os.Mkdir(admissionDir, 0o700))
+
+	require.Error(reapStaleWithLookup(root, func(int) (string, error) {
+		return "", errors.New("transient identity lookup failure")
+	}))
+	require.DirExists(runDir)
+	require.DirExists(admissionDir)
+	require.NoFileExists(filepath.Join(admissionDir, admissionClosedName))
 }
 
 func TestNewAtReapsServerAfterRunDirectoryDisappears(t *testing.T) {

--- a/internal/testutil/testtmux/owner_test.go
+++ b/internal/testutil/testtmux/owner_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofrs/flock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/procutil"
@@ -246,6 +247,135 @@ func TestOwnerCleanupRetainsSharedRoot(t *testing.T) {
 	info, err := os.Stat(root)
 	require.NoError(err)
 	require.True(info.IsDir())
+}
+
+func TestHeldAdmissionLockHelperProcess(t *testing.T) {
+	require := require.New(t)
+	admissionDir := os.Getenv("KENN_FORGE_TEST_TMUX_HELD_ADMISSION")
+	if admissionDir == "" {
+		return
+	}
+	lock := flock.New(filepath.Join(admissionDir, admissionLockName))
+	require.NoError(lock.Lock())
+	defer func() { require.NoError(lock.Unlock()) }()
+	require.NoError(os.WriteFile(
+		os.Getenv("KENN_FORGE_TEST_TMUX_HELD_ADMISSION_READY"),
+		[]byte("ready\n"),
+		0o600,
+	))
+	require.Eventually(func() bool {
+		_, err := os.Stat(os.Getenv(
+			"KENN_FORGE_TEST_TMUX_HELD_ADMISSION_RELEASE",
+		))
+		return err == nil
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+func startHeldAdmissionLockHelper(t *testing.T, admissionDir string) func() {
+	t.Helper()
+	require := require.New(t)
+	directory := t.TempDir()
+	ready := filepath.Join(directory, "ready")
+	release := filepath.Join(directory, "release")
+	command := procutil.Command(
+		os.Args[0],
+		"-test.run=^TestHeldAdmissionLockHelperProcess$",
+	)
+	command.Env = append(os.Environ(),
+		"KENN_FORGE_TEST_TMUX_HELD_ADMISSION="+admissionDir,
+		"KENN_FORGE_TEST_TMUX_HELD_ADMISSION_READY="+ready,
+		"KENN_FORGE_TEST_TMUX_HELD_ADMISSION_RELEASE="+release,
+	)
+	require.NoError(command.Start())
+	t.Cleanup(func() {
+		if command.ProcessState == nil {
+			_ = command.Process.Kill()
+			_, _ = command.Process.Wait()
+		}
+	})
+	require.Eventually(func() bool {
+		_, statErr := os.Stat(ready)
+		return statErr == nil
+	}, 5*time.Second, 10*time.Millisecond)
+	markers, err := filepath.Glob(filepath.Join(admissionDir, "starting.*"))
+	require.NoError(err)
+	require.Empty(markers)
+	return func() {
+		require.NoError(os.WriteFile(release, []byte("release\n"), 0o600))
+		require.NoError(command.Wait())
+	}
+}
+
+func runWithHeldAdmissionLock(
+	t *testing.T,
+	admissionDir string,
+	operation func() error,
+) error {
+	t.Helper()
+	require := require.New(t)
+	releaseLock := startHeldAdmissionLockHelper(t, admissionDir)
+	done := make(chan error, 1)
+	go func() { done <- operation() }()
+	var operationErr error
+	timedOut := false
+	select {
+	case operationErr = <-done:
+	case <-time.After(cleanupTimeout + 2*time.Second):
+		timedOut = true
+	}
+	releaseLock()
+	if timedOut {
+		operationErr = <-done
+		require.Fail("operation did not time out while the admission lock was held")
+	}
+	return operationErr
+}
+
+func TestOwnerCleanupTimesOutWhenAdmissionLockIsHeld(t *testing.T) {
+	require := require.New(t)
+	directory := t.TempDir()
+	owner, err := newAt(filepath.Join(directory, "root"))
+	require.NoError(err)
+
+	cleanupErr := runWithHeldAdmissionLock(
+		t, owner.admissionDir, owner.Cleanup,
+	)
+	require.ErrorIs(cleanupErr, context.DeadlineExceeded)
+	require.DirExists(owner.runDir)
+	require.DirExists(owner.admissionDir)
+}
+
+func TestReapStaleTimesOutWhenAdmissionLockIsHeld(t *testing.T) {
+	require := require.New(t)
+	root := filepath.Join(t.TempDir(), "root")
+	require.NoError(prepareRoot(root))
+	start := "dead-owner"
+	identity := processIdentity{
+		pid:        999_999,
+		startToken: tokenForStart(start),
+	}
+	runName := fmt.Sprintf(
+		"run.%d.%s.abcdef", identity.pid, identity.startToken,
+	)
+	runDir, admissionDir, err := publishOwnerState(
+		root,
+		runName,
+		ownerMarker{
+			PID:          identity.pid,
+			ProcessStart: start,
+			StartToken:   identity.startToken,
+		},
+		os.Rename,
+	)
+	require.NoError(err)
+	reapErr := runWithHeldAdmissionLock(t, admissionDir, func() error {
+		return reapStaleWithLookup(root, func(int) (string, error) {
+			return "", errProcessAbsent
+		})
+	})
+	require.ErrorIs(reapErr, context.DeadlineExceeded)
+	require.DirExists(runDir)
+	require.DirExists(admissionDir)
 }
 
 func TestOwnerCleanupPreservesStateWhenAdmissionCannotClose(t *testing.T) {

--- a/internal/testutil/testtmux/owner_test.go
+++ b/internal/testutil/testtmux/owner_test.go
@@ -1,0 +1,360 @@
+package testtmux
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/procutil"
+	"go.kenn.io/forge/internal/testutil/testsignal"
+)
+
+func requireTmux(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("real tmux tests require Unix")
+	}
+	path, err := exec.LookPath("tmux")
+	if err != nil {
+		t.Skipf("tmux is unavailable: %v", err)
+	}
+	return path
+}
+
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	directory, err := os.MkdirTemp("/tmp", "kf-tmux-test-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(directory) })
+	return directory
+}
+
+func startTmuxServer(
+	t *testing.T,
+	tmuxPath string,
+	command []string,
+) int {
+	t.Helper()
+	args := append(append([]string(nil), command[1:]...),
+		"new-session", "-d", "-s", "fixture", "sleep 30",
+	)
+	output, err := procutil.Command(command[0], args...).CombinedOutput()
+	require.NoError(t, err, string(output))
+	pidArgs := append(append([]string(nil), command[1:]...),
+		"display-message", "-p", "#{pid}",
+	)
+	output, err = procutil.Command(tmuxPath, pidArgs...).CombinedOutput()
+	require.NoError(t, err, string(output))
+	pid, err := strconv.Atoi(strings.TrimSpace(string(output)))
+	require.NoError(t, err)
+	return pid
+}
+
+func processGone(pid int) bool {
+	command := procutil.Command("/bin/kill", "-0", strconv.Itoa(pid))
+	return command.Run() != nil
+}
+
+func requireProcessGone(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if processGone(pid) {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	require.Fail(t, "process survived cleanup", "pid=%d", pid)
+}
+
+func TestParseRunName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		want      processIdentity
+		wantValid bool
+	}{
+		{
+			name:      "run.31415.0123456789ab.abcdef",
+			want:      processIdentity{pid: 31415, startToken: "0123456789ab"},
+			wantValid: true,
+		},
+		{name: "run.0.0123456789ab.abcdef"},
+		{name: "run.31415.short.abcdef"},
+		{name: "run.31415.0123456789ab.bad/slash"},
+		{name: "not-a-run"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := parseRunName(tt.name)
+			assert.Equal(t, tt.wantValid, ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRunIsLiveRequiresMatchingProcessStart(t *testing.T) {
+	t.Parallel()
+
+	lookup := func(pid int) (string, error) {
+		switch pid {
+		case 101:
+			return "same-start", nil
+		case 202:
+			return "reused-start", nil
+		default:
+			return "", errors.New("process not found")
+		}
+	}
+
+	assert.True(t, runIsLive(
+		processIdentity{pid: 101, startToken: tokenForStart("same-start")},
+		lookup,
+	))
+	assert.False(t, runIsLive(
+		processIdentity{pid: 202, startToken: tokenForStart("original-start")},
+		lookup,
+	), "a reused PID must not pin a dead run")
+	assert.False(t, runIsLive(
+		processIdentity{pid: 303, startToken: tokenForStart("gone")},
+		lookup,
+	))
+}
+
+func TestProcessStartIsStableForLiveProcess(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	if runtime.GOOS == "windows" {
+		t.Skip("the Windows identity implementation is cross-compiled here")
+	}
+	first, err := processStart(os.Getpid())
+	require.NoError(err)
+	time.Sleep(10 * time.Millisecond)
+	second, err := processStart(os.Getpid())
+	require.NoError(err)
+	assert.NotEmpty(first)
+	assert.Equal(first, second)
+}
+
+func TestProcessStillMatchesRequiresOriginalStart(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	lookup := func(pid int) (string, error) {
+		if pid == 101 {
+			return "current-start", nil
+		}
+		return "", errors.New("process not found")
+	}
+	assert.True(processStillMatches(101, "current-start", lookup))
+	assert.False(processStillMatches(101, "prior-start", lookup))
+	assert.False(processStillMatches(202, "gone", lookup))
+}
+
+func TestIdentityForSocketRequiresContainedRunPath(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	root := t.TempDir()
+	run := filepath.Join(root, "run.31415.0123456789ab.abcdef")
+	inside := filepath.Join(run, "server-1", "tmux.sock")
+	identity, ok := identityForSocket(root, inside)
+	require.True(t, ok)
+	assert.Equal(processIdentity{
+		pid:        31415,
+		startToken: "0123456789ab",
+	}, identity)
+
+	_, ok = identityForSocket(root, filepath.Join(root, "..", "escape", "tmux.sock"))
+	assert.False(ok)
+	_, ok = identityForSocket(root, filepath.Join(root, "unexpected", "tmux.sock"))
+	assert.False(ok)
+	_, ok = identityForSocket(root, "relative/tmux.sock")
+	assert.False(ok)
+}
+
+func TestOwnerCleanupStopsRegisteredServerAndPreservesControl(t *testing.T) {
+	tmuxPath := requireTmux(t)
+	root := filepath.Join(shortTempDir(t), "owned")
+	owner, err := newAt(root)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = owner.Cleanup() })
+
+	ownedCommand := owner.Command(t, tmuxPath)
+	ownedPID := startTmuxServer(t, tmuxPath, ownedCommand)
+
+	controlDir := shortTempDir(t)
+	controlSocket := filepath.Join(controlDir, "control.sock")
+	controlCommand := []string{
+		tmuxPath, "-f", "/dev/null", "-S", controlSocket,
+	}
+	controlPID := startTmuxServer(t, tmuxPath, controlCommand)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = procutil.CommandContext(
+			ctx, tmuxPath, "-S", controlSocket, "kill-server",
+		).Run()
+	})
+
+	require.NoError(t, owner.Cleanup())
+	requireProcessGone(t, ownedPID)
+	assert.False(t, processGone(controlPID), "cleanup touched an unrelated server")
+}
+
+func TestOwnerCleanupStopsRegisteredServerAfterDirectoryDisappears(t *testing.T) {
+	tmuxPath := requireTmux(t)
+	owner, err := newAt(filepath.Join(shortTempDir(t), "owned"))
+	require.NoError(t, err)
+	command := owner.Command(t, tmuxPath)
+	serverPID := startTmuxServer(t, tmuxPath, command)
+	t.Cleanup(func() {
+		if !processGone(serverPID) {
+			_ = procutil.Command("/bin/kill", "-KILL", strconv.Itoa(serverPID)).Run()
+		}
+	})
+	require.NoError(t, os.RemoveAll(owner.runDir))
+
+	require.NoError(t, owner.Cleanup())
+	requireProcessGone(t, serverPID)
+}
+
+func TestNewAtReapsServerAfterRunDirectoryDisappears(t *testing.T) {
+	require := require.New(t)
+	tmuxPath := requireTmux(t)
+	root := filepath.Join(shortTempDir(t), "owned")
+	require.NoError(os.MkdirAll(root, 0o700))
+	staleIdentity := processIdentity{
+		pid:        999999,
+		startToken: tokenForStart("dead-owner"),
+	}
+	runName := fmt.Sprintf(
+		"run.%d.%s.abcdef",
+		staleIdentity.pid,
+		staleIdentity.startToken,
+	)
+	runDir := filepath.Join(root, runName)
+	serverDir := filepath.Join(runDir, "server-abcdef")
+	require.NoError(os.MkdirAll(serverDir, 0o700))
+	socket := filepath.Join(serverDir, "tmux.sock")
+	command := []string{tmuxPath, "-f", "/dev/null", "-S", socket}
+	serverPID := startTmuxServer(t, tmuxPath, command)
+	t.Cleanup(func() {
+		if !processGone(serverPID) {
+			_ = procutil.Command("/bin/kill", "-KILL", strconv.Itoa(serverPID)).Run()
+		}
+	})
+
+	require.NoError(os.RemoveAll(runDir))
+	owner, err := newAt(root)
+	require.NoError(err)
+	t.Cleanup(func() { _ = owner.Cleanup() })
+	requireProcessGone(t, serverPID)
+}
+
+func TestNewAtRefusesUnmarkedStaleRun(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	tmuxPath := requireTmux(t)
+	root := filepath.Join(shortTempDir(t), "owned")
+	runDir := filepath.Join(
+		root,
+		"run.999999."+tokenForStart("dead-owner")+".abcdef",
+	)
+	serverDir := filepath.Join(runDir, "server-abcdef")
+	require.NoError(os.MkdirAll(serverDir, 0o700))
+	socket := filepath.Join(serverDir, "tmux.sock")
+	command := []string{tmuxPath, "-f", "/dev/null", "-S", socket}
+	serverPID := startTmuxServer(t, tmuxPath, command)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = procutil.CommandContext(ctx, tmuxPath, "-S", socket, "kill-server").Run()
+	})
+
+	owner, err := newAt(root)
+	if owner != nil {
+		t.Cleanup(func() { _ = owner.Cleanup() })
+	}
+	require.Error(err)
+	assert.False(processGone(serverPID), "ambiguous stale ownership must fail closed")
+	_, statErr := os.Stat(runDir)
+	assert.NoError(statErr)
+}
+
+func TestSignalCleanupStopsRegisteredServer(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	if os.Getenv("KENN_FORGE_TEST_TMUX_SIGNAL_HELPER") == "1" {
+		owner, err := newAt(os.Getenv("KENN_FORGE_TEST_TMUX_SIGNAL_ROOT"))
+		require.NoError(err)
+		command := owner.Command(t, os.Getenv("KENN_FORGE_TEST_TMUX_BINARY"))
+		pid := startTmuxServer(t, command[0], command)
+		require.NoError(os.WriteFile(
+			os.Getenv("KENN_FORGE_TEST_TMUX_SIGNAL_PID"),
+			[]byte(strconv.Itoa(pid)),
+			0o600,
+		))
+		testsignal.Install(owner.Cleanup, nil)
+		require.NoError(os.WriteFile(
+			os.Getenv("KENN_FORGE_TEST_TMUX_SIGNAL_READY"),
+			[]byte("ready\n"),
+			0o600,
+		))
+		select {}
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("SIGTERM cleanup requires Unix")
+	}
+
+	tmuxPath := requireTmux(t)
+	directory := shortTempDir(t)
+	ready := filepath.Join(directory, "ready")
+	pidFile := filepath.Join(directory, "server-pid")
+	command := procutil.Command(
+		os.Args[0], "-test.run=^TestSignalCleanupStopsRegisteredServer$",
+	)
+	command.Env = append(os.Environ(),
+		"KENN_FORGE_TEST_TMUX_SIGNAL_HELPER=1",
+		"KENN_FORGE_TEST_TMUX_SIGNAL_ROOT="+filepath.Join(directory, "root"),
+		"KENN_FORGE_TEST_TMUX_SIGNAL_READY="+ready,
+		"KENN_FORGE_TEST_TMUX_SIGNAL_PID="+pidFile,
+		"KENN_FORGE_TEST_TMUX_BINARY="+tmuxPath,
+	)
+	require.NoError(command.Start())
+	t.Cleanup(func() {
+		if command.ProcessState == nil {
+			_ = command.Process.Kill()
+			_, _ = command.Process.Wait()
+		}
+	})
+	require.Eventually(func() bool {
+		_, err := os.Stat(ready)
+		return err == nil
+	}, 5*time.Second, 25*time.Millisecond)
+	content, err := os.ReadFile(pidFile)
+	require.NoError(err)
+	serverPID, err := strconv.Atoi(string(content))
+	require.NoError(err)
+
+	require.NoError(command.Process.Signal(syscall.SIGTERM))
+	err = command.Wait()
+	var exitErr *exec.ExitError
+	require.ErrorAs(err, &exitErr)
+	assert.Equal(143, exitErr.ExitCode())
+	requireProcessGone(t, serverPID)
+}

--- a/internal/testutil/testtmux/owner_test.go
+++ b/internal/testutil/testtmux/owner_test.go
@@ -224,6 +224,39 @@ func TestOwnerCleanupRetainsSharedRoot(t *testing.T) {
 	require.True(info.IsDir())
 }
 
+func TestOwnerCleanupPreservesStateWhenAdmissionCannotClose(t *testing.T) {
+	require := require.New(t)
+	owner, err := newAt(filepath.Join(t.TempDir(), "root"))
+	require.NoError(err)
+	require.NoError(os.Mkdir(
+		filepath.Join(owner.admissionDir, admissionClosedName),
+		0o700,
+	))
+
+	require.Error(owner.Cleanup())
+	require.DirExists(owner.runDir)
+	require.DirExists(owner.admissionDir)
+}
+
+func TestOwnerCleanupPreservesStateWhenAdmissionDrainFails(t *testing.T) {
+	require := require.New(t)
+	root := t.TempDir()
+	runDir := filepath.Join(root, "run")
+	admissionDir := filepath.Join(root, "admission.[")
+	require.NoError(os.Mkdir(runDir, 0o700))
+	require.NoError(os.Mkdir(admissionDir, 0o700))
+	owner := &Owner{
+		root:         root,
+		runDir:       runDir,
+		admissionDir: admissionDir,
+		servers:      make(map[string]registeredServer),
+	}
+
+	require.Error(owner.Cleanup())
+	require.DirExists(runDir)
+	require.DirExists(admissionDir)
+}
+
 func TestRunIsLiveRequiresMatchingProcessStart(t *testing.T) {
 	t.Parallel()
 
@@ -302,6 +335,26 @@ func TestIdentityForSocketRequiresContainedRunPath(t *testing.T) {
 	assert.False(ok)
 	_, ok = identityForSocket(root, "relative/tmux.sock")
 	assert.False(ok)
+}
+
+func TestExplicitSocketRecognizesTmuxServerTitle(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	socket, ok := explicitSocket("tmux: server (/tmp/owned/run.1/token/tmux.sock)")
+	assert.True(ok)
+	assert.Equal("/tmp/owned/run.1/token/tmux.sock", socket)
+
+	invalid := []string{
+		"tmux: server (relative/tmux.sock)",
+		"tmux: server (/tmp/owned/tmux.sock) trailing",
+		"tmux: client (/tmp/owned/tmux.sock)",
+		"other: server (/tmp/owned/tmux.sock)",
+	}
+	for _, command := range invalid {
+		_, ok := explicitSocket(command)
+		assert.False(ok, command)
+	}
 }
 
 func TestOwnerCleanupStopsRegisteredServerAndPreservesControl(t *testing.T) {
@@ -564,6 +617,73 @@ func TestNewAtDrainsMultipleStaleAdmissionsWithinOneDeadline(t *testing.T) {
 		require.Error(<-startup.done)
 		requireProcessGone(t, startup.command.Process.Pid)
 	}
+}
+
+func TestReapStalePreservesRunWhenAdmissionCannotClose(t *testing.T) {
+	require := require.New(t)
+	root := filepath.Join(t.TempDir(), "root")
+	require.NoError(prepareRoot(root))
+	start := "dead-owner"
+	identity := processIdentity{
+		pid:        999_999,
+		startToken: tokenForStart(start),
+	}
+	runName := fmt.Sprintf(
+		"run.%d.%s.abcdef", identity.pid, identity.startToken,
+	)
+	runDir, err := publishRun(root, runName, ownerMarker{
+		PID:          identity.pid,
+		ProcessStart: start,
+		StartToken:   identity.startToken,
+	}, os.Rename)
+	require.NoError(err)
+	admissionDir := filepath.Join(root, admissionPrefix+runName)
+	require.NoError(os.Mkdir(admissionDir, 0o700))
+	require.NoError(os.Mkdir(
+		filepath.Join(admissionDir, admissionClosedName),
+		0o700,
+	))
+
+	require.Error(reapStale(root))
+	require.DirExists(runDir)
+	require.DirExists(admissionDir)
+}
+
+func TestReapStaleDefersOwnerThatDiesAfterAdmissionSnapshot(t *testing.T) {
+	require := require.New(t)
+	root := filepath.Join(t.TempDir(), "root")
+	require.NoError(prepareRoot(root))
+	start := "live-owner"
+	identity := processIdentity{
+		pid:        31415,
+		startToken: tokenForStart(start),
+	}
+	runName := fmt.Sprintf(
+		"run.%d.%s.abcdef", identity.pid, identity.startToken,
+	)
+	runDir, err := publishRun(root, runName, ownerMarker{
+		PID:          identity.pid,
+		ProcessStart: start,
+		StartToken:   identity.startToken,
+	}, os.Rename)
+	require.NoError(err)
+	admissionDir := filepath.Join(root, admissionPrefix+runName)
+	require.NoError(os.Mkdir(admissionDir, 0o700))
+
+	lookups := 0
+	lookupStart := func(pid int) (string, error) {
+		require.Equal(identity.pid, pid)
+		lookups++
+		if lookups == 1 {
+			return start, nil
+		}
+		return "", errors.New("owner exited")
+	}
+
+	require.NoError(reapStaleWithLookup(root, lookupStart))
+	require.Equal(1, lookups)
+	require.DirExists(runDir)
+	require.DirExists(admissionDir)
 }
 
 func TestNewAtReapsServerAfterRunDirectoryDisappears(t *testing.T) {

--- a/internal/testutil/testtmux/owner_test.go
+++ b/internal/testutil/testtmux/owner_test.go
@@ -316,6 +316,41 @@ func TestAdmittedCreationsPreservesMarkerWhenLookupIsIndeterminate(t *testing.T)
 	require.FileExists(marker)
 }
 
+func TestAdmittedCreationsPreservesInvalidMarker(t *testing.T) {
+	require := require.New(t)
+	admissionDir := t.TempDir()
+	marker := filepath.Join(admissionDir, "starting.invalid.token")
+	require.NoError(os.WriteFile(marker, []byte("startup-identity"), 0o600))
+
+	_, err := admittedCreationsWithLookup(
+		[]string{admissionDir},
+		func(int) (string, error) {
+			return "", errProcessAbsent
+		},
+	)
+	require.Error(err)
+	require.FileExists(marker)
+}
+
+func TestAdmittedCreationsPreservesUnreadableMarker(t *testing.T) {
+	require := require.New(t)
+	admissionDir := t.TempDir()
+	marker := filepath.Join(admissionDir, "starting.31415.token")
+	require.NoError(os.Symlink(
+		filepath.Join(admissionDir, "missing-target"), marker,
+	))
+
+	_, err := admittedCreationsWithLookup(
+		[]string{admissionDir},
+		func(int) (string, error) {
+			return "", errProcessAbsent
+		},
+	)
+	require.Error(err)
+	_, statErr := os.Lstat(marker)
+	require.NoError(statErr)
+}
+
 func TestRunProcessIdentityStateRequiresMatchingStart(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)

--- a/internal/testutil/testtmux/owner_test.go
+++ b/internal/testutil/testtmux/owner_test.go
@@ -140,6 +140,81 @@ func TestPublishRunDoesNotExposeUnmarkedFinalDirectory(t *testing.T) {
 	require.ErrorIs(err, os.ErrNotExist)
 }
 
+func TestRootLockSerializesAcrossProcesses(t *testing.T) {
+	require := require.New(t)
+	root := os.Getenv("KENN_FORGE_TEST_TMUX_LOCK_ROOT")
+	if root != "" {
+		ready := os.Getenv("KENN_FORGE_TEST_TMUX_LOCK_READY")
+		release := os.Getenv("KENN_FORGE_TEST_TMUX_LOCK_RELEASE")
+		require.NoError(withRootLock(root, func() error {
+			require.NoError(os.WriteFile(ready, []byte("ready\n"), 0o600))
+			require.Eventually(func() bool {
+				_, err := os.Stat(release)
+				return err == nil
+			}, 5*time.Second, 10*time.Millisecond)
+			return nil
+		}))
+		return
+	}
+
+	directory := t.TempDir()
+	root = filepath.Join(directory, "root")
+	require.NoError(prepareRoot(root))
+	ready := filepath.Join(directory, "ready")
+	release := filepath.Join(directory, "release")
+	command := procutil.Command(
+		os.Args[0], "-test.run=^TestRootLockSerializesAcrossProcesses$",
+	)
+	command.Env = append(os.Environ(),
+		"KENN_FORGE_TEST_TMUX_LOCK_ROOT="+root,
+		"KENN_FORGE_TEST_TMUX_LOCK_READY="+ready,
+		"KENN_FORGE_TEST_TMUX_LOCK_RELEASE="+release,
+	)
+	require.NoError(command.Start())
+	t.Cleanup(func() {
+		if command.ProcessState == nil {
+			_ = command.Process.Kill()
+			_, _ = command.Process.Wait()
+		}
+	})
+	require.Eventually(func() bool {
+		_, err := os.Stat(ready)
+		return err == nil
+	}, 5*time.Second, 10*time.Millisecond)
+
+	acquired := make(chan error, 1)
+	go func() {
+		acquired <- withRootLock(root, func() error { return nil })
+	}()
+	select {
+	case err := <-acquired:
+		require.NoError(err)
+		require.Fail("second process entered the root critical section")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	require.NoError(os.WriteFile(release, []byte("release\n"), 0o600))
+	select {
+	case err := <-acquired:
+		require.NoError(err)
+	case <-time.After(5 * time.Second):
+		require.Fail("second process did not acquire the released root lock")
+	}
+	require.NoError(command.Wait())
+}
+
+func TestOwnerCleanupRetainsSharedRoot(t *testing.T) {
+	require := require.New(t)
+	root := filepath.Join(t.TempDir(), "root")
+	owner, err := newAt(root)
+	require.NoError(err)
+
+	require.NoError(owner.Cleanup())
+	info, err := os.Stat(root)
+	require.NoError(err)
+	require.True(info.IsDir())
+}
+
 func TestRunIsLiveRequiresMatchingProcessStart(t *testing.T) {
 	t.Parallel()
 

--- a/internal/testutil/testtmux/owner_test.go
+++ b/internal/testutil/testtmux/owner_test.go
@@ -107,6 +107,39 @@ func TestParseRunName(t *testing.T) {
 	}
 }
 
+func TestSupportedMatchesPlatform(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, runtime.GOOS != "windows", Supported())
+}
+
+func TestPublishRunDoesNotExposeUnmarkedFinalDirectory(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	require := require.New(t)
+
+	root := t.TempDir()
+	runName := "run.31415.0123456789ab.abcdef"
+	marker := ownerMarker{
+		PID:          31415,
+		ProcessStart: "start",
+		StartToken:   "0123456789ab",
+	}
+	renameErr := errors.New("injected rename failure")
+	_, err := publishRun(root, runName, marker, func(staging, final string) error {
+		_, matchesFinalPattern := parseRunName(filepath.Base(staging))
+		assert.False(matchesFinalPattern)
+		_, markerErr := os.Stat(filepath.Join(staging, "owner.json"))
+		require.NoError(markerErr)
+		_, finalErr := os.Stat(final)
+		require.ErrorIs(finalErr, os.ErrNotExist)
+		return renameErr
+	})
+	require.ErrorIs(err, renameErr)
+	_, err = os.Stat(filepath.Join(root, runName))
+	require.ErrorIs(err, os.ErrNotExist)
+}
+
 func TestRunIsLiveRequiresMatchingProcessStart(t *testing.T) {
 	t.Parallel()
 

--- a/internal/testutil/testtmux/owner_test.go
+++ b/internal/testutil/testtmux/owner_test.go
@@ -149,6 +149,30 @@ func TestPublishRunDoesNotExposeUnmarkedFinalDirectory(t *testing.T) {
 	require.ErrorIs(err, os.ErrNotExist)
 }
 
+func TestPublishOwnerStateCreatesAdmissionBeforeRun(t *testing.T) {
+	require := require.New(t)
+	root := t.TempDir()
+	runName := "run.31415.0123456789ab.abcdef"
+	marker := ownerMarker{
+		PID:          31415,
+		ProcessStart: "start",
+		StartToken:   "0123456789ab",
+	}
+
+	runDir, admissionDir, err := publishOwnerState(
+		root,
+		runName,
+		marker,
+		func(staging, final string) error {
+			require.DirExists(filepath.Join(root, admissionPrefix+runName))
+			return os.Rename(staging, final)
+		},
+	)
+	require.NoError(err)
+	require.DirExists(runDir)
+	require.DirExists(admissionDir)
+}
+
 func TestRootLockSerializesAcrossProcesses(t *testing.T) {
 	require := require.New(t)
 	root := os.Getenv("KENN_FORGE_TEST_TMUX_LOCK_ROOT")
@@ -254,6 +278,22 @@ func TestOwnerCleanupPreservesStateWhenAdmissionDrainFails(t *testing.T) {
 
 	require.Error(owner.Cleanup())
 	require.DirExists(runDir)
+	require.DirExists(admissionDir)
+}
+
+func TestOwnerCleanupPreservesAdmissionWhenRunRemovalFails(t *testing.T) {
+	require := require.New(t)
+	root := t.TempDir()
+	admissionDir := filepath.Join(root, "admission")
+	require.NoError(os.Mkdir(admissionDir, 0o700))
+	owner := &Owner{
+		root:         root,
+		runDir:       filepath.Join(root, "invalid\x00run"),
+		admissionDir: admissionDir,
+		servers:      make(map[string]registeredServer),
+	}
+
+	require.Error(owner.Cleanup())
 	require.DirExists(admissionDir)
 }
 
@@ -645,6 +685,53 @@ func TestReapStalePreservesRunWhenAdmissionCannotClose(t *testing.T) {
 	))
 
 	require.Error(reapStale(root))
+	require.DirExists(runDir)
+	require.DirExists(admissionDir)
+}
+
+func TestReapStaleRemovesAdmissionWithoutRun(t *testing.T) {
+	require := require.New(t)
+	root := filepath.Join(t.TempDir(), "root")
+	require.NoError(prepareRoot(root))
+	identity := processIdentity{
+		pid:        999_999,
+		startToken: tokenForStart("dead-owner"),
+	}
+	runName := fmt.Sprintf(
+		"run.%d.%s.abcdef", identity.pid, identity.startToken,
+	)
+	admissionDir := filepath.Join(root, admissionPrefix+runName)
+	require.NoError(os.Mkdir(admissionDir, 0o700))
+
+	require.NoError(reapStaleWithLookup(root, func(int) (string, error) {
+		return "", errors.New("owner exited")
+	}))
+	require.NoDirExists(admissionDir)
+}
+
+func TestReapStalePreservesAdmissionWhenRunValidationFails(t *testing.T) {
+	require := require.New(t)
+	root := filepath.Join(t.TempDir(), "root")
+	require.NoError(prepareRoot(root))
+	identity := processIdentity{
+		pid:        999_999,
+		startToken: tokenForStart("dead-owner"),
+	}
+	runName := fmt.Sprintf(
+		"run.%d.%s.abcdef", identity.pid, identity.startToken,
+	)
+	runDir, err := publishRun(root, runName, ownerMarker{
+		PID:          identity.pid,
+		ProcessStart: "different-owner",
+		StartToken:   identity.startToken,
+	}, os.Rename)
+	require.NoError(err)
+	admissionDir := filepath.Join(root, admissionPrefix+runName)
+	require.NoError(os.Mkdir(admissionDir, 0o700))
+
+	require.Error(reapStaleWithLookup(root, func(int) (string, error) {
+		return "", errors.New("owner exited")
+	}))
 	require.DirExists(runDir)
 	require.DirExists(admissionDir)
 }

--- a/internal/testutil/testtmux/owner_test.go
+++ b/internal/testutil/testtmux/owner_test.go
@@ -410,6 +410,64 @@ esac
 	require.Equal("created\nkilled\n", string(content))
 }
 
+func TestOwnerCleanupTerminatesStalledAdmittedStartup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake tmux fixture uses Unix shell semantics")
+	}
+	require := require.New(t)
+	directory := t.TempDir()
+	owner, err := newAt(filepath.Join(directory, "root"))
+	require.NoError(err)
+	t.Cleanup(func() { _ = owner.Cleanup() })
+
+	entered := filepath.Join(directory, "entered")
+	tmuxPath := filepath.Join(directory, "fake-tmux")
+	body := `#!/bin/sh
+case "$*" in
+  *new-session*)
+	trap '' TERM
+	: > "$TEST_TMUX_ENTERED"
+	while :; do sleep 1; done
+	;;
+esac
+`
+	require.NoError(os.WriteFile(tmuxPath, []byte(body), 0o755))
+	t.Setenv("TEST_TMUX_ENTERED", entered)
+
+	tmuxCommand := owner.Command(t, tmuxPath)
+	args := append(slices.Clone(tmuxCommand[1:]), "new-session", "-d")
+	startup := procutil.Command(tmuxCommand[0], args...)
+	require.NoError(startup.Start())
+	startupDone := make(chan error, 1)
+	go func() { startupDone <- startup.Wait() }()
+	t.Cleanup(func() {
+		if !processGone(startup.Process.Pid) {
+			_ = startup.Process.Kill()
+		}
+		select {
+		case <-startupDone:
+		default:
+		}
+	})
+	require.Eventually(func() bool {
+		_, statErr := os.Stat(entered)
+		return statErr == nil
+	}, 5*time.Second, 10*time.Millisecond)
+
+	cleanupDone := make(chan error, 1)
+	go func() { cleanupDone <- owner.Cleanup() }()
+	select {
+	case cleanupErr := <-cleanupDone:
+		require.NoError(cleanupErr)
+	case <-time.After(cleanupTimeout + 2*time.Second):
+		require.Fail("cleanup did not terminate a stalled admitted tmux startup")
+		_ = startup.Process.Kill()
+		require.NoError(<-cleanupDone)
+	}
+	require.Error(<-startupDone)
+	requireProcessGone(t, startup.Process.Pid)
+}
+
 func TestNewAtReapsServerAfterRunDirectoryDisappears(t *testing.T) {
 	require := require.New(t)
 	tmuxPath := requireTmux(t)

--- a/internal/testutil/testtmux/process_identity.go
+++ b/internal/testutil/testtmux/process_identity.go
@@ -1,0 +1,62 @@
+package testtmux
+
+import (
+	"errors"
+	"fmt"
+)
+
+var errProcessAbsent = errors.New("process is absent")
+
+type processIdentityStatus uint8
+
+const (
+	processIdentityIndeterminate processIdentityStatus = iota
+	processIdentityAbsent
+	processIdentityLive
+)
+
+type processStartLookup func(int) (string, error)
+
+func lookupProcessStartState(
+	pid int,
+	lookupStart processStartLookup,
+) (string, processIdentityStatus, error) {
+	start, err := lookupStart(pid)
+	if err == nil {
+		return start, processIdentityLive, nil
+	}
+	if errors.Is(err, errProcessAbsent) {
+		return "", processIdentityAbsent, nil
+	}
+	return "", processIdentityIndeterminate,
+		fmt.Errorf("inspect process %d identity: %w", pid, err)
+}
+
+func exactProcessIdentityState(
+	pid int,
+	expectedStart string,
+	lookupStart processStartLookup,
+) (processIdentityStatus, error) {
+	actualStart, status, err := lookupProcessStartState(pid, lookupStart)
+	if err != nil || status != processIdentityLive {
+		return status, err
+	}
+	if actualStart != expectedStart {
+		return processIdentityAbsent, nil
+	}
+	return processIdentityLive, nil
+}
+
+func runProcessIdentityState(
+	identity processIdentity,
+	lookupStart processStartLookup,
+) (processIdentityStatus, error) {
+	actualStart, status, err := lookupProcessStartState(identity.pid, lookupStart)
+	if err != nil || status != processIdentityLive {
+		return status, err
+	}
+	if tokenForStart(actualStart) != identity.startToken {
+		return processIdentityAbsent, nil
+	}
+	return processIdentityLive, nil
+}

--- a/internal/testutil/testtmux/process_start_darwin.go
+++ b/internal/testutil/testtmux/process_start_darwin.go
@@ -3,6 +3,7 @@
 package testtmux
 
 import (
+	"errors"
 	"fmt"
 
 	"golang.org/x/sys/unix"
@@ -11,11 +12,20 @@ import (
 func processStart(pid int) (string, error) {
 	info, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
 	if err != nil {
-		return "", err
+		return unavailableDarwinProcessStart(pid, err)
 	}
 	if int(info.Proc.P_pid) != pid {
-		return "", fmt.Errorf("process %d identity is unavailable", pid)
+		return unavailableDarwinProcessStart(
+			pid, fmt.Errorf("sysctl returned process %d", info.Proc.P_pid),
+		)
 	}
 	start := info.Proc.P_starttime
 	return fmt.Sprintf("%d.%06d", start.Sec, start.Usec), nil
+}
+
+func unavailableDarwinProcessStart(pid int, identityErr error) (string, error) {
+	if err := unix.Kill(pid, 0); errors.Is(err, unix.ESRCH) {
+		return "", fmt.Errorf("%w: process %d", errProcessAbsent, pid)
+	}
+	return "", fmt.Errorf("read process %d identity: %w", pid, identityErr)
 }

--- a/internal/testutil/testtmux/process_start_darwin.go
+++ b/internal/testutil/testtmux/process_start_darwin.go
@@ -1,0 +1,21 @@
+//go:build darwin
+
+package testtmux
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+func processStart(pid int) (string, error) {
+	info, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil {
+		return "", err
+	}
+	if int(info.Proc.P_pid) != pid {
+		return "", fmt.Errorf("process %d identity is unavailable", pid)
+	}
+	start := info.Proc.P_starttime
+	return fmt.Sprintf("%d.%06d", start.Sec, start.Usec), nil
+}

--- a/internal/testutil/testtmux/process_start_linux.go
+++ b/internal/testutil/testtmux/process_start_linux.go
@@ -1,0 +1,30 @@
+//go:build linux
+
+package testtmux
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func processStart(pid int) (string, error) {
+	content, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return "", err
+	}
+	closingName := strings.LastIndexByte(string(content), ')')
+	if closingName < 0 {
+		return "", errors.New("process stat has no command terminator")
+	}
+	fields := strings.Fields(string(content[closingName+1:]))
+	if len(fields) <= 19 {
+		return "", errors.New("process stat has no start time")
+	}
+	if _, err := strconv.ParseUint(fields[19], 10, 64); err != nil {
+		return "", fmt.Errorf("parse process start time: %w", err)
+	}
+	return fields[19], nil
+}

--- a/internal/testutil/testtmux/process_start_linux.go
+++ b/internal/testutil/testtmux/process_start_linux.go
@@ -8,14 +8,19 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"golang.org/x/sys/unix"
 )
 
 func processStart(pid int) (string, error) {
-	content, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return "", fmt.Errorf("%w: process %d", errProcessAbsent, pid)
+	content, err := readProcessStatFromProc(pid, os.ReadFile, func(pid int) error {
+		err := unix.Kill(pid, 0)
+		if errors.Is(err, unix.ESRCH) {
+			return errProcessAbsent
 		}
+		return err
+	})
+	if err != nil {
 		return "", err
 	}
 	closingName := strings.LastIndexByte(string(content), ')')

--- a/internal/testutil/testtmux/process_start_linux.go
+++ b/internal/testutil/testtmux/process_start_linux.go
@@ -13,6 +13,9 @@ import (
 func processStart(pid int) (string, error) {
 	content, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("%w: process %d", errProcessAbsent, pid)
+		}
 		return "", err
 	}
 	closingName := strings.LastIndexByte(string(content), ')')

--- a/internal/testutil/testtmux/process_start_other.go
+++ b/internal/testutil/testtmux/process_start_other.go
@@ -1,0 +1,26 @@
+//go:build !darwin && !linux && !windows
+
+package testtmux
+
+import (
+	"errors"
+	"os"
+	"strconv"
+	"strings"
+
+	"go.kenn.io/forge/internal/procutil"
+)
+
+func processStart(pid int) (string, error) {
+	command := procutil.Command("ps", "-p", strconv.Itoa(pid), "-o", "lstart=")
+	command.Env = append(os.Environ(), "LC_ALL=C")
+	output, err := command.Output()
+	if err != nil {
+		return "", err
+	}
+	start := strings.TrimSpace(string(output))
+	if start == "" {
+		return "", errors.New("process start time is empty")
+	}
+	return start, nil
+}

--- a/internal/testutil/testtmux/process_start_other.go
+++ b/internal/testutil/testtmux/process_start_other.go
@@ -2,25 +2,8 @@
 
 package testtmux
 
-import (
-	"errors"
-	"os"
-	"strconv"
-	"strings"
+import "errors"
 
-	"go.kenn.io/forge/internal/procutil"
-)
-
-func processStart(pid int) (string, error) {
-	command := procutil.Command("ps", "-p", strconv.Itoa(pid), "-o", "lstart=")
-	command.Env = append(os.Environ(), "LC_ALL=C")
-	output, err := command.Output()
-	if err != nil {
-		return "", err
-	}
-	start := strings.TrimSpace(string(output))
-	if start == "" {
-		return "", errors.New("process start time is empty")
-	}
-	return start, nil
+func processStart(int) (string, error) {
+	return "", errors.New("high-resolution process identity is unsupported")
 }

--- a/internal/testutil/testtmux/process_start_proc.go
+++ b/internal/testutil/testtmux/process_start_proc.go
@@ -1,0 +1,23 @@
+package testtmux
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+func readProcessStatFromProc(
+	pid int,
+	readFile func(string) ([]byte, error),
+	probeProcess func(int) error,
+) ([]byte, error) {
+	content, err := readFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) &&
+			errors.Is(probeProcess(pid), errProcessAbsent) {
+			return nil, fmt.Errorf("%w: process %d", errProcessAbsent, pid)
+		}
+		return nil, err
+	}
+	return content, nil
+}

--- a/internal/testutil/testtmux/process_start_proc_test.go
+++ b/internal/testutil/testtmux/process_start_proc_test.go
@@ -1,0 +1,40 @@
+package testtmux
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadProcessStatFromProcConfirmsMissingProcess(t *testing.T) {
+	_, err := readProcessStatFromProc(
+		31415,
+		func(string) ([]byte, error) {
+			return nil, os.ErrNotExist
+		},
+		func(int) error {
+			return errProcessAbsent
+		},
+	)
+	require.ErrorIs(t, err, errProcessAbsent)
+}
+
+func TestReadProcessStatFromProcPreservesMissingStatAsIndeterminate(t *testing.T) {
+	statErr := &os.PathError{
+		Op:   "open",
+		Path: "/proc/31415/stat",
+		Err:  os.ErrNotExist,
+	}
+	_, err := readProcessStatFromProc(
+		31415,
+		func(string) ([]byte, error) {
+			return nil, statErr
+		},
+		func(int) error {
+			return nil
+		},
+	)
+	require.Same(t, statErr, err)
+	require.NotErrorIs(t, err, errProcessAbsent)
+}

--- a/internal/testutil/testtmux/process_unix.go
+++ b/internal/testutil/testtmux/process_unix.go
@@ -1,0 +1,117 @@
+//go:build !windows
+
+package testtmux
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"go.kenn.io/forge/internal/procutil"
+)
+
+type tmuxProcess struct {
+	pid     int
+	command string
+	start   string
+}
+
+func tmuxRootBase() string {
+	return "/tmp"
+}
+
+func validateDirectoryOwner(info fs.FileInfo) error {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return errors.New("directory owner is unavailable")
+	}
+	if int(stat.Uid) != os.Getuid() {
+		return fmt.Errorf("owner UID %d does not match %d", stat.Uid, os.Getuid())
+	}
+	return nil
+}
+
+func tmuxProcesses() ([]tmuxProcess, error) {
+	command := procutil.Command("ps", "-axo", "pid=,uid=,command=")
+	command.Env = append(os.Environ(), "LC_ALL=C")
+	output, err := command.Output()
+	if err != nil {
+		return nil, fmt.Errorf("list tmux processes: %w", err)
+	}
+	var processes []tmuxProcess
+	for line := range strings.SplitSeq(string(output), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+		pid, pidErr := strconv.Atoi(fields[0])
+		uid, uidErr := strconv.Atoi(fields[1])
+		if pidErr != nil || uidErr != nil || uid != os.Getuid() {
+			continue
+		}
+		executable := strings.TrimPrefix(filepathBase(fields[2]), "-")
+		if executable != "tmux" {
+			continue
+		}
+		start, startErr := processStart(pid)
+		if startErr != nil {
+			continue
+		}
+		processes = append(processes, tmuxProcess{
+			pid:     pid,
+			command: strings.Join(fields[2:], " "),
+			start:   start,
+		})
+	}
+	return processes, nil
+}
+
+func filepathBase(path string) string {
+	if index := strings.LastIndexByte(path, '/'); index >= 0 {
+		return path[index+1:]
+	}
+	return path
+}
+
+func processStillMatches(
+	pid int,
+	expectedStart string,
+	lookupStart func(int) (string, error),
+) bool {
+	actualStart, err := lookupStart(pid)
+	return err == nil && actualStart == expectedStart
+}
+
+func stopProcess(pid int, expectedStart string) error {
+	if !processStillMatches(pid, expectedStart, processStart) {
+		return nil
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("find stale tmux process %d: %w", pid, err)
+	}
+	if err := process.Signal(syscall.SIGTERM); err != nil &&
+		!errors.Is(err, os.ErrProcessDone) {
+		return fmt.Errorf("terminate stale tmux process %d: %w", pid, err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if !processStillMatches(pid, expectedStart, processStart) {
+			return nil
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	if !processStillMatches(pid, expectedStart, processStart) {
+		return nil
+	}
+	if err := process.Signal(syscall.SIGKILL); err != nil &&
+		!errors.Is(err, os.ErrProcessDone) {
+		return fmt.Errorf("kill stale tmux process %d: %w", pid, err)
+	}
+	return nil
+}

--- a/internal/testutil/testtmux/process_unix.go
+++ b/internal/testutil/testtmux/process_unix.go
@@ -43,6 +43,13 @@ func tmuxProcesses() ([]tmuxProcess, error) {
 	if err != nil {
 		return nil, fmt.Errorf("list tmux processes: %w", err)
 	}
+	return parseTmuxProcesses(output, processStart)
+}
+
+func parseTmuxProcesses(
+	output []byte,
+	lookupStart processStartLookup,
+) ([]tmuxProcess, error) {
 	var processes []tmuxProcess
 	for line := range strings.SplitSeq(string(output), "\n") {
 		fields := strings.Fields(line)
@@ -60,8 +67,11 @@ func tmuxProcesses() ([]tmuxProcess, error) {
 		if executable != "tmux" && !titledServer {
 			continue
 		}
-		start, startErr := processStart(pid)
+		start, status, startErr := lookupProcessStartState(pid, lookupStart)
 		if startErr != nil {
+			return nil, fmt.Errorf("identify tmux process %d: %w", pid, startErr)
+		}
+		if status == processIdentityAbsent {
 			continue
 		}
 		processes = append(processes, tmuxProcess{
@@ -80,17 +90,20 @@ func filepathBase(path string) string {
 	return path
 }
 
-func processStillMatches(
-	pid int,
-	expectedStart string,
-	lookupStart func(int) (string, error),
-) bool {
-	actualStart, err := lookupStart(pid)
-	return err == nil && actualStart == expectedStart
+func stopProcess(pid int, expectedStart string) error {
+	return stopProcessWithLookup(pid, expectedStart, processStart)
 }
 
-func stopProcess(pid int, expectedStart string) error {
-	if !processStillMatches(pid, expectedStart, processStart) {
+func stopProcessWithLookup(
+	pid int,
+	expectedStart string,
+	lookupStart processStartLookup,
+) error {
+	status, err := exactProcessIdentityState(pid, expectedStart, lookupStart)
+	if err != nil {
+		return fmt.Errorf("verify stale tmux process %d: %w", pid, err)
+	}
+	if status == processIdentityAbsent {
 		return nil
 	}
 	process, err := os.FindProcess(pid)
@@ -103,12 +116,20 @@ func stopProcess(pid int, expectedStart string) error {
 	}
 	deadline := time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
-		if !processStillMatches(pid, expectedStart, processStart) {
+		status, err = exactProcessIdentityState(pid, expectedStart, lookupStart)
+		if err != nil {
+			return fmt.Errorf("verify terminated tmux process %d: %w", pid, err)
+		}
+		if status == processIdentityAbsent {
 			return nil
 		}
 		time.Sleep(25 * time.Millisecond)
 	}
-	if !processStillMatches(pid, expectedStart, processStart) {
+	status, err = exactProcessIdentityState(pid, expectedStart, lookupStart)
+	if err != nil {
+		return fmt.Errorf("verify terminated tmux process %d: %w", pid, err)
+	}
+	if status == processIdentityAbsent {
 		return nil
 	}
 	if err := process.Signal(syscall.SIGKILL); err != nil &&

--- a/internal/testutil/testtmux/process_unix.go
+++ b/internal/testutil/testtmux/process_unix.go
@@ -54,8 +54,10 @@ func tmuxProcesses() ([]tmuxProcess, error) {
 		if pidErr != nil || uidErr != nil || uid != os.Getuid() {
 			continue
 		}
+		processCommand := strings.Join(fields[2:], " ")
 		executable := strings.TrimPrefix(filepathBase(fields[2]), "-")
-		if executable != "tmux" {
+		_, titledServer := tmuxServerTitleSocket(processCommand)
+		if executable != "tmux" && !titledServer {
 			continue
 		}
 		start, startErr := processStart(pid)
@@ -64,7 +66,7 @@ func tmuxProcesses() ([]tmuxProcess, error) {
 		}
 		processes = append(processes, tmuxProcess{
 			pid:     pid,
-			command: strings.Join(fields[2:], " "),
+			command: processCommand,
 			start:   start,
 		})
 	}

--- a/internal/testutil/testtmux/process_unix_test.go
+++ b/internal/testutil/testtmux/process_unix_test.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package testtmux
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTmuxProcessInventoryRejectsIndeterminateIdentity(t *testing.T) {
+	output := fmt.Appendf(nil,
+		"31415 %d tmux -S /tmp/private/tmux.sock\n", os.Getuid(),
+	)
+
+	_, err := parseTmuxProcesses(output, func(int) (string, error) {
+		return "", errors.New("transient identity lookup failure")
+	})
+	require.Error(t, err)
+}
+
+func TestStopProcessRejectsIndeterminateIdentity(t *testing.T) {
+	err := stopProcessWithLookup(
+		31415,
+		"startup-identity",
+		func(int) (string, error) {
+			return "", errors.New("transient identity lookup failure")
+		},
+	)
+	require.Error(t, err)
+}

--- a/internal/testutil/testtmux/process_windows.go
+++ b/internal/testutil/testtmux/process_windows.go
@@ -1,0 +1,64 @@
+//go:build windows
+
+package testtmux
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"strconv"
+	"strings"
+
+	"go.kenn.io/forge/internal/procutil"
+)
+
+type tmuxProcess struct {
+	pid     int
+	command string
+	start   string
+}
+
+func tmuxRootBase() string {
+	return os.TempDir()
+}
+
+func validateDirectoryOwner(fs.FileInfo) error {
+	return nil
+}
+
+func processStart(pid int) (string, error) {
+	command := procutil.Command(
+		"powershell.exe", "-NoProfile", "-NonInteractive", "-Command",
+		fmt.Sprintf(
+			"(Get-Process -Id %d -ErrorAction Stop).StartTime.ToUniversalTime().Ticks",
+			pid,
+		),
+	)
+	output, err := command.Output()
+	if err != nil {
+		return "", err
+	}
+	start := strings.TrimSpace(string(output))
+	if _, err := strconv.ParseInt(start, 10, 64); err != nil {
+		return "", fmt.Errorf("parse process start time: %w", err)
+	}
+	return start, nil
+}
+
+func tmuxProcesses() ([]tmuxProcess, error) {
+	return nil, nil
+}
+
+func processStillMatches(
+	pid int,
+	expectedStart string,
+	lookupStart func(int) (string, error),
+) bool {
+	actualStart, err := lookupStart(pid)
+	return err == nil && actualStart == expectedStart
+}
+
+func stopProcess(int, string) error {
+	return errors.New("direct tmux process recovery is unavailable on Windows")
+}

--- a/internal/testutil/testtmux/process_windows.go
+++ b/internal/testutil/testtmux/process_windows.go
@@ -50,15 +50,6 @@ func tmuxProcesses() ([]tmuxProcess, error) {
 	return nil, nil
 }
 
-func processStillMatches(
-	pid int,
-	expectedStart string,
-	lookupStart func(int) (string, error),
-) bool {
-	actualStart, err := lookupStart(pid)
-	return err == nil && actualStart == expectedStart
-}
-
 func stopProcess(int, string) error {
 	return errors.New("direct tmux process recovery is unavailable on Windows")
 }

--- a/internal/testutil/testtmux/supported_mobile.go
+++ b/internal/testutil/testtmux/supported_mobile.go
@@ -1,8 +1,8 @@
-//go:build (darwin && !ios) || (linux && !android)
+//go:build android || ios
 
 package testtmux
 
 // Supported reports whether private real-tmux test servers are available.
 func Supported() bool {
-	return true
+	return false
 }

--- a/internal/testutil/testtmux/supported_other.go
+++ b/internal/testutil/testtmux/supported_other.go
@@ -1,8 +1,8 @@
-//go:build (darwin && !ios) || (linux && !android)
+//go:build !darwin && !linux && !windows
 
 package testtmux
 
 // Supported reports whether private real-tmux test servers are available.
 func Supported() bool {
-	return true
+	return false
 }

--- a/internal/testutil/testtmux/supported_unix.go
+++ b/internal/testutil/testtmux/supported_unix.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package testtmux
+
+// Supported reports whether private real-tmux test servers are available.
+func Supported() bool {
+	return true
+}

--- a/internal/testutil/testtmux/supported_windows.go
+++ b/internal/testutil/testtmux/supported_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package testtmux
+
+// Supported reports whether private real-tmux test servers are available.
+func Supported() bool {
+	return false
+}

--- a/internal/testutil/testtmux/wrapper_unix.go
+++ b/internal/testutil/testtmux/wrapper_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package testtmux
+
+import (
+	"os"
+	"syscall"
+)
+
+func replaceWithTmux(path string, args []string) error {
+	argv := append([]string{path}, args...)
+	return syscall.Exec(path, argv, os.Environ())
+}

--- a/internal/testutil/testtmux/wrapper_windows.go
+++ b/internal/testutil/testtmux/wrapper_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package testtmux
+
+import (
+	"os"
+
+	"go.kenn.io/forge/internal/procutil"
+)
+
+func replaceWithTmux(path string, args []string) error {
+	command := procutil.Command(path, args...)
+	command.Stdin = os.Stdin
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	return command.Run()
+}

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -39,18 +39,25 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "contain local runtime test process tree: %v\n", err)
 		os.Exit(1)
 	}
-	var ownerErr error
-	privateTmuxOwner, ownerErr = testtmux.New()
-	if ownerErr != nil {
-		fmt.Fprintf(os.Stderr, "initialize private test tmux owner: %v\n", ownerErr)
-		os.Exit(1)
+	if testtmux.Supported() {
+		var ownerErr error
+		privateTmuxOwner, ownerErr = testtmux.New()
+		if ownerErr != nil {
+			fmt.Fprintf(os.Stderr, "initialize private test tmux owner: %v\n", ownerErr)
+			os.Exit(1)
+		}
 	}
 	envDir, err := os.MkdirTemp("", "kenn-forge-localruntime-tmux-env-*")
 	if err == nil {
 		_ = os.Setenv("KENN_FORGE_TMUX_ENV_DIR", envDir)
 	}
 	runCleanup, stopSignalCleanup := testsignal.Install(
-		privateTmuxOwner.Cleanup,
+		func() error {
+			if privateTmuxOwner == nil {
+				return nil
+			}
+			return privateTmuxOwner.Cleanup()
+		},
 		func(cleanupErr error) {
 			fmt.Fprintf(os.Stderr, "cleanup private test tmux servers: %v\n", cleanupErr)
 		},

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -25,7 +25,11 @@ import (
 	"go.kenn.io/forge/internal/ptyowner"
 	ptyownerruntime "go.kenn.io/forge/internal/ptyowner/runtime"
 	"go.kenn.io/forge/internal/testutil/processjob"
+	"go.kenn.io/forge/internal/testutil/testsignal"
+	"go.kenn.io/forge/internal/testutil/testtmux"
 )
+
+var privateTmuxOwner *testtmux.Owner
 
 func TestMain(m *testing.M) {
 	if os.Getenv("KENN_FORGE_LOCALRUNTIME_HELPER") == "1" {
@@ -35,11 +39,30 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "contain local runtime test process tree: %v\n", err)
 		os.Exit(1)
 	}
+	var ownerErr error
+	privateTmuxOwner, ownerErr = testtmux.New()
+	if ownerErr != nil {
+		fmt.Fprintf(os.Stderr, "initialize private test tmux owner: %v\n", ownerErr)
+		os.Exit(1)
+	}
 	envDir, err := os.MkdirTemp("", "kenn-forge-localruntime-tmux-env-*")
 	if err == nil {
 		_ = os.Setenv("KENN_FORGE_TMUX_ENV_DIR", envDir)
 	}
+	runCleanup, stopSignalCleanup := testsignal.Install(
+		privateTmuxOwner.Cleanup,
+		func(cleanupErr error) {
+			fmt.Fprintf(os.Stderr, "cleanup private test tmux servers: %v\n", cleanupErr)
+		},
+	)
 	code := m.Run()
+	if cleanupErr := runCleanup(); cleanupErr != nil {
+		fmt.Fprintf(os.Stderr, "cleanup private test tmux servers: %v\n", cleanupErr)
+		if code == 0 {
+			code = 1
+		}
+	}
+	stopSignalCleanup()
 	if err == nil {
 		_ = os.RemoveAll(envDir)
 	}
@@ -1018,24 +1041,17 @@ func TestTmuxLauncherCopiesClientEnvWithoutGlobalUpdateEnvironment(t *testing.T)
 	t.Setenv("KENN_FORGE_GITHUB_TOKEN", "client-secret")
 	t.Setenv("KENN_FORGE_STRIPPED_ENV", "client-stripped")
 
-	dir, err := os.MkdirTemp("/tmp", "kenn-forge-tmux-env-*")
-	require.NoError(err)
-	t.Cleanup(func() {
-		_ = os.RemoveAll(dir)
-	})
-	socket := filepath.Join(dir, "tmux.sock")
+	tmuxCommand := privateTmuxOwner.Command(t, tmuxPath)
+	socket := tmuxCommand[len(tmuxCommand)-1]
+	dir := filepath.Dir(socket)
 	output := filepath.Join(dir, "env-output")
 	seed := "kenn-forge-seed-" + strconv.FormatInt(time.Now().UnixNano(), 36)
 	sessionName := "kenn-forge-test-" + strconv.FormatInt(time.Now().UnixNano(), 36)
-	t.Cleanup(func() {
-		_ = procutil.Command(
-			tmuxPath, "-f", "/dev/null", "-S", socket, "kill-server",
-		).Run()
-	})
-
 	seedCmd := procutil.Command(
-		tmuxPath, "-f", "/dev/null", "-S", socket,
-		"new-session", "-d", "-s", seed, "sleep 10",
+		tmuxCommand[0], append(
+			append([]string(nil), tmuxCommand[1:]...),
+			"new-session", "-d", "-s", seed, "sleep 10",
+		)...,
 	)
 	seedCmd.Env = append(
 		sessionEnvironment(os.Environ(), []string{"KENN_FORGE_STRIPPED_ENV"}),
@@ -1067,7 +1083,6 @@ func TestTmuxLauncherCopiesClientEnvWithoutGlobalUpdateEnvironment(t *testing.T)
 	require.NotContains(paneCommand, "server-secret")
 	require.NotContains(paneCommand, "server-stripped")
 
-	tmuxCommand := []string{tmuxPath, "-f", "/dev/null", "-S", socket}
 	_, err = tmuxLauncher{
 		TmuxCommand: tmuxCommand,
 		Session:     sessionName,

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -32,6 +32,9 @@ import (
 var privateTmuxOwner *testtmux.Owner
 
 func TestMain(m *testing.M) {
+	if code, ok := testtmux.CommandWrapperExitCode(); ok {
+		os.Exit(code)
+	}
 	if os.Getenv("KENN_FORGE_LOCALRUNTIME_HELPER") == "1" {
 		os.Exit(m.Run())
 	}

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -5423,22 +5423,12 @@ func TestManagerListTmuxSessionInfosRealTmux(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	dir, err := os.MkdirTemp("/tmp", "kenn-forge-tmux-list-*")
-	require.NoError(err)
-	t.Cleanup(func() {
-		_ = os.RemoveAll(dir)
-	})
-	socket := filepath.Join(dir, "tmux.sock")
-	t.Cleanup(func() {
-		_ = procutil.Command(
-			tmuxPath, "-f", "/dev/null", "-S", socket, "kill-server",
-		).Run()
-	})
+	tmuxCommand := privateTmuxOwner.Command(t, tmuxPath)
 	run := func(args ...string) {
 		t.Helper()
 		cmd := procutil.Command(
-			tmuxPath,
-			append([]string{"-f", "/dev/null", "-S", socket}, args...)...,
+			tmuxCommand[0],
+			append(append([]string(nil), tmuxCommand[1:]...), args...)...,
 		)
 		cmd.Env = append(os.Environ(), "TERM=xterm-256color")
 		out, err := cmd.CombinedOutput()
@@ -5452,7 +5442,7 @@ func TestManagerListTmuxSessionInfosRealTmux(t *testing.T) {
 
 	d := openTestDB(t)
 	mgr := NewManager(d, t.TempDir())
-	mgr.SetTmuxCommand([]string{tmuxPath, "-f", "/dev/null", "-S", socket})
+	mgr.SetTmuxCommand(tmuxCommand)
 	run("set-option", "-t", owned, "@forge_owner", mgr.tmuxOwnerMarker())
 
 	infos, err := mgr.listTmuxSessionInfos(context.Background())

--- a/internal/workspace/testmain_test.go
+++ b/internal/workspace/testmain_test.go
@@ -13,13 +13,20 @@ var privateTmuxOwner *testtmux.Owner
 
 func TestMain(m *testing.M) {
 	var err error
-	privateTmuxOwner, err = testtmux.New()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "initialize private test tmux owner: %v\n", err)
-		os.Exit(1)
+	if testtmux.Supported() {
+		privateTmuxOwner, err = testtmux.New()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "initialize private test tmux owner: %v\n", err)
+			os.Exit(1)
+		}
 	}
 	runCleanup, stopSignalCleanup := testsignal.Install(
-		privateTmuxOwner.Cleanup,
+		func() error {
+			if privateTmuxOwner == nil {
+				return nil
+			}
+			return privateTmuxOwner.Cleanup()
+		},
 		func(cleanupErr error) {
 			fmt.Fprintf(os.Stderr, "cleanup private test tmux servers: %v\n", cleanupErr)
 		},

--- a/internal/workspace/testmain_test.go
+++ b/internal/workspace/testmain_test.go
@@ -1,0 +1,36 @@
+package workspace
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"go.kenn.io/forge/internal/testutil/testsignal"
+	"go.kenn.io/forge/internal/testutil/testtmux"
+)
+
+var privateTmuxOwner *testtmux.Owner
+
+func TestMain(m *testing.M) {
+	var err error
+	privateTmuxOwner, err = testtmux.New()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "initialize private test tmux owner: %v\n", err)
+		os.Exit(1)
+	}
+	runCleanup, stopSignalCleanup := testsignal.Install(
+		privateTmuxOwner.Cleanup,
+		func(cleanupErr error) {
+			fmt.Fprintf(os.Stderr, "cleanup private test tmux servers: %v\n", cleanupErr)
+		},
+	)
+	code := m.Run()
+	if cleanupErr := runCleanup(); cleanupErr != nil {
+		fmt.Fprintf(os.Stderr, "cleanup private test tmux servers: %v\n", cleanupErr)
+		if code == 0 {
+			code = 1
+		}
+	}
+	stopSignalCleanup()
+	os.Exit(code)
+}

--- a/internal/workspace/testmain_test.go
+++ b/internal/workspace/testmain_test.go
@@ -12,6 +12,9 @@ import (
 var privateTmuxOwner *testtmux.Owner
 
 func TestMain(m *testing.M) {
+	if code, ok := testtmux.CommandWrapperExitCode(); ok {
+		os.Exit(code)
+	}
 	var err error
 	if testtmux.Supported() {
 		privateTmuxOwner, err = testtmux.New()


### PR DESCRIPTION
Aborted Go test binaries can leave detached tmux servers alive after their temporary socket directories disappear. Those servers keep pseudoterminals open and can eventually exhaust a developer or CI host.

This gives each real private-tmux fixture a recoverable owner identity based on its process ID and start time. Normal exit and termination signals clean the registry. Later test runs can also reap a dead owner when its socket directory is gone. Cleanup accepts only same-user tmux processes under the dedicated test root and never addresses the user's default server.

<details>
<summary>Validation</summary>

- Real tmux recovery tests pass for normal cleanup, termination signals, process-ID reuse, and vanished directories.
- The affected server and workspace packages pass.
- API generation is unchanged, the short pre-commit suite passes, and golangci-lint reports zero issues.

</details>