### PR TITLE
Add Involves me filters across work views

### DIFF
--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -149,6 +149,12 @@ func (p e2eStaticProvider) Capabilities() platform.Capabilities {
 	return p.caps
 }
 
+func (p e2eStaticProvider) AuthenticatedUser(
+	context.Context, platform.RepoRef,
+) (string, error) {
+	return "alice", nil
+}
+
 func (p e2eStaticProvider) GetRepository(
 	_ context.Context,
 	ref platform.RepoRef,
@@ -1440,8 +1446,9 @@ func buildAppState(
 			issue:       gitLabIssue,
 			issueEvents: gitLabIssueEvents,
 			caps: platform.Capabilities{
-				ReadIssues:   true,
-				ReadComments: true,
+				ReadIssues:            true,
+				ReadComments:          true,
+				ReadAuthenticatedUser: true,
 			},
 		},
 	}
@@ -1451,9 +1458,10 @@ func buildAppState(
 			host:  "github.com",
 			issue: giteaCollisionIssue,
 			caps: platform.Capabilities{
-				ReadRepositories: true,
-				ReadIssues:       true,
-				AssigneeMutation: true,
+				ReadRepositories:      true,
+				ReadIssues:            true,
+				ReadAuthenticatedUser: true,
+				AssigneeMutation:      true,
 			},
 			repos: []platform.Repository{{
 				Ref: platform.RepoRef{

--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -152,7 +152,7 @@ func (p e2eStaticProvider) Capabilities() platform.Capabilities {
 func (p e2eStaticProvider) AuthenticatedUser(
 	context.Context, platform.RepoRef,
 ) (string, error) {
-	return "alice", nil
+	return "fixture-viewer", nil
 }
 
 func (p e2eStaticProvider) GetRepository(

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -130,8 +130,9 @@ builds clone routes, GitHub GraphQL fetchers where applicable, and a
 implementation; it should not masquerade as another provider.
 
 - Authenticated-viewer lookups run only for repositories selected by the request.
-  Cache successes for the process by effective credential, retry failures, and keep
-  unkeyed GitHub routes repository-scoped (`internal/server/viewer_identity.go::Server.resolveAuthenticatedViewerLogins`).
+  Include only repositories with a resolved identity, cache successes for one hour by
+  effective credential with stale-while-refresh, retry failures, and keep unkeyed GitHub routes repository-scoped
+  (`internal/server/viewer_identity.go::Server.resolveAuthenticatedViewerLogins`).
 
 Fallback token lookup is scoped by `(provider, platform_host)`. GitHub
 authorization routes may be exact-repository, owner, or host fallback. Lookup

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -129,6 +129,10 @@ builds clone routes, GitHub GraphQL fetchers where applicable, and a
 `platform.Registry`. A third provider should add metadata, a factory, and an
 implementation; it should not masquerade as another provider.
 
+- Authenticated-viewer lookups run only for repositories selected by the request.
+  Cache successes for the process by effective credential, retry failures, and keep
+  unkeyed GitHub routes repository-scoped (`internal/server/viewer_identity.go::Server.resolveAuthenticatedViewerLogins`).
+
 Fallback token lookup is scoped by `(provider, platform_host)`. GitHub
 authorization routes may be exact-repository, owner, or host fallback. Lookup
 checks repo `token_file`, repo `token_env`, a covered App installation for

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -192,6 +192,9 @@ Persisted controls must state their scope clearly.
 
 - Browser-local preferences belong in `localStorage` only when the behavior is
   intentionally per-browser and not worth server settings.
+- `Involves me` is three independent browser-local preferences for Pulls, Issues, and
+  Activity; each enabled view sends the server query so filtering happens before limits,
+  never through URL or config state (`frontend/src/lib/stores/involves-me-filter.ts`, `internal/db/queries_involvement.go`).
 - The workspace details tab is keyed by host-aware workspace identity; an unsupported
   tab may fall back only for the current live workspace, never rewrite another
   workspace's choice (`frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte::sidebarTabStorageKey`).

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -7923,6 +7923,13 @@ paths:
           schema:
             description: Exact, case-insensitive pull request or issue author filter.
             type: string
+        - description: Only include activity for pull requests and issues involving the authenticated viewer.
+          explode: false
+          in: query
+          name: involves_me
+          schema:
+            description: Only include activity for pull requests and issues involving the authenticated viewer.
+            type: boolean
         - explode: false
           in: query
           name: after
@@ -14075,6 +14082,13 @@ paths:
           name: starred
           schema:
             type: boolean
+        - description: Only include issues involving the authenticated viewer.
+          explode: false
+          in: query
+          name: involves_me
+          schema:
+            description: Only include issues involving the authenticated viewer.
+            type: boolean
         - explode: false
           in: query
           name: q
@@ -15866,6 +15880,13 @@ paths:
           in: query
           name: starred
           schema:
+            type: boolean
+        - description: Only include pull requests involving the authenticated viewer.
+          explode: false
+          in: query
+          name: involves_me
+          schema:
+            description: Only include pull requests involving the authenticated viewer.
             type: boolean
         - explode: false
           in: query

--- a/frontend/src/lib/api/generated/schema.ts
+++ b/frontend/src/lib/api/generated/schema.ts
@@ -8149,6 +8149,8 @@ export interface operations {
                 search?: string;
                 /** @description Exact, case-insensitive pull request or issue author filter. */
                 author?: string;
+                /** @description Only include activity for pull requests and issues involving the authenticated viewer. */
+                involves_me?: boolean;
                 after?: string;
                 since?: string;
             };
@@ -13113,6 +13115,8 @@ export interface operations {
                 repo?: string;
                 state?: string;
                 starred?: boolean;
+                /** @description Only include issues involving the authenticated viewer. */
+                involves_me?: boolean;
                 q?: string;
                 assignee?: string;
                 limit?: number;
@@ -14838,6 +14842,8 @@ export interface operations {
                 state?: string;
                 kanban?: string;
                 starred?: boolean;
+                /** @description Only include pull requests involving the authenticated viewer. */
+                involves_me?: boolean;
                 q?: string;
                 limit?: number;
                 offset?: number;

--- a/frontend/src/lib/components/ActivityFeed.svelte
+++ b/frontend/src/lib/components/ActivityFeed.svelte
@@ -125,7 +125,8 @@
     + (activity.getHideClosedMerged() ? 1 : 0)
     + (activity.getHideBots() ? 1 : 0)
     + (activity.getHideDefaultBranchActivity() ? 1 : 0)
-    + (grouping.getHideOrgName() ? 1 : 0),
+    + (grouping.getHideOrgName() ? 1 : 0)
+    + (activity.getInvolvesMe() ? 1 : 0),
   );
 
   let unsubSync: (() => void) | undefined;
@@ -351,6 +352,7 @@
     activity.setHideBots(false);
     activity.setHideDefaultBranchActivity(false);
     grouping.setHideOrgName(false);
+    activity.setInvolvesMe(false);
     applyFilters();
   }
 
@@ -380,6 +382,16 @@
     {
       title: "Visibility",
       items: [
+        {
+          id: "involves-me",
+          label: "Involves me",
+          active: activity.getInvolvesMe(),
+          color: "var(--accent-blue)",
+          onSelect: () => {
+            activity.setInvolvesMe(!activity.getInvolvesMe());
+            activity.loadActivity();
+          },
+        },
         {
           id: "hide-default-branch",
           label: "Hide default-branch activity",

--- a/frontend/src/lib/components/ActivityFeed.test.ts
+++ b/frontend/src/lib/components/ActivityFeed.test.ts
@@ -110,6 +110,7 @@ const enabledEvents = vi.hoisted(() => ({
   value: new Set(["comment", "review", "commit", "force_push"]),
 }));
 const showNotifications = vi.hoisted(() => ({ value: true }));
+const involvesMe = vi.hoisted(() => ({ value: false }));
 const markNotificationSeen = vi.hoisted(() => vi.fn(async () => undefined));
 const selectedAuthor = vi.hoisted(() => ({ value: undefined as string | undefined }));
 const setActivityAuthor = vi.hoisted(() =>
@@ -134,6 +135,7 @@ vi.mock("../context.js", () => ({
       getActivityAuthorsError: () => null,
       getEnabledEvents: () => enabledEvents.value,
       getShowNotifications: () => showNotifications.value,
+      getInvolvesMe: () => involvesMe.value,
       getHideClosedMerged: () => hideClosedMerged.value,
       getHideBots: () => false,
       getHideDefaultBranchActivity: () => hideDefaultBranchActivity.value,
@@ -163,6 +165,9 @@ vi.mock("../context.js", () => ({
       }),
       setShowNotifications: vi.fn((value: boolean) => {
         showNotifications.value = value;
+      }),
+      setInvolvesMe: vi.fn((value: boolean) => {
+        involvesMe.value = value;
       }),
       markNotificationSeen,
       setHideClosedMerged: vi.fn(),

--- a/frontend/src/lib/components/sidebar/IssueList.svelte
+++ b/frontend/src/lib/components/sidebar/IssueList.svelte
@@ -98,20 +98,36 @@
   }
 
   function resetCompactView(): void {
-    if (issues.getIssueFilterState() !== "open") setIssueState("open");
+    const reloadIssues = issues.getIssueFilterState() !== "open" || issues.getInvolvesMe();
+    if (issues.getIssueFilterState() !== "open") issues.setIssueFilterState("open");
     grouping.setGroupByRepo(true);
     grouping.setHideOrgName(false);
     if (issues.getHideBots()) void issues.setHideBots(false);
+    issues.setInvolvesMe(false);
+    if (reloadIssues) issues.loadIssues();
   }
 
   function resetVisibility(): void {
     grouping.setHideOrgName(false);
     if (issues.getHideBots()) void issues.setHideBots(false);
+    if (issues.getInvolvesMe()) {
+      issues.setInvolvesMe(false);
+      issues.loadIssues();
+    }
   }
 
   const visibilityFilterSection = $derived({
     title: "Visibility",
     items: [
+      {
+        id: "involves-me",
+        label: "Involves me",
+        active: issues.getInvolvesMe(),
+        onSelect: () => {
+          issues.setInvolvesMe(!issues.getInvolvesMe());
+          issues.loadIssues();
+        },
+      },
       {
         id: "hide-org-name",
         label: "Hide org name",
@@ -153,7 +169,8 @@
     issues.getIssueFilterState() !== "open"
       || !grouping.getGroupByRepo()
       || grouping.getHideOrgName()
-      || issues.getHideBots(),
+      || issues.getHideBots()
+      || issues.getInvolvesMe(),
   );
   const useCompactFilters = $derived(
     sidebarWidth <= COMPACT_FILTER_MAX_WIDTH,
@@ -233,7 +250,7 @@
       <FilterDropdown
         label="Visibility"
         title="Issue visibility"
-        active={grouping.getHideOrgName() || issues.getHideBots()}
+        active={grouping.getHideOrgName() || issues.getHideBots() || issues.getInvolvesMe()}
         showBadge={false}
         sections={[visibilityFilterSection]}
         resetLabel="Reset visibility"

--- a/frontend/src/lib/components/sidebar/PullList.svelte
+++ b/frontend/src/lib/components/sidebar/PullList.svelte
@@ -166,12 +166,14 @@
     grouping.setGroupingMode("byRepo");
     grouping.setHideOrgName(false);
     if (pulls.getFilterState() !== "open") {
-      setPullState("open");
+      pulls.setFilterState("open");
     }
+    pulls.loadPulls();
   }
 
   function clearLocalViewFilters(): void {
     pulls.clearLocalFilters();
+    pulls.loadPulls();
     grouping.setHideOrgName(false);
   }
 
@@ -199,12 +201,23 @@
   const localFilterSections = $derived.by(() => [
     {
       title: "PR",
-      items: attributeFilterOptions.map((option) => ({
-        id: `pr-${option.value}`,
-        label: option.label,
-        active: pulls.getAttributeFilters().includes(option.value),
-        onSelect: () => pulls.toggleAttributeFilter(option.value),
-      })),
+      items: [
+        {
+          id: "involves-me",
+          label: "Involves me",
+          active: pulls.getInvolvesMe(),
+          onSelect: () => {
+            pulls.setInvolvesMe(!pulls.getInvolvesMe());
+            pulls.loadPulls();
+          },
+        },
+        ...attributeFilterOptions.map((option) => ({
+          id: `pr-${option.value}`,
+          label: option.label,
+          active: pulls.getAttributeFilters().includes(option.value),
+          onSelect: () => pulls.toggleAttributeFilter(option.value),
+        })),
+      ],
     },
     {
       title: "Status",

--- a/frontend/src/lib/stores/activity.svelte.test.ts
+++ b/frontend/src/lib/stores/activity.svelte.test.ts
@@ -15,6 +15,7 @@ import {
   notificationDbId,
 } from "./activity.svelte.js";
 import { dismissFlash, getFlash, getFlashes } from "./flash.svelte.js";
+import { involvesMeFilterStorageKey } from "./involves-me-filter.js";
 
 let runtime: OwnedAppRuntime | undefined;
 
@@ -67,6 +68,7 @@ function workspaceActivity(itemNumber: number): WorkspaceActivitySubject {
 
 beforeEach(() => {
   runtime = undefined;
+  localStorage.clear();
   window.history.replaceState(null, "", "/");
 });
 
@@ -76,6 +78,23 @@ afterEach(async () => {
 });
 
 describe("activity store workspace activity", () => {
+  it("persists and sends the Involves me filter", async () => {
+    const get = vi.fn(async () => ({ data: { items: [], capped: false }, error: null }));
+    const store = createActivityStore({ client: { GET: get } as unknown as GeneratedClient });
+
+    store.setInvolvesMe(true);
+    store.loadActivity();
+    await vi.waitFor(() => expect(store.isActivityLoading()).toBe(false));
+
+    expect(localStorage.getItem(involvesMeFilterStorageKey("activity"))).toBe("1");
+    expect(get).toHaveBeenCalledWith(
+      "/activity",
+      expect.objectContaining({
+        params: { query: expect.objectContaining({ involves_me: true }) },
+      }),
+    );
+  });
+
   it("retains the complete workspace snapshot returned with an activity read", async () => {
     const snapshot = [workspaceActivity(7)];
     const client = {

--- a/frontend/src/lib/stores/activity.svelte.ts
+++ b/frontend/src/lib/stores/activity.svelte.ts
@@ -15,6 +15,7 @@ import type {
 import { ActivityWorkflow } from "./activity-workflow.js";
 import { showFlash } from "./flash.svelte.js";
 import { ProviderMutations, providerMutationFailureMessage } from "./ordered-mutations.js";
+import { readInvolvesMeFilter, writeInvolvesMeFilter } from "./involves-me-filter.js";
 
 export type TimeRange = "24h" | "7d" | "30d" | "90d";
 export type ViewMode = "flat" | "threaded";
@@ -163,6 +164,7 @@ export function createActivityStore(opts: ActivityStoreOptions) {
   let enabledItemTypes = $state<Set<ActivityItemType>>(new Set(DEFAULT_ACTIVITY_ITEM_TYPES));
   let enabledEvents = $state<Set<string>>(new Set(DEFAULT_EVENT_TYPES));
   let showNotifications = $state(true);
+  let involvesMe = $state(readInvolvesMeFilter("activity"));
   let initialized = false;
 
   // --- reads ---
@@ -240,6 +242,9 @@ export function createActivityStore(opts: ActivityStoreOptions) {
   function getShowNotifications(): boolean {
     return showNotifications;
   }
+  function getInvolvesMe(): boolean {
+    return involvesMe;
+  }
   function isInitialized(): boolean {
     return initialized;
   }
@@ -300,6 +305,10 @@ export function createActivityStore(opts: ActivityStoreOptions) {
   function setShowNotifications(v: boolean): void {
     showNotifications = v;
   }
+  function setInvolvesMe(value: boolean): void {
+    involvesMe = value;
+    writeInvolvesMeFilter("activity", value);
+  }
   // --- hydration ---
 
   function hydrateDefaults(activity: ActivitySettings): void {
@@ -344,6 +353,7 @@ export function createActivityStore(opts: ActivityStoreOptions) {
     }
     if (searchQuery) p.search = searchQuery;
     if (authorFilter) p.author = authorFilter;
+    if (involvesMe) p.involves_me = true;
     return p;
   }
 
@@ -782,6 +792,7 @@ export function createActivityStore(opts: ActivityStoreOptions) {
     getEnabledItemTypes,
     getEnabledEvents,
     getShowNotifications,
+    getInvolvesMe,
     isInitialized,
     setActivityFilterTypes,
     setActivitySearch,
@@ -798,6 +809,7 @@ export function createActivityStore(opts: ActivityStoreOptions) {
     setEnabledItemTypes,
     setEnabledEvents,
     setShowNotifications,
+    setInvolvesMe,
     hydrateDefaults,
     initializeFromMount,
     loadActivityAuthors,

--- a/frontend/src/lib/stores/involves-me-filter.ts
+++ b/frontend/src/lib/stores/involves-me-filter.ts
@@ -1,0 +1,28 @@
+export type InvolvesMeSurface = "pulls" | "issues" | "activity";
+
+const STORAGE_KEYS: Record<InvolvesMeSurface, string> = {
+  pulls: "kenn-forge:filters:pulls:involves-me",
+  issues: "kenn-forge:filters:issues:involves-me",
+  activity: "kenn-forge:filters:activity:involves-me",
+};
+
+export function readInvolvesMeFilter(surface: InvolvesMeSurface): boolean {
+  try {
+    return globalThis.localStorage?.getItem(STORAGE_KEYS[surface]) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function writeInvolvesMeFilter(surface: InvolvesMeSurface, enabled: boolean): void {
+  try {
+    if (enabled) globalThis.localStorage?.setItem(STORAGE_KEYS[surface], "1");
+    else globalThis.localStorage?.removeItem(STORAGE_KEYS[surface]);
+  } catch {
+    // localStorage can be unavailable in restricted browser contexts.
+  }
+}
+
+export function involvesMeFilterStorageKey(surface: InvolvesMeSurface): string {
+  return STORAGE_KEYS[surface];
+}

--- a/frontend/src/lib/stores/issues.svelte.test.ts
+++ b/frontend/src/lib/stores/issues.svelte.test.ts
@@ -8,6 +8,7 @@ import { mockSettings } from "../../test/mockApiFetch.js";
 import { makeTestAppRuntime } from "../testing/effect-layers.js";
 import { dismissFlash, getFlash, getFlashes } from "./flash.svelte.js";
 import { createIssuesStore as createRuntimeIssuesStore, type IssuesStoreOptions } from "./issues.svelte.js";
+import { involvesMeFilterStorageKey } from "./involves-me-filter.js";
 
 let runtime: OwnedAppRuntime | undefined;
 
@@ -30,6 +31,7 @@ async function loadIssueDetail(
 
 beforeEach(() => {
   runtime = undefined;
+  localStorage.clear();
 });
 
 afterEach(async () => {
@@ -207,6 +209,23 @@ function mockClient(overrides: Partial<GeneratedClient> = {}): GeneratedClient {
 }
 
 describe("createIssuesStore", () => {
+  it("persists and sends the Involves me filter", async () => {
+    const get = vi.fn(async () => ({ data: [], error: undefined }));
+    const store = createIssuesStore({ client: { GET: get } as unknown as GeneratedClient });
+
+    store.setInvolvesMe(true);
+    store.loadIssues();
+    await vi.waitFor(() => expect(store.isIssuesLoading()).toBe(false));
+
+    expect(localStorage.getItem(involvesMeFilterStorageKey("issues"))).toBe("1");
+    expect(get).toHaveBeenCalledWith(
+      "/issues",
+      expect.objectContaining({
+        params: { query: expect.objectContaining({ involves_me: true }) },
+      }),
+    );
+  });
+
   afterEach(() => {
     vi.useRealTimers();
   });

--- a/frontend/src/lib/stores/issues.svelte.ts
+++ b/frontend/src/lib/stores/issues.svelte.ts
@@ -35,6 +35,7 @@ import {
 import { providerItemKey } from "./provider-key.js";
 import { SettingsWorkflow, settingsErrorMessage } from "./settings-workflow.js";
 import { nextWorkspaceLifecycleTick } from "./workspace-create-pending.svelte.js";
+import { readInvolvesMeFilter, writeInvolvesMeFilter } from "./involves-me-filter.js";
 
 export type { IssueDetailSyncMode } from "./issues-workflow.js";
 
@@ -122,6 +123,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
   let loading = $state(false);
   let storeError = $state<string | null>(null);
   let filterStarred = $state(false);
+  let involvesMe = $state(readInvolvesMeFilter("issues"));
   let filterState = $state<string>("open");
   let searchQuery = $state<string | undefined>(undefined);
   let selectedIssue = $state<IssueSelection | null>(null);
@@ -183,6 +185,9 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
   }
   function getIssueFilterStarred(): boolean {
     return filterStarred;
+  }
+  function getInvolvesMe(): boolean {
+    return involvesMe;
   }
   function getIssueSearchQuery(): string | undefined {
     return searchQuery;
@@ -289,6 +294,10 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
   function setIssueFilterStarred(v: boolean): void {
     filterStarred = v;
   }
+  function setInvolvesMe(value: boolean): void {
+    involvesMe = value;
+    writeInvolvesMeFilter("issues", value);
+  }
   function setIssueSearchQuery(q: string | undefined): void {
     searchQuery = q;
   }
@@ -353,6 +362,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
       state: filterState,
       ...(globalRepo !== undefined && { repo: globalRepo }),
       ...(filterStarred && { starred: true }),
+      ...(involvesMe && { involves_me: true }),
       ...(searchQuery !== undefined && { q: searchQuery }),
       ...params,
     };
@@ -394,6 +404,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
         state: filterState,
         ...(globalRepo !== undefined && { repo: globalRepo }),
         ...(filterStarred && { starred: true }),
+        ...(involvesMe && { involves_me: true }),
         ...(searchQuery !== undefined && { q: searchQuery }),
         ...params,
       };
@@ -1786,6 +1797,8 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
     getSelectedIssue,
     getIssueFilterStarred,
     setIssueFilterStarred,
+    getInvolvesMe,
+    setInvolvesMe,
     getIssueSearchQuery,
     setIssueSearchQuery,
     getIssueFilterState,

--- a/frontend/src/lib/stores/pulls.svelte.test.ts
+++ b/frontend/src/lib/stores/pulls.svelte.test.ts
@@ -10,6 +10,7 @@ import {
   type PullsStoreOptions,
 } from "./pulls.svelte.js";
 import { dismissFlash, getFlash, getFlashes } from "./flash.svelte.js";
+import { involvesMeFilterStorageKey } from "./involves-me-filter.js";
 
 let runtime: OwnedAppRuntime | undefined;
 
@@ -28,6 +29,7 @@ async function loadPulls(store: PullsStore): Promise<void> {
 
 beforeEach(() => {
   runtime = undefined;
+  localStorage.clear();
 });
 
 afterEach(async () => {
@@ -74,6 +76,22 @@ function clientWithPulls(data: PullRequest[]): GeneratedClient {
 }
 
 describe("pulls store display order", () => {
+  it("persists and sends the Involves me filter", async () => {
+    const get = vi.fn(async () => ({ data: [], error: undefined }));
+    const store = createPullsStore({ client: { GET: get } as unknown as GeneratedClient });
+
+    store.setInvolvesMe(true);
+    await loadPulls(store);
+
+    expect(localStorage.getItem(involvesMeFilterStorageKey("pulls"))).toBe("1");
+    expect(get).toHaveBeenCalledWith(
+      "/pulls",
+      expect.objectContaining({
+        params: { query: expect.objectContaining({ involves_me: true }) },
+      }),
+    );
+  });
+
   it("aborts a superseded list request", async () => {
     let firstSignal: AbortSignal | undefined;
     const get = vi

--- a/frontend/src/lib/stores/pulls.svelte.ts
+++ b/frontend/src/lib/stores/pulls.svelte.ts
@@ -17,6 +17,7 @@ import { PullsWorkflow, type FetchPullResult } from "./pulls-workflow.js";
 import { ProviderMutations, providerMutationFailureMessage } from "./ordered-mutations.js";
 import { providerItemKey, providerMutationKey } from "./provider-key.js";
 import { nextWorkspaceLifecycleTick } from "./workspace-create-pending.svelte.js";
+import { readInvolvesMeFilter, writeInvolvesMeFilter } from "./involves-me-filter.js";
 
 export type { FetchPullResult } from "./pulls-workflow.js";
 
@@ -65,6 +66,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
   let attributeFilters = $state<PullAttributeFilter[]>([]);
   let kanbanStatusFilters = $state<KanbanStatus[]>([]);
   let filterStarred = $state(false);
+  let involvesMe = $state(readInvolvesMeFilter("pulls"));
   let filterState = $state<string>("open");
   let searchQuery = $state<string | undefined>(undefined);
   let selectedPR = $state<PullSelection | null>(null);
@@ -154,7 +156,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
   }
 
   function getLocalFilterCount(): number {
-    return attributeFilters.length + kanbanStatusFilters.length;
+    return attributeFilters.length + kanbanStatusFilters.length + Number(involvesMe);
   }
 
   function getFilterStarred(): boolean {
@@ -163,6 +165,15 @@ export function createPullsStore(opts: PullsStoreOptions) {
 
   function setFilterStarred(v: boolean): void {
     filterStarred = v;
+  }
+
+  function getInvolvesMe(): boolean {
+    return involvesMe;
+  }
+
+  function setInvolvesMe(value: boolean): void {
+    involvesMe = value;
+    writeInvolvesMeFilter("pulls", value);
   }
 
   function getFilterState(): string {
@@ -241,6 +252,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
   function clearLocalFilters(): void {
     attributeFilters = [];
     kanbanStatusFilters = [];
+    setInvolvesMe(false);
   }
 
   function getSearchQuery(): string | undefined {
@@ -451,6 +463,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
       ...(globalRepo !== undefined && { repo: globalRepo }),
       ...(filterKanban !== undefined && { kanban: filterKanban }),
       ...(filterStarred && { starred: true }),
+      ...(involvesMe && { involves_me: true }),
       ...(searchQuery !== undefined && { q: searchQuery }),
       ...params,
     };
@@ -493,6 +506,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
         ...(globalRepo !== undefined && { repo: globalRepo }),
         ...(filterKanban !== undefined && { kanban: filterKanban }),
         ...(filterStarred && { starred: true }),
+        ...(involvesMe && { involves_me: true }),
         ...(searchQuery !== undefined && { q: searchQuery }),
         ...params,
       };
@@ -582,6 +596,8 @@ export function createPullsStore(opts: PullsStoreOptions) {
     getLocalFilterCount,
     getFilterStarred,
     setFilterStarred,
+    getInvolvesMe,
+    setInvolvesMe,
     getFilterState,
     setFilterState,
     getDisplayOrderPRs,

--- a/frontend/src/lib/views/FocusListView.svelte
+++ b/frontend/src/lib/views/FocusListView.svelte
@@ -52,6 +52,15 @@
     else issues.loadIssues(repoParams);
   }
 
+  function toggleInvolvesMe(): void {
+    if (listType === "mrs") {
+      pulls.setInvolvesMe(!pulls.getInvolvesMe());
+    } else {
+      issues.setInvolvesMe(!issues.getInvolvesMe());
+    }
+    loadList();
+  }
+
   const repoLabel = $derived(repo ?? "All repositories");
 
   const repoParams = $derived(
@@ -187,6 +196,9 @@
   const itemLabel = $derived(
     listType === "mrs" ? "PRs" : "issues",
   );
+  const involvesMe = $derived(
+    listType === "mrs" ? pulls.getInvolvesMe() : issues.getInvolvesMe(),
+  );
 </script>
 
 <div class="focus-list">
@@ -232,29 +244,38 @@
         {/each}
       {/if}
     </div>
-    {#if listType === "mrs"}
-      <div class="group-toggle">
-        <button
-          class="group-btn"
-          class:group-btn--active={groupingMode === "byWorkflow"}
-          onclick={() => grouping.setGroupingMode("byWorkflow")}
-        >Status</button>
-        <button
-          class="group-btn"
-          class:group-btn--active={groupingMode === "flat"}
-          onclick={() => grouping.setGroupingMode("flat")}
-        >All</button>
-      </div>
-    {:else}
+    <div class="visibility-controls">
       <button
         type="button"
         class="visibility-btn"
-        class:visibility-btn--active={issues.getHideBots()}
-        aria-label="Hide bot-authored issues"
-        aria-pressed={issues.getHideBots()}
-        onclick={() => void issues.setHideBots(!issues.getHideBots())}
-      >Hide bots</button>
-    {/if}
+        class:visibility-btn--active={involvesMe}
+        aria-pressed={involvesMe}
+        onclick={toggleInvolvesMe}
+      >Involves me</button>
+      {#if listType === "mrs"}
+        <div class="group-toggle">
+          <button
+            class="group-btn"
+            class:group-btn--active={groupingMode === "byWorkflow"}
+            onclick={() => grouping.setGroupingMode("byWorkflow")}
+          >Status</button>
+          <button
+            class="group-btn"
+            class:group-btn--active={groupingMode === "flat"}
+            onclick={() => grouping.setGroupingMode("flat")}
+          >All</button>
+        </div>
+      {:else}
+        <button
+          type="button"
+          class="visibility-btn"
+          class:visibility-btn--active={issues.getHideBots()}
+          aria-label="Hide bot-authored issues"
+          aria-pressed={issues.getHideBots()}
+          onclick={() => void issues.setHideBots(!issues.getHideBots())}
+        >Hide bots</button>
+      {/if}
+    </div>
   </div>
   <div class="search-bar">
     <div class="search-wrap">
@@ -434,6 +455,12 @@
     background: var(--bg-inset);
     border-radius: 6px;
     padding: 2px;
+  }
+
+  .visibility-controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
     margin-left: auto;
   }
 
@@ -450,7 +477,6 @@
   }
 
   .visibility-btn {
-    margin-left: auto;
     border: 1px solid var(--border-default);
     background: var(--bg-inset);
     font-weight: 600;
@@ -602,6 +628,13 @@
   }
 
   :global(.mobile-main) .group-toggle {
+    margin-left: 0;
+  }
+
+  :global(.mobile-main) .visibility-controls {
+    flex-wrap: wrap;
+    align-items: stretch;
+    gap: var(--focus-mobile-space-sm);
     margin-left: 0;
   }
 

--- a/frontend/src/lib/views/FocusListView.test.ts
+++ b/frontend/src/lib/views/FocusListView.test.ts
@@ -3,10 +3,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
 import FocusListView from "./FocusListViewRuntimeHarness.svelte";
 import {
+  getIssueInvolvesMe,
   getIssueSearch,
+  getPullInvolvesMe,
   getPullSearch,
   resetFocusListViewState,
+  setIssueInvolvesMe,
   setIssueSearch,
+  setPullInvolvesMe,
   setPullSearch,
 } from "../../test/focusListViewState.svelte.js";
 
@@ -14,6 +18,8 @@ const pullSearch = vi.hoisted(() => vi.fn());
 const issueSearch = vi.hoisted(() => vi.fn());
 const loadPulls = vi.hoisted(() => vi.fn());
 const loadIssues = vi.hoisted(() => vi.fn());
+const setPullsInvolvesMe = vi.hoisted(() => vi.fn());
+const setIssuesInvolvesMe = vi.hoisted(() => vi.fn());
 const unsubscribeSync = vi.hoisted(() => vi.fn());
 const subscribeSyncComplete = vi.hoisted(() => vi.fn(() => unsubscribeSync));
 vi.mock("../context.js", () => ({
@@ -26,6 +32,7 @@ vi.mock("../context.js", () => ({
       setGroupingMode: vi.fn(),
     },
     issues: {
+      getInvolvesMe: getIssueInvolvesMe,
       getIssueSearchQuery: getIssueSearch,
       getHideBots: () => false,
       getIssueFilterState: () => "open",
@@ -34,6 +41,10 @@ vi.mock("../context.js", () => ({
       isIssuesLoading: () => false,
       loadIssues,
       setHideBots: vi.fn(),
+      setInvolvesMe: (value: boolean) => {
+        setIssuesInvolvesMe(value);
+        setIssueInvolvesMe(value);
+      },
       setIssueFilterState: vi.fn(),
       setIssueSearchQuery: (value: string | undefined) => {
         issueSearch(value);
@@ -41,6 +52,7 @@ vi.mock("../context.js", () => ({
       },
     },
     pulls: {
+      getInvolvesMe: getPullInvolvesMe,
       getSearchQuery: getPullSearch,
       getError: () => null,
       getFilterState: () => "open",
@@ -48,6 +60,10 @@ vi.mock("../context.js", () => ({
       isLoading: () => false,
       loadPulls,
       setFilterState: vi.fn(),
+      setInvolvesMe: (value: boolean) => {
+        setPullsInvolvesMe(value);
+        setPullInvolvesMe(value);
+      },
       setSearchQuery: (value: string | undefined) => {
         pullSearch(value);
         setPullSearch(value);
@@ -71,6 +87,8 @@ describe("FocusListView search", () => {
     issueSearch.mockClear();
     loadPulls.mockClear();
     loadIssues.mockClear();
+    setPullsInvolvesMe.mockClear();
+    setIssuesInvolvesMe.mockClear();
     unsubscribeSync.mockClear();
     subscribeSyncComplete.mockClear();
     resetFocusListViewState();
@@ -120,5 +138,21 @@ describe("FocusListView search", () => {
     expect(subscribeSyncComplete).toHaveBeenCalledTimes(1);
     expect(unsubscribeSync).not.toHaveBeenCalled();
     view.unmount();
+  });
+
+  it.each([
+    ["mrs" as const, setPullsInvolvesMe, loadPulls],
+    ["issues" as const, setIssuesInvolvesMe, loadIssues],
+  ])("uses the shared Involves me control for %s", async (listType, setInvolvesMe, loadList) => {
+    render(FocusListView, { props: { listType, repo: "acme/one" } });
+    loadList.mockClear();
+
+    const control = screen.getByRole("button", { name: "Involves me" });
+    expect(control.getAttribute("aria-pressed")).toBe("false");
+    await fireEvent.click(control);
+
+    expect(setInvolvesMe).toHaveBeenCalledWith(true);
+    expect(loadList).toHaveBeenCalledTimes(1);
+    expect(control.getAttribute("aria-pressed")).toBe("true");
   });
 });

--- a/frontend/src/lib/views/MobileActivityView.svelte
+++ b/frontend/src/lib/views/MobileActivityView.svelte
@@ -251,7 +251,8 @@
     + (activity.getHideBots() ? 1 : 0)
     + (activity.getHideDefaultBranchActivity() ? 1 : 0)
     + (grouping.getHideOrgName() ? 1 : 0)
-    + (activity.getShowNotifications() ? 0 : 1),
+    + (activity.getShowNotifications() ? 0 : 1)
+    + (activity.getInvolvesMe() ? 1 : 0),
   );
 
   const repoLabelFormatter = $derived.by(() =>
@@ -312,6 +313,11 @@
   function toggleHideNotifications(): void {
     activity.setShowNotifications(!activity.getShowNotifications());
     applyFilters();
+  }
+
+  function toggleInvolvesMe(): void {
+    activity.setInvolvesMe(!activity.getInvolvesMe());
+    activity.loadActivity();
   }
 
   function toggleHideDefaultBranchActivity(): void {
@@ -602,6 +608,14 @@
           onchange={handleRepoChange}
         />
       </div>
+
+      <button
+        type="button"
+        class="mobile-filter-toggle"
+        class:active={activity.getInvolvesMe()}
+        aria-pressed={activity.getInvolvesMe()}
+        onclick={toggleInvolvesMe}
+      >Involves me</button>
 
       <button
         type="button"

--- a/frontend/src/lib/views/MobileActivityView.test.ts
+++ b/frontend/src/lib/views/MobileActivityView.test.ts
@@ -41,6 +41,7 @@ const onSelectItem = vi.hoisted(() => vi.fn());
 const hideClosedMerged = vi.hoisted(() => ({ value: false }));
 const hideOrgName = vi.hoisted(() => ({ value: false }));
 const showNotifications = vi.hoisted(() => ({ value: true }));
+const involvesMe = vi.hoisted(() => ({ value: false }));
 const enabledItemTypes = vi.hoisted(() => ({
   value: new Set<"pr" | "issue">(["pr", "issue"]),
 }));
@@ -86,6 +87,7 @@ vi.mock("../context.js", () => ({
       getEnabledItemTypes: () => enabledItemTypes.value,
       getEnabledEvents: () => new Set(["comment", "review", "commit", "force_push"]),
       getShowNotifications: () => showNotifications.value,
+      getInvolvesMe: () => involvesMe.value,
       getHideClosedMerged: () => hideClosedMerged.value,
       getHideBots: () => false,
       getHideDefaultBranchActivity: () => false,
@@ -97,6 +99,9 @@ vi.mock("../context.js", () => ({
       setTimeRange: vi.fn(),
       setEnabledItemTypes,
       setShowNotifications,
+      setInvolvesMe: vi.fn((value: boolean) => {
+        involvesMe.value = value;
+      }),
       markNotificationSeen,
       setHideBots: vi.fn(),
       setHideDefaultBranchActivity: vi.fn(),

--- a/frontend/src/test/focusListViewState.svelte.ts
+++ b/frontend/src/test/focusListViewState.svelte.ts
@@ -1,5 +1,7 @@
 let pullSearch = $state<string | undefined>(undefined);
 let issueSearch = $state<string | undefined>(undefined);
+let pullInvolvesMe = $state(false);
+let issueInvolvesMe = $state(false);
 
 export function getPullSearch(): string | undefined {
   return pullSearch;
@@ -17,7 +19,25 @@ export function setIssueSearch(value: string | undefined): void {
   issueSearch = value;
 }
 
+export function getPullInvolvesMe(): boolean {
+  return pullInvolvesMe;
+}
+
+export function getIssueInvolvesMe(): boolean {
+  return issueInvolvesMe;
+}
+
+export function setPullInvolvesMe(value: boolean): void {
+  pullInvolvesMe = value;
+}
+
+export function setIssueInvolvesMe(value: boolean): void {
+  issueInvolvesMe = value;
+}
+
 export function resetFocusListViewState(): void {
   pullSearch = undefined;
   issueSearch = undefined;
+  pullInvolvesMe = false;
+  issueInvolvesMe = false;
 }

--- a/frontend/tests/e2e-full/involves-me-filter.spec.ts
+++ b/frontend/tests/e2e-full/involves-me-filter.spec.ts
@@ -63,4 +63,23 @@ test.describe("Involves me standard filters", () => {
       await page.evaluate((keys) => keys.map((key) => localStorage.getItem(key)), Object.values(storageKeys)),
     ).toEqual(["1", "1", "1"]);
   });
+
+  test("uses the same pull and issue filter from the phone list presentation", async ({ page }) => {
+    const baseURL = server!.info.base_url;
+    await page.setViewportSize({ width: 390, height: 844 });
+
+    await page.goto(`${baseURL}/focus/mrs?repo=github%7Cgithub.com%2Facme%2Fwidgets`);
+    await expect(page.locator(".focus-list .pull-item").first()).toBeVisible();
+    const pullsResponse = waitForInvolvesMeRequest(page, "/api/v1/pulls");
+    await page.getByRole("button", { name: "Involves me" }).click();
+    expect((await pullsResponse).ok()).toBe(true);
+    await expect(page.getByRole("button", { name: "Involves me" })).toHaveAttribute("aria-pressed", "true");
+
+    await page.goto(`${baseURL}/focus/issues?repo=github%7Cgithub.com%2Facme%2Fwidgets`);
+    await expect(page.locator(".focus-list .issue-item").first()).toBeVisible();
+    const issuesResponse = waitForInvolvesMeRequest(page, "/api/v1/issues");
+    await page.getByRole("button", { name: "Involves me" }).click();
+    expect((await issuesResponse).ok()).toBe(true);
+    await expect(page.getByRole("button", { name: "Involves me" })).toHaveAttribute("aria-pressed", "true");
+  });
 });

--- a/frontend/tests/e2e-full/involves-me-filter.spec.ts
+++ b/frontend/tests/e2e-full/involves-me-filter.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test, type Page } from "@playwright/test";
+import { startIsolatedE2EServer, type IsolatedE2EServer } from "./support/e2eServer";
+
+const storageKeys = {
+  pulls: "kenn-forge:filters:pulls:involves-me",
+  issues: "kenn-forge:filters:issues:involves-me",
+  activity: "kenn-forge:filters:activity:involves-me",
+} as const;
+
+async function selectFilter(page: Page, trigger: string): Promise<void> {
+  await page.locator(trigger).click();
+  await page.locator(".kit-filter-dropdown__item, .activity-filters__item", { hasText: "Involves me" }).click();
+}
+
+function waitForInvolvesMeRequest(page: Page, path: string): ReturnType<Page["waitForResponse"]> {
+  return page.waitForResponse((response) => {
+    const url = new URL(response.url());
+    return url.pathname === path && url.searchParams.get("involves_me") === "true";
+  });
+}
+
+test.describe("Involves me standard filters", () => {
+  let server: IsolatedE2EServer | undefined;
+
+  test.beforeAll(async () => {
+    server = await startIsolatedE2EServer();
+  });
+
+  test.afterAll(async () => {
+    await server?.stop();
+  });
+
+  test("persists independently in Pulls, Issues, and Activity", async ({ page }) => {
+    const baseURL = server!.info.base_url;
+
+    await page.goto(`${baseURL}/pulls`);
+    await expect(page.locator(".pull-item").first()).toBeVisible();
+    const pullsResponse = waitForInvolvesMeRequest(page, "/api/v1/pulls");
+    await selectFilter(page, ".compact-filter-menu .kit-filter-dropdown__btn");
+    const pullsFiltered = await pullsResponse;
+    expect(pullsFiltered.ok(), await pullsFiltered.text()).toBe(true);
+    await expect.poll(() => page.evaluate((key) => localStorage.getItem(key), storageKeys.pulls)).toBe("1");
+
+    const persistedPullsResponse = waitForInvolvesMeRequest(page, "/api/v1/pulls");
+    await page.reload();
+    expect((await persistedPullsResponse).ok()).toBe(true);
+
+    await page.goto(`${baseURL}/issues`);
+    await expect(page.locator(".issue-item").first()).toBeVisible();
+    expect(await page.evaluate((key) => localStorage.getItem(key), storageKeys.issues)).toBeNull();
+    const issuesResponse = waitForInvolvesMeRequest(page, "/api/v1/issues");
+    await selectFilter(page, ".compact-filter-menu .kit-filter-dropdown__btn");
+    expect((await issuesResponse).ok()).toBe(true);
+
+    await page.goto(baseURL);
+    await expect(page.locator(".activity-row").first()).toBeVisible();
+    expect(await page.evaluate((key) => localStorage.getItem(key), storageKeys.activity)).toBeNull();
+    const activityResponse = waitForInvolvesMeRequest(page, "/api/v1/activity");
+    await selectFilter(page, ".activity-filters__trigger");
+    expect((await activityResponse).ok()).toBe(true);
+
+    expect(
+      await page.evaluate((keys) => keys.map((key) => localStorage.getItem(key)), Object.values(storageKeys)),
+    ).toEqual(["1", "1", "1"]);
+  });
+});

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -4607,8 +4607,11 @@ type ListActivityParams struct {
 
 	// Author Exact, case-insensitive pull request or issue author filter.
 	Author *string `form:"author,omitempty" json:"author,omitempty"`
-	After  *string `form:"after,omitempty" json:"after,omitempty"`
-	Since  *string `form:"since,omitempty" json:"since,omitempty"`
+
+	// InvolvesMe Only include activity for pull requests and issues involving the authenticated viewer.
+	InvolvesMe *bool   `form:"involves_me,omitempty" json:"involves_me,omitempty"`
+	After      *string `form:"after,omitempty" json:"after,omitempty"`
+	Since      *string `form:"since,omitempty" json:"since,omitempty"`
 }
 
 // ListActivityAuthorsParams defines parameters for ListActivityAuthors.
@@ -4955,13 +4958,16 @@ type ResolveRepoItemOnHostParamsItemType string
 // ListIssuesParams defines parameters for ListIssues.
 type ListIssuesParams struct {
 	// Repo Repository filter. Accepts provider|platform_host/repo_path, with comma-separated values for multiple repositories.
-	Repo     *string `form:"repo,omitempty" json:"repo,omitempty"`
-	State    *string `form:"state,omitempty" json:"state,omitempty"`
-	Starred  *bool   `form:"starred,omitempty" json:"starred,omitempty"`
-	Q        *string `form:"q,omitempty" json:"q,omitempty"`
-	Assignee *string `form:"assignee,omitempty" json:"assignee,omitempty"`
-	Limit    *int64  `form:"limit,omitempty" json:"limit,omitempty"`
-	Offset   *int64  `form:"offset,omitempty" json:"offset,omitempty"`
+	Repo    *string `form:"repo,omitempty" json:"repo,omitempty"`
+	State   *string `form:"state,omitempty" json:"state,omitempty"`
+	Starred *bool   `form:"starred,omitempty" json:"starred,omitempty"`
+
+	// InvolvesMe Only include issues involving the authenticated viewer.
+	InvolvesMe *bool   `form:"involves_me,omitempty" json:"involves_me,omitempty"`
+	Q          *string `form:"q,omitempty" json:"q,omitempty"`
+	Assignee   *string `form:"assignee,omitempty" json:"assignee,omitempty"`
+	Limit      *int64  `form:"limit,omitempty" json:"limit,omitempty"`
+	Offset     *int64  `form:"offset,omitempty" json:"offset,omitempty"`
 }
 
 // ResolveKataIssueReferenceParams defines parameters for ResolveKataIssueReference.
@@ -5010,9 +5016,12 @@ type ListPullsParams struct {
 	State   *string `form:"state,omitempty" json:"state,omitempty"`
 	Kanban  *string `form:"kanban,omitempty" json:"kanban,omitempty"`
 	Starred *bool   `form:"starred,omitempty" json:"starred,omitempty"`
-	Q       *string `form:"q,omitempty" json:"q,omitempty"`
-	Limit   *int64  `form:"limit,omitempty" json:"limit,omitempty"`
-	Offset  *int64  `form:"offset,omitempty" json:"offset,omitempty"`
+
+	// InvolvesMe Only include pull requests involving the authenticated viewer.
+	InvolvesMe *bool   `form:"involves_me,omitempty" json:"involves_me,omitempty"`
+	Q          *string `form:"q,omitempty" json:"q,omitempty"`
+	Limit      *int64  `form:"limit,omitempty" json:"limit,omitempty"`
+	Offset     *int64  `form:"offset,omitempty" json:"offset,omitempty"`
 }
 
 // GetPullDiffParams defines parameters for GetPullDiff.
@@ -15241,6 +15250,18 @@ func NewListActivityRequest(server string, params *ListActivityParams) (*http.Re
 
 		}
 
+		if params.InvolvesMe != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "involves_me", *params.InvolvesMe, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "boolean", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
 		if params.After != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "after", *params.After, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
@@ -24813,6 +24834,18 @@ func NewListIssuesRequest(server string, params *ListIssuesParams) (*http.Reques
 
 		}
 
+		if params.InvolvesMe != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "involves_me", *params.InvolvesMe, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "boolean", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
 		if params.Q != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "q", *params.Q, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
@@ -27560,6 +27593,18 @@ func NewListPullsRequest(server string, params *ListPullsParams) (*http.Request,
 		if params.Starred != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "starred", *params.Starred, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "boolean", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.InvolvesMe != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "involves_me", *params.InvolvesMe, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "boolean", Format: ""}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -2004,6 +2004,9 @@ func (d *DB) ListMergeRequests(ctx context.Context, opts ListMergeRequestsOpts) 
 			args = append(args, condArgs...)
 		}
 	}
+	if opts.ViewerLogins != nil {
+		conds = append(conds, mergeRequestInvolvementCondition("p", opts.ViewerLogins, &args))
+	}
 
 	where := ""
 	if len(conds) > 0 {
@@ -3258,6 +3261,9 @@ func (d *DB) ListIssues(
 		// raise "malformed JSON" and fail the whole query.
 		conds = append(conds, `EXISTS (SELECT 1 FROM json_each(COALESCE(NULLIF(i.assignees_json, ''), '[]')) WHERE value = ?)`)
 		args = append(args, opts.Assignee)
+	}
+	if opts.ViewerLogins != nil {
+		conds = append(conds, issueInvolvementCondition("i", opts.ViewerLogins, &args))
 	}
 
 	where := ""

--- a/internal/db/queries_activity.go
+++ b/internal/db/queries_activity.go
@@ -91,6 +91,9 @@ func (d *DB) ListActivity(
 		whereClauses = append(whereClauses, "LOWER(item_author) = LOWER(?)")
 		args = append(args, opts.Author)
 	}
+	if opts.ViewerLogins != nil {
+		whereClauses = append(whereClauses, activityInvolvementCondition(opts.ViewerLogins, &args))
+	}
 
 	// Time window filter.
 	if opts.Since != nil {

--- a/internal/db/queries_involvement.go
+++ b/internal/db/queries_involvement.go
@@ -1,0 +1,222 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// ListInvolvedWorkspaceSubjectKeys returns the subject identities that should
+// survive the Involves me filter in workspace-derived activity.
+func (d *DB) ListInvolvedWorkspaceSubjectKeys(
+	ctx context.Context, viewers []RepoViewerLogin, candidates []WorkspaceSubjectKey,
+) (map[WorkspaceSubjectKey]struct{}, error) {
+	keys := make(map[WorkspaceSubjectKey]struct{})
+	for _, subject := range []struct {
+		itemType string
+		table    string
+		alias    string
+		involves func(string, []RepoViewerLogin, *[]any) string
+	}{
+		{WorkspaceItemTypePullRequest, "forge_merge_requests", "p", mergeRequestInvolvementCondition},
+		{WorkspaceItemTypeIssue, "forge_issues", "i", issueInvolvementCondition},
+	} {
+		var args []any
+		candidateCondition := workspaceSubjectCandidateCondition(
+			subject.alias, subject.itemType, candidates, &args,
+		)
+		if candidateCondition == "" {
+			continue
+		}
+		involvementCondition := subject.involves(subject.alias, viewers, &args)
+		query := fmt.Sprintf(`
+			SELECT %[1]s.repo_id, %[1]s.number
+			FROM %[2]s %[1]s
+			JOIN forge_repos r ON r.id = %[1]s.repo_id
+			WHERE r.lifecycle_state = 'active'
+			  AND %[3]s
+			  AND %[4]s`, subject.alias, subject.table, candidateCondition, involvementCondition)
+		rows, err := d.ro.QueryContext(ctx, query, args...)
+		if err != nil {
+			return nil, fmt.Errorf("list involved workspace %s subjects: %w", subject.itemType, err)
+		}
+		for rows.Next() {
+			var key WorkspaceSubjectKey
+			key.ItemType = subject.itemType
+			if err := rows.Scan(&key.RepoID, &key.ItemNumber); err != nil {
+				rows.Close()
+				return nil, fmt.Errorf("scan involved workspace %s subject: %w", subject.itemType, err)
+			}
+			keys[key] = struct{}{}
+		}
+		if err := rows.Close(); err != nil {
+			return nil, fmt.Errorf("close involved workspace %s subjects: %w", subject.itemType, err)
+		}
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("list involved workspace %s subject rows: %w", subject.itemType, err)
+		}
+	}
+	return keys, nil
+}
+
+func workspaceSubjectCandidateCondition(
+	alias, itemType string, candidates []WorkspaceSubjectKey, args *[]any,
+) string {
+	groups := make([]string, 0, len(candidates))
+	seen := make(map[[2]int64]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.ItemType != itemType || candidate.RepoID <= 0 || candidate.ItemNumber <= 0 {
+			continue
+		}
+		key := [2]int64{candidate.RepoID, int64(candidate.ItemNumber)}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		groups = append(groups, fmt.Sprintf("(%s.repo_id = ? AND %s.number = ?)", alias, alias))
+		*args = append(*args, candidate.RepoID, candidate.ItemNumber)
+	}
+	if len(groups) == 0 {
+		return ""
+	}
+	return "(" + strings.Join(groups, " OR ") + ")"
+}
+
+func mergeRequestInvolvementCondition(
+	alias string, viewers []RepoViewerLogin, args *[]any,
+) string {
+	if len(viewers) == 0 {
+		return "0 = 1"
+	}
+	groups := make([]string, 0, len(viewers))
+	for _, viewer := range viewers {
+		login := strings.TrimSpace(viewer.Login)
+		if viewer.RepoID <= 0 || login == "" {
+			continue
+		}
+		groups = append(groups, fmt.Sprintf(`(%[1]s.repo_id = ? AND (
+			LOWER(%[1]s.author) = LOWER(?)
+			OR EXISTS (
+				SELECT 1 FROM json_each(COALESCE(NULLIF(%[1]s.assignees_json, ''), '[]'))
+				WHERE LOWER(value) = LOWER(?)
+			)
+			OR EXISTS (
+				SELECT 1 FROM json_each(COALESCE(NULLIF(%[1]s.reviewers_json, ''), '[]'))
+				WHERE LOWER(value) = LOWER(?)
+			)
+			OR EXISTS (
+				SELECT 1 FROM forge_mr_events involvement_event
+				WHERE involvement_event.merge_request_id = %[1]s.id
+				  AND involvement_event.event_type IN ('issue_comment', 'review', 'review_comment')
+				  AND LOWER(involvement_event.author) = LOWER(?)
+			)
+			OR EXISTS (
+				SELECT 1 FROM forge_notification_items involvement_notification
+				WHERE involvement_notification.repo_id = %[1]s.repo_id
+				  AND involvement_notification.item_type = 'pr'
+				  AND involvement_notification.item_number = %[1]s.number
+				  AND (
+					involvement_notification.participating = 1
+					OR involvement_notification.reason IN (
+						'assign', 'author', 'comment', 'invitation',
+						'mention', 'review_requested', 'team_mention'
+					)
+				  )
+			)
+		))`, alias))
+		*args = append(*args, viewer.RepoID, login, login, login, login)
+	}
+	if len(groups) == 0 {
+		return "0 = 1"
+	}
+	return "(" + strings.Join(groups, " OR ") + ")"
+}
+
+func issueInvolvementCondition(
+	alias string, viewers []RepoViewerLogin, args *[]any,
+) string {
+	if len(viewers) == 0 {
+		return "0 = 1"
+	}
+	groups := make([]string, 0, len(viewers))
+	for _, viewer := range viewers {
+		login := strings.TrimSpace(viewer.Login)
+		if viewer.RepoID <= 0 || login == "" {
+			continue
+		}
+		groups = append(groups, fmt.Sprintf(`(%[1]s.repo_id = ? AND (
+			LOWER(%[1]s.author) = LOWER(?)
+			OR EXISTS (
+				SELECT 1 FROM json_each(COALESCE(NULLIF(%[1]s.assignees_json, ''), '[]'))
+				WHERE LOWER(value) = LOWER(?)
+			)
+			OR EXISTS (
+				SELECT 1 FROM forge_issue_events involvement_event
+				WHERE involvement_event.issue_id = %[1]s.id
+				  AND involvement_event.event_type = 'issue_comment'
+				  AND LOWER(involvement_event.author) = LOWER(?)
+			)
+			OR EXISTS (
+				SELECT 1 FROM forge_notification_items involvement_notification
+				WHERE involvement_notification.repo_id = %[1]s.repo_id
+				  AND involvement_notification.item_type = 'issue'
+				  AND involvement_notification.item_number = %[1]s.number
+				  AND (
+					involvement_notification.participating = 1
+					OR involvement_notification.reason IN (
+						'assign', 'author', 'comment', 'invitation',
+						'mention', 'review_requested', 'team_mention'
+					)
+				  )
+			)
+		))`, alias))
+		*args = append(*args, viewer.RepoID, login, login, login)
+	}
+	if len(groups) == 0 {
+		return "0 = 1"
+	}
+	return "(" + strings.Join(groups, " OR ") + ")"
+}
+
+func activityInvolvementCondition(viewers []RepoViewerLogin, args *[]any) string {
+	if len(viewers) == 0 {
+		return "0 = 1"
+	}
+	groups := make([]string, 0, len(viewers))
+	for _, viewer := range viewers {
+		login := strings.TrimSpace(viewer.Login)
+		if viewer.RepoID <= 0 || login == "" {
+			continue
+		}
+
+		var prArgs []any
+		prCondition := mergeRequestInvolvementCondition(
+			"involved_pr", []RepoViewerLogin{viewer}, &prArgs,
+		)
+		var issueArgs []any
+		issueCondition := issueInvolvementCondition(
+			"involved_issue", []RepoViewerLogin{viewer}, &issueArgs,
+		)
+		groups = append(groups, `(unified.repo_id = ? AND (
+			(unified.item_type = 'pr' AND EXISTS (
+				SELECT 1 FROM forge_merge_requests involved_pr
+				WHERE involved_pr.repo_id = unified.repo_id
+				  AND involved_pr.number = unified.item_number
+				  AND `+prCondition+`
+			))
+			OR (unified.item_type = 'issue' AND EXISTS (
+				SELECT 1 FROM forge_issues involved_issue
+				WHERE involved_issue.repo_id = unified.repo_id
+				  AND involved_issue.number = unified.item_number
+				  AND `+issueCondition+`
+			))
+		))`)
+		*args = append(*args, viewer.RepoID)
+		*args = append(*args, prArgs...)
+		*args = append(*args, issueArgs...)
+	}
+	if len(groups) == 0 {
+		return "0 = 1"
+	}
+	return "(" + strings.Join(groups, " OR ") + ")"
+}

--- a/internal/db/queries_involvement_test.go
+++ b/internal/db/queries_involvement_test.go
@@ -1,0 +1,147 @@
+package db
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListMergeRequestsInvolvingViewer(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	repoID := insertTestRepo(t, d, "acme", "widget")
+	viewer := []RepoViewerLogin{{RepoID: repoID, Login: "Alice"}}
+
+	authorID := insertTestMRWithOptions(t, d, testMR(repoID, 1, withMRAuthor("alice")))
+	assignee := testMR(repoID, 2)
+	assignee.AssigneesJSON = `["ALICE"]`
+	assigneeID := insertTestMRWithOptions(t, d, assignee)
+	reviewer := testMR(repoID, 3)
+	reviewer.ReviewersJSON = `["aLiCe"]`
+	reviewerID := insertTestMRWithOptions(t, d, reviewer)
+	reviewedID := insertTestMRWithOptions(t, d, testMR(repoID, 4))
+	commentedID := insertTestMRWithOptions(t, d, testMR(repoID, 5))
+	commitOnlyID := insertTestMRWithOptions(t, d, testMR(repoID, 6))
+	insertTestMRWithOptions(t, d, testMR(repoID, 7))
+	notifiedID := insertTestMRWithOptions(t, d, testMR(repoID, 8))
+	insertTestMRWithOptions(t, d, testMR(repoID, 9))
+
+	require.NoError(d.UpsertMREvents(ctx, []MREvent{
+		{MergeRequestID: reviewedID, EventType: "review", Author: "ALICE", CreatedAt: baseTime(), DedupeKey: "reviewed"},
+		{MergeRequestID: commentedID, EventType: "issue_comment", Author: "alice", CreatedAt: baseTime(), DedupeKey: "commented"},
+		{MergeRequestID: commitOnlyID, EventType: "commit", Author: "alice", CreatedAt: baseTime(), DedupeKey: "commit-only"},
+	}))
+	mention := notificationFixture("mention-involvement", "mention", baseTime())
+	mention.RepoID = &repoID
+	mention.ItemNumber = new(8)
+	mention.Participating = false
+	ciOnly := notificationFixture("ci-only", "ci_activity", baseTime())
+	ciOnly.RepoID = &repoID
+	ciOnly.ItemNumber = new(9)
+	ciOnly.Participating = false
+	require.NoError(d.UpsertNotifications(ctx, []Notification{mention, ciOnly}))
+
+	got, err := d.ListMergeRequests(ctx, ListMergeRequestsOpts{ViewerLogins: viewer, State: "all"})
+	require.NoError(err)
+	assert.ElementsMatch([]int64{
+		authorID, assigneeID, reviewerID, reviewedID, commentedID, notifiedID,
+	}, mergeRequestIDs(got))
+
+	limited, err := d.ListMergeRequests(ctx, ListMergeRequestsOpts{ViewerLogins: viewer, State: "all", Limit: 2})
+	require.NoError(err)
+	assert.Len(limited, 2, "the involvement predicate must run before pagination")
+
+	workspaceKeys, err := d.ListInvolvedWorkspaceSubjectKeys(ctx, viewer, []WorkspaceSubjectKey{
+		{RepoID: repoID, ItemType: WorkspaceItemTypePullRequest, ItemNumber: 1},
+		{RepoID: repoID, ItemType: WorkspaceItemTypePullRequest, ItemNumber: 7},
+	})
+	require.NoError(err)
+	assert.Equal(map[WorkspaceSubjectKey]struct{}{
+		{RepoID: repoID, ItemType: WorkspaceItemTypePullRequest, ItemNumber: 1}: {},
+	}, workspaceKeys)
+}
+
+func TestListIssuesInvolvingViewer(t *testing.T) {
+	d := openTestDB(t)
+	ctx := t.Context()
+	repoID := insertTestRepo(t, d, "acme", "widget")
+	viewer := []RepoViewerLogin{{RepoID: repoID, Login: "Alice"}}
+
+	authorID := insertTestIssueWithOptions(t, d, testIssue(repoID, 1, withIssueAuthor("alice")))
+	assignee := testIssue(repoID, 2)
+	assignee.AssigneesJSON = `["ALICE"]`
+	assigneeID := insertTestIssueWithOptions(t, d, assignee)
+	commentedID := insertTestIssueWithOptions(t, d, testIssue(repoID, 3))
+	insertTestIssueWithOptions(t, d, testIssue(repoID, 4))
+	require.NoError(t, d.UpsertIssueEvents(ctx, []IssueEvent{{
+		IssueID: commentedID, EventType: "issue_comment", Author: "aLiCe",
+		CreatedAt: baseTime(), DedupeKey: "commented",
+	}}))
+
+	got, err := d.ListIssues(ctx, ListIssuesOpts{ViewerLogins: viewer, State: "all"})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []int64{authorID, assigneeID, commentedID}, issueIDs(got))
+}
+
+func TestListActivityInvolvingViewerUsesSubjectInvolvement(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	repoID := insertTestRepo(t, d, "acme", "widget")
+	viewer := []RepoViewerLogin{{RepoID: repoID, Login: "Alice"}}
+	now := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
+
+	involvedID := insertTestMRWithOptions(t, d, testMR(repoID, 1,
+		withMRAuthor("alice"), withMRActivity(now.Add(-time.Hour))))
+	commitOnlyID := insertTestMRWithOptions(t, d, testMR(repoID, 2,
+		withMRAuthor("other"), withMRActivity(now.Add(-time.Hour))))
+	commentedID := insertTestIssueWithOptions(t, d, testIssue(repoID, 3,
+		withIssueAuthor("other"), withIssueActivity(now.Add(-time.Hour))))
+	insertTestIssueWithOptions(t, d, testIssue(repoID, 4,
+		withIssueAuthor("other"), withIssueActivity(now.Add(-time.Hour))))
+
+	require.NoError(d.UpsertMREvents(ctx, []MREvent{
+		{MergeRequestID: involvedID, EventType: "commit", Author: "other", CreatedAt: now, DedupeKey: "involved-commit"},
+		{MergeRequestID: commitOnlyID, EventType: "commit", Author: "ALICE", CreatedAt: now, DedupeKey: "viewer-commit-only"},
+	}))
+	require.NoError(d.UpsertIssueEvents(ctx, []IssueEvent{{
+		IssueID: commentedID, EventType: "issue_comment", Author: "ALICE",
+		CreatedAt: now, DedupeKey: "viewer-comment",
+	}}))
+
+	got, err := d.ListActivity(ctx, ListActivityOpts{ViewerLogins: viewer, Limit: 100})
+	require.NoError(err)
+	gotKeys := make([]string, 0, len(got))
+	for _, item := range got {
+		gotKeys = append(gotKeys, fmt.Sprintf("%s:%s:%d", item.Source, item.ItemType, item.ItemNumber))
+		assert.NotEmpty(item.ItemType, "repository-only activity is not involvement")
+		assert.NotEqual(2, item.ItemNumber, "commit authorship alone is not involvement")
+		assert.NotEqual(4, item.ItemNumber)
+	}
+	assert.Contains(gotKeys, "pr:pr:1")
+	assert.Contains(gotKeys, "pre:pr:1", "all events on an involved subject remain visible")
+	assert.Contains(gotKeys, "issue:issue:3")
+	assert.Contains(gotKeys, "ise:issue:3")
+}
+
+func mergeRequestIDs(items []MergeRequest) []int64 {
+	ids := make([]int64, 0, len(items))
+	for _, item := range items {
+		ids = append(ids, item.ID)
+	}
+	return ids
+}
+
+func issueIDs(items []Issue) []int64 {
+	ids := make([]int64, 0, len(items))
+	for _, item := range items {
+		ids = append(ids, item.ID)
+	}
+	return ids
+}

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -883,6 +883,10 @@ type ListMergeRequestsOpts struct {
 	Limit             int
 	Offset            int
 	WorkspaceActivity []ItemActivityOverride
+	// ViewerLogins limits results to subjects involving the authenticated
+	// viewer in each repository. nil disables the filter; an empty non-nil
+	// slice matches no subjects.
+	ViewerLogins []RepoViewerLogin
 }
 
 type ItemActivityOverride struct {
@@ -908,6 +912,13 @@ type WorkspaceSubjectMetadata struct {
 	State        string
 	URL          string
 	Author       string
+}
+
+// RepoViewerLogin binds a provider-authenticated login to the stable local
+// repository identity whose credentials produced it.
+type RepoViewerLogin struct {
+	RepoID int64
+	Login  string
 }
 
 type RepoFilter struct {
@@ -982,6 +993,7 @@ type ListIssuesOpts struct {
 	Limit             int
 	Offset            int
 	WorkspaceActivity []ItemActivityOverride
+	ViewerLogins      []RepoViewerLogin
 }
 
 type StarredItem struct {
@@ -1341,6 +1353,9 @@ type ListActivityOpts struct {
 	ItemTypes []string
 	Search    string // title/body search
 	Author    string // exact, case-insensitive PR or issue author filter
+	// ViewerLogins limits rows to PR and issue subjects involving the
+	// authenticated viewer. Repository-only rows never match.
+	ViewerLogins []RepoViewerLogin
 	// ExcludeNotifications drops notification rows from the union before
 	// ordering/limit. Notifications are always enabled in normal operation;
 	// the server only sets this when no config is loaded (nil-config

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -624,7 +624,6 @@ type liveClient struct {
 	quotaRegistry           *QuotaRegistry
 	viewerMu                sync.Mutex
 	viewerLogin             string
-	viewerLoginAt           time.Time
 	viewerLoginCacheKey     string
 }
 
@@ -1675,12 +1674,9 @@ func (c *liveClient) ListRepositoriesByOwner(
 
 func (c *liveClient) authenticatedLogin(ctx context.Context) (string, error) {
 	cacheKey := c.authenticatedViewerCacheKey()
-	now := time.Now()
 	c.viewerMu.Lock()
 	defer c.viewerMu.Unlock()
-	if c.viewerLogin != "" &&
-		c.viewerLoginCacheKey == cacheKey &&
-		now.Sub(c.viewerLoginAt) < authenticatedViewerLoginTTL {
+	if c.viewerLogin != "" && c.viewerLoginCacheKey == cacheKey {
 		return c.viewerLogin, nil
 	}
 	user, resp, err := c.writeGH().Users.Get(ctx, "")
@@ -1693,7 +1689,6 @@ func (c *liveClient) authenticatedLogin(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("authenticated user login is empty")
 	}
 	c.viewerLogin = login
-	c.viewerLoginAt = now
 	c.viewerLoginCacheKey = cacheKey
 	return login, nil
 }

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -624,6 +624,7 @@ type liveClient struct {
 	quotaRegistry           *QuotaRegistry
 	viewerMu                sync.Mutex
 	viewerLogin             string
+	viewerLoginAt           time.Time
 	viewerLoginCacheKey     string
 }
 
@@ -1676,7 +1677,9 @@ func (c *liveClient) authenticatedLogin(ctx context.Context) (string, error) {
 	cacheKey := c.authenticatedViewerCacheKey()
 	c.viewerMu.Lock()
 	defer c.viewerMu.Unlock()
-	if c.viewerLogin != "" && c.viewerLoginCacheKey == cacheKey {
+	if c.viewerLogin != "" &&
+		c.viewerLoginCacheKey == cacheKey &&
+		time.Since(c.viewerLoginAt) < authenticatedViewerLoginTTL {
 		return c.viewerLogin, nil
 	}
 	user, resp, err := c.writeGH().Users.Get(ctx, "")
@@ -1689,6 +1692,7 @@ func (c *liveClient) authenticatedLogin(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("authenticated user login is empty")
 	}
 	c.viewerLogin = login
+	c.viewerLoginAt = time.Now()
 	c.viewerLoginCacheKey = cacheKey
 	return login, nil
 }

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -63,6 +64,32 @@ func TestNewClientEmptyHost(t *testing.T) {
 	c, err := NewClient(testTokenSource("test-token"), "", nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, c)
+}
+
+func TestAuthenticatedViewerLoginRefreshesExpiredCache(t *testing.T) {
+	var login atomic.Value
+	login.Store("alice")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v3/user", r.URL.Path)
+		_, _ = fmt.Fprintf(w, `{"login":%q}`, login.Load().(string))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(testTokenSource("token"), "github.com", nil, nil, WithBaseURLForTesting(server.URL))
+	require.NoError(t, err)
+	live := client.(*liveClient)
+
+	first, err := live.AuthenticatedViewerLogin(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "alice", first)
+	login.Store("bob")
+	live.viewerMu.Lock()
+	live.viewerLoginAt = time.Now().Add(-authenticatedViewerLoginTTL - time.Minute)
+	live.viewerMu.Unlock()
+
+	second, err := live.AuthenticatedViewerLogin(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "bob", second)
 }
 
 func TestNativeStackClientDecodesPullHintsAndStackPages(t *testing.T) {

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -1900,7 +1900,12 @@ type gitHubClientProvider struct {
 	host         string
 	client       Client
 	viewerMu     sync.Mutex
-	viewerLogins map[string]string
+	viewerLogins map[string]authenticatedViewerLoginCacheEntry
+}
+
+type authenticatedViewerLoginCacheEntry struct {
+	login     string
+	fetchedAt time.Time
 }
 
 type authenticatedViewerLoginClient interface {
@@ -1912,6 +1917,8 @@ type authenticatedViewerCacheKeyClient interface {
 }
 
 var errParentSnapshotAdvanced = errors.New("provider parent snapshot advanced during child refresh")
+
+const authenticatedViewerLoginTTL = time.Hour
 
 type githubLabelClient interface {
 	ListRepoLabels(ctx context.Context, owner, repo string) ([]*gh.Label, error)
@@ -2078,8 +2085,8 @@ func (p *gitHubClientProvider) authenticatedViewerLoginForRepo(
 	cacheKey := p.authenticatedViewerLookupKeyForRepo(owner, name)
 	p.viewerMu.Lock()
 	defer p.viewerMu.Unlock()
-	if login := p.viewerLogins[cacheKey]; login != "" {
-		return login, nil
+	if entry, ok := p.viewerLogins[cacheKey]; ok && time.Since(entry.fetchedAt) < authenticatedViewerLoginTTL {
+		return entry.login, nil
 	}
 
 	var login string
@@ -2103,9 +2110,9 @@ func (p *gitHubClientProvider) authenticatedViewerLoginForRepo(
 		return "", fmt.Errorf("authenticated viewer login is empty")
 	}
 	if p.viewerLogins == nil {
-		p.viewerLogins = make(map[string]string)
+		p.viewerLogins = make(map[string]authenticatedViewerLoginCacheEntry)
 	}
-	p.viewerLogins[cacheKey] = login
+	p.viewerLogins[cacheKey] = authenticatedViewerLoginCacheEntry{login: login, fetchedAt: time.Now()}
 	return login, nil
 }
 

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -1897,12 +1897,10 @@ func livenessHeadForRound(normalized, existing *db.MergeRequest) string {
 }
 
 type gitHubClientProvider struct {
-	host           string
-	client         Client
-	viewerMu       sync.Mutex
-	viewerLogin    string
-	viewerCacheAt  time.Time
-	viewerCacheKey string
+	host         string
+	client       Client
+	viewerMu     sync.Mutex
+	viewerLogins map[string]string
 }
 
 type authenticatedViewerLoginClient interface {
@@ -1912,8 +1910,6 @@ type authenticatedViewerLoginClient interface {
 type authenticatedViewerCacheKeyClient interface {
 	AuthenticatedViewerCacheKey() string
 }
-
-const authenticatedViewerLoginTTL = time.Minute
 
 var errParentSnapshotAdvanced = errors.New("provider parent snapshot advanced during child refresh")
 
@@ -2079,14 +2075,11 @@ func (p *gitHubClientProvider) ViewerAuthoredMergeRequest(
 func (p *gitHubClientProvider) authenticatedViewerLoginForRepo(
 	ctx context.Context, owner, name string,
 ) (string, error) {
-	cacheKey := p.authenticatedViewerCacheKeyForRepo(owner, name)
-	now := time.Now()
+	cacheKey := p.authenticatedViewerLookupKeyForRepo(owner, name)
 	p.viewerMu.Lock()
 	defer p.viewerMu.Unlock()
-	if p.viewerLogin != "" &&
-		p.viewerCacheKey == cacheKey &&
-		now.Sub(p.viewerCacheAt) < authenticatedViewerLoginTTL {
-		return p.viewerLogin, nil
+	if login := p.viewerLogins[cacheKey]; login != "" {
+		return login, nil
 	}
 
 	var login string
@@ -2109,10 +2102,23 @@ func (p *gitHubClientProvider) authenticatedViewerLoginForRepo(
 	if login == "" {
 		return "", fmt.Errorf("authenticated viewer login is empty")
 	}
-	p.viewerLogin = login
-	p.viewerCacheAt = now
-	p.viewerCacheKey = cacheKey
+	if p.viewerLogins == nil {
+		p.viewerLogins = make(map[string]string)
+	}
+	p.viewerLogins[cacheKey] = login
 	return login, nil
+}
+
+func (p *gitHubClientProvider) AuthenticatedUserCacheKey(ref platform.RepoRef) string {
+	return p.authenticatedViewerLookupKeyForRepo(ref.Owner, ref.Name)
+}
+
+func (p *gitHubClientProvider) authenticatedViewerLookupKeyForRepo(owner, name string) string {
+	if cacheKey := p.authenticatedViewerCacheKeyForRepo(owner, name); cacheKey != "" {
+		return cacheKey
+	}
+	return "repository:" + strings.ToLower(strings.TrimSpace(owner)) + "/" +
+		strings.ToLower(strings.TrimSpace(name))
 }
 
 func (p *gitHubClientProvider) authenticatedViewerCacheKeyForRepo(owner, name string) string {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -1703,7 +1703,7 @@ func TestGitHubProviderPublishDiffReviewDraftApproveSubmitsReview(t *testing.T) 
 	assert.Equal("inline note", mock.createdReviewComments[0].GetBody())
 }
 
-func TestGitHubProviderViewerAuthoredMergeRequestCacheExpires(t *testing.T) {
+func TestGitHubProviderViewerAuthoredMergeRequestCachesForProcessLifetime(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	logins := []string{"marius", "octocat"}
@@ -1726,14 +1726,10 @@ func TestGitHubProviderViewerAuthoredMergeRequestCacheExpires(t *testing.T) {
 	assert.True(authored)
 	assert.EqualValues(1, mock.authenticatedViewerCalls.Load())
 
-	provider.viewerMu.Lock()
-	provider.viewerCacheAt = time.Now().Add(-authenticatedViewerLoginTTL - time.Second)
-	provider.viewerMu.Unlock()
-
 	authored, err = provider.ViewerAuthoredMergeRequest(t.Context(), mr)
 	require.NoError(err)
-	assert.False(authored)
-	assert.EqualValues(2, mock.authenticatedViewerCalls.Load())
+	assert.True(authored)
+	assert.EqualValues(1, mock.authenticatedViewerCalls.Load())
 }
 
 func TestGitHubProviderApplyReviewSuggestionsDelegatesToClient(t *testing.T) {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -1703,7 +1703,7 @@ func TestGitHubProviderPublishDiffReviewDraftApproveSubmitsReview(t *testing.T) 
 	assert.Equal("inline note", mock.createdReviewComments[0].GetBody())
 }
 
-func TestGitHubProviderViewerAuthoredMergeRequestCachesForProcessLifetime(t *testing.T) {
+func TestGitHubProviderViewerAuthoredMergeRequestRefreshesExpiredCache(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	logins := []string{"marius", "octocat"}
@@ -1726,10 +1726,17 @@ func TestGitHubProviderViewerAuthoredMergeRequestCachesForProcessLifetime(t *tes
 	assert.True(authored)
 	assert.EqualValues(1, mock.authenticatedViewerCalls.Load())
 
+	provider.viewerMu.Lock()
+	for key, entry := range provider.viewerLogins {
+		entry.fetchedAt = time.Now().Add(-authenticatedViewerLoginTTL - time.Minute)
+		provider.viewerLogins[key] = entry
+	}
+	provider.viewerMu.Unlock()
+
 	authored, err = provider.ViewerAuthoredMergeRequest(t.Context(), mr)
 	require.NoError(err)
-	assert.True(authored)
-	assert.EqualValues(1, mock.authenticatedViewerCalls.Load())
+	assert.False(authored)
+	assert.EqualValues(2, mock.authenticatedViewerCalls.Load())
 }
 
 func TestGitHubProviderApplyReviewSuggestionsDelegatesToClient(t *testing.T) {

--- a/internal/platform/client.go
+++ b/internal/platform/client.go
@@ -73,6 +73,13 @@ type AuthenticatedUserResolver interface {
 	AuthenticatedUser(ctx context.Context, ref RepoRef) (string, error)
 }
 
+// AuthenticatedUserCacheKeyResolver identifies the effective credential used
+// for a repository without exposing credential material. Repositories with the
+// same non-empty key share one authenticated-user lookup for the process.
+type AuthenticatedUserCacheKeyResolver interface {
+	AuthenticatedUserCacheKey(ref RepoRef) string
+}
+
 type IssueReader interface {
 	ListOpenIssues(ctx context.Context, ref RepoRef) ([]Issue, error)
 	GetIssue(ctx context.Context, ref RepoRef, number int) (Issue, error)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1883,6 +1883,60 @@ func TestAPIListPulls(t *testing.T) {
 	assert.Equal("acme/widget", body[0].Repo.RepoPath)
 }
 
+func TestAPIInvolvesMeFiltersPullsIssuesAndActivity(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	mock := &mockGH{
+		authenticatedViewerLoginFn: func(context.Context) (string, error) {
+			return "TestUser", nil
+		},
+	}
+	srv, database := setupTestServerWithMock(t, mock)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	seedPR(t, database, "acme", "widget", 1,
+		withSeedPRAuthor("testuser"), withSeedPRTimes(now, now, now))
+	seedPR(t, database, "acme", "widget", 2,
+		withSeedPRAuthor("someone-else"), withSeedPRTimes(now, now, now))
+	seedIssue(t, database, "acme", "widget", 3, "open")
+	repo, err := database.GetRepoByIdentity(ctx, verifiedGitHubRepoIdentity("github.com", "acme", "widget"))
+	require.NoError(err)
+	require.NotNil(repo)
+	_, err = database.UpsertIssue(ctx, &db.Issue{
+		RepoID: repo.ID, PlatformID: 4000, Number: 4,
+		URL: "https://github.com/acme/widget/issues/4", Title: "Unrelated issue",
+		Author: "someone-else", State: "open",
+		CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+
+	pullsRR := doJSON(t, srv, http.MethodGet, "/api/v1/pulls?state=all&involves_me=true", nil)
+	require.Equal(http.StatusOK, pullsRR.Code, pullsRR.Body.String())
+	var pulls []pullapi.MergeRequestResponse
+	require.NoError(json.Unmarshal(pullsRR.Body.Bytes(), &pulls))
+	require.Len(pulls, 1)
+	assert.Equal(1, pulls[0].Number)
+
+	issuesRR := doJSON(t, srv, http.MethodGet, "/api/v1/issues?state=all&involves_me=true", nil)
+	require.Equal(http.StatusOK, issuesRR.Code, issuesRR.Body.String())
+	var issues []issueapi.IssueResponse
+	require.NoError(json.Unmarshal(issuesRR.Body.Bytes(), &issues))
+	require.Len(issues, 1)
+	assert.Equal(3, issues[0].Number)
+
+	activityRR := doJSON(t, srv, http.MethodGet, "/api/v1/activity?involves_me=true", nil)
+	require.Equal(http.StatusOK, activityRR.Code, activityRR.Body.String())
+	var activity activityResponse
+	require.NoError(json.Unmarshal(activityRR.Body.Bytes(), &activity))
+	require.Len(activity.Items, 2)
+	for _, item := range activity.Items {
+		assert.Contains([]int{1, 3}, item.ItemNumber)
+	}
+	assert.Equal(1, mock.authenticatedViewerCalls,
+		"viewer identity should be shared by concurrent view requests during the cache TTL")
+}
+
 func TestAPIPullResponsesNormalizeMissingKanbanStateToNew(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -123,13 +123,14 @@ type streamEventsInput struct {
 }
 
 type listActivityInput struct {
-	Repo      string   `query:"repo" doc:"Repository filter. Accepts provider|platform_host/repo_path, with comma-separated values for multiple repositories."`
-	Types     []string `query:"types"`
-	ItemTypes []string `query:"item_types" doc:"Item scopes included before limiting activity results: pr, issue, or repo."`
-	Search    string   `query:"search"`
-	Author    string   `query:"author" doc:"Exact, case-insensitive pull request or issue author filter."`
-	After     string   `query:"after"`
-	Since     string   `query:"since"`
+	Repo       string   `query:"repo" doc:"Repository filter. Accepts provider|platform_host/repo_path, with comma-separated values for multiple repositories."`
+	Types      []string `query:"types"`
+	ItemTypes  []string `query:"item_types" doc:"Item scopes included before limiting activity results: pr, issue, or repo."`
+	Search     string   `query:"search"`
+	Author     string   `query:"author" doc:"Exact, case-insensitive pull request or issue author filter."`
+	InvolvesMe bool     `query:"involves_me" doc:"Only include activity for pull requests and issues involving the authenticated viewer."`
+	After      string   `query:"after"`
+	Since      string   `query:"since"`
 }
 
 type listActivityAuthorsInput struct {
@@ -1266,6 +1267,13 @@ func (s *Server) listActivity(ctx context.Context, input *listActivityInput) (*l
 	}
 
 	opts.Limit = activitySafetyCap + 1
+	if input.InvolvesMe {
+		viewerLogins, err := s.resolveAuthenticatedViewerLogins(ctx)
+		if err != nil {
+			return nil, err
+		}
+		opts.ViewerLogins = viewerLogins
+	}
 
 	if input.Since != "" {
 		t, err := time.Parse(time.RFC3339, input.Since)
@@ -1326,6 +1334,33 @@ func (s *Server) listActivity(ctx context.Context, input *listActivityInput) (*l
 	if err != nil {
 		slog.Error("list workspace activity failed", "err", err)
 		return nil, httpapi.Internal("list workspace activity failed")
+	}
+	if opts.ViewerLogins != nil {
+		workspaceSubjectKeys := make([]db.WorkspaceSubjectKey, 0,
+			len(workspaceSnapshot.Subjects)+len(workspaceSnapshot.OwnReferences))
+		for key := range workspaceSnapshot.Subjects {
+			workspaceSubjectKeys = append(workspaceSubjectKeys, key)
+		}
+		for key := range workspaceSnapshot.OwnReferences {
+			workspaceSubjectKeys = append(workspaceSubjectKeys, key)
+		}
+		involvedSubjects, err := s.db.ListInvolvedWorkspaceSubjectKeys(
+			ctx, opts.ViewerLogins, workspaceSubjectKeys,
+		)
+		if err != nil {
+			slog.Error("list involved workspace subjects failed", "err", err)
+			return nil, httpapi.Internal("list workspace activity failed")
+		}
+		for key := range workspaceSnapshot.Subjects {
+			if _, ok := involvedSubjects[key]; !ok {
+				delete(workspaceSnapshot.Subjects, key)
+			}
+		}
+		for key := range workspaceSnapshot.OwnReferences {
+			if _, ok := involvedSubjects[key]; !ok {
+				delete(workspaceSnapshot.OwnReferences, key)
+			}
+		}
 	}
 
 	capped := len(items) > activitySafetyCap

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1268,7 +1268,7 @@ func (s *Server) listActivity(ctx context.Context, input *listActivityInput) (*l
 
 	opts.Limit = activitySafetyCap + 1
 	if input.InvolvesMe {
-		viewerLogins, err := s.resolveAuthenticatedViewerLogins(ctx)
+		viewerLogins, err := s.resolveAuthenticatedViewerLogins(ctx, opts.RepoFilters)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/server/issueapi/handler.go
+++ b/internal/server/issueapi/handler.go
@@ -29,6 +29,7 @@ type Deps struct {
 	Syncer            *ghclient.Syncer
 	Now               func() time.Time
 	WorkspaceSubjects func(context.Context) (workspaceapi.WorkspaceSubjectSnapshot, error)
+	ViewerLogins      func(context.Context) ([]db.RepoViewerLogin, error)
 
 	FilterRepos                       func([]db.Repo) []db.Repo
 	RepoOperations                    func(db.Repo) httpapi.RepoOperations
@@ -41,6 +42,7 @@ type Handler struct {
 	syncer            *ghclient.Syncer
 	now               func() time.Time
 	workspaceSubjects func(context.Context) (workspaceapi.WorkspaceSubjectSnapshot, error)
+	viewerLogins      func(context.Context) ([]db.RepoViewerLogin, error)
 
 	filterRepos             func([]db.Repo) []db.Repo
 	repoOperations          func(db.Repo) httpapi.RepoOperations
@@ -58,6 +60,7 @@ func New(deps Deps) *Handler {
 		syncer:                  deps.Syncer,
 		now:                     now,
 		workspaceSubjects:       deps.WorkspaceSubjects,
+		viewerLogins:            deps.ViewerLogins,
 		filterRepos:             deps.FilterRepos,
 		repoOperations:          deps.RepoOperations,
 		markClosedNotifications: deps.MarkClosedLinkedNotificationsDone,

--- a/internal/server/issueapi/handler.go
+++ b/internal/server/issueapi/handler.go
@@ -29,7 +29,7 @@ type Deps struct {
 	Syncer            *ghclient.Syncer
 	Now               func() time.Time
 	WorkspaceSubjects func(context.Context) (workspaceapi.WorkspaceSubjectSnapshot, error)
-	ViewerLogins      func(context.Context) ([]db.RepoViewerLogin, error)
+	ViewerLogins      func(context.Context, []db.RepoFilter) ([]db.RepoViewerLogin, error)
 
 	FilterRepos                       func([]db.Repo) []db.Repo
 	RepoOperations                    func(db.Repo) httpapi.RepoOperations
@@ -42,7 +42,7 @@ type Handler struct {
 	syncer            *ghclient.Syncer
 	now               func() time.Time
 	workspaceSubjects func(context.Context) (workspaceapi.WorkspaceSubjectSnapshot, error)
-	viewerLogins      func(context.Context) ([]db.RepoViewerLogin, error)
+	viewerLogins      func(context.Context, []db.RepoFilter) ([]db.RepoViewerLogin, error)
 
 	filterRepos             func([]db.Repo) []db.Repo
 	repoOperations          func(db.Repo) httpapi.RepoOperations

--- a/internal/server/issueapi/routes.go
+++ b/internal/server/issueapi/routes.go
@@ -48,7 +48,7 @@ func (s *Handler) listIssues(ctx context.Context, input *listIssuesInput) (*list
 		if s.viewerLogins == nil {
 			return nil, httpapi.Internal("authenticated viewer lookup unavailable")
 		}
-		opts.ViewerLogins, err = s.viewerLogins(ctx)
+		opts.ViewerLogins, err = s.viewerLogins(ctx, opts.RepoFilters)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/server/issueapi/routes.go
+++ b/internal/server/issueapi/routes.go
@@ -38,12 +38,22 @@ func (s *Handler) listIssues(ctx context.Context, input *listIssuesInput) (*list
 			})
 		}
 	}
-	issues, err := s.db.ListIssues(ctx, db.ListIssuesOpts{
+	opts := db.ListIssuesOpts{
 		State: input.State, Search: input.Q, Starred: input.Starred,
 		Assignee: input.Assignee, Limit: input.Limit, Offset: input.Offset,
 		RepoFilters:       parseRepoFilters(input.Repo),
 		WorkspaceActivity: overrides,
-	})
+	}
+	if input.InvolvesMe {
+		if s.viewerLogins == nil {
+			return nil, httpapi.Internal("authenticated viewer lookup unavailable")
+		}
+		opts.ViewerLogins, err = s.viewerLogins(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+	issues, err := s.db.ListIssues(ctx, opts)
 	if err != nil {
 		return nil, httpapi.Internal("list issues failed")
 	}

--- a/internal/server/issueapi/types.go
+++ b/internal/server/issueapi/types.go
@@ -40,13 +40,14 @@ type IssueDetailResponse struct {
 }
 
 type listIssuesInput struct {
-	Repo     string `query:"repo" doc:"Repository filter. Accepts provider|platform_host/repo_path, with comma-separated values for multiple repositories."`
-	State    string `query:"state"`
-	Starred  bool   `query:"starred"`
-	Q        string `query:"q"`
-	Assignee string `query:"assignee"`
-	Limit    int    `query:"limit"`
-	Offset   int    `query:"offset"`
+	Repo       string `query:"repo" doc:"Repository filter. Accepts provider|platform_host/repo_path, with comma-separated values for multiple repositories."`
+	State      string `query:"state"`
+	Starred    bool   `query:"starred"`
+	InvolvesMe bool   `query:"involves_me" doc:"Only include issues involving the authenticated viewer."`
+	Q          string `query:"q"`
+	Assignee   string `query:"assignee"`
+	Limit      int    `query:"limit"`
+	Offset     int    `query:"offset"`
 }
 
 type listIssuesOutput = httpapi.BodyOutput[[]IssueResponse]

--- a/internal/server/pullapi/handler.go
+++ b/internal/server/pullapi/handler.go
@@ -35,6 +35,7 @@ type Deps struct {
 	DeferredMergeMaxWait time.Duration
 	DeleteWorkspace      func(context.Context, string) error
 	WorkspaceSubjects    func(context.Context) (workspaceapi.WorkspaceSubjectSnapshot, error)
+	ViewerLogins         func(context.Context) ([]db.RepoViewerLogin, error)
 
 	FleetSelfKey                  func(string) string
 	FilterRepos                   func([]db.Repo) []db.Repo
@@ -57,6 +58,7 @@ type Handler struct {
 	deleteWorkspace   func(context.Context, string) error
 	now               func() time.Time
 	workspaceSubjects func(context.Context) (workspaceapi.WorkspaceSubjectSnapshot, error)
+	viewerLogins      func(context.Context) ([]db.RepoViewerLogin, error)
 
 	fleetSelfKey                  func(string) string
 	filterRepos                   func([]db.Repo) []db.Repo
@@ -103,6 +105,7 @@ func New(deps Deps) *Handler {
 		deleteWorkspace:               deps.DeleteWorkspace,
 		now:                           now,
 		workspaceSubjects:             deps.WorkspaceSubjects,
+		viewerLogins:                  deps.ViewerLogins,
 		fleetSelfKey:                  deps.FleetSelfKey,
 		filterRepos:                   deps.FilterRepos,
 		repoOperations:                deps.RepoOperations,

--- a/internal/server/pullapi/handler.go
+++ b/internal/server/pullapi/handler.go
@@ -35,7 +35,7 @@ type Deps struct {
 	DeferredMergeMaxWait time.Duration
 	DeleteWorkspace      func(context.Context, string) error
 	WorkspaceSubjects    func(context.Context) (workspaceapi.WorkspaceSubjectSnapshot, error)
-	ViewerLogins         func(context.Context) ([]db.RepoViewerLogin, error)
+	ViewerLogins         func(context.Context, []db.RepoFilter) ([]db.RepoViewerLogin, error)
 
 	FleetSelfKey                  func(string) string
 	FilterRepos                   func([]db.Repo) []db.Repo
@@ -58,7 +58,7 @@ type Handler struct {
 	deleteWorkspace   func(context.Context, string) error
 	now               func() time.Time
 	workspaceSubjects func(context.Context) (workspaceapi.WorkspaceSubjectSnapshot, error)
-	viewerLogins      func(context.Context) ([]db.RepoViewerLogin, error)
+	viewerLogins      func(context.Context, []db.RepoFilter) ([]db.RepoViewerLogin, error)
 
 	fleetSelfKey                  func(string) string
 	filterRepos                   func([]db.Repo) []db.Repo

--- a/internal/server/pullapi/routes.go
+++ b/internal/server/pullapi/routes.go
@@ -401,7 +401,7 @@ func (s *Handler) listPulls(ctx context.Context, input *listPullsInput) (*listPu
 		if s.viewerLogins == nil {
 			return nil, httpapi.Internal("authenticated viewer lookup unavailable")
 		}
-		opts.ViewerLogins, err = s.viewerLogins(ctx)
+		opts.ViewerLogins, err = s.viewerLogins(ctx, opts.RepoFilters)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/server/pullapi/routes.go
+++ b/internal/server/pullapi/routes.go
@@ -34,13 +34,14 @@ const (
 )
 
 type listPullsInput struct {
-	Repo    string `query:"repo" doc:"Repository filter. Accepts provider|platform_host/repo_path, with comma-separated values for multiple repositories."`
-	State   string `query:"state"`
-	Kanban  string `query:"kanban"`
-	Starred bool   `query:"starred"`
-	Q       string `query:"q"`
-	Limit   int    `query:"limit"`
-	Offset  int    `query:"offset"`
+	Repo       string `query:"repo" doc:"Repository filter. Accepts provider|platform_host/repo_path, with comma-separated values for multiple repositories."`
+	State      string `query:"state"`
+	Kanban     string `query:"kanban"`
+	Starred    bool   `query:"starred"`
+	InvolvesMe bool   `query:"involves_me" doc:"Only include pull requests involving the authenticated viewer."`
+	Q          string `query:"q"`
+	Limit      int    `query:"limit"`
+	Offset     int    `query:"offset"`
 }
 
 type listPullsOutput = httpapi.BodyOutput[[]MergeRequestResponse]
@@ -395,6 +396,15 @@ func (s *Handler) listPulls(ctx context.Context, input *listPullsInput) (*listPu
 		Offset:            input.Offset,
 		RepoFilters:       parseRepoFilters(input.Repo),
 		WorkspaceActivity: overrides,
+	}
+	if input.InvolvesMe {
+		if s.viewerLogins == nil {
+			return nil, httpapi.Internal("authenticated viewer lookup unavailable")
+		}
+		opts.ViewerLogins, err = s.viewerLogins(ctx)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	mrs, err := s.db.ListMergeRequests(ctx, opts)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -206,8 +206,8 @@ type Server struct {
 	writeCredProbes        map[string]writeCredentialProbe
 	writeCredProbeInFlight map[string]chan struct{}
 	viewerLoginMu          sync.Mutex
-	viewerLoginCache       map[int64]viewerLoginCacheEntry
-	viewerLoginInFlight    map[int64]*viewerLoginCall
+	viewerLoginCache       map[string]string
+	viewerLoginInFlight    map[string]*viewerLoginCall
 	docsAPI                *docsapi.Handler
 	kataAPI                *kata.Handler
 	repoBrowserAPI         *repobrowserapi.Handler

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -206,7 +206,7 @@ type Server struct {
 	writeCredProbes        map[string]writeCredentialProbe
 	writeCredProbeInFlight map[string]chan struct{}
 	viewerLoginMu          sync.Mutex
-	viewerLoginCache       map[string]string
+	viewerLoginCache       map[string]viewerLoginCacheEntry
 	viewerLoginInFlight    map[string]*viewerLoginCall
 	docsAPI                *docsapi.Handler
 	kataAPI                *kata.Handler

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -205,6 +205,9 @@ type Server struct {
 	writeCredProbeMu       sync.Mutex
 	writeCredProbes        map[string]writeCredentialProbe
 	writeCredProbeInFlight map[string]chan struct{}
+	viewerLoginMu          sync.Mutex
+	viewerLoginCache       map[int64]viewerLoginCacheEntry
+	viewerLoginInFlight    map[int64]*viewerLoginCall
 	docsAPI                *docsapi.Handler
 	kataAPI                *kata.Handler
 	repoBrowserAPI         *repobrowserapi.Handler
@@ -988,6 +991,7 @@ func newServer(
 			return err
 		},
 		WorkspaceSubjects: s.workspaceAPI.WorkspaceSubjectSnapshot,
+		ViewerLogins:      s.resolveAuthenticatedViewerLogins,
 		FleetSelfKey:      s.fleetAPI.SelfKey,
 		FilterRepos: func(repos []db.Repo) []db.Repo {
 			if s.cfg == nil {
@@ -1009,6 +1013,7 @@ func newServer(
 		Syncer:            syncer,
 		Now:               func() time.Time { return s.now() },
 		WorkspaceSubjects: s.workspaceAPI.WorkspaceSubjectSnapshot,
+		ViewerLogins:      s.resolveAuthenticatedViewerLogins,
 		FilterRepos: func(repos []db.Repo) []db.Repo {
 			if s.cfg == nil {
 				return repos

--- a/internal/server/viewer_identity.go
+++ b/internal/server/viewer_identity.go
@@ -4,11 +4,22 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/platform"
 	"go.kenn.io/forge/internal/server/httpapi"
 )
+
+const (
+	authenticatedViewerLoginTTL            = time.Hour
+	authenticatedViewerLoginRefreshTimeout = 30 * time.Second
+)
+
+type viewerLoginCacheEntry struct {
+	login     string
+	fetchedAt time.Time
+}
 
 type viewerLoginCall struct {
 	done  chan struct{}
@@ -37,12 +48,12 @@ func (s *Server) resolveAuthenticatedViewerLogins(
 		host := httpapi.ProviderHost(repo)
 		resolver, err := s.syncer.Registry().AuthenticatedUserResolver(kind, host)
 		if err != nil {
-			return nil, httpapi.ProviderCallProblem(err, string(kind), host)
+			continue
 		}
 		cacheKey := authenticatedViewerCacheKey(kind, host, repo, resolver)
 		login, err := s.authenticatedViewerLogin(ctx, cacheKey, repo, resolver)
 		if err != nil {
-			return nil, err
+			continue
 		}
 		viewers = append(viewers, db.RepoViewerLogin{RepoID: repo.ID, Login: login})
 	}
@@ -116,11 +127,14 @@ func (s *Server) authenticatedViewerLogin(
 ) (string, error) {
 	s.viewerLoginMu.Lock()
 	if s.viewerLoginCache == nil {
-		s.viewerLoginCache = make(map[string]string)
+		s.viewerLoginCache = make(map[string]viewerLoginCacheEntry)
 	}
-	if login := s.viewerLoginCache[cacheKey]; login != "" {
+	if entry, ok := s.viewerLoginCache[cacheKey]; ok {
+		if time.Since(entry.fetchedAt) >= authenticatedViewerLoginTTL {
+			s.refreshAuthenticatedViewerLogin(ctx, cacheKey, repo, resolver)
+		}
 		s.viewerLoginMu.Unlock()
-		return login, nil
+		return entry.login, nil
 	}
 	if call, ok := s.viewerLoginInFlight[cacheKey]; ok {
 		s.viewerLoginMu.Unlock()
@@ -137,6 +151,40 @@ func (s *Server) authenticatedViewerLogin(
 	call := &viewerLoginCall{done: make(chan struct{})}
 	s.viewerLoginInFlight[cacheKey] = call
 	s.viewerLoginMu.Unlock()
+	s.resolveAuthenticatedViewerLogin(ctx, cacheKey, repo, resolver, call)
+	return call.login, call.err
+}
+
+func (s *Server) refreshAuthenticatedViewerLogin(
+	ctx context.Context,
+	cacheKey string,
+	repo db.Repo,
+	resolver platform.AuthenticatedUserResolver,
+) {
+	if _, ok := s.viewerLoginInFlight[cacheKey]; ok {
+		return
+	}
+	if s.viewerLoginInFlight == nil {
+		s.viewerLoginInFlight = make(map[string]*viewerLoginCall)
+	}
+	call := &viewerLoginCall{done: make(chan struct{})}
+	s.viewerLoginInFlight[cacheKey] = call
+	refreshCtx, cancel := context.WithTimeout(
+		context.WithoutCancel(ctx), authenticatedViewerLoginRefreshTimeout,
+	)
+	go func() {
+		defer cancel()
+		s.resolveAuthenticatedViewerLogin(refreshCtx, cacheKey, repo, resolver, call)
+	}()
+}
+
+func (s *Server) resolveAuthenticatedViewerLogin(
+	ctx context.Context,
+	cacheKey string,
+	repo db.Repo,
+	resolver platform.AuthenticatedUserResolver,
+	call *viewerLoginCall,
+) {
 
 	kind := httpapi.ProviderKind(repo)
 	host := httpapi.ProviderHost(repo)
@@ -153,9 +201,10 @@ func (s *Server) authenticatedViewerLogin(
 	s.viewerLoginMu.Lock()
 	delete(s.viewerLoginInFlight, cacheKey)
 	if call.err == nil {
-		s.viewerLoginCache[cacheKey] = call.login
+		s.viewerLoginCache[cacheKey] = viewerLoginCacheEntry{
+			login: call.login, fetchedAt: time.Now(),
+		}
 	}
 	close(call.done)
 	s.viewerLoginMu.Unlock()
-	return call.login, call.err
 }

--- a/internal/server/viewer_identity.go
+++ b/internal/server/viewer_identity.go
@@ -4,18 +4,11 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/platform"
 	"go.kenn.io/forge/internal/server/httpapi"
 )
-
-const viewerLoginCacheTTL = time.Minute
-
-type viewerLoginCacheEntry struct {
-	login     string
-	expiresAt time.Time
-}
 
 type viewerLoginCall struct {
 	done  chan struct{}
@@ -24,7 +17,7 @@ type viewerLoginCall struct {
 }
 
 func (s *Server) resolveAuthenticatedViewerLogins(
-	ctx context.Context,
+	ctx context.Context, filters []db.RepoFilter,
 ) ([]db.RepoViewerLogin, error) {
 	if s.syncer == nil {
 		return nil, httpapi.Internal("authenticated viewer lookup unavailable")
@@ -36,10 +29,18 @@ func (s *Server) resolveAuthenticatedViewerLogins(
 	if s.cfg != nil {
 		repos = s.filterConfiguredRepos(repos)
 	}
+	repos = filterViewerLoginRepos(repos, filters)
 
 	viewers := make([]db.RepoViewerLogin, 0, len(repos))
 	for _, repo := range repos {
-		login, err := s.authenticatedViewerLogin(ctx, repo)
+		kind := httpapi.ProviderKind(repo)
+		host := httpapi.ProviderHost(repo)
+		resolver, err := s.syncer.Registry().AuthenticatedUserResolver(kind, host)
+		if err != nil {
+			return nil, httpapi.ProviderCallProblem(err, string(kind), host)
+		}
+		cacheKey := authenticatedViewerCacheKey(kind, host, repo, resolver)
+		login, err := s.authenticatedViewerLogin(ctx, cacheKey, repo, resolver)
 		if err != nil {
 			return nil, err
 		}
@@ -48,22 +49,80 @@ func (s *Server) resolveAuthenticatedViewerLogins(
 	return viewers, nil
 }
 
-func (s *Server) authenticatedViewerLogin(ctx context.Context, repo db.Repo) (string, error) {
-	now := s.now().UTC()
-	s.viewerLoginMu.Lock()
-	if s.viewerLoginCache == nil {
-		s.viewerLoginCache = make(map[int64]viewerLoginCacheEntry)
+func filterViewerLoginRepos(repos []db.Repo, filters []db.RepoFilter) []db.Repo {
+	if len(filters) == 0 {
+		return repos
 	}
-	for repoID, entry := range s.viewerLoginCache {
-		if !entry.expiresAt.After(now) {
-			delete(s.viewerLoginCache, repoID)
+	filtered := make([]db.Repo, 0, len(repos))
+	for _, repo := range repos {
+		for _, filter := range filters {
+			if viewerRepoMatchesFilter(repo, filter) {
+				filtered = append(filtered, repo)
+				break
+			}
 		}
 	}
-	if entry, ok := s.viewerLoginCache[repo.ID]; ok {
-		s.viewerLoginMu.Unlock()
-		return entry.login, nil
+	return filtered
+}
+
+func viewerRepoMatchesFilter(repo db.Repo, filter db.RepoFilter) bool {
+	if filter.Platform != "" && !strings.EqualFold(repo.Platform, filter.Platform) {
+		return false
 	}
-	if call, ok := s.viewerLoginInFlight[repo.ID]; ok {
+	if filter.PlatformHost != "" && !strings.EqualFold(repo.PlatformHost, filter.PlatformHost) {
+		return false
+	}
+	if filter.RepoPath != "" {
+		return canonicalViewerRepoPath(repo.RepoPath) == canonicalViewerRepoPath(filter.RepoPath)
+	}
+	return filter.RepoOwner != "" && filter.RepoName != "" &&
+		strings.EqualFold(repo.Owner, filter.RepoOwner) &&
+		strings.EqualFold(repo.Name, filter.RepoName)
+}
+
+func canonicalViewerRepoPath(value string) string {
+	parts := strings.Split(strings.Trim(value, "/ "), "/")
+	for i := range parts {
+		parts[i] = strings.ToLower(strings.TrimSpace(parts[i]))
+	}
+	return strings.Join(parts, "/")
+}
+
+func authenticatedViewerCacheKey(
+	kind platform.Kind,
+	host string,
+	repo db.Repo,
+	resolver platform.AuthenticatedUserResolver,
+) string {
+	credentialKey := ""
+	if keyed, ok := resolver.(platform.AuthenticatedUserCacheKeyResolver); ok {
+		credentialKey = strings.TrimSpace(keyed.AuthenticatedUserCacheKey(httpapi.PlatformRepoRef(repo)))
+	}
+	if credentialKey == "" {
+		if kind == platform.KindGitHub {
+			credentialKey = fmt.Sprintf("repository:%d", repo.ID)
+		} else {
+			credentialKey = "provider-host"
+		}
+	}
+	return strings.Join([]string{string(kind), strings.ToLower(host), credentialKey}, "\x00")
+}
+
+func (s *Server) authenticatedViewerLogin(
+	ctx context.Context,
+	cacheKey string,
+	repo db.Repo,
+	resolver platform.AuthenticatedUserResolver,
+) (string, error) {
+	s.viewerLoginMu.Lock()
+	if s.viewerLoginCache == nil {
+		s.viewerLoginCache = make(map[string]string)
+	}
+	if login := s.viewerLoginCache[cacheKey]; login != "" {
+		s.viewerLoginMu.Unlock()
+		return login, nil
+	}
+	if call, ok := s.viewerLoginInFlight[cacheKey]; ok {
 		s.viewerLoginMu.Unlock()
 		select {
 		case <-call.done:
@@ -73,32 +132,28 @@ func (s *Server) authenticatedViewerLogin(ctx context.Context, repo db.Repo) (st
 		}
 	}
 	if s.viewerLoginInFlight == nil {
-		s.viewerLoginInFlight = make(map[int64]*viewerLoginCall)
+		s.viewerLoginInFlight = make(map[string]*viewerLoginCall)
 	}
 	call := &viewerLoginCall{done: make(chan struct{})}
-	s.viewerLoginInFlight[repo.ID] = call
+	s.viewerLoginInFlight[cacheKey] = call
 	s.viewerLoginMu.Unlock()
 
 	kind := httpapi.ProviderKind(repo)
 	host := httpapi.ProviderHost(repo)
-	resolver, err := s.syncer.Registry().AuthenticatedUserResolver(kind, host)
-	if err == nil {
-		call.login, err = resolver.AuthenticatedUser(ctx, httpapi.PlatformRepoRef(repo))
-		call.login = strings.TrimSpace(call.login)
-		if err == nil && call.login == "" {
-			err = fmt.Errorf("provider returned an empty authenticated login")
-		}
+	var err error
+	call.login, err = resolver.AuthenticatedUser(ctx, httpapi.PlatformRepoRef(repo))
+	call.login = strings.TrimSpace(call.login)
+	if err == nil && call.login == "" {
+		err = fmt.Errorf("provider returned an empty authenticated login")
 	}
 	if err != nil {
 		call.err = httpapi.ProviderCallProblem(err, string(kind), host)
 	}
 
 	s.viewerLoginMu.Lock()
-	delete(s.viewerLoginInFlight, repo.ID)
+	delete(s.viewerLoginInFlight, cacheKey)
 	if call.err == nil {
-		s.viewerLoginCache[repo.ID] = viewerLoginCacheEntry{
-			login: call.login, expiresAt: s.now().UTC().Add(viewerLoginCacheTTL),
-		}
+		s.viewerLoginCache[cacheKey] = call.login
 	}
 	close(call.done)
 	s.viewerLoginMu.Unlock()

--- a/internal/server/viewer_identity.go
+++ b/internal/server/viewer_identity.go
@@ -1,0 +1,106 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/server/httpapi"
+)
+
+const viewerLoginCacheTTL = time.Minute
+
+type viewerLoginCacheEntry struct {
+	login     string
+	expiresAt time.Time
+}
+
+type viewerLoginCall struct {
+	done  chan struct{}
+	login string
+	err   error
+}
+
+func (s *Server) resolveAuthenticatedViewerLogins(
+	ctx context.Context,
+) ([]db.RepoViewerLogin, error) {
+	if s.syncer == nil {
+		return nil, httpapi.Internal("authenticated viewer lookup unavailable")
+	}
+	repos, err := s.db.ListRepos(ctx)
+	if err != nil {
+		return nil, httpapi.Internal("load repositories for authenticated viewer failed")
+	}
+	if s.cfg != nil {
+		repos = s.filterConfiguredRepos(repos)
+	}
+
+	viewers := make([]db.RepoViewerLogin, 0, len(repos))
+	for _, repo := range repos {
+		login, err := s.authenticatedViewerLogin(ctx, repo)
+		if err != nil {
+			return nil, err
+		}
+		viewers = append(viewers, db.RepoViewerLogin{RepoID: repo.ID, Login: login})
+	}
+	return viewers, nil
+}
+
+func (s *Server) authenticatedViewerLogin(ctx context.Context, repo db.Repo) (string, error) {
+	now := s.now().UTC()
+	s.viewerLoginMu.Lock()
+	if s.viewerLoginCache == nil {
+		s.viewerLoginCache = make(map[int64]viewerLoginCacheEntry)
+	}
+	for repoID, entry := range s.viewerLoginCache {
+		if !entry.expiresAt.After(now) {
+			delete(s.viewerLoginCache, repoID)
+		}
+	}
+	if entry, ok := s.viewerLoginCache[repo.ID]; ok {
+		s.viewerLoginMu.Unlock()
+		return entry.login, nil
+	}
+	if call, ok := s.viewerLoginInFlight[repo.ID]; ok {
+		s.viewerLoginMu.Unlock()
+		select {
+		case <-call.done:
+			return call.login, call.err
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
+	if s.viewerLoginInFlight == nil {
+		s.viewerLoginInFlight = make(map[int64]*viewerLoginCall)
+	}
+	call := &viewerLoginCall{done: make(chan struct{})}
+	s.viewerLoginInFlight[repo.ID] = call
+	s.viewerLoginMu.Unlock()
+
+	kind := httpapi.ProviderKind(repo)
+	host := httpapi.ProviderHost(repo)
+	resolver, err := s.syncer.Registry().AuthenticatedUserResolver(kind, host)
+	if err == nil {
+		call.login, err = resolver.AuthenticatedUser(ctx, httpapi.PlatformRepoRef(repo))
+		call.login = strings.TrimSpace(call.login)
+		if err == nil && call.login == "" {
+			err = fmt.Errorf("provider returned an empty authenticated login")
+		}
+	}
+	if err != nil {
+		call.err = httpapi.ProviderCallProblem(err, string(kind), host)
+	}
+
+	s.viewerLoginMu.Lock()
+	delete(s.viewerLoginInFlight, repo.ID)
+	if call.err == nil {
+		s.viewerLoginCache[repo.ID] = viewerLoginCacheEntry{
+			login: call.login, expiresAt: s.now().UTC().Add(viewerLoginCacheTTL),
+		}
+	}
+	close(call.done)
+	s.viewerLoginMu.Unlock()
+	return call.login, call.err
+}

--- a/internal/server/viewer_identity_test.go
+++ b/internal/server/viewer_identity_test.go
@@ -1,0 +1,199 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/db"
+	ghclient "go.kenn.io/forge/internal/github"
+	"go.kenn.io/forge/internal/platform"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+)
+
+type viewerIdentityProvider struct {
+	kind      platform.Kind
+	host      string
+	cacheKeys map[string]string
+	logins    map[string]string
+	errs      map[string]error
+
+	mu    sync.Mutex
+	calls []string
+}
+
+func (p *viewerIdentityProvider) Platform() platform.Kind { return p.kind }
+func (p *viewerIdentityProvider) Host() string            { return p.host }
+func (p *viewerIdentityProvider) Capabilities() platform.Capabilities {
+	return platform.Capabilities{ReadAuthenticatedUser: true}
+}
+func (p *viewerIdentityProvider) AuthenticatedUser(_ context.Context, ref platform.RepoRef) (string, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls = append(p.calls, ref.RepoPath)
+	if err := p.errs[ref.RepoPath]; err != nil {
+		return "", err
+	}
+	return p.logins[ref.RepoPath], nil
+}
+func (p *viewerIdentityProvider) AuthenticatedUserCacheKey(ref platform.RepoRef) string {
+	return p.cacheKeys[ref.RepoPath]
+}
+func (p *viewerIdentityProvider) callCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.calls)
+}
+
+func newViewerIdentityTestServer(
+	t *testing.T,
+	providers []*viewerIdentityProvider,
+	repos []platform.RepoRef,
+) (*Server, map[string]int64) {
+	t.Helper()
+	database := dbtest.Open(t)
+	providerList := make([]platform.Provider, 0, len(providers))
+	for _, provider := range providers {
+		providerList = append(providerList, provider)
+	}
+	registry, err := platform.NewRegistry(providerList...)
+	require.NoError(t, err)
+	refs := make([]ghclient.RepoRef, 0, len(repos))
+	repoIDs := make(map[string]int64, len(repos))
+	for _, repo := range repos {
+		id, err := database.UpsertRepo(t.Context(), platform.DBRepoIdentity(repo))
+		require.NoError(t, err)
+		repoIDs[repo.RepoPath] = id
+		refs = append(refs, ghclient.RepoRef{
+			Platform: repo.Platform, PlatformHost: repo.Host,
+			Owner: repo.Owner, Name: repo.Name, RepoPath: repo.RepoPath,
+			PlatformExternalID: repo.PlatformExternalID,
+		})
+	}
+	syncer := ghclient.NewSyncerWithRegistry(registry, database, nil, refs, time.Hour, nil, nil)
+	t.Cleanup(syncer.Stop)
+	return &Server{db: database, syncer: syncer}, repoIDs
+}
+
+func TestResolveAuthenticatedViewerLoginsRestrictsProviderCallsToRepoFilters(t *testing.T) {
+	selected := &viewerIdentityProvider{
+		kind: platform.KindGitHub, host: "github.com",
+		cacheKeys: map[string]string{"acme/widget": "selected-credential"},
+		logins:    map[string]string{"acme/widget": "alice"},
+	}
+	unrelated := &viewerIdentityProvider{
+		kind: platform.KindGitLab, host: "gitlab.example.com",
+		cacheKeys: map[string]string{"other/tool": "unrelated-credential"},
+		errs:      map[string]error{"other/tool": errors.New("unavailable credential")},
+	}
+	srv, repoIDs := newViewerIdentityTestServer(t, []*viewerIdentityProvider{selected, unrelated}, []platform.RepoRef{
+		{Platform: platform.KindGitHub, Host: "github.com", Owner: "acme", Name: "widget", RepoPath: "acme/widget", PlatformExternalID: "repo-widget"},
+		{Platform: platform.KindGitLab, Host: "gitlab.example.com", Owner: "other", Name: "tool", RepoPath: "other/tool", PlatformExternalID: "repo-tool"},
+	})
+
+	got, err := srv.resolveAuthenticatedViewerLogins(t.Context(), []db.RepoFilter{{
+		Platform: "github", PlatformHost: "github.com", RepoPath: "acme/widget",
+	}})
+	require.NoError(t, err)
+	assert.Equal(t, []db.RepoViewerLogin{{RepoID: repoIDs["acme/widget"], Login: "alice"}}, got)
+	assert.Equal(t, 1, selected.callCount())
+	assert.Zero(t, unrelated.callCount())
+}
+
+func TestResolveAuthenticatedViewerLoginsCachesByEffectiveCredentialForProcessLifetime(t *testing.T) {
+	provider := &viewerIdentityProvider{
+		kind: platform.KindGitHub, host: "github.com",
+		cacheKeys: map[string]string{
+			"acme/widget": "shared-credential",
+			"acme/gadget": "shared-credential",
+		},
+		logins: map[string]string{
+			"acme/widget": "alice",
+			"acme/gadget": "alice",
+		},
+	}
+	srv, _ := newViewerIdentityTestServer(t, []*viewerIdentityProvider{provider}, []platform.RepoRef{
+		{Platform: platform.KindGitHub, Host: "github.com", Owner: "acme", Name: "widget", RepoPath: "acme/widget", PlatformExternalID: "repo-widget"},
+		{Platform: platform.KindGitHub, Host: "github.com", Owner: "acme", Name: "gadget", RepoPath: "acme/gadget", PlatformExternalID: "repo-gadget"},
+	})
+
+	first, err := srv.resolveAuthenticatedViewerLogins(t.Context(), nil)
+	require.NoError(t, err)
+	require.Len(t, first, 2)
+	second, err := srv.resolveAuthenticatedViewerLogins(t.Context(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+	assert.Equal(t, 1, provider.callCount())
+}
+
+func TestResolveAuthenticatedViewerLoginsDoesNotCacheFailures(t *testing.T) {
+	provider := &viewerIdentityProvider{
+		kind: platform.KindGitHub, host: "github.com",
+		cacheKeys: map[string]string{"acme/widget": "credential"},
+		logins:    map[string]string{"acme/widget": "alice"},
+		errs:      map[string]error{"acme/widget": errors.New("temporary failure")},
+	}
+	srv, _ := newViewerIdentityTestServer(t, []*viewerIdentityProvider{provider}, []platform.RepoRef{{
+		Platform: platform.KindGitHub, Host: "github.com", Owner: "acme", Name: "widget", RepoPath: "acme/widget", PlatformExternalID: "repo-widget",
+	}})
+
+	_, err := srv.resolveAuthenticatedViewerLogins(t.Context(), nil)
+	require.Error(t, err)
+	delete(provider.errs, "acme/widget")
+	got, err := srv.resolveAuthenticatedViewerLogins(t.Context(), nil)
+	require.NoError(t, err)
+	assert.Len(t, got, 1)
+	assert.Equal(t, 2, provider.callCount())
+}
+
+type unkeyedViewerIdentityProvider struct {
+	base *viewerIdentityProvider
+}
+
+func (p *unkeyedViewerIdentityProvider) Platform() platform.Kind { return p.base.Platform() }
+func (p *unkeyedViewerIdentityProvider) Host() string            { return p.base.Host() }
+func (p *unkeyedViewerIdentityProvider) Capabilities() platform.Capabilities {
+	return p.base.Capabilities()
+}
+func (p *unkeyedViewerIdentityProvider) AuthenticatedUser(
+	ctx context.Context, ref platform.RepoRef,
+) (string, error) {
+	return p.base.AuthenticatedUser(ctx, ref)
+}
+
+func TestResolveAuthenticatedViewerLoginsKeepsUnkeyedGitHubReposSeparate(t *testing.T) {
+	base := &viewerIdentityProvider{
+		kind: platform.KindGitHub, host: "github.com",
+		logins: map[string]string{
+			"acme/widget": "alice",
+			"other/tool":  "bob",
+		},
+	}
+	provider := &unkeyedViewerIdentityProvider{base: base}
+	database := dbtest.Open(t)
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(t, err)
+	refs := []ghclient.RepoRef{
+		{Platform: platform.KindGitHub, PlatformHost: "github.com", Owner: "acme", Name: "widget", RepoPath: "acme/widget", PlatformExternalID: "repo-widget"},
+		{Platform: platform.KindGitHub, PlatformHost: "github.com", Owner: "other", Name: "tool", RepoPath: "other/tool", PlatformExternalID: "repo-tool"},
+	}
+	for _, ref := range refs {
+		_, err := database.UpsertRepo(t.Context(), platform.DBRepoIdentity(platform.RepoRef{
+			Platform: ref.Platform, Host: ref.PlatformHost, Owner: ref.Owner, Name: ref.Name,
+			RepoPath: ref.RepoPath, PlatformExternalID: ref.PlatformExternalID,
+		}))
+		require.NoError(t, err)
+	}
+	syncer := ghclient.NewSyncerWithRegistry(registry, database, nil, refs, time.Hour, nil, nil)
+	t.Cleanup(syncer.Stop)
+	srv := &Server{db: database, syncer: syncer}
+
+	got, err := srv.resolveAuthenticatedViewerLogins(t.Context(), nil)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, 2, base.callCount())
+}

--- a/internal/server/viewer_identity_test.go
+++ b/internal/server/viewer_identity_test.go
@@ -49,6 +49,12 @@ func (p *viewerIdentityProvider) callCount() int {
 	return len(p.calls)
 }
 
+func (p *viewerIdentityProvider) setLogin(repoPath, login string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.logins[repoPath] = login
+}
+
 func newViewerIdentityTestServer(
 	t *testing.T,
 	providers []*viewerIdentityProvider,
@@ -104,7 +110,7 @@ func TestResolveAuthenticatedViewerLoginsRestrictsProviderCallsToRepoFilters(t *
 	assert.Zero(t, unrelated.callCount())
 }
 
-func TestResolveAuthenticatedViewerLoginsCachesByEffectiveCredentialForProcessLifetime(t *testing.T) {
+func TestResolveAuthenticatedViewerLoginsRefreshesExpiredCredentialCacheInBackground(t *testing.T) {
 	provider := &viewerIdentityProvider{
 		kind: platform.KindGitHub, host: "github.com",
 		cacheKeys: map[string]string{
@@ -124,10 +130,26 @@ func TestResolveAuthenticatedViewerLoginsCachesByEffectiveCredentialForProcessLi
 	first, err := srv.resolveAuthenticatedViewerLogins(t.Context(), nil)
 	require.NoError(t, err)
 	require.Len(t, first, 2)
+	provider.setLogin("acme/widget", "bob")
+	provider.setLogin("acme/gadget", "bob")
+	srv.viewerLoginMu.Lock()
+	for key, entry := range srv.viewerLoginCache {
+		entry.fetchedAt = time.Now().Add(-authenticatedViewerLoginTTL - time.Minute)
+		srv.viewerLoginCache[key] = entry
+	}
+	srv.viewerLoginMu.Unlock()
+
 	second, err := srv.resolveAuthenticatedViewerLogins(t.Context(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, first, second)
-	assert.Equal(t, 1, provider.callCount())
+	require.Eventually(t, func() bool { return provider.callCount() == 2 }, time.Second, 10*time.Millisecond)
+
+	third, err := srv.resolveAuthenticatedViewerLogins(t.Context(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, []db.RepoViewerLogin{
+		{RepoID: first[0].RepoID, Login: "bob"},
+		{RepoID: first[1].RepoID, Login: "bob"},
+	}, third)
 }
 
 func TestResolveAuthenticatedViewerLoginsDoesNotCacheFailures(t *testing.T) {
@@ -141,13 +163,34 @@ func TestResolveAuthenticatedViewerLoginsDoesNotCacheFailures(t *testing.T) {
 		Platform: platform.KindGitHub, Host: "github.com", Owner: "acme", Name: "widget", RepoPath: "acme/widget", PlatformExternalID: "repo-widget",
 	}})
 
-	_, err := srv.resolveAuthenticatedViewerLogins(t.Context(), nil)
-	require.Error(t, err)
-	delete(provider.errs, "acme/widget")
 	got, err := srv.resolveAuthenticatedViewerLogins(t.Context(), nil)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+	delete(provider.errs, "acme/widget")
+	got, err = srv.resolveAuthenticatedViewerLogins(t.Context(), nil)
 	require.NoError(t, err)
 	assert.Len(t, got, 1)
 	assert.Equal(t, 2, provider.callCount())
+}
+
+func TestResolveAuthenticatedViewerLoginsKeepsAvailableRepositories(t *testing.T) {
+	provider := &viewerIdentityProvider{
+		kind: platform.KindGitHub, host: "github.com",
+		cacheKeys: map[string]string{
+			"acme/widget": "available-credential",
+			"other/tool":  "unavailable-credential",
+		},
+		logins: map[string]string{"acme/widget": "alice"},
+		errs:   map[string]error{"other/tool": errors.New("unavailable credential")},
+	}
+	srv, repoIDs := newViewerIdentityTestServer(t, []*viewerIdentityProvider{provider}, []platform.RepoRef{
+		{Platform: platform.KindGitHub, Host: "github.com", Owner: "acme", Name: "widget", RepoPath: "acme/widget", PlatformExternalID: "repo-widget"},
+		{Platform: platform.KindGitHub, Host: "github.com", Owner: "other", Name: "tool", RepoPath: "other/tool", PlatformExternalID: "repo-tool"},
+	})
+
+	got, err := srv.resolveAuthenticatedViewerLogins(t.Context(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, []db.RepoViewerLogin{{RepoID: repoIDs["acme/widget"], Login: "alice"}}, got)
 }
 
 type unkeyedViewerIdentityProvider struct {

--- a/internal/testutil/fixture_client.go
+++ b/internal/testutil/fixture_client.go
@@ -93,6 +93,10 @@ func (c *FixtureClient) MarkNotificationThreadRead(
 	return nil
 }
 
+func (c *FixtureClient) AuthenticatedViewerLogin(context.Context) (string, error) {
+	return "alice", nil
+}
+
 func (c *FixtureClient) SetMergePullRequestError(err error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/testutil/fixture_client.go
+++ b/internal/testutil/fixture_client.go
@@ -94,7 +94,7 @@ func (c *FixtureClient) MarkNotificationThreadRead(
 }
 
 func (c *FixtureClient) AuthenticatedViewerLogin(context.Context) (string, error) {
-	return "alice", nil
+	return "fixture-viewer", nil
 }
 
 func (c *FixtureClient) SetMergePullRequestError(err error) {


### PR DESCRIPTION
- Add an `Involves me` option to Pulls, Issues, and Activity, including focus/mobile pull and issue lists.
- Use the same persisted pull and issue filter state across desktop and focus presentations.
- Resolve authenticated identity only for repositories selected by the request. Include repositories whose identity is available, and cache successes for one hour by effective credential with stale-while-refresh.
- Apply involvement before pagination.

### Screenshot

![Activity filter dropdown showing the Involves me visibility option](https://github.com/user-attachments/assets/c77a0a38-47ed-43bd-a658-c20ffc74f8bb)

Closes #897

<sup>generated by a clanker</sup>
