### PR TITLE
test: wait for terminal readiness before pane focus

### DIFF
--- a/frontend/tests/e2e-full/issue-list.spec.ts
+++ b/frontend/tests/e2e-full/issue-list.spec.ts
@@ -234,6 +234,7 @@ test.describe("issue detail pane focus", () => {
     const workspacePane = page.locator('[data-pane-key="workspace"]');
     const conversationLeaf = conversationPane.locator("xpath=ancestor::*[contains(@class, 'tabbed-panel-leaf')][1]");
     const workspaceLeaf = workspacePane.locator("xpath=ancestor::*[contains(@class, 'tabbed-panel-leaf')][1]");
+    await expect(workspaceLeaf.locator("canvas, .xterm-screen").first()).toBeVisible();
     const conversationTab = conversationLeaf.getByRole("tab", { name: "Conversation" });
     await conversationTab.focus();
     await expect(conversationTab).toBeFocused();


### PR DESCRIPTION
Firefox could intermittently lose the Conversation tab's focus because the terminal renderer finished mounting afterward and applied its queued navigation focus.

- Wait for the terminal created by the test to render before exercising explicit pane focus.
- Preserve the production soft-focus behavior while removing timing-dependent test results on loaded Firefox runners.
- Keep the change scoped to test synchronization; runtime behavior is unchanged.

<sup>generated by a clanker</sup>
