### PR TITLE
test: make repository visibility cleanup deterministic

### DIFF
--- a/context/testing.md
+++ b/context/testing.md
@@ -9,6 +9,11 @@ Test server constructors that create a Workspace manager must apply their
 isolated test tmux command; they must never fall back to the host tmux server
 (`internal/server/kata/test_helpers_test.go::newKataTestServer`).
 
+Persistent-config server fixtures start the real config watcher. When a request
+saves config, provider fakes must resolve the post-save repository set and tests
+must await the config event before asserting converged state
+(`internal/server/settings_test.go::setupTestServerWithConfigContent`).
+
 ## Live GraphQL validation
 
 GraphQL query shape changes must be validated against GitHub's live GraphQL API before they are merged. The local test suite includes a gated live test:

--- a/internal/server/settings_visibility_test.go
+++ b/internal/server/settings_visibility_test.go
@@ -271,7 +271,21 @@ name = "widget"
 [[repos]]
 owner = "acme"
 name = "wid*"
-`, &mockGH{})
+`, &mockGH{
+		listReposByOwnerFn: func(
+			_ context.Context, owner string,
+		) ([]*gh.Repository, error) {
+			return []*gh.Repository{{
+				NodeID:   new("R_widget"),
+				Name:     new("widget"),
+				Owner:    &gh.User{Login: new(owner)},
+				Archived: new(false),
+			}}, nil
+		},
+	})
+	waitForConfigWatcher(t, srv, 2*time.Second)
+	stream := streamConfigEvents(t, srv)
+	defer stream.Close()
 
 	seedVerifiedRepo(t, database, db.RepoIdentity{
 		Platform:       "github",
@@ -302,6 +316,8 @@ name = "wid*"
 		"/api/v1/repo/github/acme/widget", nil,
 	)
 	require.Equal(http.StatusNoContent, rr.Code, rr.Body.String())
+	event := waitForConfigEvent(t, stream, 2*time.Second)
+	require.True(event.Valid, event.Error)
 
 	hidden, err := database.HiddenRepos(t.Context())
 	require.NoError(err)


### PR DESCRIPTION
- Make the repository-visibility DELETE test wait for its config-watcher reload before asserting the catalog.
- Return the glob-matched repository from the provider fixture so direct deletion and asynchronous reload converge on the same state.
- Record the persistent-config watcher constraint for future server tests.
