### PR TITLE
Close merge modal before deleting workspace

### DIFF
--- a/context/deferred-merge.md
+++ b/context/deferred-merge.md
@@ -29,11 +29,11 @@ supersession, completion events, or pending-state presentation.
   merge; queueing a second one returns 409 `already_pending`, so the UI must
   not offer deferred actions while `deferred_merge_pending` is true.
 - Deferred merge requests retain the selected workspace ID; only a successful
-  provider merge reaches non-force deletion
+  provider merge reaches durable background-deletion admission
   (`internal/server/pullapi/deferred_merge.go::completeDeferredMerge`).
-- A successful completion event carries `deleted_workspace_id` only when cleanup removed the requested workspace.
-  Cleanup warnings preserve the workspace and omit that field; clients publish confirmed deletion before view refreshes
-  (`internal/server/pullapi/deferred_merge.go::DeferredMergeCompletedPayload`).
+- Successful completion can carry `workspace_cleanup_pending`; cleanup completion
+  is reported independently by workspace lifecycle events, so the merge event
+  never infers deletion (`internal/server/pullapi/deferred_merge.go::DeferredMergeCompletedPayload`).
 - Frontend callbacks distinguish queue acknowledgement from provider merge
   completion. A queued outcome closes the modal and refreshes pending state; it
   never publishes workspace deletion (`frontend/src/lib/stores/detail.svelte.ts::MergePullOutcome`).

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -129,13 +129,21 @@ Interactive surfaces must agree on which item is selected.
   Deleting the exact `(hostKey, workspaceId)` named by the active terminal route
   must replace that history entry with the Workspaces list; pushing a redirect lets
   Back rehost the dead workspace (`frontend/src/lib/stores/workspace-host.svelte.ts::notifyWorkspaceDeleted`).
-- Automatic launchers and workspace mutations stay blocked during inline or merge-triggered deletion and explicit
-  startup; merge cleanup uses local host identity and the full host deletion notification before pending state clears
-  (`frontend/src/lib/stores/workspace-host.svelte.ts::notifyWorkspaceDeleted`).
-- Immediate and deferred merge cleanup is optional partial success, represented by the generated
-  `delete_workspace_id` request field and `workspace_cleanup_warning` result. A warning keeps the workspace live and
-  is presented as a warning, while only `merged: true` with no warning publishes the deleted workspace ID
-  (`frontend/src/lib/components/detail/MergeModal.svelte`, `frontend/src/lib/stores/detail.svelte.ts::mergePull`).
+- Merge success closes the modal after the cleanup-admission attempt, not teardown:
+  `deleting`/`deletion_failed` remain workspace states, and only the provider-aware
+  `workspace_deleted` event tombstones the row and reconciles visible item data
+  (`frontend/src/lib/app-stores.svelte.ts::createAppStores`).
+- Pull and issue detail actions route `deleting`/`deletion_failed` workspaces to
+  Workspaces recovery; inline hosts must not reopen their terminals
+  (`frontend/src/lib/components/detail/PullDetail.svelte::workspaceActionButton`).
+- A `deletion_failed` workspace exposes the same confirmed force-delete recovery
+  on local and fleet rows; fleet requests forward `force=true` to the owning host
+  (`frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte::confirmDeleteWorkspaceFromList`).
+- A terminal view whose loaded workspace is `deleting` or `deletion_failed`
+  blocks its normal runtime and workspace actions. It renders deletion progress
+  or confirmed force-delete recovery instead, retaining the exact workspace and
+  fleet-host target through confirmation
+  (`frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte::openForceDeleteRecovery`).
 - Catalog-backed routes must normalize missing selections even when the catalog
   is empty: select the first available item or `null`, and clear dependent route
   identity (`frontend/src/lib/components/docs/DocsWorkspace.svelte::loadFolders`).

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -136,12 +136,24 @@ embedder protocol for arbitrary host state.
   (`frontend/src/lib/stores/detail.svelte.ts::applyRefreshedDetail`).
 - `DELETE /workspaces/{id}`: tear down a kenn-forge-managed workspace and its
   local resources.
-  - Force-delete blocks new setup generations before joining the current worker,
-    so creation or retry cannot materialize resources after cleanup and row removal.
-    Deletions are reference-counted per workspace ID; setup dispatched during
-    deletion queues and replays only if every concurrent deletion fails — one
-    success closes admission permanently, and a dropped replay would strand an
-    accepted retry in "creating"
+  - Every admitted deletion persists `deleting` before destructive work and
+    `deletion_failed` on failure. Synchronous safe-delete rejection occurs
+    before admission so a dirty workspace remains usable (`internal/server/workspaceapi/workspace_deletion.go::Handler.runWorkspaceDeletion`, `internal/server/workspaceapi/routes_handlers.go::Handler.DeleteWorkspace`).
+  - Confirmed removal emits full provider/repository/item identity; merge and
+    ordinary deletion share this lifecycle (`internal/server/workspaceapi/workspace_deletion.go::Handler.publishWorkspaceDeleted`).
+  - Deletion admission is a compare-and-swap from stable `ready`, `error`, or
+    `deletion_failed` state. A concurrent setup that wins the race and moves the
+    row to `creating` receives a conflict instead of being overwritten; once
+    deletion is admitted, retry requests also conflict until teardown succeeds
+    or leaves an explicit `deletion_failed` row. Deletions remain
+    reference-counted per workspace ID so one failed concurrent request cannot
+    reopen setup while another owns teardown
+    (`internal/db/queries.go::DB.BeginWorkspaceDeletion`, `internal/server/workspaceapi/routes_handlers.go::Handler.DeleteWorkspace`).
+  - Delete conflicts use stable `worktreeDirty`,
+    `workspaceSetupInProgress`, and `workspaceDeletionInProgress` problem
+    codes. The server checks lifecycle state before and after dirty preflight;
+    clients offer force deletion only for a dirty worktree and refresh into
+    the authoritative lifecycle state for setup/deletion races
     (`internal/server/workspaceapi/routes_handlers.go::Handler.DeleteWorkspace`).
   - Setup rejects occupied destinations before clone/fetch and again under the
     repo lock before mutation. Branch creation and failed-add cleanup use ref

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -62,6 +62,16 @@ The base workspace `tmux` tab is the exception:
 Workspace deletion is intentionally conservative.
 
 - First decide whether deletion is allowed, including dirty-worktree checks.
+- Persist deletion intent before destructive work; failures remain visible and
+  retryable, while interrupted attempts become explicit failures after restart
+  (`internal/server/workspaceapi/workspace_deletion.go::Handler.runWorkspaceDeletion`).
+- Setup generations are process-local, so startup must change persisted
+  `creating` rows to `error` and `deleting` rows to `deletion_failed`
+  (`internal/server/workspaceapi/lifecycle.go::Handler.Start`).
+- Lifecycle writers that act on a previously observed status must use a
+  conditional transition. In particular, tmux pruning cannot replace an
+  admitted `deleting` state with a stale `ready` to `error` write
+  (`internal/db/queries.go::DB.MarkReadyWorkspaceError`).
 - Only after a clean preflight may runtime sessions and shells be stopped.
 - Only after runtime shutdown succeeds should destructive worktree and DB
   teardown continue.

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -3718,6 +3718,8 @@ components:
           type: string
         sha:
           type: string
+        workspace_cleanup_pending:
+          type: boolean
         workspace_cleanup_warning:
           type: string
       required:
@@ -4710,8 +4712,10 @@ components:
             - unsupportedCapability
             - upstreamError
             - validationError
+            - workspaceDeletionInProgress
             - workspaceDirectoryNotReusable
             - workspaceNotFound
+            - workspaceSetupInProgress
             - worktreeDirty
           examples:
             - badRequest

--- a/frontend/src/app-stores.test.ts
+++ b/frontend/src/app-stores.test.ts
@@ -598,25 +598,32 @@ describe("app store event wiring", () => {
     expect(onNotification).not.toHaveBeenCalled();
   });
 
