### PR TITLE
fix(archive): stop retrying deleted GitHub issues

### DIFF
--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -441,6 +441,10 @@ fallback repository listing.
 - Updated issue scans query one second before the durable watermark while keeping cursor identity bound to the original boundary. Updated pull-request scans run newest-first across the same overlap. (`internal/github/pages.go::ListIssuesPage`, `internal/github/pages.go::ListMergeRequestsPage`)
 - Durable pull-request inventory bypasses the process-local list ETag cache. Archive cursors require response bodies, so a bodyless `304 Not Modified` must not turn an unchanged maintenance scan into a retryable failure. (`internal/github/pages.go::liveClient.ListInventoryPullRequestsPage`)
 - Repository probes classify only authentication/access/not-found responses; transient probe failures remain retryable and non-destructive. Issue and pull-request lookups compare the response repository with the requested source identity so transfers become moved outcomes instead of source-owned snapshots. (`internal/github/pages.go::archiveRepositoryProbeError`, `internal/github/pages.go::githubArchiveDestination`)
+- After repository-wide issue disablement is classified, a 410 from GitHub's
+  single-issue endpoint means deleted; map it to `removed_upstream` only at
+  that lookup boundary, never across GitHub endpoints.
+  (`internal/github/pages.go::gitHubClientProvider.classifyIssueLookup`)
 - A previously-open issue whose GitHub-classified lookup is a true removal
   (not_found, no destination) is tombstoned closed locally; otherwise it would
   fail every cycle forever. Transfers and provider-neutral bare 404s (GitLab

--- a/internal/github/archive_lifecycle_test.go
+++ b/internal/github/archive_lifecycle_test.go
@@ -235,6 +235,30 @@ func (p *preemptibleArchiveProvider) GetIssue(
 }
 
 func TestArchiveHydrationPRShapedIssueBecomesTerminalInSQLite(t *testing.T) {
+	testArchiveHydrationMissingGitHubIssueBecomesTerminalInSQLite(
+		t,
+		http.StatusOK,
+		`{"id":11,"node_id":"PR_11","number":11,"repository_url":"https://api.github.com/repos/acme/widget","html_url":"https://github.com/acme/widget/pull/11","title":"actually a pull request","state":"closed","user":{"login":"author"},"pull_request":{"url":"https://api.github.com/repos/acme/widget/pulls/11"},"created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-02T00:00:00Z","closed_at":"2025-01-02T00:00:00Z"}`,
+		"terminal archive lookup must not hydrate the PR-shaped issue again",
+	)
+}
+
+func TestArchiveHydrationDeletedGitHubIssueBecomesTerminalInSQLite(t *testing.T) {
+	testArchiveHydrationMissingGitHubIssueBecomesTerminalInSQLite(
+		t,
+		http.StatusGone,
+		`{"message":"This issue was deleted"}`,
+		"terminal archive lookup must not hydrate the deleted issue again",
+	)
+}
+
+func testArchiveHydrationMissingGitHubIssueBecomesTerminalInSQLite(
+	t *testing.T,
+	hydrationCode int,
+	hydrationBody string,
+	retryAssertion string,
+) {
+	t.Helper()
 	assert := assert.New(t)
 	require := require.New(t)
 	database := dbtest.Open(t)
@@ -270,7 +294,8 @@ func TestArchiveHydrationPRShapedIssueBecomesTerminalInSQLite(t *testing.T) {
 			_, _ = w.Write([]byte(`[]`))
 		case "/api/v3/repos/acme/widget/issues/11":
 			hydrationCalls.Add(1)
-			_, _ = w.Write([]byte(`{"id":11,"node_id":"PR_11","number":11,"repository_url":"https://api.github.com/repos/acme/widget","html_url":"https://github.com/acme/widget/pull/11","title":"actually a pull request","state":"closed","user":{"login":"author"},"pull_request":{"url":"https://api.github.com/repos/acme/widget/pulls/11"},"created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-02T00:00:00Z","closed_at":"2025-01-02T00:00:00Z"}`))
+			w.WriteHeader(hydrationCode)
+			_, _ = w.Write([]byte(hydrationBody))
 		default:
 			http.NotFound(w, r)
 		}
@@ -327,8 +352,7 @@ func TestArchiveHydrationPRShapedIssueBecomesTerminalInSQLite(t *testing.T) {
 	assert.Equal(int32(1), hydrationCalls.Load())
 
 	require.NoError(service.RunEligible(t.Context()))
-	assert.Equal(int32(1), hydrationCalls.Load(),
-		"terminal archive lookup must not hydrate the PR-shaped issue again")
+	assert.Equal(int32(1), hydrationCalls.Load(), retryAssertion)
 }
 
 func TestArchiveHydrationKeepsIncompleteMergedGitHubPRFailed(t *testing.T) {

--- a/internal/github/pages.go
+++ b/internal/github/pages.go
@@ -102,6 +102,14 @@ func (p *gitHubClientProvider) classifyIssueLookup(
 	); disabledErr != nil {
 		return "", nil, disabledErr
 	}
+	// GitHub documents 410 from the single-issue endpoint as a deleted
+	// issue. Repository-wide issue disablement uses the same status but is
+	// classified above, so every remaining 410 here is a definitive parent
+	// removal rather than a transient transport failure. Keep this mapping at
+	// the issue lookup boundary; 410 has different meanings on other endpoints.
+	if githubStatusCode(err) == http.StatusGone {
+		return lookupRemoved, nil, nil
+	}
 	mapped := p.archiveTransportError(platform.ArchiveCapabilityHistoricalIssues, err)
 	if errors.Is(mapped, platform.ErrRateLimited) {
 		return "", nil, mapped

--- a/internal/github/pages_test.go
+++ b/internal/github/pages_test.go
@@ -88,6 +88,10 @@ func TestGitHubLiveGetMapsLookupOutcomes(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/v3/repos/acme/widget/issues/9", "/api/v3/repos/acme/widget/pulls/9":
 			http.Error(w, `{"message":"Not Found"}`, http.StatusNotFound)
+		case "/api/v3/repos/acme/widget/issues/12":
+			http.Error(w, `{"message":"This issue was deleted"}`, http.StatusGone)
+		case "/api/v3/repos/acme/widget/issues/13":
+			http.Error(w, `{"message":"Issues are disabled for this repo"}`, http.StatusGone)
 		case "/api/v3/repos/acme/widget/issues/8", "/api/v3/repos/acme/widget/pulls/8":
 			http.Error(w, `{"message":"Forbidden"}`, http.StatusForbidden)
 		case "/api/v3/repos/acme/widget/issues/10":
@@ -109,6 +113,12 @@ func TestGitHubLiveGetMapsLookupOutcomes(t *testing.T) {
 	_, removedIssueErr := provider.GetIssue(t.Context(), ref, 9)
 	require.ErrorIs(removedIssueErr, platform.ErrNotFound)
 	require.ErrorIs(removedIssueErr, platform.ErrLookupNotPresent)
+	_, deletedIssueErr := provider.GetIssue(t.Context(), ref, 12)
+	require.ErrorIs(deletedIssueErr, platform.ErrNotFound)
+	require.ErrorIs(deletedIssueErr, platform.ErrLookupNotPresent)
+	_, disabledIssueErr := provider.GetIssue(t.Context(), ref, 13)
+	require.ErrorIs(disabledIssueErr, platform.ErrRepositoryFeatureDisabled)
+	require.NotErrorIs(disabledIssueErr, platform.ErrLookupNotPresent)
 	_, removedMRErr := provider.GetMergeRequest(t.Context(), ref, 9)
 	require.ErrorIs(removedMRErr, platform.ErrNotFound)
 	require.ErrorIs(removedMRErr, platform.ErrLookupNotPresent)

--- a/internal/server/e2etest/archive_poison_items_test.go
+++ b/internal/server/e2etest/archive_poison_items_test.go
@@ -34,6 +34,7 @@ func TestArchiveAPIPersistsTerminalAndBackoffOutcomesE2E(t *testing.T) {
 		now: time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC),
 	}
 	var prShapedCalls atomic.Int32
+	var deletedCalls atomic.Int32
 	var transientCalls atomic.Int32
 	providerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -52,7 +53,8 @@ func TestArchiveAPIPersistsTerminalAndBackoffOutcomesE2E(t *testing.T) {
 			}
 			_, _ = w.Write([]byte(`{"data":{"repository":{"issues":{"nodes":[
 				{"id":"I_11","databaseId":11,"number":11,"title":"stale issue identity","state":"CLOSED","body":"","url":"https://github.com/acme/widget/issues/11","author":{"login":"author"},"createdAt":"2025-01-01T00:00:00Z","updatedAt":"2025-01-02T00:00:00Z","closedAt":"2025-01-02T00:00:00Z","comments":{"totalCount":0},"labels":{"nodes":[]},"assignees":{"nodes":[]}},
-				{"id":"I_12","databaseId":12,"number":12,"title":"transient issue","state":"CLOSED","body":"","url":"https://github.com/acme/widget/issues/12","author":{"login":"author"},"createdAt":"2025-01-03T00:00:00Z","updatedAt":"2025-01-04T00:00:00Z","closedAt":"2025-01-04T00:00:00Z","comments":{"totalCount":0},"labels":{"nodes":[]},"assignees":{"nodes":[]}}
+				{"id":"I_12","databaseId":12,"number":12,"title":"transient issue","state":"CLOSED","body":"","url":"https://github.com/acme/widget/issues/12","author":{"login":"author"},"createdAt":"2025-01-03T00:00:00Z","updatedAt":"2025-01-04T00:00:00Z","closedAt":"2025-01-04T00:00:00Z","comments":{"totalCount":0},"labels":{"nodes":[]},"assignees":{"nodes":[]}},
+				{"id":"I_13","databaseId":13,"number":13,"title":"deleted issue","state":"CLOSED","body":"","url":"https://github.com/acme/widget/issues/13","author":{"login":"author"},"createdAt":"2025-01-05T00:00:00Z","updatedAt":"2025-01-06T00:00:00Z","closedAt":"2025-01-06T00:00:00Z","comments":{"totalCount":0},"labels":{"nodes":[]},"assignees":{"nodes":[]}}
 			],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}`))
 		case "/api/v3/repos/acme/widget/pulls":
 			_, _ = w.Write([]byte(`[]`))
@@ -65,6 +67,10 @@ func TestArchiveAPIPersistsTerminalAndBackoffOutcomesE2E(t *testing.T) {
 			transientCalls.Add(1)
 			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = w.Write([]byte(`{"message":"temporary outage"}`))
+		case "/api/v3/repos/acme/widget/issues/13":
+			deletedCalls.Add(1)
+			w.WriteHeader(http.StatusGone)
+			_, _ = w.Write([]byte(`{"message":"This issue was deleted"}`))
 		default:
 			http.NotFound(w, r)
 		}
@@ -127,6 +133,7 @@ func TestArchiveAPIPersistsTerminalAndBackoffOutcomesE2E(t *testing.T) {
 	require.NoError(archiveService.RunEligible(t.Context())) // merge-request inventory
 	require.NoError(archiveService.RunEligible(t.Context())) // PR-shaped issue hydration
 	require.Error(archiveService.RunEligible(t.Context()))   // first transient failure
+	require.NoError(archiveService.RunEligible(t.Context())) // deleted issue hydration
 
 	repo, err := database.GetRepoByIdentity(t.Context(), platform.DBRepoIdentity(ref))
 	require.NoError(err)
@@ -148,6 +155,22 @@ func TestArchiveAPIPersistsTerminalAndBackoffOutcomesE2E(t *testing.T) {
 		repo.ID, db.ArchiveItemTypeIssue, 11,
 	).Scan(&lifecycle))
 	assert.Equal(db.ArchiveLifecycleStateRemovedUpstream, lifecycle)
+	deleted, err := database.GetDatasetProgress(
+		t.Context(), repo.ID, db.ArchiveItemTypeIssue, 13, db.ArchiveDatasetLookup,
+	)
+	require.NoError(err)
+	assert.Equal(db.ArchiveDatasetProgressTerminal, deleted.Status)
+	assert.Zero(deleted.AttemptCount)
+	assert.Nil(deleted.NextRetryAt)
+	require.NotNil(deleted.LastErrorCode)
+	assert.Equal(string(platform.ErrCodeNotFound), *deleted.LastErrorCode)
+
+	require.NoError(database.ReadDB().QueryRowContext(t.Context(), `
+		SELECT lifecycle_state FROM forge_archive_items
+		WHERE repo_id = ? AND item_type = ? AND item_number = ?`,
+		repo.ID, db.ArchiveItemTypeIssue, 13,
+	).Scan(&lifecycle))
+	assert.Equal(db.ArchiveLifecycleStateRemovedUpstream, lifecycle)
 
 	failed, err := database.GetDatasetProgress(
 		t.Context(), repo.ID, db.ArchiveItemTypeIssue, 12, db.ArchiveDatasetLookup,
@@ -162,16 +185,18 @@ func TestArchiveAPIPersistsTerminalAndBackoffOutcomesE2E(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(status.JSON200)
 	require.Len(*status.JSON200, 1)
-	assert.Equal(int64(2), (*status.JSON200)[0].Counts.Items)
-	assert.Equal(int64(1), (*status.JSON200)[0].Counts.CompleteItems)
+	assert.Equal(int64(3), (*status.JSON200)[0].Counts.Items)
+	assert.Equal(int64(2), (*status.JSON200)[0].Counts.CompleteItems)
 	assert.Equal(int64(1), (*status.JSON200)[0].Counts.FailedItems)
 	assert.Equal(int32(1), prShapedCalls.Load())
+	assert.Equal(int32(1), deletedCalls.Load())
 	assert.Equal(int32(1), transientCalls.Load())
 
 	// Neither terminal work nor a failed item whose retry is in the future may
 	// spend another provider call.
 	require.NoError(archiveService.RunEligible(t.Context()))
 	assert.Equal(int32(1), prShapedCalls.Load())
+	assert.Equal(int32(1), deletedCalls.Load())
 	assert.Equal(int32(1), transientCalls.Load())
 
 	clock.now = clock.now.Add(time.Minute)
@@ -201,14 +226,16 @@ func TestArchiveAPIPersistsTerminalAndBackoffOutcomesE2E(t *testing.T) {
 	clock.now = clock.now.Add(3 * time.Minute)
 	require.NoError(archiveService.RunEligible(t.Context()))
 	assert.Equal(int32(1), prShapedCalls.Load(), "terminal issue must never be fetched again")
+	assert.Equal(int32(1), deletedCalls.Load(), "deleted issue must never be fetched again")
 	assert.Equal(int32(3), transientCalls.Load(), "retry before next_retry_at must stay provider-free")
 
 	status, err = api.HTTP.ListArchiveStatusWithResponse(t.Context(), nil)
 	require.NoError(err)
 	require.NotNil(status.JSON200)
 	require.Len(*status.JSON200, 1)
-	assert.Equal(int64(1), (*status.JSON200)[0].Counts.CompleteItems)
+	assert.Equal(int64(2), (*status.JSON200)[0].Counts.CompleteItems)
 	assert.Equal(int64(1), (*status.JSON200)[0].Counts.FailedItems)
 	assert.Equal(int32(1), prShapedCalls.Load(), "status reads must not call the provider")
+	assert.Equal(int32(1), deletedCalls.Load(), "status reads must not call the provider")
 	assert.Equal(int32(3), transientCalls.Load(), "status reads must not call the provider")
 }


### PR DESCRIPTION
GitHub returns `410 Gone` when an issue was deleted from a repository the caller can read. Forge treated that definitive response as transient, so one deleted issue could keep historical archive readiness failed forever.

This keeps repository-wide issue disablement distinct and treats only the single-issue endpoint's remaining `410` response as removed upstream. Archive hydration can then finish without weakening retries for ambiguous provider failures.