### PR TITLE
fix: prevent local hook host contention

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ DEV_CLONE_PORT ?= 8092
 DEV_CLONE_FRONTEND_PORT ?= 5175
 
 .PHONY: ensure-embed-dir ensure-tmp-dir check-air air-install build build-release install \
-        rust-pty-manager rust-test vite-plus-install frontend-deps check-vite-plus-bin frontend githubapp-frontend frontend-dev frontend-dev-bun frontend-check frontend-check-no-deps api-generate roborev-api-generate \
+        rust-pty-manager rust-test vite-plus-install frontend-deps check-vite-plus-bin frontend githubapp-frontend frontend-dev frontend-dev-bun frontend-check frontend-check-no-deps frontend-check-core-no-deps frontend-effect-diagnostics api-generate roborev-api-generate \
         docs-build docs-vercel-build docs-branding-check docs-deploy-staging docs-deploy \
         dev dev-ephemeral dev-ephemeral-stop test test-short test-integration test-e2e test-e2e-roborev test-fleet-container test-fleet-drive-container test-gitlab-container gitlab-fixture-bake vet check-mise lint lint-check nilaway testify-helper-check \
         profile-workspace-switch otel-lgtm \
@@ -157,15 +157,21 @@ frontend-dev-bun: frontend-deps
 frontend-check: frontend-deps
 	$(MAKE) frontend-check-no-deps
 
-# Same checks without the bun install prerequisite. The pre-commit hook uses
-# this target because the priority-4 frontend-deps hook already installed
-# deps; running bun install again here would mutate node_modules while other
-# priority-10 Node hooks read it.
-frontend-check-no-deps: check-vite-plus-bin
+# Same checks without the bun install prerequisite. CI and explicit local
+# checks retain the full-project Effect diagnostics.
+frontend-check-no-deps: frontend-check-core-no-deps
+	$(MAKE) frontend-effect-diagnostics
+
+# The pre-commit hook uses this core target because frontend-deps already
+# installed dependencies and full-project Effect diagnostics are retained in
+# CI instead of blocking every local commit.
+frontend-check-core-no-deps: check-vite-plus-bin
 	$(VITE_PLUS_BIN) fmt --check frontend packages/github-app-ui --no-error-on-unmatched-pattern --threads=1
 	$(VITE_PLUS_BIN) lint frontend packages/github-app-ui '!frontend/dist/**' '!packages/github-app-ui/dist/**' '!frontend/test-results/**' '!packages/github-app-ui/test-results/**' '!frontend/src/lib/api/generated/**' '!frontend/src/lib/api/roborev/generated/**' --no-error-on-unmatched-pattern --threads=1
 	cd frontend && node node_modules/@kenn-io/kit-ui/bin/kit-ui-check.mjs src
 	$(VITE_PLUS_BIN) run svelte-check
+
+frontend-effect-diagnostics: check-vite-plus-bin
 	cd frontend && node node_modules/@effect/language-service/cli.js diagnostics --project tsconfig.json --format text --severity error
 
 # Build and verify the public documentation, including generated screenshots.