-  it("publishes the workspace ID carried by deferred merge completion", async () => {
-    compose();
+  it("publishes confirmed workspace deletion with its item identity", async () => {
+    compose({ getPage: () => "pulls" });
 
     await acceptEvent(
-      captured.store?.options.onDeferredMergeCompleted?.({
+      captured.store?.options.onWorkspaceDeleted?.({
+        workspace_id: "ws-1",
         provider: "github",
         platform_host: "github.com",
         repo_path: "acme/widget",
         owner: "acme",
         name: "widget",
         number: 42,
-        head_sha: "2222222",
-        status: "merged",
-        merged: true,
-        completed_at: "2026-07-10T15:00:00Z",
-        deleted_workspace_id: "ws-1",
+        item_type: "pull_request",
       }),
     );
 
-    expect(notifyWorkspaceDeleted).toHaveBeenCalledWith("ws-1");
+    expect(notifyWorkspaceDeleted).toHaveBeenCalledWith("ws-1", undefined, {
+      provider: "github",
+      platformHost: "github.com",
+      owner: "acme",
+      name: "widget",
+      repoPath: "acme/widget",
+      number: 42,
+      itemType: "pull_request",
+    });
+    expect(reconcilePullsEffect).toHaveBeenCalledOnce();
+    expect(loadPulls).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/lib/api/generated/schema.ts
+++ b/frontend/src/lib/api/generated/schema.ts
@@ -6326,6 +6326,7 @@ export interface components {
             merged: boolean;
             message: string;
             sha: string;
+            workspace_cleanup_pending?: boolean;
             workspace_cleanup_warning?: string;
         };
         MergePRInputBody: {
@@ -6718,7 +6719,7 @@ export interface components {
              * @example badRequest
              * @enum {string}
              */
-            code: "badRequest" | "branchConflict" | "branchInUse" | "branchProtected" | "commentNotFound" | "conflict" | "destinationExists" | "forbidden" | "hookFailed" | "internalError" | "issueNotFound" | "mutationOutcomeUnknown" | "notFound" | "payloadTooLarge" | "projectNotFound" | "pullNotFound" | "rateLimited" | "repoNotFound" | "resyncRequired" | "serviceUnavailable" | "settingsUnavailable" | "toolMissing" | "toolUnauthenticated" | "unauthorized" | "unsupportedCapability" | "upstreamError" | "validationError" | "workspaceDirectoryNotReusable" | "workspaceNotFound" | "worktreeDirty";
+            code: "badRequest" | "branchConflict" | "branchInUse" | "branchProtected" | "commentNotFound" | "conflict" | "destinationExists" | "forbidden" | "hookFailed" | "internalError" | "issueNotFound" | "mutationOutcomeUnknown" | "notFound" | "payloadTooLarge" | "projectNotFound" | "pullNotFound" | "rateLimited" | "repoNotFound" | "resyncRequired" | "serviceUnavailable" | "settingsUnavailable" | "toolMissing" | "toolUnauthenticated" | "unauthorized" | "unsupportedCapability" | "upstreamError" | "validationError" | "workspaceDeletionInProgress" | "workspaceDirectoryNotReusable" | "workspaceNotFound" | "workspaceSetupInProgress" | "worktreeDirty";
             /**
              * @description A human-readable explanation specific to this occurrence of the problem.
              * @example Property foo is required but is missing.
@@ -18863,7 +18864,7 @@ export const mergeRequestKanbanStatusValues: ReadonlyArray<FlattenedDeepRequired
 export const mergeRequestStateValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["MergeRequest"]["State"]> = ["open", "closed", "merged"];
 export const mergeRequestResponseKanbanStatusValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["MergeRequestResponse"]["KanbanStatus"]> = ["new", "reviewing", "waiting", "awaiting_merge"];
 export const mergeRequestResponseStateValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["MergeRequestResponse"]["State"]> = ["open", "closed", "merged"];
-export const problemErrorCodeValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["ProblemError"]["code"]> = ["badRequest", "branchConflict", "branchInUse", "branchProtected", "commentNotFound", "conflict", "destinationExists", "forbidden", "hookFailed", "internalError", "issueNotFound", "mutationOutcomeUnknown", "notFound", "payloadTooLarge", "projectNotFound", "pullNotFound", "rateLimited", "repoNotFound", "resyncRequired", "serviceUnavailable", "settingsUnavailable", "toolMissing", "toolUnauthenticated", "unauthorized", "unsupportedCapability", "upstreamError", "validationError", "workspaceDirectoryNotReusable", "workspaceNotFound", "worktreeDirty"];
+export const problemErrorCodeValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["ProblemError"]["code"]> = ["badRequest", "branchConflict", "branchInUse", "branchProtected", "commentNotFound", "conflict", "destinationExists", "forbidden", "hookFailed", "internalError", "issueNotFound", "mutationOutcomeUnknown", "notFound", "payloadTooLarge", "projectNotFound", "pullNotFound", "rateLimited", "repoNotFound", "resyncRequired", "serviceUnavailable", "settingsUnavailable", "toolMissing", "toolUnauthenticated", "unauthorized", "unsupportedCapability", "upstreamError", "validationError", "workspaceDeletionInProgress", "workspaceDirectoryNotReusable", "workspaceNotFound", "workspaceSetupInProgress", "worktreeDirty"];
 export const syncStatusLast_error_codeValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["SyncStatus"]["last_error_code"]> = ["localSyncCeilingExhausted"];
 export const workflowStateMetaResponseStatusValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["WorkflowStateMetaResponse"]["status"]> = ["new", "reviewing", "waiting", "awaiting_merge"];
 export const workspaceResponseAgent_stateValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["WorkspaceResponse"]["agent_state"]> = ["idle", "working", "input", "approval", "done"];

--- a/frontend/src/lib/app-stores.svelte.ts
+++ b/frontend/src/lib/app-stores.svelte.ts
@@ -227,6 +227,21 @@ export function createAppStores(options: AppStoreOptions): AppStoreComposition {
     onDataChanged: refreshVisibleData,
     onSyncStatus: (status) => Effect.sync(() => syncStore.setSyncStatus(status)),
     onConfigChanged: handleConfigChanged,
+    onWorkspaceDeleted: (event) =>
+      Effect.gen(function* () {
+        yield* Effect.sync(() =>
+          notifyWorkspaceDeleted(event.workspace_id, undefined, {
+            provider: event.provider,
+            platformHost: event.platform_host,
+            owner: event.owner,
+            name: event.name,
+            repoPath: event.repo_path,
+            number: event.number,
+            itemType: event.item_type,
+          }),
+        );
+        yield* refreshVisibleData();
+      }),
     ...(errorCb !== undefined && { onTerminalFailure: errorCb, onRecoverableFailure: errorCb }),
     onPRDetailRefreshed: (ref) => {
       const detail = detailStore.getDetail();
@@ -266,10 +281,6 @@ export function createAppStores(options: AppStoreOptions): AppStoreComposition {
     },
     onDeferredMergeCompleted: (event) =>
       Effect.gen(function* () {
-        const deletedWorkspaceID = event.deleted_workspace_id;
-        if (deletedWorkspaceID) {
-          yield* Effect.sync(() => notifyWorkspaceDeleted(deletedWorkspaceID));
-        }
         const refreshes: Array<Effect.Effect<void, ProviderEventsError, AppServices>> = [
           pullsStore.reconcilePullsEffect(),
           activityStore.reconcileActivityEffect(),

--- a/frontend/src/lib/components/detail/IssueDetail.svelte
+++ b/frontend/src/lib/components/detail/IssueDetail.svelte
@@ -610,6 +610,9 @@
         // "Open Workspace" for a workspace that no longer exists.
         resolveControllerlessWorkspaceRef(itemIdentity, issues.getIssueDetail()?.workspace ?? null),
   );
+  const workspaceDeletionLifecycle = $derived(
+    workspace?.status === "deleting" || workspace?.status === "deletion_failed",
+  );
 
   // Once a detail load lands for the identity this component is currently
   // showing, let the inline controller drop its override if the envelope
@@ -1268,9 +1271,9 @@
           {#if inlineWorkspace}
             <Button
               class="btn--workspace"
-              disabled={staleIssue}
+              disabled={staleIssue || workspaceDeletionLifecycle}
               onclick={() => {
-                if (staleIssue) return;
+                if (staleIssue || workspaceDeletionLifecycle) return;
                 inlineWorkspace.focusTerminal();
               }}
               tone="info"
@@ -1286,12 +1289,16 @@
               disabled={staleIssue}
               onclick={() => {
                 if (staleIssue) return;
-                inlineWorkspace.openInWorkspaces(workspace);
+                if (workspaceDeletionLifecycle) {
+                  navigate("/workspaces");
+                } else {
+                  inlineWorkspace.openInWorkspaces(workspace);
+                }
               }}
               tone="neutral"
               surface="soft"
               size="sm"
-              label="Open in Workspaces"
+              label={workspaceDeletionLifecycle ? "View in Workspaces" : "Open in Workspaces"}
               shortLabel="Workspaces"
             >
               <ExternalLinkIcon size="14" strokeWidth="2.2" aria-hidden="true" />
@@ -1302,13 +1309,13 @@
               disabled={staleIssue}
               onclick={() => {
                 if (staleIssue) return;
-                navigate(`/terminal/${workspace.id}`);
+                navigate(workspaceDeletionLifecycle ? "/workspaces" : `/terminal/${workspace.id}`);
               }}
               tone="info"
               surface="soft"
               size="sm"
-              label="Open Workspace"
-              shortLabel="Workspace"
+              label={workspaceDeletionLifecycle ? "View in Workspaces" : "Open Workspace"}
+              shortLabel={workspaceDeletionLifecycle ? "Workspaces" : "Workspace"}
             >
               <MonitorUpIcon size="14" strokeWidth="2.2" aria-hidden="true" />
             </Button>

--- a/frontend/src/lib/components/detail/IssueDetail.test.ts
+++ b/frontend/src/lib/components/detail/IssueDetail.test.ts
@@ -918,6 +918,22 @@ describe("IssueDetail inline workspace handoff", () => {
     expect(navigate).not.toHaveBeenCalled();
   });
 
+  it.each(["deleting", "deletion_failed"])(
+    "routes an inline %s workspace to recovery instead of opening its runtime",
+    async (status) => {
+      const detail = issueDetail();
+      detail.workspace = { id: "ws-1", status };
+      const controller = createTestController("split");
+      controller.effectiveWorkspaceRef = vi.fn((_identity, envelopeRef) => envelopeRef ?? null);
+
+      const { navigate } = renderIssueDetail(detail, undefined, { inlineWorkspace: controller });
+
+      await fireEvent.click(screen.getByRole("button", { name: "View in Workspaces" }));
+      expect(navigate).toHaveBeenCalledWith("/workspaces");
+      expect(controller.openInWorkspaces).not.toHaveBeenCalled();
+    },
+  );
+
   it("without a controller open renders a single Open Workspace button that navigates", async () => {
     const detail = issueDetail();
     detail.workspace = { id: "ws-1", status: "ready" };
@@ -928,6 +944,20 @@ describe("IssueDetail inline workspace handoff", () => {
     await fireEvent.click(screen.getByRole("button", { name: "Open Workspace" }));
     expect(navigate).toHaveBeenCalledWith("/terminal/ws-1");
   });
+
+  it.each(["deleting", "deletion_failed"])(
+    "routes a %s workspace to recovery instead of opening its runtime",
+    async (status) => {
+      const detail = issueDetail();
+      detail.workspace = { id: "ws-1", status };
+
+      const { navigate } = renderIssueDetail(detail);
+
+      expect(screen.queryByRole("button", { name: "Create Workspace" })).toBeNull();
+      await fireEvent.click(screen.getByRole("button", { name: "View in Workspaces" }));
+      expect(navigate).toHaveBeenCalledWith("/workspaces");
+    },
+  );
 
   it("without a controller a session-deleted envelope workspace is masked", async () => {
     // Controller-less views subscribe to no invalidation: after a deletion

--- a/frontend/src/lib/components/detail/MergeModal.svelte
+++ b/frontend/src/lib/components/detail/MergeModal.svelte
@@ -14,11 +14,6 @@
   import { getStores } from "../../context.js";
   import { showFlash } from "../../stores/flash.svelte.js";
   import { pushModalFrame } from "../../stores/keyboard/modal-stack.svelte.js";
-  import {
-    beginWorkspaceDeletion,
-    endWorkspaceDeletion,
-    markWorkspaceIdDeleted,
-  } from "../../stores/workspace-create-pending.svelte.js";
 
   const { detail } = getStores();
 
@@ -56,7 +51,7 @@
     /** Warning shown when the configured override permits a mid-stack merge. */
     midStackWarning?: string | undefined;
     onclose: () => void;
-    onmerged: (cleanupWarning?: string, deletedWorkspaceId?: string) => void;
+    onmerged: (cleanupWarning?: string) => void;
     /** Called when a deferred merge was accepted and now waits on CI. */
     onqueued: () => void;
     onstateconflict?: ((
@@ -177,8 +172,6 @@
     error = null;
     let problemHandled = false;
     const params = mergeParams();
-    const cleanupWorkspaceId = deferred ? undefined : params.delete_workspace_id;
-    if (cleanupWorkspaceId) beginWorkspaceDeletion(cleanupWorkspaceId, undefined);
     detail.mergePull({ provider, platformHost, owner, name, repoPath }, number, params, deferred, {
       onProblem: (problem) => {
         problemHandled = handleMergeProblem(problem);
@@ -191,14 +184,9 @@
           onqueued();
           return;
         }
-        const deletedWorkspaceId = cleanupWorkspaceId && outcome.cleanupWarning === undefined
-          ? cleanupWorkspaceId
-          : undefined;
-        if (deletedWorkspaceId) markWorkspaceIdDeleted(deletedWorkspaceId);
-        onmerged(outcome.cleanupWarning, deletedWorkspaceId);
+        onmerged(outcome.cleanupWarning);
       },
       onSettled: () => {
-        if (cleanupWorkspaceId) endWorkspaceDeletion(cleanupWorkspaceId, undefined);
         activeMergeSubmission = null;
       },
     });

--- a/frontend/src/lib/components/detail/MergeModal.svelte.test.ts
+++ b/frontend/src/lib/components/detail/MergeModal.svelte.test.ts
@@ -133,7 +133,7 @@ describe("MergeModal acknowledged merge commands", () => {
     expect(mockMergePull.mock.calls[0]?.[2]).toMatchObject({ delete_workspace_id: "ws-1" });
   });
 
-  it("keeps immediate workspace cleanup pending until the merge settles", async () => {
+  it("closes after merge acknowledgement without claiming cleanup finished", async () => {
     let succeed = () => {};
     let settle = () => {};
     const onmerged = vi.fn();
@@ -148,12 +148,12 @@ describe("MergeModal acknowledged merge commands", () => {
     renderModal({ workspaceId: "ws-1", onmerged });
 
     await confirmMerge();
-    expect(isWorkspaceDeletionPending("ws-1", undefined)).toBe(true);
+    expect(isWorkspaceDeletionPending("ws-1", undefined)).toBe(false);
 
     succeed();
-    expect(isWorkspaceIdDeleted("ws-1")).toBe(true);
-    expect(onmerged).toHaveBeenCalledWith(undefined, "ws-1");
-    expect(isWorkspaceDeletionPending("ws-1", undefined)).toBe(true);
+    expect(isWorkspaceIdDeleted("ws-1")).toBe(false);
+    expect(onmerged).toHaveBeenCalledWith(undefined);
+    expect(isWorkspaceDeletionPending("ws-1", undefined)).toBe(false);
 
     settle();
     expect(isWorkspaceDeletionPending("ws-1", undefined)).toBe(false);
@@ -174,7 +174,7 @@ describe("MergeModal acknowledged merge commands", () => {
     await confirmMerge();
 
     expect(isWorkspaceIdDeleted("ws-1")).toBe(false);
-    expect(onmerged).toHaveBeenCalledWith("workspace has uncommitted changes", undefined);
+    expect(onmerged).toHaveBeenCalledWith("workspace has uncommitted changes");
   });
 
   it("omits the head pin when the rendered head is unknown", async () => {

--- a/frontend/src/lib/components/detail/PullDetail.svelte
+++ b/frontend/src/lib/components/detail/PullDetail.svelte
@@ -118,7 +118,6 @@
     recordWorkspaceCreated,
     resolveControllerlessWorkspaceRef,
   } from "../../stores/workspace-create-pending.svelte.js";
-  import { notifyWorkspaceDeleted } from "../../stores/workspace-host.svelte.js";
 
   type ChipTrailing = ComponentProps<typeof Chip>["trailing"];
 
@@ -808,6 +807,7 @@
 
   let repoSettings = $state<RepoSettings | null>(null);
   let showMergeModal = $state(false);
+  let mergeModalSettings = $state<RepoSettings | null>(null);
 
   // Head-pinning conflict state (context/provider-architecture.md
   // "Head binding"). Merge echoes the rendered reviewed head, while
@@ -1101,7 +1101,13 @@
       stores: { detail: detailStore },
       requireHeadPin: capabilities.mutation_head_binding,
       ...(detailHeadSha !== "" && { expectedHeadSha: detailHeadSha }),
-      setMergeModalOpen: (open: boolean) => { showMergeModal = open; },
+      setMergeModalOpen: (open: boolean) => {
+        if (open) {
+          if (repoSettings === null) return;
+          mergeModalSettings = { ...repoSettings };
+        }
+        showMergeModal = open;
+      },
       onAfterOpenMerge: closeActionMenu,
     };
   }
@@ -1156,6 +1162,9 @@
         // session-deleted workspace ID is masked instead of re-offering
         // "Open Workspace" for a workspace that no longer exists.
         resolveControllerlessWorkspaceRef(itemIdentity, detailStore.getDetail()?.workspace ?? null),
+  );
+  const workspaceDeletionLifecycle = $derived(
+    workspace?.status === "deleting" || workspace?.status === "deletion_failed",
   );
 
   // Once a detail load lands for the identity this component is currently
@@ -2435,9 +2444,9 @@
           {#if inlineWorkspace}
             <Button
               class="btn--workspace"
-              disabled={stalePR}
+              disabled={stalePR || workspaceDeletionLifecycle}
               onclick={() => {
-                if (stalePR) return;
+                if (stalePR || workspaceDeletionLifecycle) return;
                 closeActionMenu();
                 inlineWorkspace.focusTerminal();
               }}
@@ -2455,13 +2464,21 @@
               onclick={() => {
                 if (stalePR) return;
                 closeActionMenu();
-                inlineWorkspace.openInWorkspaces(workspace);
+                if (workspaceDeletionLifecycle) {
+                  navigate("/workspaces");
+                } else {
+                  inlineWorkspace.openInWorkspaces(workspace);
+                }
               }}
               tone="neutral"
               surface="soft"
               size="sm"
-              ariaLabel={compactLabels ? "Open in Workspaces" : undefined}
-              label={compactLabels ? "Workspaces" : "Open in Workspaces"}
+              ariaLabel={compactLabels
+                ? workspaceDeletionLifecycle ? "View in Workspaces" : "Open in Workspaces"
+                : undefined}
+              label={workspaceDeletionLifecycle
+                ? compactLabels ? "Workspaces" : "View in Workspaces"
+                : compactLabels ? "Workspaces" : "Open in Workspaces"}
             >
               <ExternalLinkIcon size="14" strokeWidth="2.2" aria-hidden="true" />
             </Button>
@@ -2472,13 +2489,17 @@
               onclick={() => {
                 if (stalePR) return;
                 closeActionMenu();
-                navigate(`/terminal/${workspace.id}`);
+                navigate(workspaceDeletionLifecycle ? "/workspaces" : `/terminal/${workspace.id}`);
               }}
               tone="info"
               surface="soft"
               size="sm"
-              ariaLabel={compactLabels ? "Open Workspace" : undefined}
-              label={compactLabels ? "Workspace" : "Open Workspace"}
+              ariaLabel={compactLabels
+                ? workspaceDeletionLifecycle ? "View in Workspaces" : "Open Workspace"
+                : undefined}
+              label={workspaceDeletionLifecycle
+                ? compactLabels ? "Workspaces" : "View in Workspaces"
+                : compactLabels ? "Workspace" : "Open Workspace"}
             >
               <MonitorUpIcon size="14" strokeWidth="2.2" aria-hidden="true" />
             </Button>
@@ -2773,9 +2794,10 @@
         </div>
       {/if}
 
-      {#if showMergeModal && repoSettings && hasEnabledMergeMethod(repoSettings) && capabilities.merge_mutation && repoSettings.viewerCanMerge && !stalePR && !hasMergeConflicts(pr)}
+      {#if showMergeModal && mergeModalSettings}
         {@const d = detailStore.getDetail()!}
         {@const p = d.merge_request}
+        {@const settings = mergeModalSettings}
         <MergeModal
           {owner}
           {name}
@@ -2787,9 +2809,9 @@
           prBody={p.Body}
           prAuthor={p.Author}
           prAuthorDisplayName={p.AuthorDisplayName}
-          allowSquash={repoSettings.allowSquash}
-          allowMerge={repoSettings.allowMerge}
-          allowRebase={repoSettings.allowRebase}
+          allowSquash={settings.allowSquash}
+          allowMerge={settings.allowMerge}
+          allowRebase={settings.allowRebase}
           expectedHeadSha={detailHeadSha}
           requireHeadPin={capabilities.mutation_head_binding}
           routeGeneration={mutationRouteGeneration}
@@ -2811,10 +2833,7 @@
               repoPath,
             });
           }}
-          onmerged={(_cleanupWarning, deletedWorkspaceId) => {
-            if (deletedWorkspaceId) {
-              notifyWorkspaceDeleted(deletedWorkspaceId, undefined, itemIdentity);
-            }
+          onmerged={() => {
             showMergeModal = false;
             detailStore.loadDetail(owner, name, number, {
               provider,

--- a/frontend/src/lib/components/detail/PullDetail.test.ts
+++ b/frontend/src/lib/components/detail/PullDetail.test.ts
@@ -1545,7 +1545,7 @@ describe("PullDetail approvals", () => {
     notifyWorkspaceDeleted.mockRestore();
   });
 
-  it("publishes confirmed merge cleanup with the full pull identity", async () => {
+  it("waits for the workspace deletion event instead of treating merge success as deletion", async () => {
     const notifyWorkspaceDeleted = vi.spyOn(workspaceHost, "notifyWorkspaceDeleted");
     const detail = pullDetail();
     detail.repo.capabilities.merge_mutation = true;
@@ -1586,18 +1586,57 @@ describe("PullDetail approvals", () => {
       }),
     );
 
-    await waitFor(() => {
-      expect(notifyWorkspaceDeleted).toHaveBeenCalledWith("ws-1", undefined, {
-        provider: "github",
-        platformHost: "github.com",
-        owner: "acme",
-        name: "widget",
-        repoPath: "acme/widget",
-        number: 1,
-        itemType: "pull",
-      });
-    });
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Merge Pull Request" })).toBeNull());
+    expect(notifyWorkspaceDeleted).not.toHaveBeenCalled();
     notifyWorkspaceDeleted.mockRestore();
+  });
+
+  it("keeps an in-flight merge modal mounted across transient eligibility refreshes", async () => {
+    const detail = pullDetail();
+    detail.repo.capabilities.merge_mutation = true;
+    let resolveMerge!: (value: unknown) => void;
+    const apiClient = {
+      GET: vi.fn(async () => ({
+        data: {
+          AllowSquashMerge: true,
+          AllowMergeCommit: false,
+          AllowRebaseMerge: false,
+          ViewerCanMerge: true,
+        },
+      })),
+      POST: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            resolveMerge = resolve;
+          }),
+      ),
+    };
+    const { rerender } = renderPullDetail(
+      detail,
+      {
+        AllowSquashMerge: true,
+        AllowMergeCommit: false,
+        AllowRebaseMerge: false,
+        ViewerCanMerge: true,
+      },
+      apiClient,
+    );
+
+    await fireEvent.click(await screen.findByRole("button", { name: "Squash and merge" }));
+    await fireEvent.click(
+      within(screen.getByRole("dialog", { name: "Merge Pull Request" })).getByRole("button", {
+        name: "Squash and merge",
+      }),
+    );
+    expect(screen.getByRole("button", { name: "Merging..." })).toBeTruthy();
+
+    detail.repo.capabilities.merge_mutation = false;
+    await rerender({ hideWorkspaceAction: false });
+    expect(screen.getByRole("dialog", { name: "Merge Pull Request" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Merging..." })).toBeTruthy();
+
+    resolveMerge({ data: { merged: true, sha: "merge-sha", message: "merged" } });
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Merge Pull Request" })).toBeNull());
   });
 
   it("opens the merge modal in deferred mode when aggregate CI is pending without check rows", async () => {
@@ -2243,6 +2282,25 @@ describe("PullDetail inline workspace handoff", () => {
     expect(navigate).not.toHaveBeenCalled();
   });
 
+  it.each(["deleting", "deletion_failed"])(
+    "routes an inline %s workspace to recovery instead of opening its runtime",
+    async (status) => {
+      const detail = pullDetail();
+      detail.workspace = { id: "ws-1", status };
+      const controller = createTestController("split");
+      controller.effectiveWorkspaceRef = vi.fn((_identity, envelopeRef) => envelopeRef ?? null);
+
+      const { navigate } = renderPullDetail(detail, undefined, undefined, {
+        hideWorkspaceAction: false,
+        inlineWorkspace: controller,
+      });
+
+      await fireEvent.click(screen.getAllByRole("button", { name: "View in Workspaces" })[0]!);
+      expect(navigate).toHaveBeenCalledWith("/workspaces");
+      expect(controller.openInWorkspaces).not.toHaveBeenCalled();
+    },
+  );
+
   it("without a controller open renders a single Open Workspace button that navigates", async () => {
     const detail = pullDetail();
     detail.workspace = { id: "ws-1", status: "ready" };
@@ -2255,6 +2313,22 @@ describe("PullDetail inline workspace handoff", () => {
     await fireEvent.click(screen.getAllByRole("button", { name: "Open Workspace" })[0]!);
     expect(navigate).toHaveBeenCalledWith("/terminal/ws-1");
   });
+
+  it.each(["deleting", "deletion_failed"])(
+    "routes a %s workspace to recovery instead of opening its runtime",
+    async (status) => {
+      const detail = pullDetail();
+      detail.workspace = { id: "ws-1", status };
+
+      const { navigate } = renderPullDetail(detail, undefined, undefined, {
+        hideWorkspaceAction: false,
+      });
+
+      expect(screen.queryByRole("button", { name: "Create Workspace" })).toBeNull();
+      await fireEvent.click(screen.getAllByRole("button", { name: "View in Workspaces" })[0]!);
+      expect(navigate).toHaveBeenCalledWith("/workspaces");
+    },
+  );
 
   it("without a controller a session-deleted envelope workspace is masked", async () => {
     // Controller-less views subscribe to no invalidation: after a deletion

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -156,6 +156,7 @@
     y: number;
   } | null>(null);
   let deleteConfirmWorkspace = $state<Workspace | null>(null);
+  let deleteConfirmForce = $state(false);
   let workspaceAction = $state<{
     workspaceKey: string;
     action: "push" | "pull" | "reveal" | "delete";
@@ -717,8 +718,8 @@
 
   function workspaceStatus(ws: Workspace): StatusDotStatus {
     if (ws.status === "ready") return "idle";
-    if (ws.status === "creating") return "working";
-    if (ws.status === "error") return "unclean";
+    if (ws.status === "creating" || ws.status === "deleting") return "working";
+    if (ws.status === "error" || ws.status === "deletion_failed") return "unclean";
     return "stale";
   }
 
@@ -726,6 +727,8 @@
     if (ws.status === "ready") return "Workspace ready";
     if (ws.status === "creating") return "Creating workspace";
     if (ws.status === "error") return "Workspace error";
+    if (ws.status === "deleting") return "Deleting workspace";
+    if (ws.status === "deletion_failed") return "Deletion failed";
     return `Workspace ${ws.status}`;
   }
 
@@ -817,6 +820,7 @@
   }
 
   function openWorkspace(ws: Workspace): void {
+    if (ws.status === "deleting" || ws.status === "deletion_failed") return;
     const doneVersion = doneStateVersion(ws);
     if (doneVersion !== null) {
       acknowledgedDoneStates = {
@@ -1042,7 +1046,8 @@
   }
 
   function workspaceActionsDisabled(ws: Workspace): boolean {
-    return isWorkspaceActionDisabled?.(ws.id, ws.fleet_host_key) ?? false;
+    return ws.status === "deleting" || ws.status === "deletion_failed" ||
+      (isWorkspaceActionDisabled?.(ws.id, ws.fleet_host_key) ?? false);
   }
 
   function workspaceBusyLabel(ws: Workspace): string {
@@ -1058,7 +1063,9 @@
     ws: Workspace,
     action: "push" | "pull" | "reveal" | "delete",
   ): boolean {
-    if (workspaceAction !== null || workspaceActionsDisabled(ws)) return false;
+    const externallyDisabled = isWorkspaceActionDisabled?.(ws.id, ws.fleet_host_key) ?? false;
+    const deletionDisabled = ws.status === "deleting" || externallyDisabled;
+    if (workspaceAction !== null || (action === "delete" ? deletionDisabled : workspaceActionsDisabled(ws))) return false;
     workspaceAction = { workspaceKey: workspaceRowKey(ws), action };
     return true;
   }
@@ -1148,31 +1155,39 @@
     );
   }
 
-  function openDeleteWorkspaceDialog(ws: Workspace): void {
+  function openDeleteWorkspaceDialog(ws: Workspace, force = false): void {
     deleteConfirmWorkspace = ws;
+    deleteConfirmForce = force;
     closeContextMenu();
   }
 
   function closeDeleteWorkspaceDialog(): void {
     if (deleteConfirmWorkspace && workspaceActionMatches(deleteConfirmWorkspace, "delete")) return;
     deleteConfirmWorkspace = null;
+    deleteConfirmForce = false;
   }
 
   function confirmDeleteWorkspaceFromList(): void {
     const ws = deleteConfirmWorkspace;
-    if (!ws || workspaceActionsDisabled(ws) || !startWorkspaceAction(ws, "delete")) return;
+    if (!ws || !startWorkspaceAction(ws, "delete")) return;
     onWorkspaceDeletePendingChange?.(ws.id, ws.fleet_host_key, true);
     const hostKey = ws.fleet_host_key;
     const command = hostKey
       ? executeOpaqueGeneratedApiRequest("delete remote workspace", (generatedClient, signal) =>
           generatedClient.DELETE("/fleet/hosts/{host_key}/workspaces/{id}", {
-            params: { path: { host_key: hostKey, id: ws.id } },
+            params: {
+              path: { host_key: hostKey, id: ws.id },
+              ...(deleteConfirmForce ? { query: { force: true } } : {}),
+            },
             signal,
           }),
         ).pipe(Effect.asVoid)
       : executeGeneratedApiRequest("delete workspace", (generatedClient, signal) =>
           generatedClient.DELETE("/workspaces/{id}", {
-            params: { path: { id: ws.id } },
+            params: {
+              path: { id: ws.id },
+              ...(deleteConfirmForce ? { query: { force: true } } : {}),
+            },
             signal,
           }),
         ).pipe(Effect.asVoid);
@@ -1207,6 +1222,7 @@
             onWorkspaceDeletePendingChange?.(ws.id, hostKey, false);
             finishWorkspaceAction(ws);
             deleteConfirmWorkspace = null;
+            deleteConfirmForce = false;
           }),
         ),
       ),
@@ -1493,6 +1509,12 @@
                   size={6}
                 />
                 <span class="ws-name">{displayName(ws)}</span>
+                {#if ws.status === "deleting" || ws.status === "deletion_failed"}
+                  <span
+                    class={["workspace-lifecycle-state", `workspace-lifecycle-state--${ws.status}`]}
+                    title={ws.error_message ?? workspaceStatusLabel(ws)}
+                  >{workspaceStatusLabel(ws)}</span>
+                {/if}
                 {#if agentState}
                   <span
                     class={["agent-state", `agent-state--${agentState.tone}`]}
@@ -1763,25 +1785,39 @@
       class="kit-filter-dropdown__item active workspace-context-danger"
       role="menuitem"
       type="button"
-      disabled={actionDisabled}
+      disabled={actionBusy || menuWorkspace.status === "deleting" || (isWorkspaceActionDisabled?.(menuWorkspace.id, menuWorkspace.fleet_host_key) ?? false)}
       onclick={() => {
         openDeleteWorkspaceDialog(menuWorkspace);
       }}
     >
       <span class="kit-filter-dropdown__dot filter-dot--danger"></span>
-      <span class="kit-filter-dropdown__label">{workspaceActionMatches(menuWorkspace, "delete") ? "Deleting..." : "Delete workspace..."}</span>
+      <span class="kit-filter-dropdown__label">{workspaceActionMatches(menuWorkspace, "delete") ? "Deleting..." : menuWorkspace.status === "deletion_failed" ? "Retry deletion..." : "Delete workspace..."}</span>
     </button>
+    {#if menuWorkspace.status === "deletion_failed"}
+      <button
+        class="kit-filter-dropdown__item active workspace-context-danger"
+        role="menuitem"
+        type="button"
+        disabled={actionBusy || (isWorkspaceActionDisabled?.(menuWorkspace.id, menuWorkspace.fleet_host_key) ?? false)}
+        onclick={() => openDeleteWorkspaceDialog(menuWorkspace, true)}
+      >
+        <span class="kit-filter-dropdown__dot filter-dot--danger"></span>
+        <span class="kit-filter-dropdown__label">Force delete workspace...</span>
+      </button>
+    {/if}
   </div>
 {/if}
 
 <ConfirmDialog
   open={deleteConfirmWorkspace !== null && hostVisible}
-  title="Delete workspace?"
+  title={deleteConfirmForce ? "Force delete workspace?" : deleteConfirmWorkspace?.status === "deletion_failed" ? "Retry workspace deletion?" : "Delete workspace?"}
   message={deleteConfirmWorkspace
     ? `Delete workspace "${displayName(deleteConfirmWorkspace)}"?`
     : ""}
-  hint="This removes its managed worktree and runtime sessions."
-  confirmLabel="Delete workspace"
+  hint={deleteConfirmForce
+    ? "This discards uncommitted changes and removes the managed worktree and runtime sessions."
+    : deleteConfirmWorkspace?.error_message ?? "This removes its managed worktree and runtime sessions."}
+  confirmLabel={deleteConfirmForce ? "Force delete workspace" : deleteConfirmWorkspace?.status === "deletion_failed" ? "Retry deletion" : "Delete workspace"}
   pendingLabel="Deleting…"
   busy={deleteConfirmBusy}
   tone="danger"
@@ -2067,6 +2103,21 @@
 
   .ws-row.selected .ws-name {
     font-weight: 600;
+  }
+
+  .workspace-lifecycle-state {
+    flex-shrink: 0;
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    line-height: 1;
+  }
+
+  .workspace-lifecycle-state--deleting {
+    color: var(--accent-blue);
+  }
+
+  .workspace-lifecycle-state--deletion_failed {
+    color: var(--accent-red);
   }
 
   .agent-state {

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -82,6 +82,7 @@ interface WorkspaceFixtureOptions {
   agentState?: "idle" | "working" | "input" | "approval" | "done" | null;
   agentStateUpdatedAt?: string | null;
   status?: string;
+  errorMessage?: string | null;
   associatedPRNumber?: number | null;
 }
 
@@ -111,6 +112,7 @@ function workspaceFixture({
   agentState = null,
   agentStateUpdatedAt = null,
   status = "ready",
+  errorMessage = null,
   associatedPRNumber = null,
 }: WorkspaceFixtureOptions) {
   // Kata and ad-hoc workspaces carry no joined provider item metadata.
@@ -140,6 +142,7 @@ function workspaceFixture({
     agent_state: agentState,
     agent_state_updated_at: agentStateUpdatedAt,
     status,
+    error_message: errorMessage,
     created_at: createdAt,
     tmux_last_output_at: tmuxLastOutputAt,
     item_last_activity_at: itemLastActivityAt,
@@ -1760,6 +1763,8 @@ describe("WorkspaceListSidebar", () => {
     ["ready", "Workspace ready", "kit-status-dot--idle"],
     ["creating", "Creating workspace", "kit-status-dot--working"],
     ["error", "Workspace error", "kit-status-dot--unclean"],
+    ["deleting", "Deleting workspace", "kit-status-dot--working"],
+    ["deletion_failed", "Deletion failed", "kit-status-dot--unclean"],
     ["pending", "Workspace pending", "kit-status-dot--stale"],
   ] as const)("maps %s workspace state to the shared semantic status", async (status, label, className) => {
     mockGet.mockResolvedValue({
@@ -1783,6 +1788,55 @@ describe("WorkspaceListSidebar", () => {
     });
 
     expect((await screen.findByLabelText(label)).classList.contains(className)).toBe(true);
+  });
+
+  it("keeps failed deletion visible with retry and confirmed force-delete recovery", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        workspaces: [
+          workspaceFixture({
+            id: "ws-delete-failed",
+            provider: "github",
+            platformHost: "github.com",
+            owner: "kenn-io",
+            name: "kenn-forge",
+            number: 9,
+            status: "deletion_failed",
+            errorMessage: "workspace has uncommitted changes: notes.txt",
+          }),
+        ],
+      },
+    });
+    mockDelete.mockResolvedValue({
+      data: undefined,
+      error: undefined,
+      response: { ok: true, status: 204 },
+    });
+
+    const { container } = render(WorkspaceListSidebar, {
+      props: { selectedId: "ws-delete-failed" },
+    });
+
+    expect((await screen.findByText("Deletion failed")).getAttribute("title")).toBe(
+      "workspace has uncommitted changes: notes.txt",
+    );
+    await fireEvent.click(container.querySelector(".ws-row")!);
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    await fireEvent.contextMenu(container.querySelector(".ws-row")!);
+    expect((screen.getByRole("menuitem", { name: "Retry deletion..." }) as HTMLButtonElement).disabled).toBe(false);
+    await fireEvent.click(screen.getByRole("menuitem", { name: "Force delete workspace..." }));
+
+    const dialog = await screen.findByRole("dialog", { name: "Force delete workspace?" });
+    expect(dialog.textContent).toContain("This discards uncommitted changes");
+    await fireEvent.click(within(dialog).getByRole("button", { name: "Force delete workspace" }));
+
+    await waitFor(() => {
+      expect(mockDelete).toHaveBeenCalledWith("/workspaces/{id}", {
+        params: { path: { id: "ws-delete-failed" }, query: { force: true } },
+        signal: expect.any(AbortSignal),
+      });
+    });
   });
 
   it("does not describe an externally disabled workspace as active work", async () => {
@@ -2235,7 +2289,7 @@ describe("WorkspaceListSidebar", () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it("omits local filesystem actions for remote workspace context menus", async () => {
+  it("omits local filesystem actions and offers force-delete recovery for remote workspaces", async () => {
     mockGet.mockImplementation((path: string, options?: { params?: { path?: { host_key?: string } } }) => {
       if (path === "/snapshot") {
         return Promise.resolve({
@@ -2282,12 +2336,19 @@ describe("WorkspaceListSidebar", () => {
                 name: "service",
                 number: 12,
                 title: "Remote workspace",
+                status: "deletion_failed",
+                errorMessage: "workspace has uncommitted changes: notes.txt",
               }),
             ],
           },
         });
       }
       return Promise.resolve({ data: { workspaces: [] } });
+    });
+    mockDelete.mockResolvedValue({
+      data: undefined,
+      error: undefined,
+      response: { ok: true, status: 204 },
     });
 
     const { container } = render(WorkspaceListSidebar, {
@@ -2301,6 +2362,20 @@ describe("WorkspaceListSidebar", () => {
     expect(screen.queryByRole("menuitem", { name: "Copy worktree path" })).toBeNull();
     expect(screen.queryByRole("menuitem", { name: "Reveal in Finder" })).toBeNull();
     expect(screen.getByRole("menuitem", { name: "Refresh git status" })).toBeTruthy();
+    await fireEvent.click(screen.getByRole("menuitem", { name: "Force delete workspace..." }));
+
+    const dialog = await screen.findByRole("dialog", { name: "Force delete workspace?" });
+    await fireEvent.click(within(dialog).getByRole("button", { name: "Force delete workspace" }));
+
+    await waitFor(() => {
+      expect(mockDelete).toHaveBeenCalledWith("/fleet/hosts/{host_key}/workspaces/{id}", {
+        params: {
+          path: { host_key: "epyc", id: "ws-remote" },
+          query: { force: true },
+        },
+        signal: expect.any(AbortSignal),
+      });
+    });
   });
 
   it("does not show push or pull commands for diverged workspace branches", async () => {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.host-visible.browser.svelte.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.host-visible.browser.svelte.ts
@@ -101,7 +101,14 @@ function workspaceRoutes(): MockRouteOverride {
     // the force-delete confirmation dialog under test — there is no
     // separate "are you sure" step before the first delete attempt.
     if (req.url.pathname === "/api/v1/workspaces/ws-1" && req.method === "DELETE") {
-      return jsonResponse({ detail: "Workspace has uncommitted changes." }, 409);
+      return jsonResponse(
+        {
+          code: "worktreeDirty",
+          detail: "Workspace has uncommitted changes.",
+          status: 409,
+        },
+        409,
+      );
     }
     return null;
   };

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -120,6 +120,7 @@
     RefreshIcon,
   } from "../../icons.ts";
   import { apiErrorMessage } from "../../api/runtime.js";
+  import { ProblemCodes } from "../../api/problems.js";
   import { configuredAPIPath } from "../../api/runtime-base.js";
   import {
     executeGeneratedApiRequest,
@@ -400,6 +401,7 @@
   let lastDiffSnapshotVersion = "";
   let forcePromptMessage = $state<string | null>(null);
   let forcePromptForId = $state<string | null>(null);
+  let forcePromptHostKey = $state<string | undefined>(undefined);
   // Identity snapshot captured when the 409 arrived, while the loaded
   // envelope still described the delete target: the user can switch
   // workspaces before confirming the force delete, after which the live
@@ -1428,7 +1430,16 @@
       isDeletingWorkspaceTarget(target, workspaceId, workspaceHostKey),
     ) || isWorkspaceDeletionPending(workspaceId, workspaceHostKey),
   );
-  const actionsBlocked = $derived(transitioning || deletingSelectedWorkspace || forceDeleting);
+  const workspaceDeletionLifecycleActive = $derived(
+    workspaceLive &&
+      (workspace?.status === "deleting" || workspace?.status === "deletion_failed"),
+  );
+  const actionsBlocked = $derived(
+    transitioning ||
+      deletingSelectedWorkspace ||
+      workspaceDeletionLifecycleActive ||
+      forceDeleting,
+  );
   const inlineDockMode = $derived(inlineDock?.getMode() ?? null);
   const inlineDockExpandBlocked = $derived(getStackDepth() > 0);
   const modalOpen = $derived(
@@ -2578,10 +2589,22 @@
             return true;
           }
           if (!force && response.status === 409) {
-            previouslyFocusedEl = deleteTriggerElements.get(runtimeMutationTargetKey(state.request.target)) ?? null;
-            forcePromptForId = id;
-            forcePromptIdentity = state.request.options.identity;
-            forcePromptMessage = apiErrorMessage(error, "Workspace has uncommitted changes.");
+            if (error?.code === ProblemCodes.worktreeDirty) {
+              previouslyFocusedEl = deleteTriggerElements.get(runtimeMutationTargetKey(state.request.target)) ?? null;
+              forcePromptForId = id;
+              forcePromptHostKey = hostKey;
+              forcePromptIdentity = state.request.options.identity;
+              forcePromptMessage = apiErrorMessage(error, "Workspace has uncommitted changes.");
+            } else if (
+              error?.code === ProblemCodes.workspaceSetupInProgress ||
+              error?.code === ProblemCodes.workspaceDeletionInProgress
+            ) {
+              requestWorkspace();
+            } else {
+              showFlash(apiErrorMessage(error, "Workspace deletion could not start."), {
+                tone: "danger",
+              });
+            }
             clearRuntimeMutationPending(state);
             return true;
           }
@@ -2593,6 +2616,7 @@
           if (force) {
             forcePromptMessage = null;
             forcePromptForId = null;
+            forcePromptHostKey = undefined;
             forcePromptIdentity = undefined;
           }
           clearRuntimeMutationPending(state);
@@ -3508,6 +3532,28 @@
     };
   }
 
+  function openForceDeleteRecovery(triggerEl: HTMLElement | null = null): void {
+    if (
+      !workspaceLive ||
+      !workspace ||
+      workspace.status !== "deletion_failed" ||
+      forceDeleting
+    ) {
+      return;
+    }
+    previouslyFocusedEl =
+      triggerEl ??
+      (document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null);
+    forcePromptForId = workspace.id;
+    forcePromptHostKey = workspaceHostKey;
+    forcePromptIdentity = workspaceIdentitySnapshot(workspace.id);
+    forcePromptMessage =
+      workspace.error_message ??
+      "Workspace deletion failed. Force deletion can remove the remaining workspace artifacts.";
+  }
+
   /**
    * Every workspace Delete confirms first. The strip's trash is a 13px icon beside
    * the controls trigger, one slip from firing, and the backend refuses only a
@@ -3629,7 +3675,7 @@
     if (forceDeleting) return;
     const targetId = forcePromptForId;
     if (targetId === null) return;
-    const targetHostKey = workspaceHostKey;
+    const targetHostKey = forcePromptHostKey;
     // Prefer the snapshot taken at 409 time; the live envelope may belong
     // to a different workspace after an A -> B switch.
     const targetIdentity = forcePromptIdentity ?? workspaceIdentitySnapshot(targetId);
@@ -3665,6 +3711,7 @@
     if (forceDeleting) return;
     forcePromptMessage = null;
     forcePromptForId = null;
+    forcePromptHostKey = undefined;
     forcePromptIdentity = undefined;
   }
 
@@ -3773,6 +3820,7 @@
     // they're no longer looking at.
     forcePromptMessage = null;
     forcePromptForId = null;
+    forcePromptHostKey = undefined;
     forcePromptIdentity = undefined;
     stopPromptSession = null;
     stopSessionStopping = false;
@@ -4139,6 +4187,40 @@
               void handleDelete(event.currentTarget)}
           >
             Delete
+          </button>
+          {@render inlineCollapseControl()}
+        </div>
+      {:else if workspace.status === "deleting"}
+        <div class="state-message">
+          <Spinner size={18} />
+          <span>Deleting workspace...</span>
+          {@render inlineCollapseControl()}
+        </div>
+      {:else if workspace.status === "deletion_failed"}
+        <div class="state-message error">
+          <span
+            class="error-icon-badge"
+            role="img"
+            aria-label="Workspace deletion failed"
+          >
+            <AlertIcon
+              class="error-icon"
+              size="14"
+              strokeWidth="2.4"
+              aria-hidden="true"
+            />
+          </span>
+          <span>
+            {workspace.error_message ??
+              "Workspace deletion failed."}
+          </span>
+          <button
+            class="retry-btn danger"
+            disabled={forceDeleting}
+            onclick={(event) =>
+              openForceDeleteRecovery(event.currentTarget)}
+          >
+            Force delete workspace
           </button>
           {@render inlineCollapseControl()}
         </div>

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -2634,6 +2634,150 @@ describe("WorkspaceTerminalView", () => {
     await waitFor(() => expect(window.location.pathname).toBe("/workspaces"));
   });
 
+  it("renders persisted workspace deletion as progress instead of an interactive terminal", async () => {
+    const deletingWorkspace = {
+      ...workspaceResponse,
+      status: "deleting",
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((input: Request | URL | string) => {
+        const request = input instanceof Request ? input : new Request(input);
+        const { pathname } = new URL(request.url);
+        if (pathname.endsWith("/workspaces/ws-1")) {
+          return Promise.resolve(Response.json(deletingWorkspace));
+        }
+        if (pathname.endsWith("/api/v1/workspaces")) {
+          return Promise.resolve(Response.json({ workspaces: [deletingWorkspace] }));
+        }
+        return Promise.resolve(Response.json({}));
+      }),
+    );
+
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+      },
+    });
+
+    expect(await screen.findByText("Deleting workspace...")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Launch" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Refresh workspace details" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Delete" })).toBeNull();
+  });
+
+  it("offers confirmed force-delete recovery for a persisted deletion failure", async () => {
+    const failedWorkspace = {
+      ...workspaceResponse,
+      status: "deletion_failed",
+      error_message: "Workspace deletion failed after stopping its runtime.",
+    };
+    const fetchMock = vi.fn().mockImplementation((input: Request | URL | string, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      const { pathname, searchParams } = new URL(request.url);
+      if (request.method === "DELETE" && pathname.endsWith("/workspaces/ws-1")) {
+        expect(searchParams.get("force")).toBe("true");
+        return Promise.resolve(new Response(null, { status: 204 }));
+      }
+      if (pathname.endsWith("/workspaces/ws-1")) {
+        return Promise.resolve(Response.json(failedWorkspace));
+      }
+      if (pathname.endsWith("/api/v1/workspaces")) {
+        return Promise.resolve(Response.json({ workspaces: [failedWorkspace] }));
+      }
+      return Promise.resolve(Response.json({}));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    window.history.pushState({}, "", "/terminal/ws-1");
+    const onWorkspaceDeleted = vi.fn();
+
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+        workspaceHostKey: "member",
+        onWorkspaceDeleted,
+      },
+    });
+
+    expect(await screen.findByText(failedWorkspace.error_message)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Launch" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Delete" })).toBeNull();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Force delete workspace" }));
+    await fireEvent.click(await screen.findByRole("button", { name: "Force delete" }));
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([input, init]) => {
+          const request = input instanceof Request ? input : new Request(input, init);
+          const { pathname, searchParams } = new URL(request.url);
+          return (
+            request.method === "DELETE" &&
+            pathname === "/api/v1/fleet/hosts/member/workspaces/ws-1" &&
+            searchParams.get("force") === "true"
+          );
+        }),
+      ).toBe(true);
+    });
+    await waitFor(() => expect(onWorkspaceDeleted).toHaveBeenCalledWith("ws-1", "member", workspaceItemIdentity));
+  });
+
+  it.each([
+    ["workspaceSetupInProgress", "creating", "Setting up workspace..."],
+    ["workspaceDeletionInProgress", "deleting", "Deleting workspace..."],
+  ])("refreshes lifecycle state instead of offering force delete for %s", async (code, status, lifecycleMessage) => {
+    let deletionAttempted = false;
+    const lifecycleWorkspace = {
+      ...workspaceResponse,
+      status,
+    };
+    const fetchMock = vi.fn().mockImplementation((input: Request | URL | string, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      const { pathname } = new URL(request.url);
+      if (request.method === "DELETE" && pathname.endsWith("/workspaces/ws-1")) {
+        deletionAttempted = true;
+        return Promise.resolve(
+          Response.json(
+            {
+              code,
+              detail:
+                status === "creating"
+                  ? "workspace setup is still in progress"
+                  : "workspace deletion is already in progress",
+              status: 409,
+            },
+            { status: 409 },
+          ),
+        );
+      }
+      if (pathname.endsWith("/workspaces/ws-1")) {
+        return Promise.resolve(Response.json(deletionAttempted ? lifecycleWorkspace : workspaceResponse));
+      }
+      if (pathname.endsWith("/api/v1/workspaces")) {
+        return Promise.resolve(
+          Response.json({
+            workspaces: [deletionAttempted ? lifecycleWorkspace : workspaceResponse],
+          }),
+        );
+      }
+      return Promise.resolve(Response.json({}));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+      },
+    });
+
+    await screen.findByRole("button", { name: "Delete" });
+    await clickDeleteAndConfirm();
+
+    expect(await screen.findByText(lifecycleMessage)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Force delete" })).toBeNull();
+    expect(screen.queryByText("Workspace has uncommitted changes.")).toBeNull();
+  });
+
   it("issues no delete until the confirmation is accepted, and none on cancel", async () => {
     // Delete removes a worktree whose unpushed commits go with it, from a
     // one-click strip button — so every entry point confirms first.
@@ -2913,7 +3057,16 @@ describe("WorkspaceTerminalView", () => {
         if (searchParams.get("force") === "true") {
           return forceDeleteRequest.promise;
         }
-        return Promise.resolve(Response.json({ detail: "Workspace has uncommitted changes." }, { status: 409 }));
+        return Promise.resolve(
+          Response.json(
+            {
+              code: "worktreeDirty",
+              detail: "Workspace has uncommitted changes.",
+              status: 409,
+            },
+            { status: 409 },
+          ),
+        );
       }
       if (pathname.endsWith("/workspaces/ws-1")) {
         return Promise.resolve(Response.json(workspaceResponse));

--- a/frontend/src/lib/components/terminal/workspace-list-schema.ts
+++ b/frontend/src/lib/components/terminal/workspace-list-schema.ts
@@ -27,6 +27,7 @@ export type WorkspaceListItem = Pick<
     readonly associated_pr_number?: Exclude<GeneratedWorkspace["associated_pr_number"], undefined> | null;
     readonly commits_ahead?: number | null;
     readonly commits_behind?: number | null;
+    readonly error_message?: GeneratedWorkspace["error_message"] | null;
     readonly item_last_activity_at?: string | null;
     readonly mr_additions?: number | null;
     readonly mr_deletions?: number | null;
@@ -68,6 +69,7 @@ const Workspace = Schema.Struct({
   commits_ahead: Schema.optionalKey(Schema.NullOr(Schema.Number)),
   commits_behind: Schema.optionalKey(Schema.NullOr(Schema.Number)),
   created_at: Schema.String,
+  error_message: Schema.optionalKey(Schema.NullOr(Schema.String)),
   git_head_ref: Schema.String,
   id: Schema.String,
   item_key: Schema.optionalKey(Schema.String),

--- a/frontend/src/lib/stores/events.svelte.ts
+++ b/frontend/src/lib/stores/events.svelte.ts
@@ -15,6 +15,7 @@ import {
   type WorkspacePRRefreshQueuedEvent,
   type WorkspacePushedHeadChangedEvent,
   type WorkspaceCreatedEvent,
+  type WorkspaceDeletedEvent,
   type WorkspaceStatusEvent,
 } from "./provider-events-workflow.js";
 
@@ -27,6 +28,7 @@ export interface EventsStoreOptions {
   readonly onReconnectStale?: () => Effect.Effect<void, ProviderEventsError, AppServices>;
   readonly onWorkspaceCreated?: (event: WorkspaceCreatedEvent) => Effect.Effect<void, ProviderEventsError, AppServices>;
   readonly onWorkspaceStatus?: (event: WorkspaceStatusEvent) => Effect.Effect<void, ProviderEventsError, AppServices>;
+  readonly onWorkspaceDeleted?: (event: WorkspaceDeletedEvent) => Effect.Effect<void, ProviderEventsError, AppServices>;
   readonly onWorkspacePushedHeadChanged?: (
     event: WorkspacePushedHeadChangedEvent,
   ) => Effect.Effect<void, ProviderEventsError, AppServices>;
@@ -75,6 +77,8 @@ export function createEventsStore(opts: EventsStoreOptions) {
         return opts.onWorkspaceCreated?.(event.payload) ?? Effect.void;
       case "workspace_status":
         return opts.onWorkspaceStatus?.(event.payload) ?? Effect.void;
+      case "workspace_deleted":
+        return opts.onWorkspaceDeleted?.(event.payload) ?? Effect.void;
       case "workspace_pushed_head_changed":
         return opts.onWorkspacePushedHeadChanged?.(event.payload) ?? Effect.void;
       case "workspace_pr_associated":

--- a/frontend/src/lib/stores/provider-events-workflow.test.ts
+++ b/frontend/src/lib/stores/provider-events-workflow.test.ts
@@ -120,7 +120,7 @@ it.layer(ProviderEventsTest)("provider event checkpoint resume", (it) => {
 });
 
 it.layer(ProviderEventsTest)("workspace lifecycle events", (it) => {
-  it.effect("decodes workspace creation and status events", () =>
+  it.effect("decodes workspace creation, status, and confirmed deletion events", () =>
     Effect.gen(function* () {
       const probe = yield* ProviderEventsProbe;
       const events = yield* Queue.unbounded<ProviderEvent>();
@@ -135,6 +135,21 @@ it.layer(ProviderEventsTest)("workspace lifecycle events", (it) => {
 
       emitFrame(source, "workspace_created", { id: "ws-1", created: false }, "1");
       emitFrame(source, "workspace_status", { id: "ws-1", status: "ready" }, "2");
+      emitFrame(
+        source,
+        "workspace_deleted",
+        {
+          workspace_id: "ws-1",
+          provider: "github",
+          platform_host: "github.com",
+          repo_path: "acme/widget",
+          owner: "acme",
+          name: "widget",
+          number: 42,
+          item_type: "pull_request",
+        },
+        "3",
+      );
 
       const created = yield* Queue.take(events);
       assert.strictEqual(created.type, "workspace_created");
@@ -147,6 +162,13 @@ it.layer(ProviderEventsTest)("workspace lifecycle events", (it) => {
       if (status.type === "workspace_status") {
         assert.strictEqual(status.payload.id, "ws-1");
         assert.strictEqual(status.payload.status, "ready");
+      }
+      const deleted = yield* Queue.take(events);
+      assert.strictEqual(deleted.type, "workspace_deleted");
+      if (deleted.type === "workspace_deleted") {
+        assert.strictEqual(deleted.payload.workspace_id, "ws-1");
+        assert.strictEqual(deleted.payload.repo_path, "acme/widget");
+        assert.strictEqual(deleted.payload.item_type, "pull_request");
       }
       yield* Fiber.interrupt(fiber);
     }),

--- a/frontend/src/lib/stores/provider-events-workflow.ts
+++ b/frontend/src/lib/stores/provider-events-workflow.ts
@@ -57,6 +57,12 @@ export class WorkspaceStatusEvent extends Schema.Class<WorkspaceStatusEvent>("Wo
   status: Schema.optionalKey(Schema.String),
 }) {}
 
+export class WorkspaceDeletedEvent extends Schema.Class<WorkspaceDeletedEvent>("WorkspaceDeletedEvent")({
+  workspace_id: Schema.String,
+  ...providerItemFields,
+  item_type: Schema.String,
+}) {}
+
 export class WorkspacePRRefreshQueuedEvent extends Schema.Class<WorkspacePRRefreshQueuedEvent>(
   "WorkspacePRRefreshQueuedEvent",
 )({
@@ -99,7 +105,7 @@ export class DeferredMergeCompletedEvent extends Schema.Class<DeferredMergeCompl
   message: Schema.optionalKey(Schema.String),
   error: Schema.optionalKey(Schema.String),
   workspace_cleanup_warning: Schema.optionalKey(Schema.String),
-  deleted_workspace_id: Schema.optionalKey(Schema.String),
+  workspace_cleanup_pending: Schema.optionalKey(Schema.Boolean),
   completed_at: Schema.String,
 }) {}
 
@@ -118,6 +124,7 @@ export type ProviderEvent =
   | { readonly type: "reconnect.stale" }
   | { readonly type: "workspace_created"; readonly payload: WorkspaceCreatedEvent }
   | { readonly type: "workspace_status"; readonly payload: WorkspaceStatusEvent }
+  | { readonly type: "workspace_deleted"; readonly payload: WorkspaceDeletedEvent }
   | { readonly type: "workspace_pushed_head_changed"; readonly payload: WorkspacePushedHeadChangedEvent }
   | { readonly type: "workspace_pr_associated"; readonly payload: WorkspacePRAssociatedEvent }
   | { readonly type: "workspace_pr_refresh_queued"; readonly payload: WorkspacePRRefreshQueuedEvent }
@@ -221,6 +228,7 @@ const providerEventTypes: ReadonlyArray<ProviderEventType> = [
   "reconnect.stale",
   "workspace_created",
   "workspace_status",
+  "workspace_deleted",
   "workspace_pushed_head_changed",
   "workspace_pr_associated",
   "workspace_pr_refresh_queued",
@@ -308,6 +316,13 @@ const decodeProviderEvent = Effect.fn("ProviderEvents.decodeFrame")(function* (f
       return {
         type: "workspace_status",
         payload: yield* Schema.decodeUnknownEffect(WorkspaceStatusEvent)(payload).pipe(
+          Effect.mapError((cause) => invalidFrame(frame, cause)),
+        ),
+      } satisfies ProviderEvent;
+    case "workspace_deleted":
+      return {
+        type: "workspace_deleted",
+        payload: yield* Schema.decodeUnknownEffect(WorkspaceDeletedEvent)(payload).pipe(
           Effect.mapError((cause) => invalidFrame(frame, cause)),
         ),
       } satisfies ProviderEvent;

--- a/frontend/tests/e2e-full/detail-action-buttons.spec.ts
+++ b/frontend/tests/e2e-full/detail-action-buttons.spec.ts
@@ -389,7 +389,7 @@ test.describe("detail action buttons", () => {
     }
   });
 
-  test("a merge cleanup warning keeps the linked workspace and reports partial success", async ({ page }) => {
+  test("a merge cleanup failure remains visible and supports force-delete recovery", async ({ page }) => {
     test.skip(
       !hasCommand("git") || !hasCommand("tmux", ["-V"]),
       "git and tmux are required for the real workspace flow",
@@ -432,10 +432,53 @@ test.describe("detail action buttons", () => {
       const mergeResponse = await mergeResponsePromise;
       expect(mergeResponse.status()).toBe(200);
       expect(await mergeResponse.json()).toMatchObject({
-        workspace_cleanup_warning: expect.stringMatching(/uncommitted changes/i),
+        workspace_cleanup_pending: true,
       });
-      await expect(page.locator(".kit-flash-stack").getByRole("status")).toContainText("workspace was not pruned");
-      expect((await apiContext.get(`/api/v1/workspaces/${createdWorkspace.id}`)).status()).toBe(200);
+      await expect(modal).toBeHidden();
+      await expect
+        .poll(async () => {
+          const response = await apiContext.get(`/api/v1/workspaces/${createdWorkspace.id}`);
+          if (!response.ok()) return null;
+          return ((await response.json()) as WorkspaceStatusResponse).status;
+        })
+        .toBe("deletion_failed");
+
+      await page.goto(`${server.info.base_url}/workspaces`);
+      await expect(page.locator(".workspace-lifecycle-state--deletion_failed")).toHaveText("Deletion failed");
+
+      const failedWorkspaceRow = page.locator(".ws-row").filter({
+        has: page.locator(".workspace-lifecycle-state--deletion_failed"),
+      });
+      await failedWorkspaceRow.click({ button: "right" });
+      await page.getByRole("menuitem", { name: "Force delete workspace..." }).click();
+
+      const forceDeleteDialog = page.getByRole("dialog", { name: "Force delete workspace?" });
+      await expect(forceDeleteDialog).toBeVisible();
+      const forceDeleteResponsePromise = page.waitForResponse((response) => {
+        const url = new URL(response.url());
+        return (
+          response.request().method() === "DELETE" &&
+          url.pathname === `/api/v1/workspaces/${createdWorkspace.id}` &&
+          url.searchParams.get("force") === "true"
+        );
+      });
+      await forceDeleteDialog.getByRole("button", { name: "Force delete workspace" }).click();
+      expect((await forceDeleteResponsePromise).status()).toBe(204);
+
+      await expect
+        .poll(async () => (await apiContext.get(`/api/v1/workspaces/${createdWorkspace.id}`)).status())
+        .toBe(404);
+      await expect
+        .poll(async () => {
+          try {
+            await access(readyWorkspace.worktree_path);
+            return true;
+          } catch {
+            return false;
+          }
+        })
+        .toBe(false);
+      await expect(failedWorkspaceRow).toHaveCount(0);
     } finally {
       await api?.dispose();
       await isolatedServer?.stop();

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -688,8 +688,10 @@ const (
 	UnsupportedCapability         ProblemErrorCode = "unsupportedCapability"
 	UpstreamError                 ProblemErrorCode = "upstreamError"
 	ValidationError               ProblemErrorCode = "validationError"
+	WorkspaceDeletionInProgress   ProblemErrorCode = "workspaceDeletionInProgress"
 	WorkspaceDirectoryNotReusable ProblemErrorCode = "workspaceDirectoryNotReusable"
 	WorkspaceNotFound             ProblemErrorCode = "workspaceNotFound"
+	WorkspaceSetupInProgress      ProblemErrorCode = "workspaceSetupInProgress"
 	WorktreeDirty                 ProblemErrorCode = "worktreeDirty"
 )
 
@@ -750,9 +752,13 @@ func (e ProblemErrorCode) Valid() bool {
 		return true
 	case ValidationError:
 		return true
+	case WorkspaceDeletionInProgress:
+		return true
 	case WorkspaceDirectoryNotReusable:
 		return true
 	case WorkspaceNotFound:
+		return true
+	case WorkspaceSetupInProgress:
 		return true
 	case WorktreeDirty:
 		return true
@@ -2808,6 +2814,7 @@ type MergePRBody struct {
 	Merged                  bool    `json:"merged"`
 	Message                 string  `json:"message"`
 	Sha                     string  `json:"sha"`
+	WorkspaceCleanupPending *bool   `json:"workspace_cleanup_pending,omitempty"`
 	WorkspaceCleanupWarning *string `json:"workspace_cleanup_warning,omitempty"`
 }
 

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -11,6 +11,8 @@ import (
 	"time"
 )
 
+var ErrWorkspaceSetupInProgress = errors.New("workspace setup is still in progress")
+
 // listSearchCondition returns a SQL condition and args for a free-text search.
 // Unquoted whitespace-separated terms are ANDed. Within each term, the title
 // is searched as "#{number} {title}" so substring queries can match the
@@ -4801,6 +4803,113 @@ func (d *DB) UpdateWorkspaceStatus(
 	)
 	if err != nil {
 		return fmt.Errorf("update workspace status: %w", err)
+	}
+	return nil
+}
+
+// MarkReadyWorkspaceError records a runtime failure only while the workspace
+// is still ready. A false result means another lifecycle transition won the
+// race and must not be overwritten by the stale failure observation.
+func (d *DB) MarkReadyWorkspaceError(
+	ctx context.Context, id, message string,
+) (bool, error) {
+	result, err := d.execContext(ctx, `
+		UPDATE forge_workspaces
+		SET status = 'error', error_message = ?
+		WHERE id = ? AND status = 'ready'`,
+		message, id,
+	)
+	if err != nil {
+		return false, fmt.Errorf("mark ready workspace error: %w", err)
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("read ready workspace error result: %w", err)
+	}
+	return rowsAffected == 1, nil
+}
+
+// BeginWorkspaceDeletion atomically admits one deletion attempt from a stable
+// workspace state and clears any error left by an earlier attempt. A false
+// result means another deletion is already responsible for the workspace.
+func (d *DB) BeginWorkspaceDeletion(ctx context.Context, id string) (bool, error) {
+	result, err := d.execContext(ctx, `
+		UPDATE forge_workspaces
+		SET status = 'deleting', error_message = NULL
+		WHERE id = ? AND status IN ('ready', 'error', 'deletion_failed')`,
+		id,
+	)
+	if err != nil {
+		return false, fmt.Errorf("begin workspace deletion: %w", err)
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("read workspace deletion result: %w", err)
+	}
+	if rowsAffected == 1 {
+		return true, nil
+	}
+	var status string
+	err = d.ro.QueryRowContext(ctx, `SELECT status FROM forge_workspaces WHERE id = ?`, id).Scan(&status)
+	if errors.Is(err, sql.ErrNoRows) || status == "deleting" {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read workspace status after deletion admission: %w", err)
+	}
+	if status == "creating" {
+		return false, ErrWorkspaceSetupInProgress
+	}
+	return false, fmt.Errorf("workspace status %q does not permit deletion", status)
+}
+
+// FailWorkspaceDeletion preserves a failed teardown as a recoverable row.
+func (d *DB) FailWorkspaceDeletion(ctx context.Context, id, message string) error {
+	result, err := d.execContext(ctx, `
+		UPDATE forge_workspaces
+		SET status = 'deletion_failed', error_message = ?
+		WHERE id = ? AND status = 'deleting'`,
+		message, id,
+	)
+	if err != nil {
+		return fmt.Errorf("fail workspace deletion: %w", err)
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read workspace deletion failure result: %w", err)
+	}
+	if rowsAffected != 1 {
+		return fmt.Errorf("fail workspace deletion: workspace is not deleting")
+	}
+	return nil
+}
+
+// FailInterruptedWorkspaceDeletions makes daemon-interrupted destructive work
+// explicit. Retrying it always requires another user action.
+func (d *DB) FailInterruptedWorkspaceDeletions(ctx context.Context, message string) error {
+	_, err := d.execContext(ctx, `
+		UPDATE forge_workspaces
+		SET status = 'deletion_failed', error_message = ?
+		WHERE status = 'deleting'`,
+		message,
+	)
+	if err != nil {
+		return fmt.Errorf("fail interrupted workspace deletions: %w", err)
+	}
+	return nil
+}
+
+// FailInterruptedWorkspaceSetups makes process-local setup work that could not
+// survive a daemon restart explicit and retryable.
+func (d *DB) FailInterruptedWorkspaceSetups(ctx context.Context, message string) error {
+	_, err := d.execContext(ctx, `
+		UPDATE forge_workspaces
+		SET status = 'error', error_message = ?
+		WHERE status = 'creating'`,
+		message,
+	)
+	if err != nil {
+		return fmt.Errorf("fail interrupted workspace setups: %w", err)
 	}
 	return nil
 }

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -4025,6 +4025,202 @@ func TestWorkspaceCRUD(t *testing.T) {
 	assert.Nil(noSuch)
 }
 
+func TestWorkspaceDeletionLifecycle(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+
+	insert := func(id, status string) {
+		require.NoError(d.InsertWorkspace(ctx, &Workspace{
+			ID:              id,
+			PlatformHost:    "github.com",
+			RepoOwner:       "acme",
+			RepoName:        id,
+			ItemType:        WorkspaceItemTypePullRequest,
+			ItemNumber:      42,
+			GitHeadRef:      "feature/delete",
+			WorkspaceBranch: "kenn-forge/pr-42",
+			WorktreePath:    "/tmp/" + id,
+			TmuxSession:     "kenn-forge-" + id,
+			Status:          status,
+		}))
+	}
+
+	insert("ws-delete", "ready")
+	started, err := d.BeginWorkspaceDeletion(ctx, "ws-delete")
+	require.NoError(err)
+	assert.True(started)
+	started, err = d.BeginWorkspaceDeletion(ctx, "ws-delete")
+	require.NoError(err)
+	assert.False(started)
+
+	got, err := d.GetWorkspace(ctx, "ws-delete")
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal("deleting", got.Status)
+	assert.Nil(got.ErrorMessage)
+
+	require.NoError(d.FailWorkspaceDeletion(ctx, "ws-delete", "worktree is dirty"))
+	got, err = d.GetWorkspace(ctx, "ws-delete")
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal("deletion_failed", got.Status)
+	require.NotNil(got.ErrorMessage)
+	assert.Equal("worktree is dirty", *got.ErrorMessage)
+
+	started, err = d.BeginWorkspaceDeletion(ctx, "ws-delete")
+	require.NoError(err)
+	assert.True(started)
+
+	insert("ws-interrupted", "deleting")
+	require.NoError(d.FailInterruptedWorkspaceDeletions(
+		ctx, "deletion interrupted by server restart",
+	))
+	for _, id := range []string{"ws-delete", "ws-interrupted"} {
+		got, err = d.GetWorkspace(ctx, id)
+		require.NoError(err)
+		require.NotNil(got)
+		assert.Equal("deletion_failed", got.Status)
+		require.NotNil(got.ErrorMessage)
+		assert.Equal("deletion interrupted by server restart", *got.ErrorMessage)
+	}
+}
+
+func TestFailInterruptedWorkspaceSetups(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+
+	insert := func(id, status string) {
+		require.NoError(d.InsertWorkspace(ctx, &Workspace{
+			ID:           id,
+			PlatformHost: "github.com",
+			RepoOwner:    "acme",
+			RepoName:     id,
+			ItemType:     WorkspaceItemTypePullRequest,
+			ItemNumber:   42,
+			GitHeadRef:   "feature/setup",
+			WorktreePath: "/tmp/" + id,
+			TmuxSession:  "kenn-forge-" + id,
+			Status:       status,
+		}))
+	}
+	insert("ws-creating", "creating")
+	insert("ws-ready", "ready")
+
+	require.NoError(d.FailInterruptedWorkspaceSetups(
+		ctx, "setup interrupted by server restart",
+	))
+
+	creating, err := d.GetWorkspace(ctx, "ws-creating")
+	require.NoError(err)
+	require.NotNil(creating)
+	assert.Equal("error", creating.Status)
+	require.NotNil(creating.ErrorMessage)
+	assert.Equal("setup interrupted by server restart", *creating.ErrorMessage)
+
+	ready, err := d.GetWorkspace(ctx, "ws-ready")
+	require.NoError(err)
+	require.NotNil(ready)
+	assert.Equal("ready", ready.Status)
+	assert.Nil(ready.ErrorMessage)
+}
+
+func TestReadyWorkspaceErrorDoesNotOverwriteAdmittedDeletion(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+
+	require.NoError(d.InsertWorkspace(ctx, &Workspace{
+		ID:              "ws-prune-delete-race",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        WorkspaceItemTypePullRequest,
+		ItemNumber:      42,
+		GitHeadRef:      "feature/delete",
+		WorkspaceBranch: "kenn-forge/pr-42",
+		WorktreePath:    "/tmp/ws-prune-delete-race",
+		TmuxSession:     "kenn-forge-ws-prune-delete-race",
+		Status:          "ready",
+	}))
+
+	// Simulate pruning reading a ready workspace before deletion wins the
+	// durable transition. Its stale error write must not replace deleting.
+	stale, err := d.GetWorkspace(ctx, "ws-prune-delete-race")
+	require.NoError(err)
+	require.Equal("ready", stale.Status)
+	started, err := d.BeginWorkspaceDeletion(ctx, stale.ID)
+	require.NoError(err)
+	require.True(started)
+
+	updated, err := d.MarkReadyWorkspaceError(
+		ctx, stale.ID, "tmux session is no longer running",
+	)
+	require.NoError(err)
+	assert.False(updated)
+
+	got, err := d.GetWorkspace(ctx, stale.ID)
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal("deleting", got.Status)
+}
+
+func TestFailWorkspaceDeletionRequiresDeletingState(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+
+	require.NoError(d.InsertWorkspace(ctx, &Workspace{
+		ID:           "ws-ready",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     WorkspaceItemTypePullRequest,
+		ItemNumber:   42,
+		GitHeadRef:   "feature/delete",
+		WorktreePath: "/tmp/ws-ready",
+		TmuxSession:  "kenn-forge-ws-ready",
+		Status:       "ready",
+	}))
+
+	err := d.FailWorkspaceDeletion(ctx, "ws-ready", "teardown failed")
+	require.ErrorContains(err, "workspace is not deleting")
+}
+
+func TestBeginWorkspaceDeletionRejectsCreatingWorkspace(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+
+	require.NoError(d.InsertWorkspace(ctx, &Workspace{
+		ID:              "ws-creating",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        WorkspaceItemTypePullRequest,
+		ItemNumber:      42,
+		GitHeadRef:      "feature/setup",
+		WorkspaceBranch: "kenn-forge/pr-42",
+		WorktreePath:    "/tmp/ws-creating",
+		TmuxSession:     "kenn-forge-ws-creating",
+		Status:          "creating",
+	}))
+
+	started, err := d.BeginWorkspaceDeletion(ctx, "ws-creating")
+	require.ErrorIs(err, ErrWorkspaceSetupInProgress)
+	assert.False(started)
+
+	got, err := d.GetWorkspace(ctx, "ws-creating")
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal("creating", got.Status)
+}
+
 func TestUpdateWorkspaceBranchRejectsMissingWorkspace(t *testing.T) {
 	d := openTestDB(t)
 

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -1292,7 +1292,7 @@ type Workspace struct {
 	WorktreePath    string
 	TmuxSession     string
 	TerminalBackend string
-	Status          string // "creating", "ready", "error"
+	Status          string // "creating", "ready", "error", "deleting", "deletion_failed"
 	ErrorMessage    *string
 	CreatedAt       time.Time
 	KataMetadata    *WorkspaceKataMetadata

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -25798,10 +25798,11 @@ func cleanupWorkspaceServerFixtureArtifactsWithContext(
 	var errs []error
 	for _, ws := range workspaces {
 		_, err := func() ([]string, error) {
-			beforeDestructive := func(stopCtx context.Context) {
+			beforeDestructive := func(stopCtx context.Context) error {
 				if srv.runtime != nil {
 					srv.runtime.StopWorkspace(stopCtx, ws.ID)
 				}
+				return nil
 			}
 			if srv.runtime != nil {
 				srv.runtime.BeginStopping(ws.ID)
@@ -28575,6 +28576,70 @@ exit 0
 	assert.Equal("⠴ claude-activity", *listed.TmuxPaneTitle)
 }
 
+func TestWorkspaceDeletionRecoversAcrossServerRestartE2E(t *testing.T) {
+	t.Parallel()
+	acquireRootWorkspaceGitSlot(t)
+
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := setupWorkspaceServerFixture(t, nil)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+
+	// Persist the same admission transition performed by DELETE immediately
+	// before destructive teardown. This is the durable state a process crash
+	// can leave behind.
+	started, err := fixture.database.BeginWorkspaceDeletion(ctx, ws.Id)
+	require.NoError(err)
+	require.True(started)
+	gracefulShutdown(t, fixture.server)
+	var databasePath string
+	require.NoError(fixture.database.ReadDB().QueryRowContext(
+		ctx, "SELECT file FROM pragma_database_list WHERE name = 'main'",
+	).Scan(&databasePath))
+	restartedDatabase, err := db.OpenPreparedForTest(databasePath)
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(restartedDatabase.Close()) })
+
+	restarted := New(
+		restartedDatabase, fixture.server.syncer, nil, "/", nil,
+		ServerOptions{
+			Clones:                     fixture.clones,
+			WorktreeDir:                fixture.worktrees,
+			PtyOwnerInProcess:          true,
+			DisableWorkspaceEnrichment: true,
+		},
+	)
+	t.Cleanup(func() { gracefulShutdown(t, restarted) })
+	restartedClient := setupTestClient(t, restarted)
+
+	getResp, err := restartedClient.HTTP.GetWorkspaceWithResponse(ctx, ws.Id)
+	require.NoError(err)
+	require.Equal(http.StatusOK, getResp.StatusCode(), string(getResp.Body))
+	require.NotNil(getResp.JSON200)
+	assert.Equal("deletion_failed", getResp.JSON200.Status)
+	require.NotNil(getResp.JSON200.ErrorMessage)
+	assert.Equal(
+		"workspace deletion was interrupted by a server restart; retry deletion to continue",
+		*getResp.JSON200.ErrorMessage,
+	)
+
+	force := true
+	deleteResp, err := restartedClient.HTTP.DeleteWorkspaceWithResponse(
+		ctx, ws.Id, &generated.DeleteWorkspaceParams{Force: &force},
+	)
+	require.NoError(err)
+	require.Equal(
+		http.StatusNoContent, deleteResp.StatusCode(), string(deleteResp.Body),
+	)
+
+	getResp, err = restartedClient.HTTP.GetWorkspaceWithResponse(ctx, ws.Id)
+	require.NoError(err)
+	assert.Equal(http.StatusNotFound, getResp.StatusCode())
+	_, err = os.Stat(ws.WorktreePath)
+	assert.True(os.IsNotExist(err))
+}
+
 func TestWorkspaceDeleteStopsRuntimeSessionsE2E(t *testing.T) {
 	runParallelPTYE2E(t)
 
@@ -28713,15 +28778,18 @@ func TestMergeWorkspaceCleanupDeletesWorkspaceAfterConfirmedMerge(t *testing.T) 
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	var response struct {
 		Merged                  bool   `json:"merged"`
+		WorkspaceCleanupPending bool   `json:"workspace_cleanup_pending"`
 		WorkspaceCleanupWarning string `json:"workspace_cleanup_warning"`
 	}
 	require.NoError(json.NewDecoder(rr.Body).Decode(&response))
 	assert.True(response.Merged)
+	assert.True(response.WorkspaceCleanupPending)
 	assert.Empty(response.WorkspaceCleanupWarning)
-	stored, err := database.GetWorkspace(ctx, ws.Id)
-	require.NoError(err)
-	assert.Nil(stored)
-	_, err = os.Stat(ws.WorktreePath)
+	require.Eventually(func() bool {
+		stored, getErr := database.GetWorkspace(ctx, ws.Id)
+		return getErr == nil && stored == nil
+	}, 5*time.Second, 10*time.Millisecond)
+	_, err := os.Stat(ws.WorktreePath)
 	assert.ErrorIs(err, os.ErrNotExist)
 }
 

--- a/internal/server/httpapi/problems.go
+++ b/internal/server/httpapi/problems.go
@@ -65,8 +65,10 @@ const (
 	CodeUnsupportedCapability         ProblemCode = "unsupportedCapability"
 	CodeUpstreamError                 ProblemCode = "upstreamError"
 	CodeValidationError               ProblemCode = "validationError"
+	CodeWorkspaceDeletionInProgress   ProblemCode = "workspaceDeletionInProgress"
 	CodeWorkspaceDirectoryNotReusable ProblemCode = "workspaceDirectoryNotReusable"
 	CodeWorkspaceNotFound             ProblemCode = "workspaceNotFound"
+	CodeWorkspaceSetupInProgress      ProblemCode = "workspaceSetupInProgress"
 	CodeWorktreeDirty                 ProblemCode = "worktreeDirty"
 )
 
@@ -102,8 +104,10 @@ func allProblemCodes() []ProblemCode {
 		CodeUnsupportedCapability,
 		CodeUpstreamError,
 		CodeValidationError,
+		CodeWorkspaceDeletionInProgress,
 		CodeWorkspaceDirectoryNotReusable,
 		CodeWorkspaceNotFound,
+		CodeWorkspaceSetupInProgress,
 		CodeWorktreeDirty,
 	}
 }
@@ -144,7 +148,7 @@ type ProblemError struct {
 
 	// Code is the machine-readable error code drawn from the closed enum
 	// in allProblemCodes(). Frontend logic branches on this value.
-	Code ProblemCode `json:"code" enum:"badRequest,branchConflict,branchInUse,branchProtected,commentNotFound,conflict,destinationExists,forbidden,hookFailed,internalError,issueNotFound,mutationOutcomeUnknown,notFound,payloadTooLarge,projectNotFound,pullNotFound,rateLimited,repoNotFound,resyncRequired,serviceUnavailable,settingsUnavailable,toolMissing,toolUnauthenticated,unauthorized,unsupportedCapability,upstreamError,validationError,workspaceDirectoryNotReusable,workspaceNotFound,worktreeDirty" example:"badRequest" doc:"Machine-readable error code. Stable across occurrences."`
+	Code ProblemCode `json:"code" enum:"badRequest,branchConflict,branchInUse,branchProtected,commentNotFound,conflict,destinationExists,forbidden,hookFailed,internalError,issueNotFound,mutationOutcomeUnknown,notFound,payloadTooLarge,projectNotFound,pullNotFound,rateLimited,repoNotFound,resyncRequired,serviceUnavailable,settingsUnavailable,toolMissing,toolUnauthenticated,unauthorized,unsupportedCapability,upstreamError,validationError,workspaceDeletionInProgress,workspaceDirectoryNotReusable,workspaceNotFound,workspaceSetupInProgress,worktreeDirty" example:"badRequest" doc:"Machine-readable error code. Stable across occurrences."`
 
 	// Details is a free-form map of machine-readable context for this
 	// occurrence (e.g. {capability: "merge_mutation"} or

--- a/internal/server/pullapi/deferred_merge.go
+++ b/internal/server/pullapi/deferred_merge.go
@@ -60,21 +60,21 @@ type deferredMergeTargetSnapshot struct {
 }
 
 type DeferredMergeCompletedPayload struct {
-	Provider           string `json:"provider"`
-	PlatformHost       string `json:"platform_host"`
-	RepoPath           string `json:"repo_path"`
-	Owner              string `json:"owner"`
-	Name               string `json:"name"`
-	Number             int    `json:"number"`
-	HeadSHA            string `json:"head_sha"`
-	Status             string `json:"status"`
-	Merged             bool   `json:"merged,omitempty"`
-	SHA                string `json:"sha,omitempty"`
-	Message            string `json:"message,omitempty"`
-	Error              string `json:"error,omitempty"`
-	CompletedAt        string `json:"completed_at"`
-	Warning            string `json:"workspace_cleanup_warning,omitempty"`
-	DeletedWorkspaceID string `json:"deleted_workspace_id,omitempty"`
+	Provider                string `json:"provider"`
+	PlatformHost            string `json:"platform_host"`
+	RepoPath                string `json:"repo_path"`
+	Owner                   string `json:"owner"`
+	Name                    string `json:"name"`
+	Number                  int    `json:"number"`
+	HeadSHA                 string `json:"head_sha"`
+	Status                  string `json:"status"`
+	Merged                  bool   `json:"merged,omitempty"`
+	SHA                     string `json:"sha,omitempty"`
+	Message                 string `json:"message,omitempty"`
+	Error                   string `json:"error,omitempty"`
+	CompletedAt             string `json:"completed_at"`
+	Warning                 string `json:"workspace_cleanup_warning,omitempty"`
+	WorkspaceCleanupPending bool   `json:"workspace_cleanup_pending,omitempty"`
 }
 
 func (s *Handler) deferMergePR(
@@ -420,33 +420,22 @@ func (s *Handler) completeDeferredMerge(
 	s.publish(Event{
 		Type: "deferred_merge_completed",
 		Data: DeferredMergeCompletedPayload{
-			Provider:     string(repoProviderKind(repo)),
-			PlatformHost: repoProviderHost(repo),
-			RepoPath:     repo.RepoPath,
-			Owner:        repo.Owner,
-			Name:         repo.Name,
-			Number:       number,
-			HeadSHA:      deferredMergeHeadSHA(body, queuedTarget.HeadSHA),
-			Status:       "merged",
-			Merged:       result.Merged,
-			SHA:          result.SHA,
-			Message:      result.Message,
-			CompletedAt:  formatUTCRFC3339(s.now().UTC()),
-			Warning:      result.WorkspaceCleanupWarning,
-			DeletedWorkspaceID: deferredMergeDeletedWorkspaceID(
-				result.Merged,
-				body.DeleteWorkspaceID,
-				result.WorkspaceCleanupWarning,
-			),
+			Provider:                string(repoProviderKind(repo)),
+			PlatformHost:            repoProviderHost(repo),
+			RepoPath:                repo.RepoPath,
+			Owner:                   repo.Owner,
+			Name:                    repo.Name,
+			Number:                  number,
+			HeadSHA:                 deferredMergeHeadSHA(body, queuedTarget.HeadSHA),
+			Status:                  "merged",
+			Merged:                  result.Merged,
+			SHA:                     result.SHA,
+			Message:                 result.Message,
+			CompletedAt:             formatUTCRFC3339(s.now().UTC()),
+			Warning:                 result.WorkspaceCleanupWarning,
+			WorkspaceCleanupPending: result.WorkspaceCleanupPending,
 		},
 	})
-}
-
-func deferredMergeDeletedWorkspaceID(merged bool, requestedID, cleanupWarning string) string {
-	if !merged || requestedID == "" || cleanupWarning != "" {
-		return ""
-	}
-	return requestedID
 }
 
 func (s *Handler) ensureDeferredMergeTargetUnchanged(ctx context.Context, repo db.Repo, number int, queuedTarget deferredMergeTargetSnapshot) error {

--- a/internal/server/pullapi/deferred_merge_integration_test.go
+++ b/internal/server/pullapi/deferred_merge_integration_test.go
@@ -207,8 +207,8 @@ func (p *deferredMergeTestProvider) MergeMergeRequest(
 }
 
 type deferredMergeTestOptions struct {
-	deferredMergeMaxWait time.Duration
-	deleteWorkspace      func(context.Context, string) error
+	deferredMergeMaxWait   time.Duration
+	queueWorkspaceDeletion func(string) error
 }
 
 type deferredMergeTestRecordedEvent struct {
@@ -260,12 +260,12 @@ func newDeferredMergeHTTPFixture(
 		},
 	})
 	handler := New(Deps{
-		DB:                   database,
-		Resolver:             resolver,
-		Syncer:               syncer,
-		DeleteWorkspace:      opts.deleteWorkspace,
-		Now:                  func() time.Time { return now },
-		DeferredMergeMaxWait: opts.deferredMergeMaxWait,
+		DB:                     database,
+		Resolver:               resolver,
+		Syncer:                 syncer,
+		QueueWorkspaceDeletion: opts.queueWorkspaceDeletion,
+		Now:                    func() time.Time { return now },
+		DeferredMergeMaxWait:   opts.deferredMergeMaxWait,
 		Broadcast: func(event Event) uint64 {
 			events <- deferredMergeTestRecordedEvent{Event: event}
 			return 0
@@ -460,9 +460,9 @@ func TestDeferMergeEndpointQueuesMergeAndBroadcastsCompletion(t *testing.T) {
 		now,
 		0,
 		deferredMergeTestOptions{
-			deleteWorkspace: func(_ context.Context, id string) error {
+			queueWorkspaceDeletion: func(id string) error {
 				deletedID = id
-				return errors.New("workspace has uncommitted changes: notes.txt")
+				return nil
 			},
 		},
 	)
@@ -522,8 +522,8 @@ func TestDeferMergeEndpointQueuesMergeAndBroadcastsCompletion(t *testing.T) {
 	require.True(completed.Merged)
 	require.Equal("merge-sha", completed.SHA)
 	require.Equal("2026-06-15T12:00:00Z", completed.CompletedAt)
-	require.Equal("workspace has uncommitted changes: notes.txt", completed.Warning)
-	require.Empty(completed.DeletedWorkspaceID)
+	require.Empty(completed.Warning)
+	require.True(completed.WorkspaceCleanupPending)
 	require.Equal("ws-1", deletedID)
 
 	stored, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)

--- a/internal/server/pullapi/handler.go
+++ b/internal/server/pullapi/handler.go
@@ -26,16 +26,16 @@ type ConfigSnapshot struct {
 }
 
 type Deps struct {
-	DB                   *db.DB
-	Resolver             *httpapi.RepositoryResolver
-	Syncer               *ghclient.Syncer
-	Clones               *gitclone.Manager
-	Config               ConfigSnapshot
-	Now                  func() time.Time
-	DeferredMergeMaxWait time.Duration
-	DeleteWorkspace      func(context.Context, string) error
-	WorkspaceSubjects    func(context.Context) (workspaceapi.WorkspaceSubjectSnapshot, error)
-	ViewerLogins         func(context.Context, []db.RepoFilter) ([]db.RepoViewerLogin, error)
+	DB                     *db.DB
+	Resolver               *httpapi.RepositoryResolver
+	Syncer                 *ghclient.Syncer
+	Clones                 *gitclone.Manager
+	Config                 ConfigSnapshot
+	Now                    func() time.Time
+	DeferredMergeMaxWait   time.Duration
+	QueueWorkspaceDeletion func(string) error
+	WorkspaceSubjects      func(context.Context) (workspaceapi.WorkspaceSubjectSnapshot, error)
+	ViewerLogins           func(context.Context, []db.RepoFilter) ([]db.RepoViewerLogin, error)
 
 	FleetSelfKey                  func(string) string
 	FilterRepos                   func([]db.Repo) []db.Repo
@@ -51,14 +51,14 @@ type Deps struct {
 }
 
 type Handler struct {
-	db                *db.DB
-	resolver          *httpapi.RepositoryResolver
-	syncer            *ghclient.Syncer
-	clones            *gitclone.Manager
-	deleteWorkspace   func(context.Context, string) error
-	now               func() time.Time
-	workspaceSubjects func(context.Context) (workspaceapi.WorkspaceSubjectSnapshot, error)
-	viewerLogins      func(context.Context, []db.RepoFilter) ([]db.RepoViewerLogin, error)
+	db                     *db.DB
+	resolver               *httpapi.RepositoryResolver
+	syncer                 *ghclient.Syncer
+	clones                 *gitclone.Manager
+	queueWorkspaceDeletion func(string) error
+	now                    func() time.Time
+	workspaceSubjects      func(context.Context) (workspaceapi.WorkspaceSubjectSnapshot, error)
+	viewerLogins           func(context.Context, []db.RepoFilter) ([]db.RepoViewerLogin, error)
 
 	fleetSelfKey                  func(string) string
 	filterRepos                   func([]db.Repo) []db.Repo
@@ -102,7 +102,7 @@ func New(deps Deps) *Handler {
 		resolver:                      deps.Resolver,
 		syncer:                        deps.Syncer,
 		clones:                        deps.Clones,
-		deleteWorkspace:               deps.DeleteWorkspace,
+		queueWorkspaceDeletion:        deps.QueueWorkspaceDeletion,
 		now:                           now,
 		workspaceSubjects:             deps.WorkspaceSubjects,
 		viewerLogins:                  deps.ViewerLogins,

--- a/internal/server/pullapi/routes.go
+++ b/internal/server/pullapi/routes.go
@@ -304,6 +304,7 @@ type mergePRBody struct {
 	Merged                  bool   `json:"merged"`
 	SHA                     string `json:"sha"`
 	Message                 string `json:"message"`
+	WorkspaceCleanupPending bool   `json:"workspace_cleanup_pending,omitempty"`
 	WorkspaceCleanupWarning string `json:"workspace_cleanup_warning,omitempty"`
 }
 
@@ -1756,7 +1757,7 @@ func (s *Handler) mergePRWithBody(
 		)
 	}
 
-	workspaceCleanupWarning := ""
+	workspaceCleanup := workspaceCleanupResult{}
 	if result.Merged {
 		// Record the transition through the same close-detection flow the
 		// periodic sync uses rather than an eager local state write. The sync
@@ -1783,14 +1784,15 @@ func (s *Handler) mergePRWithBody(
 		// (A deferred worker completing through this same path supersedes its
 		// own handle, which is a no-op by the time it broadcasts completion.)
 		s.supersedeDeferredMerge(deferredMergeKey(*repo, number))
-		workspaceCleanupWarning = s.cleanupMergedWorkspace(ctx, body.DeleteWorkspaceID)
+		workspaceCleanup = s.queueMergedWorkspaceCleanup(body.DeleteWorkspaceID)
 	}
 
 	return mergePRBody{
 		Merged:                  result.Merged,
 		SHA:                     result.SHA,
 		Message:                 result.Message,
-		WorkspaceCleanupWarning: workspaceCleanupWarning,
+		WorkspaceCleanupPending: workspaceCleanup.Pending,
+		WorkspaceCleanupWarning: workspaceCleanup.Warning,
 	}, nil
 }
 

--- a/internal/server/pullapi/workspace_cleanup.go
+++ b/internal/server/pullapi/workspace_cleanup.go
@@ -1,20 +1,21 @@
 package pullapi
 
-import (
-	"context"
-)
+type workspaceCleanupResult struct {
+	Pending bool
+	Warning string
+}
 
-func (s *Handler) cleanupMergedWorkspace(ctx context.Context, workspaceID string) string {
+func (s *Handler) queueMergedWorkspaceCleanup(workspaceID string) workspaceCleanupResult {
 	if workspaceID == "" {
-		return ""
+		return workspaceCleanupResult{}
 	}
-	if s.deleteWorkspace == nil {
-		return "workspace cleanup is unavailable"
+	if s.queueWorkspaceDeletion == nil {
+		return workspaceCleanupResult{Warning: "workspace cleanup is unavailable"}
 	}
 
-	err := s.deleteWorkspace(ctx, workspaceID)
+	err := s.queueWorkspaceDeletion(workspaceID)
 	if err != nil {
-		return err.Error()
+		return workspaceCleanupResult{Warning: err.Error()}
 	}
-	return ""
+	return workspaceCleanupResult{Pending: true}
 }

--- a/internal/server/pullapi/workspace_cleanup_test.go
+++ b/internal/server/pullapi/workspace_cleanup_test.go
@@ -1,46 +1,44 @@
 package pullapi
 
 import (
-	"context"
 	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDeferredMergeDeletedWorkspaceIDRequiresConfirmedCleanup(t *testing.T) {
-	assert := assert.New(t)
-	assert.Equal("ws-1", deferredMergeDeletedWorkspaceID(true, "ws-1", ""))
-	assert.Empty(deferredMergeDeletedWorkspaceID(true, "ws-1", "workspace has changes"))
-	assert.Empty(deferredMergeDeletedWorkspaceID(false, "ws-1", ""))
-	assert.Empty(deferredMergeDeletedWorkspaceID(true, "", ""))
-}
-
-func TestCleanupMergedWorkspaceCallsExistingDeletionHandler(t *testing.T) {
-	var deletedID string
+func TestQueueMergedWorkspaceCleanupAcknowledgesPendingDeletion(t *testing.T) {
+	queued := make(chan string, 1)
 	handler := New(Deps{
-		DeleteWorkspace: func(_ context.Context, id string) error {
-			deletedID = id
+		QueueWorkspaceDeletion: func(id string) error {
+			queued <- id
 			return nil
 		},
 	})
 
-	warning := handler.cleanupMergedWorkspace(t.Context(), "ws-1")
+	result := handler.queueMergedWorkspaceCleanup("ws-1")
 
-	assert.Empty(t, warning)
-	assert.Equal(t, "ws-1", deletedID)
+	assert.True(t, result.Pending)
+	assert.Empty(t, result.Warning)
+	assert.Equal(t, "ws-1", <-queued)
 }
 
-func TestCleanupMergedWorkspaceReturnsDeletionWarning(t *testing.T) {
+func TestQueueMergedWorkspaceCleanupReturnsAdmissionWarning(t *testing.T) {
 	handler := New(Deps{
-		DeleteWorkspace: func(context.Context, string) error {
-			return errors.New("workspace has uncommitted changes: notes.txt")
+		QueueWorkspaceDeletion: func(string) error {
+			return errors.New("workspace setup is still in progress")
 		},
 	})
 
-	assert.Equal(
-		t,
-		"workspace has uncommitted changes: notes.txt",
-		handler.cleanupMergedWorkspace(t.Context(), "ws-1"),
-	)
+	result := handler.queueMergedWorkspaceCleanup("ws-1")
+
+	assert.False(t, result.Pending)
+	assert.Equal(t, "workspace setup is still in progress", result.Warning)
+}
+
+func TestQueueMergedWorkspaceCleanupWithoutWorkspaceIsComplete(t *testing.T) {
+	result := New(Deps{}).queueMergedWorkspaceCleanup("")
+
+	assert.False(t, result.Pending)
+	assert.Empty(t, result.Warning)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -984,20 +984,17 @@ func newServer(
 		ConfigRepoPath:   configRepoPath,
 	})
 	s.pullAPI = pullapi.New(pullapi.Deps{
-		DB:                   database,
-		Resolver:             repoResolver,
-		Syncer:               syncer,
-		Clones:               clones,
-		Config:               pullConfigSnapshot(cfg),
-		Now:                  func() time.Time { return s.now() },
-		DeferredMergeMaxWait: deferredMergeMaxWait,
-		DeleteWorkspace: func(ctx context.Context, id string) error {
-			_, err := s.workspaceAPI.DeleteWorkspace(ctx, &workspaceapi.DeleteWorkspaceInput{ID: id})
-			return err
-		},
-		WorkspaceSubjects: s.workspaceAPI.WorkspaceSubjectSnapshot,
-		ViewerLogins:      s.resolveAuthenticatedViewerLogins,
-		FleetSelfKey:      s.fleetAPI.SelfKey,
+		DB:                     database,
+		Resolver:               repoResolver,
+		Syncer:                 syncer,
+		Clones:                 clones,
+		Config:                 pullConfigSnapshot(cfg),
+		Now:                    func() time.Time { return s.now() },
+		DeferredMergeMaxWait:   deferredMergeMaxWait,
+		QueueWorkspaceDeletion: s.workspaceAPI.QueueWorkspaceDeletion,
+		WorkspaceSubjects:      s.workspaceAPI.WorkspaceSubjectSnapshot,
+		ViewerLogins:           s.resolveAuthenticatedViewerLogins,
+		FleetSelfKey:           s.fleetAPI.SelfKey,
 		FilterRepos: func(repos []db.Repo) []db.Repo {
 			if s.cfg == nil {
 				return repos

--- a/internal/server/workspaceapi/lifecycle.go
+++ b/internal/server/workspaceapi/lifecycle.go
@@ -27,6 +27,21 @@ func (h *Handler) Start(parent context.Context, disableMonitors bool) {
 	h.lifecycleStarted = true
 	h.lifecycleMu.Unlock()
 
+	if h.db != nil {
+		recoveryCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := h.db.FailInterruptedWorkspaceSetups(
+			recoveryCtx, interruptedWorkspaceSetupMessage,
+		); err != nil {
+			slog.Error("recover interrupted workspace setups", "err", err)
+		}
+		if err := h.db.FailInterruptedWorkspaceDeletions(
+			recoveryCtx, interruptedWorkspaceDeletionMessage,
+		); err != nil {
+			slog.Error("recover interrupted workspace deletions", "err", err)
+		}
+		cancel()
+	}
+
 	h.runBackground(func(ctx context.Context) {
 		select {
 		case <-parent.Done():

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -2488,7 +2488,7 @@ func workspaceRuntimeLaunchError(err error) error {
 func (s *Handler) DeleteWorkspace(
 	ctx context.Context, input *DeleteWorkspaceInput,
 ) (*struct{}, error) {
-	if s.workspaces == nil {
+	if s.workspaces == nil || s.db == nil {
 		return nil, httpapi.ServiceUnavailable("workspace manager not configured")
 	}
 
@@ -2499,32 +2499,56 @@ func (s *Handler) DeleteWorkspace(
 	// reopens admission only after every concurrent deletion has finished.
 	defer func() { s.finishWorkspaceDeleting(input.ID, deleted) }()
 
-	if s.runtime != nil {
-		// Block new launches before the dirty preflight; existing
-		// sessions are stopped only after the preflight passes.
-		s.runtime.BeginStopping(input.ID)
-	}
-	defer func() {
-		if s.runtime != nil {
-			s.runtime.EndStopping(input.ID)
-		}
-	}()
 	if err := waitForWorkspaceSetup(ctx, setupDone); err != nil {
 		return nil, httpapi.Internal("wait for workspace setup: " + err.Error())
 	}
-	dirty, err := s.workspaces.Delete(
-		ctx, input.ID, input.Force,
-		func(stopCtx context.Context) {
-			if s.runtime != nil {
-				sessions := s.runtime.ListSessions(input.ID)
-				s.runtime.StopWorkspace(stopCtx, input.ID)
-				for _, session := range sessions {
-					s.removeAgentActivityRuntimeSession(session.Key)
-				}
-			}
-		},
-	)
+	ws, err := s.db.GetWorkspace(ctx, input.ID)
 	if err != nil {
+		return nil, httpapi.Internal("get workspace: " + err.Error())
+	}
+	if ws == nil {
+		return nil, httpapi.NotFound(httpapi.CodeWorkspaceNotFound, "workspace not found", nil)
+	}
+	if problem := workspaceDeletionLifecycleProblem(ws.Status); problem != nil {
+		return nil, problem
+	}
+	admitted := false
+	err = s.runWorkspaceDeletion(ctx, input.ID, nil, input.Force, func(admitCtx context.Context) error {
+		started, err := s.db.BeginWorkspaceDeletion(admitCtx, input.ID)
+		if err != nil {
+			return err
+		}
+		if !started {
+			return errWorkspaceDeletionInProgress
+		}
+		admitted = true
+		s.broadcastWorkspaceStatus(input.ID)
+		return nil
+	})
+	if err != nil {
+		if admitted {
+			s.persistWorkspaceDeletionFailure(input.ID, err.Error())
+		}
+		var dirty *workspaceDirtyDeletionError
+		if errors.As(err, &dirty) {
+			current, getErr := s.db.GetWorkspace(ctx, input.ID)
+			if getErr != nil {
+				return nil, httpapi.Internal("recheck workspace before dirty response: " + getErr.Error())
+			}
+			if current == nil {
+				return nil, httpapi.NotFound(httpapi.CodeWorkspaceNotFound, "workspace not found", nil)
+			}
+			if problem := workspaceDeletionLifecycleProblem(current.Status); problem != nil {
+				return nil, problem
+			}
+			return nil, httpapi.Conflict(httpapi.CodeWorktreeDirty, err.Error(), nil)
+		}
+		if errors.Is(err, errWorkspaceDeletionInProgress) {
+			return nil, httpapi.Conflict(httpapi.CodeWorkspaceDeletionInProgress, err.Error(), nil)
+		}
+		if errors.Is(err, db.ErrWorkspaceSetupInProgress) {
+			return nil, httpapi.Conflict(httpapi.CodeWorkspaceSetupInProgress, err.Error(), nil)
+		}
 		if errors.Is(err, workspace.ErrWorkspaceNotFound) {
 			return nil, httpapi.NotFound(httpapi.CodeWorkspaceNotFound, err.Error(), nil)
 		}
@@ -2533,11 +2557,27 @@ func (s *Handler) DeleteWorkspace(
 		}
 		return nil, httpapi.Internal("delete workspace: " + err.Error())
 	}
-	if len(dirty) > 0 {
-		return nil, httpapi.Conflict(httpapi.CodeConflict,
-			"workspace has uncommitted changes: "+strings.Join(dirty, ", "), nil)
-	}
 
 	deleted = true
+	s.publishWorkspaceDeleted(ws)
 	return nil, nil
+}
+
+func workspaceDeletionLifecycleProblem(status string) error {
+	switch status {
+	case "creating":
+		return httpapi.Conflict(
+			httpapi.CodeWorkspaceSetupInProgress,
+			"workspace setup is still in progress",
+			nil,
+		)
+	case "deleting":
+		return httpapi.Conflict(
+			httpapi.CodeWorkspaceDeletionInProgress,
+			errWorkspaceDeletionInProgress.Error(),
+			nil,
+		)
+	default:
+		return nil
+	}
 }

--- a/internal/server/workspaceapi/workspace_deletion.go
+++ b/internal/server/workspaceapi/workspace_deletion.go
@@ -1,0 +1,164 @@
+package workspaceapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/workspace"
+)
+
+const (
+	interruptedWorkspaceDeletionMessage = "workspace deletion was interrupted by a server restart; retry deletion to continue"
+	interruptedWorkspaceSetupMessage    = "workspace setup was interrupted by a server restart; retry setup or delete the workspace"
+)
+
+var errWorkspaceDeletionInProgress = errors.New("workspace deletion already in progress")
+
+type workspaceDirtyDeletionError struct {
+	files []string
+}
+
+func (e *workspaceDirtyDeletionError) Error() string {
+	return "workspace has uncommitted changes: " + strings.Join(e.files, ", ")
+}
+
+type workspaceDeletedEventData struct {
+	WorkspaceID  string `json:"workspace_id"`
+	Provider     string `json:"provider"`
+	PlatformHost string `json:"platform_host"`
+	Owner        string `json:"owner"`
+	Name         string `json:"name"`
+	RepoPath     string `json:"repo_path"`
+	Number       int    `json:"number"`
+	ItemType     string `json:"item_type"`
+}
+
+func workspaceDeletedEvent(ws *db.Workspace) workspaceDeletedEventData {
+	return workspaceDeletedEventData{
+		WorkspaceID:  ws.ID,
+		Provider:     ws.Platform,
+		PlatformHost: ws.PlatformHost,
+		Owner:        ws.RepoOwner,
+		Name:         ws.RepoName,
+		RepoPath:     ws.RepoOwner + "/" + ws.RepoName,
+		Number:       ws.ItemNumber,
+		ItemType:     ws.ItemType,
+	}
+}
+
+// QueueWorkspaceDeletion durably admits teardown before returning, then runs
+// the destructive work under the workspace domain's lifecycle.
+func (s *Handler) QueueWorkspaceDeletion(id string) error {
+	if s == nil || s.workspaces == nil || s.db == nil {
+		return errors.New("workspace cleanup is unavailable")
+	}
+	ctx := s.lifecycleCtx
+	ws, err := s.db.GetWorkspace(ctx, id)
+	if err != nil {
+		return fmt.Errorf("get workspace: %w", err)
+	}
+	if ws == nil {
+		return workspace.ErrWorkspaceNotFound
+	}
+	if ws.Status == "deleting" {
+		return nil
+	}
+	if ws.Status == "creating" {
+		return db.ErrWorkspaceSetupInProgress
+	}
+	started, err := s.db.BeginWorkspaceDeletion(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !started {
+		return nil
+	}
+	setupDone := s.markWorkspaceDeleting(id)
+	s.broadcastWorkspaceStatus(id)
+	if s.runBackground(func(ctx context.Context) {
+		s.finishQueuedWorkspaceDeletion(ctx, ws, setupDone, false)
+	}) {
+		return nil
+	}
+
+	s.finishWorkspaceDeleting(id, false)
+	s.persistWorkspaceDeletionFailure(id, "workspace deletion could not start because the server is shutting down")
+	return errors.New("workspace deletion could not start because the server is shutting down")
+}
+
+func (s *Handler) finishQueuedWorkspaceDeletion(
+	ctx context.Context, ws *db.Workspace, setupDone <-chan struct{}, force bool,
+) {
+	deleted := false
+	defer func() { s.finishWorkspaceDeleting(ws.ID, deleted) }()
+	err := s.runWorkspaceDeletion(ctx, ws.ID, setupDone, force, nil)
+	if err != nil {
+		s.persistWorkspaceDeletionFailure(ws.ID, err.Error())
+		slog.Warn("delete queued workspace", "workspace_id", ws.ID, "err", err)
+		return
+	}
+	deleted = true
+	s.publishWorkspaceDeleted(ws)
+}
+
+func (s *Handler) runWorkspaceDeletion(
+	ctx context.Context, id string, setupDone <-chan struct{}, force bool,
+	admit func(context.Context) error,
+) error {
+	if s.runtime != nil {
+		s.runtime.BeginStopping(id)
+		defer s.runtime.EndStopping(id)
+	}
+	if err := waitForWorkspaceSetup(ctx, setupDone); err != nil {
+		return fmt.Errorf("wait for workspace setup: %w", err)
+	}
+	dirty, err := s.workspaces.Delete(
+		ctx, id, force,
+		func(stopCtx context.Context) error {
+			if admit != nil {
+				if err := admit(stopCtx); err != nil {
+					return err
+				}
+			}
+			if s.runtime == nil {
+				return nil
+			}
+			sessions := s.runtime.ListSessions(id)
+			s.runtime.StopWorkspace(stopCtx, id)
+			for _, session := range sessions {
+				s.removeAgentActivityRuntimeSession(session.Key)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return err
+	}
+	if len(dirty) > 0 {
+		return &workspaceDirtyDeletionError{files: dirty}
+	}
+	return nil
+}
+
+func (s *Handler) persistWorkspaceDeletionFailure(id, message string) {
+	if s == nil || s.db == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := s.db.FailWorkspaceDeletion(ctx, id, message); err != nil {
+		slog.Error("persist workspace deletion failure", "workspace_id", id, "err", err)
+		return
+	}
+	s.broadcastWorkspaceStatus(id)
+}
+
+func (s *Handler) publishWorkspaceDeleted(ws *db.Workspace) {
+	s.hub.Broadcast(Event{Type: "workspace_deleted", Data: workspaceDeletedEvent(ws)})
+	s.broadcastWorkspaceStatus(ws.ID)
+}

--- a/internal/server/workspaceapi/workspace_deletion_test.go
+++ b/internal/server/workspaceapi/workspace_deletion_test.go
@@ -1,0 +1,297 @@
+package workspaceapi
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/server/httpapi"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+	"go.kenn.io/forge/internal/workspace"
+)
+
+func TestDeleteWorkspaceRejectsConcurrentSetup(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	database := dbtest.Open(t)
+	base := t.TempDir()
+	insertDeletionTestWorkspace(
+		t, database, "ws-creating", filepath.Join(base, "missing"), "creating",
+	)
+	handler := New(Deps{
+		DB:         database,
+		Workspaces: workspace.NewManager(database, base),
+	})
+
+	_, err := handler.DeleteWorkspace(t.Context(), &DeleteWorkspaceInput{
+		ID: "ws-creating",
+	})
+	problem, ok := err.(*httpapi.ProblemError)
+	require.True(ok, "want *ProblemError, got %T", err)
+	assert.Equal(http.StatusConflict, problem.Status)
+	assert.Equal(httpapi.CodeWorkspaceSetupInProgress, problem.Code)
+	assert.Contains(problem.Detail, "setup is still in progress")
+
+	got, err := database.GetWorkspace(t.Context(), "ws-creating")
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal("creating", got.Status)
+}
+
+func TestDeleteWorkspaceReportsDeletionAlreadyInProgress(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	database := dbtest.Open(t)
+	base := t.TempDir()
+	insertDeletionTestWorkspace(
+		t, database, "ws-deleting", filepath.Join(base, "missing"), "deleting",
+	)
+	handler := New(Deps{
+		DB:         database,
+		Workspaces: workspace.NewManager(database, base),
+	})
+
+	_, err := handler.DeleteWorkspace(t.Context(), &DeleteWorkspaceInput{
+		ID: "ws-deleting",
+	})
+	problem, ok := err.(*httpapi.ProblemError)
+	require.True(ok, "want *ProblemError, got %T", err)
+	assert.Equal(http.StatusConflict, problem.Status)
+	assert.Equal(httpapi.CodeWorkspaceDeletionInProgress, problem.Code)
+	assert.Contains(problem.Detail, "deletion already in progress")
+}
+
+func insertDeletionTestWorkspace(
+	t *testing.T, database *db.DB, id, path, status string,
+) {
+	t.Helper()
+	require.NoError(t, database.InsertWorkspace(t.Context(), &db.Workspace{
+		ID:              id,
+		Platform:        "github",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        db.WorkspaceItemTypePullRequest,
+		ItemNumber:      42,
+		GitHeadRef:      "feature/delete",
+		WorkspaceBranch: "kenn-forge/pr-42",
+		WorktreePath:    path,
+		TmuxSession:     "kenn-forge-" + id,
+		Status:          status,
+	}))
+}
+
+func TestQueueWorkspaceDeletionPersistsFailure(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	base := t.TempDir()
+	worktreePath := filepath.Join(base, "ws-dirty")
+	require.NoError(os.MkdirAll(worktreePath, 0o755))
+	runGit(t, worktreePath, "init")
+	require.NoError(os.WriteFile(
+		filepath.Join(worktreePath, "notes.txt"), []byte("keep me\n"), 0o644,
+	))
+	insertDeletionTestWorkspace(t, database, "ws-dirty", worktreePath, "ready")
+
+	var mu sync.Mutex
+	var events []Event
+	handler := New(Deps{
+		DB:         database,
+		Workspaces: workspace.NewManager(database, base),
+		Broadcast: func(event Event) uint64 {
+			mu.Lock()
+			events = append(events, event)
+			mu.Unlock()
+			return 1
+		},
+	})
+	handler.Start(t.Context(), true)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(handler.Shutdown(ctx))
+	})
+
+	require.NoError(handler.QueueWorkspaceDeletion("ws-dirty"))
+	mu.Lock()
+	require.NotEmpty(events)
+	assert.Equal("workspace_status", events[0].Type)
+	mu.Unlock()
+
+	require.Eventually(func() bool {
+		got, err := database.GetWorkspace(t.Context(), "ws-dirty")
+		return err == nil && got != nil && got.Status == "deletion_failed"
+	}, 3*time.Second, 10*time.Millisecond)
+	got, err := database.GetWorkspace(t.Context(), "ws-dirty")
+	require.NoError(err)
+	require.NotNil(got)
+	require.NotNil(got.ErrorMessage)
+	assert.Contains(*got.ErrorMessage, "notes.txt")
+}
+
+func TestDeleteWorkspaceDirtyPreservesReadyStatus(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	base := t.TempDir()
+	worktreePath := filepath.Join(base, "ws-dirty")
+	require.NoError(os.MkdirAll(worktreePath, 0o755))
+	runGit(t, worktreePath, "init")
+	require.NoError(os.WriteFile(
+		filepath.Join(worktreePath, "notes.txt"), []byte("keep me\n"), 0o644,
+	))
+	insertDeletionTestWorkspace(t, database, "ws-dirty", worktreePath, "ready")
+
+	handler := New(Deps{
+		DB:         database,
+		Workspaces: workspace.NewManager(database, base),
+	})
+	_, err := handler.DeleteWorkspace(t.Context(), &DeleteWorkspaceInput{ID: "ws-dirty"})
+	problem, ok := err.(*httpapi.ProblemError)
+	require.True(ok, "want *ProblemError, got %T", err)
+	assert.Equal(http.StatusConflict, problem.Status)
+	assert.Equal(httpapi.CodeWorktreeDirty, problem.Code)
+
+	got, err := database.GetWorkspace(t.Context(), "ws-dirty")
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal("ready", got.Status)
+	assert.Nil(got.ErrorMessage)
+}
+
+func TestDeleteWorkspacePersistsFailureAfterAdmission(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	base := t.TempDir()
+	script := filepath.Join(base, "failing-tmux")
+	require.NoError(os.WriteFile(
+		script,
+		[]byte("#!/bin/sh\necho 'permission denied' >&2\nexit 1\n"),
+		0o755,
+	))
+	insertDeletionTestWorkspace(
+		t, database, "ws-failure", filepath.Join(base, "missing"), "ready",
+	)
+	manager := workspace.NewManager(database, base)
+	manager.SetTmuxCommand([]string{script})
+	var events []Event
+	handler := New(Deps{
+		DB:         database,
+		Workspaces: manager,
+		Broadcast: func(event Event) uint64 {
+			events = append(events, event)
+			return 1
+		},
+	})
+
+	_, err := handler.DeleteWorkspace(t.Context(), &DeleteWorkspaceInput{
+		ID: "ws-failure", Force: true,
+	})
+	require.Error(err)
+	assert.Contains(err.Error(), "permission denied")
+
+	got, err := database.GetWorkspace(t.Context(), "ws-failure")
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal("deletion_failed", got.Status)
+	require.NotNil(got.ErrorMessage)
+	assert.Contains(*got.ErrorMessage, "permission denied")
+	require.Len(events, 2)
+	assert.Equal("workspace_status", events[0].Type)
+	assert.Equal("workspace_status", events[1].Type)
+}
+
+func TestDeleteWorkspacePublishesConfirmedIdentity(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	base := t.TempDir()
+	insertDeletionTestWorkspace(
+		t, database, "ws-delete", filepath.Join(base, "missing"), "ready",
+	)
+	var events []Event
+	handler := New(Deps{
+		DB:         database,
+		Workspaces: workspace.NewManager(database, base),
+		Broadcast: func(event Event) uint64 {
+			events = append(events, event)
+			return 1
+		},
+	})
+
+	_, err := handler.DeleteWorkspace(t.Context(), &DeleteWorkspaceInput{
+		ID: "ws-delete", Force: true,
+	})
+	require.NoError(err)
+	got, err := database.GetWorkspace(t.Context(), "ws-delete")
+	require.NoError(err)
+	assert.Nil(got)
+
+	require.Len(events, 3)
+	assert.Equal("workspace_status", events[0].Type)
+	assert.Equal("workspace_deleted", events[1].Type)
+	deleted, ok := events[1].Data.(workspaceDeletedEventData)
+	require.True(ok)
+	assert.Equal(workspaceDeletedEventData{
+		WorkspaceID:  "ws-delete",
+		Provider:     "github",
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+		RepoPath:     "acme/widget",
+		Number:       42,
+		ItemType:     db.WorkspaceItemTypePullRequest,
+	}, deleted)
+	assert.Equal("workspace_status", events[2].Type)
+}
+
+func TestStartMarksInterruptedWorkspaceDeletionFailed(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	insertDeletionTestWorkspace(t, database, "ws-interrupted", t.TempDir(), "deleting")
+	handler := New(Deps{DB: database})
+	handler.Start(t.Context(), true)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(handler.Shutdown(ctx))
+	})
+
+	got, err := database.GetWorkspace(t.Context(), "ws-interrupted")
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal("deletion_failed", got.Status)
+	require.NotNil(got.ErrorMessage)
+	assert.Equal(interruptedWorkspaceDeletionMessage, *got.ErrorMessage)
+}
+
+func TestStartMarksInterruptedWorkspaceSetupFailed(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	insertDeletionTestWorkspace(t, database, "ws-interrupted", t.TempDir(), "creating")
+	handler := New(Deps{DB: database})
+	handler.Start(t.Context(), true)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(handler.Shutdown(ctx))
+	})
+
+	got, err := database.GetWorkspace(t.Context(), "ws-interrupted")
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal("error", got.Status)
+	require.NotNil(got.ErrorMessage)
+	assert.Equal(interruptedWorkspaceSetupMessage, *got.ErrorMessage)
+}

--- a/internal/server/workspacetest/workspace_concurrent_e2e_test.go
+++ b/internal/server/workspacetest/workspace_concurrent_e2e_test.go
@@ -185,12 +185,9 @@ exec "$@"
 
 	retryResp, err := fixture.client.HTTP.RetryWorkspaceWithResponse(ctx, ws.Id)
 	require.NoError(err)
-	require.Equal(http.StatusAccepted, retryResp.StatusCode())
-	require.Never(func() bool {
-		_, statErr := os.Lstat(ws.WorktreePath)
-		return statErr == nil
-	}, time.Second, 10*time.Millisecond,
-		"retry recreated the worktree while deletion was paused")
+	require.Equal(http.StatusConflict, retryResp.StatusCode())
+	_, err = os.Lstat(ws.WorktreePath)
+	require.NoError(err, "rejected retry must not alter the worktree")
 
 	require.NoError(os.WriteFile(release, []byte("release\n"), 0o600))
 	var result deleteResult
@@ -210,12 +207,11 @@ exec "$@"
 	assert.Equal(1, listBareWorktrees(t, fixture.bare))
 }
 
-// TestWorkspaceRetryDuringFailedDeleteReplaysSetupE2E covers a retry accepted
-// while a DELETE is in flight and the DELETE then fails. The retry has already
-// moved the row to "creating", so its queued setup must replay once deletion
-// admission reopens; dropping it would leave the workspace stuck in
-// "creating" with no worker attached.
-func TestWorkspaceRetryDuringFailedDeleteReplaysSetupE2E(t *testing.T) {
+// TestWorkspaceRetryDuringFailedDeleteIsRejectedE2E covers a retry attempted
+// while an admitted DELETE is in flight and the DELETE then fails. The retry
+// must not move the durable row back to creating or attach a setup worker to
+// resources that teardown already owns.
+func TestWorkspaceRetryDuringFailedDeleteIsRejectedE2E(t *testing.T) {
 	t.Parallel()
 	acquireWorkspaceGitSlot(t)
 
@@ -308,12 +304,9 @@ exec "$@"
 
 	retryResp, err := fixture.client.HTTP.RetryWorkspaceWithResponse(ctx, ws.Id)
 	require.NoError(err)
-	require.Equal(http.StatusAccepted, retryResp.StatusCode())
-	require.Never(func() bool {
-		_, statErr := os.Lstat(ws.WorktreePath)
-		return statErr == nil
-	}, time.Second, 10*time.Millisecond,
-		"retry recreated the worktree while deletion was in flight")
+	require.Equal(http.StatusConflict, retryResp.StatusCode())
+	_, err = os.Lstat(ws.WorktreePath)
+	require.NoError(err, "rejected retry must not alter the worktree")
 
 	require.NoError(os.WriteFile(release, []byte("release\n"), 0o600))
 	var result deleteResult
@@ -325,9 +318,11 @@ exec "$@"
 	require.NoError(result.err)
 	require.Equal(http.StatusInternalServerError, result.status)
 
-	recovered := waitForWorkspaceReady(t, ctx, fixture.client, ws.Id)
-	assert.Equal("ready", recovered.Status)
-	_, err = os.Lstat(recovered.WorktreePath)
+	stored, err := fixture.database.GetWorkspace(ctx, ws.Id)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal("deletion_failed", stored.Status)
+	_, err = os.Lstat(stored.WorktreePath)
 	require.NoError(err)
 	assert.Equal(2, listBareWorktrees(t, fixture.bare))
 }
@@ -335,8 +330,8 @@ exec "$@"
 // TestWorkspaceFailedConcurrentDeleteKeepsSetupBlockedE2E covers two DELETEs
 // racing on one workspace: one fails fast on the dirty preflight while the
 // other is still inside destructive cleanup. The failed request must not
-// reopen setup admission, so a retry accepted during the overlap cannot
-// materialize a worktree for the row the surviving DELETE removes.
+// reopen setup admission, and a retry during the overlap must remain rejected
+// until the surviving DELETE finishes.
 func TestWorkspaceFailedConcurrentDeleteKeepsSetupBlockedE2E(t *testing.T) {
 	t.Parallel()
 	acquireWorkspaceGitSlot(t)
@@ -401,8 +396,9 @@ exec "$@"
 	require.NoError(fixture.database.UpdateWorkspaceStatus(
 		ctx, ws.Id, "error", &msg,
 	))
-	// An untracked file makes the second, non-force DELETE fail its dirty
-	// preflight while the first DELETE is paused in destructive cleanup.
+	// Keep the worktree dirty while the first DELETE is paused in destructive
+	// cleanup. The second, non-force DELETE must still report the authoritative
+	// deleting lifecycle instead of offering force recovery for the dirty tree.
 	require.NoError(os.WriteFile(
 		ws.WorktreePath+"/untracked.txt", []byte("dirty\n"), 0o600,
 	))
@@ -430,20 +426,22 @@ exec "$@"
 	}, 5*time.Second, 10*time.Millisecond)
 
 	noForce := false
-	dirtyResp, err := fixture.client.HTTP.DeleteWorkspaceWithResponse(
+	conflictResp, err := fixture.client.HTTP.DeleteWorkspaceWithResponse(
 		ctx, ws.Id, &generated.DeleteWorkspaceParams{Force: &noForce},
 	)
 	require.NoError(err)
-	require.Equal(http.StatusConflict, dirtyResp.StatusCode())
+	require.Equal(http.StatusConflict, conflictResp.StatusCode())
+	require.NotNil(conflictResp.ApplicationproblemJSONDefault)
+	assert.Equal(
+		generated.WorkspaceDeletionInProgress,
+		conflictResp.ApplicationproblemJSONDefault.Code,
+	)
 
 	retryResp, err := fixture.client.HTTP.RetryWorkspaceWithResponse(ctx, ws.Id)
 	require.NoError(err)
-	require.Equal(http.StatusAccepted, retryResp.StatusCode())
-	require.Never(func() bool {
-		_, statErr := os.Lstat(ws.WorktreePath)
-		return statErr == nil
-	}, time.Second, 10*time.Millisecond,
-		"retry recreated the worktree after the failed delete unblocked setup")
+	require.Equal(http.StatusConflict, retryResp.StatusCode())
+	_, err = os.Lstat(ws.WorktreePath)
+	require.NoError(err, "rejected retry must not alter the worktree")
 
 	require.NoError(os.WriteFile(release, []byte("release\n"), 0o600))
 	var result deleteResult

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -2627,11 +2627,12 @@ func validateLocalBranchName(
 // cleanup. It exists so callers can stop background processes
 // that might still write to the worktree — e.g. agent shells
 // launched into the workspace — without that cleanup running on
-// a 409 dirty rejection. Pass nil if you have nothing to do
-// between the preflight and the destructive part.
+// a 409 dirty rejection. Returning an error stops deletion before
+// cleanup starts. Pass nil if you have nothing to do between the
+// preflight and the destructive part.
 func (m *Manager) Delete(
 	ctx context.Context, id string, force bool,
-	beforeDestructive func(context.Context),
+	beforeDestructive func(context.Context) error,
 ) (dirty []string, err error) {
 	ws, err := m.db.GetWorkspace(ctx, id)
 	if err != nil {
@@ -2656,7 +2657,9 @@ func (m *Manager) Delete(
 	}
 
 	if beforeDestructive != nil {
-		beforeDestructive(ctx)
+		if err := beforeDestructive(ctx); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := m.cleanupWorkspaceArtifactsForDelete(ctx, ws); err != nil {
@@ -3880,12 +3883,11 @@ func (m *Manager) PruneMissingTmuxSessions(ctx context.Context) (bool, error) {
 			"workspace_id", ws.ID,
 			"tmux_session", ws.TmuxSession,
 		)
-		if err := m.db.UpdateWorkspaceStatus(
-			ctx, ws.ID, "error", &msg,
-		); err != nil {
+		updated, err := m.db.MarkReadyWorkspaceError(ctx, ws.ID, msg)
+		if err != nil {
 			return changed, err
 		}
-		changed = true
+		changed = changed || updated
 	}
 	return changed, nil
 }

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -4945,6 +4945,38 @@ func TestManagerDeleteFailsWhenTmuxKillFails(t *testing.T) {
 	)
 }
 
+func TestManagerDeleteStopsBeforeTeardownWhenAdmissionFails(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	script, record := writeRecorderScript(t)
+
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMR(t, d, repoID, 42, "feature/thing")
+
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{script, "wrap"})
+
+	ctx := context.Background()
+	ws, err := mgr.Create(ctx, "github", "github.com", "acme", "widget", 42)
+	require.NoError(err)
+
+	admissionErr := errors.New("admission failed")
+	dirty, err := mgr.Delete(ctx, ws.ID, true, func(context.Context) error {
+		return admissionErr
+	})
+	assert.Nil(dirty)
+	require.ErrorIs(err, admissionErr)
+
+	got, getErr := mgr.Get(ctx, ws.ID)
+	require.NoError(getErr)
+	require.NotNil(got)
+	assert.Equal(ws.ID, got.ID)
+	_, statErr := os.Stat(record)
+	assert.ErrorIs(statErr, os.ErrNotExist)
+}
+
 func TestManagerDeleteTreatsTmuxServerExitDuringKillAsGone(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)


### PR DESCRIPTION
Deleting a workspace after merge can take much longer than the provider merge itself. The merge dialog stayed mounted throughout teardown, so live refreshes could repeatedly remove and restore it. If teardown failed, the transient warning also left no durable recovery state.

This change treats provider merge completion and workspace teardown as separate phases. Once deletion is durably admitted, the merge response closes the dialog while Workspaces shows the workspace as deleting. A failed teardown remains visible as deletion failed and offers retry or confirmed force deletion. A server restart converts interrupted deletion into the same explicit recovery state.

<details>
<summary>Validation</summary>

- Full pre-commit suite passed, including golangci-lint, frontend checks, and short Go tests.
- Focused database, workspace API, pull API, server integration, and frontend regression tests passed.
- Generated API clients and context documentation checks passed.

</details>