--- a/cmd/e2e-server/main_test.go
+++ b/cmd/e2e-server/main_test.go
@@ -606,10 +606,11 @@ func waitForServerInfo(
 ) e2eServerInfo {
 	t.Helper()
 	r := require.New(t)
-	// 30s headroom: run() does SeedFixtures + SetupDiffRepo + stack
-	// detection before it starts listening, and `go test ./...` can
-	// run this test under parallel load.
-	deadline := time.Now().Add(30 * time.Second)
+	// run() does SeedFixtures + SetupDiffRepo + stack detection before it
+	// starts listening. Cold race-enabled startup can take over 30 seconds
+	// when packages run concurrently in CI, so leave enough headroom for
+	// resource contention while retaining a bounded readiness failure.
+	deadline := time.Now().Add(90 * time.Second)
 	for time.Now().Before(deadline) {
 		select {
 		case err := <-done:

--- a/cmd/kenn-forge/lock_e2e_test.go
+++ b/cmd/kenn-forge/lock_e2e_test.go
@@ -46,6 +46,9 @@ func buildForgeVersion(t *testing.T, runtimeVersion string) string {
 
 func buildForgeWithLDFlags(t *testing.T, ldflags string) string {
 	t.Helper()
+	if testing.Short() {
+		t.Skip("test builds and launches a real kenn-forge daemon")
+	}
 	binDir := t.TempDir()
 	binPath := filepath.Join(binDir, "kenn-forge")
 	if runtime.GOOS == "windows" {

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -6,6 +6,12 @@ fixtures, or changing shell-script coverage.
 - Pass `-shuffle=on` when invoking `go test` directly; `make test` and
   `make test-short` already include it. Do not pass redundant `-count=1`; use
   `-count=N` only when `N > 1` for repeated runs.
+- Local Go hooks must use bounded concurrency and separate heavy consumers into
+  ordered priority groups; keep the shared Go cache across worktrees (`scripts/run-hook-go.sh`, `prek.toml:53`).
+- `-short` must skip tests that build and launch real kenn-forge daemons or run
+  load-sensitive sync E2Es; those flows belong in full Go lanes (`cmd/kenn-forge/lock_e2e_test.go::buildForgeWithLDFlags`, `internal/server/e2etest/sync_cooldown_test.go::TestTriggerSyncE2EPrioritizesNonDefaultHostFilter`).
+- Pre-commit runs frontend core checks without full-project Effect diagnostics;
+  explicit frontend checks and CI retain Effect coverage (`Makefile::frontend-check-no-deps`).
 - Do not use `-v` unless the user requests it or a particular failure genuinely
   needs verbose output.
 - Prefer table-driven Go tests. Use testify `require` for preconditions and

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -47,6 +47,9 @@ Natural process exit should collapse stale runtime state quickly.
 - PTY-owner process exit may precede final output; keep subscribers alive for a
   bounded drain or loaded runners lose the last repaint
   (`internal/workspace/localruntime/manager.go::watchPtyOwner`).
+- PTY output EOF may precede process wait; give wait a bounded chance to publish
+  the real exit code without marking the owner fully exited before replay drains
+  (`internal/ptyowner/owner.go::exitCodeAfterOutputClose`).
 
 The base workspace `tmux` tab is the exception:
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -67,29 +67,31 @@ func TestNewClientEmptyHost(t *testing.T) {
 }
 
 func TestAuthenticatedViewerLoginRefreshesExpiredCache(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	var login atomic.Value
 	login.Store("alice")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/api/v3/user", r.URL.Path)
+		assert.Equal("/api/v3/user", r.URL.Path)
 		_, _ = fmt.Fprintf(w, `{"login":%q}`, login.Load().(string))
 	}))
 	defer server.Close()
 
 	client, err := NewClient(testTokenSource("token"), "github.com", nil, nil, WithBaseURLForTesting(server.URL))
-	require.NoError(t, err)
+	require.NoError(err)
 	live := client.(*liveClient)
 
 	first, err := live.AuthenticatedViewerLogin(t.Context())
-	require.NoError(t, err)
-	assert.Equal(t, "alice", first)
+	require.NoError(err)
+	assert.Equal("alice", first)
 	login.Store("bob")
 	live.viewerMu.Lock()
 	live.viewerLoginAt = time.Now().Add(-authenticatedViewerLoginTTL - time.Minute)
 	live.viewerMu.Unlock()
 
 	second, err := live.AuthenticatedViewerLogin(t.Context())
-	require.NoError(t, err)
-	assert.Equal(t, "bob", second)
+	require.NoError(err)
+	assert.Equal("bob", second)
 }
 
 func TestNativeStackClientDecodesPullHintsAndStackPages(t *testing.T) {

--- a/internal/ptyowner/owner.go
+++ b/internal/ptyowner/owner.go
@@ -23,6 +23,7 @@ const maxOutputReplay = 64 * 1024
 const (
 	maxOwnerConnections      = 32
 	ownerFirstRequestTimeout = 5 * time.Second
+	ownerExitCodeGracePeriod = 200 * time.Millisecond
 	maxOwnerFirstRequestSize = 8 * 1024
 	maxOwnerRequestSize      = 96 * 1024
 	maxOwnerInputSize        = 64 * 1024
@@ -54,6 +55,7 @@ type owner struct {
 	exitCode                int
 	exited                  bool
 	done                    chan struct{}
+	processExited           chan struct{}
 	drainDone               chan struct{}
 	stopRequested           chan struct{}
 	activeAttachmentsDone   chan struct{}
@@ -131,6 +133,7 @@ func RunOwner(ctx context.Context, opts Options) error {
 		subscribers:            make(map[chan []byte]struct{}),
 		exitCode:               -1,
 		done:                   make(chan struct{}),
+		processExited:          make(chan struct{}),
 		drainDone:              make(chan struct{}),
 		stopRequested:          make(chan struct{}),
 		activeAttachmentsDone:  make(chan struct{}),
@@ -332,7 +335,7 @@ func (o *owner) handleAttach(
 				return
 			}
 		}
-		code := o.currentExitCode()
+		code := o.exitCodeAfterOutputClose()
 		writeMu.Lock()
 		_ = enc.Encode(Response{
 			Type: ResponseExit, OK: true, ExitCode: &code,
@@ -471,12 +474,15 @@ func (o *owner) drainOutput() {
 
 func (o *owner) wait() {
 	code := waitExitCode(o.cmd.Wait())
+	o.mu.Lock()
+	o.exitCode = code
+	o.mu.Unlock()
+	close(o.processExited)
 	select {
 	case <-o.drainDone:
 	case <-time.After(500 * time.Millisecond):
 	}
 	o.mu.Lock()
-	o.exitCode = code
 	o.exited = true
 	o.activeAttachmentsAtExit = o.activeAttachments > 0
 	o.mu.Unlock()
@@ -567,6 +573,14 @@ func (o *owner) currentExitCode() int {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	return o.exitCode
+}
+
+func (o *owner) exitCodeAfterOutputClose() int {
+	select {
+	case <-o.processExited:
+	case <-time.After(ownerExitCodeGracePeriod):
+	}
+	return o.currentExitCode()
 }
 
 func resolveExecutable(name string) (string, error) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -29473,12 +29473,11 @@ func TestWorkspaceRuntimePlainShellTerminalWebSocketE2E(t *testing.T) {
 	require.Contains(got.String(), "echo:ping")
 }
 
-// TestWorkspaceRuntimePlainShellTerminalDeliversExitFrameE2E pins the
+// TestWorkspaceRuntimePlainShellTerminalDeliversActualExitCodeE2E pins the
 // websocket "exited" text frame contract through the real runtime stack. The
-// frontend's ShellDrawer only fires onExit when this frame arrives; without it
-// the drawer doesn't auto-close on shell exit and the user is stranded on a
-// dead session.
-func TestWorkspaceRuntimePlainShellTerminalDeliversExitFrameE2E(t *testing.T) {
+// helper closes its PTY shortly before exiting so this exercises the window
+// where PTY EOF can arrive before process wait publishes the exit code.
+func TestWorkspaceRuntimePlainShellTerminalDeliversActualExitCodeE2E(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test fixture uses /bin/sh")
 	}
@@ -29492,7 +29491,7 @@ func TestWorkspaceRuntimePlainShellTerminalDeliversExitFrameE2E(t *testing.T) {
 			Command: []string{filepath.Join(dir, "missing-tmux")},
 		},
 		Shell: config.Shell{
-			Command: serverRuntimeHelperCommand("pty-close-on-input-then-sleep"),
+			Command: serverRuntimeHelperCommand("pty-close-on-input-then-exit"),
 		},
 	}
 	fixture := setupWorkspaceServerFixtureWithOptions(
@@ -29505,6 +29504,11 @@ func TestWorkspaceRuntimePlainShellTerminalDeliversExitFrameE2E(t *testing.T) {
 
 	shell := launchPlainShellRuntimeSession(t, ctx, client, ws.Id)
 	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, shell.Key)
+	stored, err := fixture.database.ListWorkspaceRuntimeSessions(ctx, ws.Id)
+	require.NoError(err)
+	require.Len(stored, 1)
+	require.Equal(shell.Key, stored[0].SessionKey)
+	require.Empty(stored[0].TmuxSession)
 
 	ts := httptest.NewServer(srv)
 	t.Cleanup(ts.Close)
@@ -29514,10 +29518,9 @@ func TestWorkspaceRuntimePlainShellTerminalDeliversExitFrameE2E(t *testing.T) {
 	conn := dialWebSocketForTest(t, ctx, wsURL, "shell")
 	defer conn.Close(websocket.StatusNormalClosure, "done")
 
-	// Trigger after attach so the session cannot naturally exit before the
-	// websocket connects. The focused bridge test below covers the fast
-	// outputDone-before-Done race directly; this e2e keeps the real runtime
-	// contract pinned without depending on backend-specific PTY EOF timing.
+	// Trigger after attach so the session cannot exit before the websocket
+	// connects. The helper's short delay makes PTY EOF reliably precede process
+	// exit while remaining inside the owner's bounded exit-code grace period.
 	require.NoError(conn.Write(ctx, websocket.MessageBinary, []byte("close\n")))
 	readCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
@@ -29538,15 +29541,28 @@ func TestWorkspaceRuntimePlainShellTerminalDeliversExitFrameE2E(t *testing.T) {
 		}
 		require.NoError(json.Unmarshal(data, &msg))
 		require.Equal("exited", msg.Type)
-		// ExitCode may be 7 (cmd.Wait completed before writeRuntimeExit
-		// reads the snapshot) or -1 (writeRuntimeExit read snapshot
-		// before watchSession populated ExitCode). Both are "the
-		// session ended" signals the frontend treats identically;
-		// pinning a specific value would be timing-dependent.
-		require.NotEqual(0, msg.Code,
-			"non-success exit must report non-zero (or -1)")
-		return
+		require.Equal(7, msg.Code)
+		break
 	}
+
+	require.Eventually(func() bool {
+		runtimeResp, runtimeErr := client.HTTP.GetWorkspaceRuntimeWithResponse(
+			ctx, ws.Id,
+		)
+		if runtimeErr != nil || runtimeResp.StatusCode() != http.StatusOK ||
+			runtimeResp.JSON200 == nil {
+			return false
+		}
+		if runtimeResp.JSON200.Sessions != nil {
+			for _, session := range *runtimeResp.JSON200.Sessions {
+				if session.Key == shell.Key {
+					return false
+				}
+			}
+		}
+		rows, rowsErr := fixture.database.ListWorkspaceRuntimeSessions(ctx, ws.Id)
+		return rowsErr == nil && len(rows) == 0
+	}, 5*time.Second, 20*time.Millisecond)
 }
 
 // TestBridgeRuntimeAttachmentOutputClosedEmitsExitFrameBeforeDone pins the
@@ -30565,6 +30581,17 @@ func TestServerRuntimeHelperProcess(t *testing.T) {
 		_ = os.Stdout.Close()
 		_ = os.Stderr.Close()
 		time.Sleep(2 * time.Second)
+		os.Exit(7)
+	case "pty-close-on-input-then-exit":
+		_, err := bufio.NewReader(os.Stdin).ReadString('\n')
+		if err != nil {
+			os.Exit(2)
+		}
+		signal.Ignore(syscall.SIGHUP, syscall.SIGTERM, syscall.SIGINT)
+		_ = os.Stdin.Close()
+		_ = os.Stdout.Close()
+		_ = os.Stderr.Close()
+		time.Sleep(50 * time.Millisecond)
 		os.Exit(7)
 	default:
 		os.Exit(2)

--- a/internal/server/e2etest/sync_cooldown_test.go
+++ b/internal/server/e2etest/sync_cooldown_test.go
@@ -187,6 +187,9 @@ name = "third"
 }
 
 func TestTriggerSyncE2EPrioritizesNonDefaultHostFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("sync prioritization e2e runs in the full Go test lane")
+	}
 	require := require.New(t)
 
 	var mu sync.Mutex

--- a/internal/server/viewer_identity_test.go
+++ b/internal/server/viewer_identity_test.go
@@ -86,6 +86,7 @@ func newViewerIdentityTestServer(
 }
 
 func TestResolveAuthenticatedViewerLoginsRestrictsProviderCallsToRepoFilters(t *testing.T) {
+	assert := assert.New(t)
 	selected := &viewerIdentityProvider{
 		kind: platform.KindGitHub, host: "github.com",
 		cacheKeys: map[string]string{"acme/widget": "selected-credential"},
@@ -105,12 +106,14 @@ func TestResolveAuthenticatedViewerLoginsRestrictsProviderCallsToRepoFilters(t *
 		Platform: "github", PlatformHost: "github.com", RepoPath: "acme/widget",
 	}})
 	require.NoError(t, err)
-	assert.Equal(t, []db.RepoViewerLogin{{RepoID: repoIDs["acme/widget"], Login: "alice"}}, got)
-	assert.Equal(t, 1, selected.callCount())
-	assert.Zero(t, unrelated.callCount())
+	assert.Equal([]db.RepoViewerLogin{{RepoID: repoIDs["acme/widget"], Login: "alice"}}, got)
+	assert.Equal(1, selected.callCount())
+	assert.Zero(unrelated.callCount())
 }
 
 func TestResolveAuthenticatedViewerLoginsRefreshesExpiredCredentialCacheInBackground(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	provider := &viewerIdentityProvider{
 		kind: platform.KindGitHub, host: "github.com",
 		cacheKeys: map[string]string{
@@ -128,8 +131,8 @@ func TestResolveAuthenticatedViewerLoginsRefreshesExpiredCredentialCacheInBackgr
 	})
 
 	first, err := srv.resolveAuthenticatedViewerLogins(t.Context(), nil)
-	require.NoError(t, err)
-	require.Len(t, first, 2)
+	require.NoError(err)
+	require.Len(first, 2)
 	provider.setLogin("acme/widget", "bob")
 	provider.setLogin("acme/gadget", "bob")
 	srv.viewerLoginMu.Lock()
@@ -140,19 +143,21 @@ func TestResolveAuthenticatedViewerLoginsRefreshesExpiredCredentialCacheInBackgr
 	srv.viewerLoginMu.Unlock()
 
 	second, err := srv.resolveAuthenticatedViewerLogins(t.Context(), nil)
-	require.NoError(t, err)
-	assert.Equal(t, first, second)
-	require.Eventually(t, func() bool { return provider.callCount() == 2 }, time.Second, 10*time.Millisecond)
+	require.NoError(err)
+	assert.Equal(first, second)
+	require.Eventually(func() bool { return provider.callCount() == 2 }, time.Second, 10*time.Millisecond)
 
 	third, err := srv.resolveAuthenticatedViewerLogins(t.Context(), nil)
-	require.NoError(t, err)
-	assert.Equal(t, []db.RepoViewerLogin{
+	require.NoError(err)
+	assert.Equal([]db.RepoViewerLogin{
 		{RepoID: first[0].RepoID, Login: "bob"},
 		{RepoID: first[1].RepoID, Login: "bob"},
 	}, third)
 }
 
 func TestResolveAuthenticatedViewerLoginsDoesNotCacheFailures(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	provider := &viewerIdentityProvider{
 		kind: platform.KindGitHub, host: "github.com",
 		cacheKeys: map[string]string{"acme/widget": "credential"},
@@ -164,13 +169,13 @@ func TestResolveAuthenticatedViewerLoginsDoesNotCacheFailures(t *testing.T) {
 	}})
 
 	got, err := srv.resolveAuthenticatedViewerLogins(t.Context(), nil)
-	require.NoError(t, err)
-	assert.Empty(t, got)
+	require.NoError(err)
+	assert.Empty(got)
 	delete(provider.errs, "acme/widget")
 	got, err = srv.resolveAuthenticatedViewerLogins(t.Context(), nil)
-	require.NoError(t, err)
-	assert.Len(t, got, 1)
-	assert.Equal(t, 2, provider.callCount())
+	require.NoError(err)
+	assert.Len(got, 1)
+	assert.Equal(2, provider.callCount())
 }
 
 func TestResolveAuthenticatedViewerLoginsKeepsAvailableRepositories(t *testing.T) {
@@ -209,6 +214,8 @@ func (p *unkeyedViewerIdentityProvider) AuthenticatedUser(
 }
 
 func TestResolveAuthenticatedViewerLoginsKeepsUnkeyedGitHubReposSeparate(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	base := &viewerIdentityProvider{
 		kind: platform.KindGitHub, host: "github.com",
 		logins: map[string]string{
@@ -219,7 +226,7 @@ func TestResolveAuthenticatedViewerLoginsKeepsUnkeyedGitHubReposSeparate(t *test
 	provider := &unkeyedViewerIdentityProvider{base: base}
 	database := dbtest.Open(t)
 	registry, err := platform.NewRegistry(provider)
-	require.NoError(t, err)
+	require.NoError(err)
 	refs := []ghclient.RepoRef{
 		{Platform: platform.KindGitHub, PlatformHost: "github.com", Owner: "acme", Name: "widget", RepoPath: "acme/widget", PlatformExternalID: "repo-widget"},
 		{Platform: platform.KindGitHub, PlatformHost: "github.com", Owner: "other", Name: "tool", RepoPath: "other/tool", PlatformExternalID: "repo-tool"},
@@ -229,14 +236,14 @@ func TestResolveAuthenticatedViewerLoginsKeepsUnkeyedGitHubReposSeparate(t *test
 			Platform: ref.Platform, Host: ref.PlatformHost, Owner: ref.Owner, Name: ref.Name,
 			RepoPath: ref.RepoPath, PlatformExternalID: ref.PlatformExternalID,
 		}))
-		require.NoError(t, err)
+		require.NoError(err)
 	}
 	syncer := ghclient.NewSyncerWithRegistry(registry, database, nil, refs, time.Hour, nil, nil)
 	t.Cleanup(syncer.Stop)
 	srv := &Server{db: database, syncer: syncer}
 
 	got, err := srv.resolveAuthenticatedViewerLogins(t.Context(), nil)
-	require.NoError(t, err)
-	require.Len(t, got, 2)
-	assert.Equal(t, 2, base.callCount())
+	require.NoError(err)
+	require.Len(got, 2)
+	assert.Equal(2, base.callCount())
 }

--- a/internal/server/workspaceapi/workspace_runtime_terminal.go
+++ b/internal/server/workspaceapi/workspace_runtime_terminal.go
@@ -389,9 +389,9 @@ func bridgeRuntimeAttachment(
 		//      onExit fires. attachment.Done follows in a separate
 		//      goroutine and can lag noticeably for wrapped sessions
 		//      (systemd-run --wait collecting the transient unit),
-		//      so we do NOT gate the frame on attachment.Done —
-		//      ExitCode may be nil and writeRuntimeExit emits -1,
-		//      which the frontend treats identically.
+		//      so we do NOT gate the frame on attachment.Done. PTY-owner
+		//      sessions publish their exit code before closing subscribers;
+		//      other backends may still emit -1 when process wait lags EOF.
 		//
 		//   2. broadcast dropped this subscriber because its 64-slot
 		//      buffer filled (slow client, congested writer, etc.).

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -1940,6 +1940,17 @@ func (s *session) drainOutput() {
 				s.broadcast(chunk)
 			}
 		}
+		// The PTY-owner client records the process exit code before closing
+		// Output. Publish that code before closing runtime subscribers so an
+		// HTTP terminal bridge that observes output EOF first does not emit -1
+		// while watchPtyOwner is still waiting to update the session snapshot.
+		if exitCode := s.pty.ExitCode(); exitCode != -1 {
+			s.mu.Lock()
+			if s.info.ExitCode == nil {
+				s.info.ExitCode = &exitCode
+			}
+			s.mu.Unlock()
+		}
 		s.closeSubscribers()
 		return
 	}

--- a/prek.toml
+++ b/prek.toml
@@ -9,8 +9,8 @@ default_stages = ["pre-commit"]
 #   4   frontend-deps (bun install mutates node_modules, which every
 #       Node-based hook below reads; it must finish before they start)
 #   5   api-generate (rewrites generated Go/TS consumed by later groups)
-#   10  independent lanes: Go lint (sole Go mutator), frontend, rust, scripts
-#   20  read-only Go consumers that must see fixed and regenerated code
+#   10  independent lanes: bounded Go lint, frontend core, rust, scripts
+#   20+ bounded Go consumers, serialized to avoid multiplying host load
 
 [[repos]]
 repo = "builtin"
@@ -40,21 +40,21 @@ hooks = [
   { id = "cargo-fmt", name = "cargo fmt", language = "system", entry = "cargo fmt --all", files = "^(Cargo\\.toml|Cargo\\.lock|rust/.*\\.rs|rust/.*/Cargo\\.toml)$", pass_filenames = false, priority = 3 },
   { id = "frontend-deps", name = "install workspace dependencies", language = "system", entry = "make frontend-deps", always_run = true, pass_filenames = false, priority = 4 },
   { id = "api-generate", name = "regenerate api clients", language = "system", entry = "make api-generate", files = "^(go\\.mod|go\\.sum|cmd/kenn-forge-openapi/.*\\.go|internal/server/.*\\.go|internal/db/.*\\.go|internal/apiclient/.*|frontend/package\\.json|frontend/bun\\.lock)$", exclude = "^(internal/apiclient/generated/client\\.gen\\.go|internal/apiclient/spec/openapi\\.json)$", pass_filenames = false, priority = 5 },
-  { id = "golangci-lint", name = "golangci-lint --fix", language = "system", entry = "make lint", files = "^(go\\.mod|go\\.sum|.*\\.go)$", pass_filenames = false, priority = 10 },
-  { id = "golangci-lint-check", name = "golangci-lint check", language = "system", entry = "make lint-check", stages = [
+  { id = "golangci-lint", name = "golangci-lint --fix", language = "system", entry = "./scripts/run-hook-go.sh make lint", files = "^(go\\.mod|go\\.sum|.*\\.go)$", pass_filenames = false, priority = 10 },
+  { id = "golangci-lint-check", name = "golangci-lint check", language = "system", entry = "./scripts/run-hook-go.sh make lint-check", stages = [
     "pre-push",
   ], always_run = true, pass_filenames = false, priority = 10 },
-  { id = "frontend-check", name = "vite-plus frontend check", language = "system", entry = "make frontend-check-no-deps", files = "^(vite\\.config\\.ts|package\\.json|bun\\.lock|frontend/((src|tests)/.*\\.(svelte|ts)|package\\.json|tsconfig\\.json|vite\\.config\\.ts|playwright(-e2e)?\\.config\\.ts)|packages/(ui|github-app-ui)/(src/.*\\.(svelte|ts)|package\\.json|tsconfig\\.json))$", pass_filenames = false, priority = 10 },
+  { id = "frontend-check", name = "vite-plus frontend core check", language = "system", entry = "make frontend-check-core-no-deps", files = "^(vite\\.config\\.ts|package\\.json|bun\\.lock|frontend/((src|tests)/.*\\.(svelte|ts)|package\\.json|tsconfig\\.json|vite\\.config\\.ts|playwright(-e2e)?\\.config\\.ts)|packages/(ui|github-app-ui)/(src/.*\\.(svelte|ts)|package\\.json|tsconfig\\.json))$", pass_filenames = false, priority = 10 },
   { id = "cargo-clippy", name = "cargo clippy", language = "system", entry = "cargo clippy --workspace --all-targets -- -D warnings", files = "^(Cargo\\.toml|Cargo\\.lock|rust/.*\\.(rs|toml)|rust/.*/Cargo\\.toml)$", pass_filenames = false, priority = 10 },
   { id = "frontend-api-client-check", name = "prevent manual frontend /api/v1 calls", language = "system", entry = "make frontend-api-client-check", files = "^(scripts/lint-api-urls\\.(mjs|test\\.mjs)|frontend/src/.*\\.(svelte|ts|js|tsx|jsx))$", pass_filenames = false, priority = 10 },
   { id = "font-size-token-check", name = "enforce font-size design tokens", language = "system", entry = "make font-size-token-check", files = "^(scripts/check-font-size-tokens\\.(ts|test\\.ts)|frontend/src/.*\\.(svelte|css|ts))$", pass_filenames = false, priority = 10 },
   { id = "script-tests", name = "script regression tests", language = "system", entry = "make script-tests", files = "^(scripts/.*\\.(mjs|ts|sh|py)|frontend/scripts/.*\\.ts|docs/screenshots/.*\\.(md|ts)|package\\.json|bun\\.lock)$", pass_filenames = false, priority = 10 },
   { id = "playwright-version-check", name = "browser CI image matches pinned toolchain", language = "system", entry = "make playwright-version-check", files = "^(scripts/check-playwright-version\\.mjs|\\.github/docker/playwright/Dockerfile|\\.github/workflows/ci\\.yml|package\\.json|frontend/package\\.json|packages/github-app-ui/package\\.json)$", pass_filenames = false, priority = 10 },
-  { id = "go-test-short", name = "go test (short)", language = "system", entry = "make test-short-precommit", files = "^(go\\.mod|go\\.sum|.*\\.go)$", pass_filenames = false, priority = 20 },
-  { id = "testify-helper-check", name = "testify helper check", language = "system", entry = "make testify-helper-check", files = "^(go\\.mod|go\\.sum|.*\\.go)$", pass_filenames = false, priority = 20 },
-  { id = "huma-route-check", name = "prevent non-Huma Go routes", language = "system", entry = "make huma-route-check", files = "^(tools/nohttpmux/.*\\.go|cmd/.*\\.go|internal/.*\\.go|kenn-forge\\.go)$", pass_filenames = false, priority = 20 },
-  { id = "migration-history-check", name = "enforce immutable history and one migration per PR", language = "system", entry = "go run ./tools/migrationhistorycheck", files = "^internal/db/migrations/.*$", pass_filenames = false, priority = 20 },
-  { id = "nilaway", name = "nilaway", language = "system", entry = "make nilaway", stages = [
+  { id = "go-test-short", name = "go test (short)", language = "system", entry = "./scripts/run-hook-go.sh make test-short-precommit", files = "^(go\\.mod|go\\.sum|.*\\.go)$", pass_filenames = false, priority = 20 },
+  { id = "testify-helper-check", name = "testify helper check", language = "system", entry = "./scripts/run-hook-go.sh make testify-helper-check", files = "^(go\\.mod|go\\.sum|.*\\.go)$", pass_filenames = false, priority = 21 },
+  { id = "huma-route-check", name = "prevent non-Huma Go routes", language = "system", entry = "./scripts/run-hook-go.sh make huma-route-check", files = "^(tools/nohttpmux/.*\\.go|cmd/.*\\.go|internal/.*\\.go|kenn-forge\\.go)$", pass_filenames = false, priority = 22 },
+  { id = "migration-history-check", name = "enforce immutable history and one migration per PR", language = "system", entry = "./scripts/run-hook-go.sh make migration-history-check", files = "^internal/db/migrations/.*$", pass_filenames = false, priority = 23 },
+  { id = "nilaway", name = "nilaway", language = "system", entry = "./scripts/run-hook-go.sh make nilaway", stages = [
     "pre-push",
   ], types_or = [
     "go",

--- a/scripts/dev-clone-db.test.mjs
+++ b/scripts/dev-clone-db.test.mjs
@@ -38,8 +38,8 @@ test("dev-clone-db copies source database and rewrites cloned config", async () 
 
   const { stdout } = await execFileAsync("bash", ["scripts/dev-clone-db.sh"], {
     env: {
-      ...process.env,
       HOME: home,
+      PATH: ["/usr/local/bin", "/opt/homebrew/bin", "/usr/bin", "/bin"].join(path.delimiter),
       KENN_FORGE_CONFIG: "",
       KENN_FORGE_DEV_CLONE_DIR: resolvedCloneDir,
       KENN_FORGE_DEV_CLONE_PORT: "8123",

--- a/scripts/run-hook-go.sh
+++ b/scripts/run-hook-go.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+hook_concurrency=${KENN_FORGE_HOOK_GO_CONCURRENCY:-4}
+case "$hook_concurrency" in
+  ''|*[!0-9]*|0)
+    echo "KENN_FORGE_HOOK_GO_CONCURRENCY must be a positive integer" >&2
+    exit 2
+    ;;
+esac
+
+export GOMAXPROCS=${GOMAXPROCS:-$hook_concurrency}
+export GO_TEST_P=${GO_TEST_P:-$hook_concurrency}
+
+exec "$@"

--- a/scripts/run-hook-go.test.mjs
+++ b/scripts/run-hook-go.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const script = fileURLToPath(new URL("./run-hook-go.sh", import.meta.url));
+
+function run(env = {}) {
+  return spawnSync(script, ["sh", "-c", "printf '%s|%s' \"$GOMAXPROCS\" \"$GO_TEST_P\""], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GOMAXPROCS: "",
+      GO_TEST_P: "",
+      KENN_FORGE_HOOK_GO_CONCURRENCY: "",
+      ...env,
+    },
+  });
+}
+
+function assertSucceeded(result) {
+  assert.equal(result.status, 0, result.error?.message ?? result.stderr ?? "hook runner failed");
+}
+
+test("Go hooks default to four-way concurrency", () => {
+  const result = run();
+
+  assertSucceeded(result);
+  assert.equal(result.stdout, "4|4");
+});
+
+test("Go hook concurrency is configurable", () => {
+  const result = run({ KENN_FORGE_HOOK_GO_CONCURRENCY: "2" });
+
+  assertSucceeded(result);
+  assert.equal(result.stdout, "2|2");
+});
+
+test("Go hooks preserve explicit tool-specific limits", () => {
+  const result = run({
+    GOMAXPROCS: "3",
+    GO_TEST_P: "5",
+    KENN_FORGE_HOOK_GO_CONCURRENCY: "2",
+  });
+
+  assertSucceeded(result);
+  assert.equal(result.stdout, "3|5");
+});


### PR DESCRIPTION
## Summary

Parallel Forge worktrees could each launch several uncapped Go consumers while every frontend commit also ran the full-project Effect diagnostic. Under load, process and test cleanup was starved long enough to look deadlocked and to destabilize timing-sensitive tests.

Local hooks now cap Go concurrency at four workers by default and serialize heavyweight Go consumers within each worktree. The full Effect diagnostic remains part of explicit frontend checks and CI, but no longer runs on every commit. Real daemon lifecycle and load-sensitive sync tests likewise remain in the full suite instead of the short commit lane.

Worktrees stay independent and continue sharing the normal Go cache. The cap can be overridden when a developer intentionally wants a different local budget.

Regression coverage now executes the hook wrapper and verifies the child process environment. Tests that only mirrored hook configuration entries, priorities, or a boolean inversion have been removed.

The same contention exposed a PTY race where output could close just before process wait published the real exit code. The PTY owner now waits briefly for that result, and the local runtime records it before closing output subscribers.

A deterministic SQLite-backed HTTP/WebSocket end-to-end test launches a helper that closes its PTY shortly before exiting nonzero. It requires the exact exit code from the runtime terminal API and verifies the runtime session is removed from both the API and persisted SQLite state.

Race-enabled end-to-end startup retains a bounded readiness wait, increased from 30 to 90 seconds so cold and loaded CI runners do not fail before the server has started.
