### PR TITLE
fix(archive): complete scans for disabled repository features

### DIFF
--- a/context/retries-and-backoffs.md
+++ b/context/retries-and-backoffs.md
@@ -91,14 +91,10 @@ Recording a disabled result must preserve any earlier same-scope item failure so
 and ETag invalidation state survives the cooldown. (`internal/github/sync.go::indexSyncRepo`)
 Apply the gate before shared budget exhaustion so suppressed work cannot starve
 unaffected scopes. (`internal/github/sync.go::drainDetailQueue`)
-Archive inventory, maintenance, and hydration share this in-memory gate; pre-provider
-deferral skips only that repo/type so unaffected streams and later same-host repositories
-remain eligible. (`internal/archive/scheduler.go::runProviderHostWork`)
-Feature deferral preserves scan cursors and pending lookup state and is never persisted as
-provider-budget or item-retry state. (`internal/github/sync.go::Admit`)
-Hydration excludes the cooled repository feature only while selecting work in the current
-pass, so unaffected due items remain eligible and restart or manual recovery can resume
-immediately. (`internal/archive/scheduler.go::runNextHydrationWork`)
+Archive inventory and maintenance bypass cached feature cooldowns and commit empty streams only
+after a live disabled response; a live recovery reopens an unsupported historical stream only when
+the provider declares that inventory capability, while hydration keeps honoring the cooldown.
+(`internal/github/sync.go::Admit`, `internal/archive/`)
 
 ## Shared clone slot: `Manager.EnsureClone`
 

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -44,6 +44,6 @@ fixtures, or changing shell-script coverage.
   must seed now-relative instants, not absolute calendar dates — pinned dates
   age out and the test starts failing on a later calendar day
   (`internal/server/e2etest/notifications_test.go::TestNotificationSyncReconcilesReusedRouteE2E`).
-- Build boundary-size Git histories through one fast-import stream, not a
-  subprocess per add/commit; parallel packages share process capacity
-  (`internal/testutil/gitfixture/history.go::AppendFileCommits`).
+- Build boundary-size Git histories through one fast-import stream, and disable
+  auto-maintenance on every fixture command; detached commit-graph writes can
+  race local clone hardlinks. (`internal/server/repobrowserapi/handler_test.go::serverRepoBrowserGit`)

--- a/internal/archive/inventory.go
+++ b/internal/archive/inventory.go
@@ -30,7 +30,8 @@ func (s *Service) inventoryPage(ctx context.Context, repo resolvedRepository, st
 		commit.Coverage = db.ArchiveCoverageUnsupported
 	} else {
 		requestCtx, complete, err := s.admit(
-			ctx, repo, itemType, archiveFeatureReadAttemptCost(repo.Ref.Platform),
+			withInventoryProbe(ctx), repo, itemType,
+			archiveFeatureReadAttemptCost(repo.Ref.Platform),
 		)
 		if err != nil {
 			if errors.Is(err, errAdmissionDeferred) {

--- a/internal/archive/maintenance.go
+++ b/internal/archive/maintenance.go
@@ -169,13 +169,8 @@ func (s *Service) promptPages(
 			complete(invalidErr, false)
 			return invalidErr
 		}
-		if featureAvailable && archiveInventorySupported(repo, itemType) {
-			if err := s.db.ReconcileArchiveInventoryAvailable(
-				ctx, repo.ID, itemType, s.now(),
-			); err != nil {
-				return err
-			}
-		}
+		commit.InventoryAvailable = featureAvailable &&
+			archiveInventorySupported(repo, itemType)
 		halted, err := s.commitInventoryPage(ctx, commit)
 		if err != nil {
 			return err

--- a/internal/archive/maintenance.go
+++ b/internal/archive/maintenance.go
@@ -90,8 +90,15 @@ func (s *Service) promptPages(
 	}
 	cursor := scan.Cursor()
 	for {
+		commit := db.ArchiveInventoryCommit{
+			RepoID: repo.ID, ItemType: itemType,
+			RefreshReason:  db.ArchiveRefreshReasonPrompt,
+			ScanGeneration: scan.Generation, InputCursor: cursor,
+			Now: s.now(),
+		}
 		requestCtx, complete, err := s.admit(
-			ctx, repo, itemType, archiveFeatureReadAttemptCost(repo.Ref.Platform),
+			withInventoryProbe(ctx), repo, itemType,
+			archiveFeatureReadAttemptCost(repo.Ref.Platform),
 		)
 		if err != nil {
 			if errors.Is(err, errAdmissionDeferred) {
@@ -103,12 +110,7 @@ func (s *Service) promptPages(
 			Order:        platform.ItemOrderUpdated,
 			UpdatedSince: &since, Cursor: cursor,
 		}
-		commit := db.ArchiveInventoryCommit{
-			RepoID: repo.ID, ItemType: itemType,
-			RefreshReason:  db.ArchiveRefreshReasonPrompt,
-			ScanGeneration: scan.Generation, InputCursor: cursor,
-			Now: s.now(),
-		}
+		featureAvailable := false
 		switch itemType {
 		case db.ArchiveItemTypeIssue:
 			page, err := repo.Issues.ListIssuesPage(requestCtx, repo.Ref, query)
@@ -130,6 +132,7 @@ func (s *Service) promptPages(
 					"list updated issues for %s: %w", archiveRepoIdentityKey(repo.Ref), err,
 				))
 			}
+			featureAvailable = true
 			commit.NextCursor, commit.Exhausted = page.NextCursor, page.Exhausted
 			commit.Items = make([]db.ArchiveInventoryItem, 0, len(page.Items))
 			for _, item := range page.Items {
@@ -155,6 +158,7 @@ func (s *Service) promptPages(
 					"list updated merge requests for %s: %w", archiveRepoIdentityKey(repo.Ref), err,
 				))
 			}
+			featureAvailable = true
 			commit.NextCursor, commit.Exhausted = page.NextCursor, page.Exhausted
 			commit.Items = make([]db.ArchiveInventoryItem, 0, len(page.Items))
 			for _, item := range page.Items {
@@ -164,6 +168,13 @@ func (s *Service) promptPages(
 			invalidErr := fmt.Errorf("archive maintenance: invalid item type %q", itemType)
 			complete(invalidErr, false)
 			return invalidErr
+		}
+		if featureAvailable && archiveInventorySupported(repo, itemType) {
+			if err := s.db.ReconcileArchiveInventoryAvailable(
+				ctx, repo.ID, itemType, s.now(),
+			); err != nil {
+				return err
+			}
 		}
 		halted, err := s.commitInventoryPage(ctx, commit)
 		if err != nil {

--- a/internal/archive/maintenance_test.go
+++ b/internal/archive/maintenance_test.go
@@ -190,6 +190,57 @@ func TestPromptMaintenanceCompletesDisabledRepositoryFeature(t *testing.T) {
 	assert.Equal(db.ArchiveCoverageSupported, states[0].IssuesCoverage)
 }
 
+func TestPromptMaintenancePauseRejectsInFlightAvailabilityReconciliation(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	ref := archiveServiceRef(platform.KindGitHub, "github.test", "repo")
+	repoID := archiveServiceSeedRepo(t, database, ref)
+	provider := newArchiveServiceProvider(ref.Platform, ref.Host)
+	provider.issueInventoryErr = platform.RepositoryFeatureDisabled(
+		ref.Platform, ref.Host, platform.RepositoryFeatureIssues,
+		errors.New("issues disabled"),
+	)
+	service := archiveMaintenanceService(t, database, provider, ref, now)
+	for range 8 {
+		require.NoError(service.RunEligible(t.Context()))
+	}
+
+	before, err := database.ListArchiveRepoStates(t.Context(), []int64{repoID})
+	require.NoError(err)
+	require.Len(before, 1)
+	require.NotNil(before[0].InitialCompletedAt)
+	assert.True(before[0].IssueInventory.Complete())
+	assert.Equal(db.ArchiveCoverageUnsupported, before[0].IssuesCoverage)
+
+	provider.issueInventoryErr = nil
+	provider.updatedIssueStarted = make(chan struct{})
+	provider.updatedIssueRelease = make(chan struct{})
+	maintenanceAt := now.Add(time.Hour)
+	service.clock = fixedClock{value: maintenanceAt}
+	service.SetMaintenanceInterval(time.Minute)
+
+	runDone := make(chan error, 1)
+	go func() { runDone <- service.RunEligible(t.Context()) }()
+	<-provider.updatedIssueStarted
+	paused, err := service.Pause(t.Context(), []platform.RepoRef{ref})
+	require.NoError(err)
+	require.Len(paused, 1)
+	assert.Equal(db.ArchiveStatusPaused, paused[0].Progress.Status)
+	close(provider.updatedIssueRelease)
+	require.NoError(<-runDone)
+
+	after, err := database.ListArchiveRepoStates(t.Context(), []int64{repoID})
+	require.NoError(err)
+	require.Len(after, 1)
+	assert.Equal(db.ArchiveCoverageUnsupported, after[0].IssuesCoverage)
+	assert.True(after[0].IssueInventory.Complete())
+	assert.Equal(before[0].IssueInventory.Generation, after[0].IssueInventory.Generation)
+	assert.Equal(before[0].InitialCompletedAt, after[0].InitialCompletedAt)
+	assert.False(after[0].MaintenanceIssues.Complete())
+}
+
 func archiveMaintenanceService(
 	t *testing.T,
 	database *db.DB,

--- a/internal/archive/service.go
+++ b/internal/archive/service.go
@@ -50,6 +50,23 @@ type FeatureDeferral struct {
 	Detail  string
 }
 
+type inventoryProbeContextKey struct{}
+
+// withInventoryProbe marks enumeration reads that must verify current provider
+// state instead of consuming a cached repository-feature cooldown. Hydration
+// deliberately does not carry this marker.
+func withInventoryProbe(ctx context.Context) context.Context {
+	return context.WithValue(ctx, inventoryProbeContextKey{}, true)
+}
+
+// InventoryProbeRequested reports whether archive enumeration needs a live
+// feature probe. Admission implementations use this to bypass cached feature
+// cooldowns without weakening hydration suppression.
+func InventoryProbeRequested(ctx context.Context) bool {
+	requested, _ := ctx.Value(inventoryProbeContextKey{}).(bool)
+	return requested
+}
+
 type Admission interface {
 	Admit(context.Context, platform.RepoRef, db.ArchiveItemType, int) (AdmissionResult, error)
 }

--- a/internal/archive/service_test.go
+++ b/internal/archive/service_test.go
@@ -673,6 +673,55 @@ func TestArchiveDiscoverySkipsUnsupportedInventoryStream(t *testing.T) {
 	assert.Equal([]string{"issues"}, provider.calls)
 }
 
+func TestArchiveMaintenanceDoesNotReopenStaticallyUnsupportedInventoryStream(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	ref := archiveServiceRef(platform.KindGitLab, "gitlab.test", "repo")
+	repoID := archiveServiceSeedRepo(t, database, ref)
+	provider := newArchiveServiceProvider(ref.Platform, ref.Host)
+	provider.caps.Archive.HistoricalMergeRequests = false
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, nil, now)
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
+	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
+	require.NoError(err)
+
+	require.NoError(service.RunEligible(t.Context()))
+	require.NoError(service.RunEligible(t.Context()))
+	initialStartedAt := now.Add(-2 * time.Hour)
+	_, err = database.WriteDB().ExecContext(t.Context(), `
+		UPDATE forge_archive_repos
+		SET initial_started_at = ?, initial_completed_at = ?,
+			maintenance_watermark = NULL, maintenance_succeeded_at = NULL
+		WHERE repo_id = ?`, initialStartedAt, now, repoID)
+	require.NoError(err)
+	states, err := database.ListArchiveRepoStates(t.Context(), []int64{repoID})
+	require.NoError(err)
+	require.Len(states, 1)
+	require.NotNil(states[0].InitialCompletedAt)
+	assert.True(states[0].MergeRequestInventory.Complete())
+	assert.Equal(db.ArchiveCoverageUnsupported, states[0].MergeRequestsCoverage)
+	unsupportedGeneration := states[0].MergeRequestInventory.Generation
+
+	service.clock = fixedClock{value: now.Add(5 * time.Minute)}
+	resolved, err := service.resolveRepositories(t.Context(), []platform.RepoRef{ref}, true)
+	require.NoError(err)
+	require.Len(resolved, 1)
+	require.NoError(service.promptMaintenance(t.Context(), resolved[0], states[0]))
+
+	states, err = database.ListArchiveRepoStates(t.Context(), []int64{repoID})
+	require.NoError(err)
+	require.Len(states, 1)
+	assert.Contains(provider.calls, "updated_mrs:", "maintenance must still read updated merge requests")
+	assert.Equal(unsupportedGeneration, states[0].MergeRequestInventory.Generation)
+	assert.True(states[0].MergeRequestInventory.Complete())
+	assert.Equal(db.ArchiveCoverageUnsupported, states[0].MergeRequestsCoverage)
+	assert.NotNil(states[0].InitialCompletedAt)
+}
+
 func TestArchiveInventoryReopensRepositoryFeatureAfterReenable(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/archive/service_test.go
+++ b/internal/archive/service_test.go
@@ -1004,6 +1004,8 @@ type archiveServiceProvider struct {
 	issueInventoryRelease chan struct{}
 	updatedIssuePages     map[string]platform.Page[platform.Issue]
 	updatedIssueErrors    map[string]error
+	updatedIssueStarted   chan struct{}
+	updatedIssueRelease   chan struct{}
 	updatedMRPages        map[string]platform.Page[platform.MergeRequest]
 	updatedMRErrors       map[string]error
 	updatedIssueSince     []time.Time
@@ -1035,6 +1037,18 @@ func (p *archiveServiceProvider) ListIssuesPage(ctx context.Context, ref platfor
 	if query.UpdatedSince != nil {
 		p.record("updated_issues:" + query.Cursor)
 		p.updatedIssueSince = append(p.updatedIssueSince, *query.UpdatedSince)
+		if p.updatedIssueStarted != nil {
+			select {
+			case <-p.updatedIssueStarted:
+			default:
+				close(p.updatedIssueStarted)
+			}
+			select {
+			case <-p.updatedIssueRelease:
+			case <-ctx.Done():
+				return platform.Page[platform.Issue]{}, ctx.Err()
+			}
+		}
 		if err := p.updatedIssueErrors[query.Cursor]; err != nil {
 			return platform.Page[platform.Issue]{}, err
 		}

--- a/internal/db/queries_archive.go
+++ b/internal/db/queries_archive.go
@@ -198,6 +198,40 @@ func (d *DB) PauseArchives(ctx context.Context, repoIDs []int64, now time.Time) 
 	})
 }
 
+// ReconcileArchiveInventoryAvailable reopens historical inventory after a
+// live maintenance read proves that a previously unsupported provider stream
+// is available. The active prompt boundary stays in place so the successful
+// maintenance response and the historical replay cover both sides of the
+// feature transition.
+func (d *DB) ReconcileArchiveInventoryAvailable(
+	ctx context.Context,
+	repoID int64,
+	itemType ArchiveItemType,
+	now time.Time,
+) error {
+	if repoID <= 0 {
+		return errors.New("reconcile archive inventory availability: repository is required")
+	}
+	if itemType != ArchiveItemTypeIssue && itemType != ArchiveItemTypeMergeRequest {
+		return fmt.Errorf(
+			"reconcile archive inventory availability: invalid item type %q",
+			itemType,
+		)
+	}
+	now = now.UTC()
+	return d.Tx(ctx, func(tx *sql.Tx) error {
+		if err := requireArchiveRepoIDs(
+			ctx, tx, "forge_archive_repos", []int64{repoID},
+		); err != nil {
+			return err
+		}
+		_, err := reconcileArchiveInventoryAvailableTx(
+			ctx, tx, repoID, itemType, now,
+		)
+		return err
+	})
+}
+
 // ReconcileArchiveCoverage records current provider capabilities and reopens
 // inventory that can now replace a previously unsupported result.
 func (d *DB) ReconcileArchiveCoverage(ctx context.Context, repoID int64, coverage ArchiveCoverageSet, now time.Time) error {
@@ -219,54 +253,19 @@ func (d *DB) ReconcileArchiveCoverage(ctx context.Context, repoID int64, coverag
 			return err
 		}
 		for _, inventory := range []struct {
-			desired ArchiveCoverage
-			scan    ArchiveScanKind
-			column  string
+			desired  ArchiveCoverage
+			itemType ArchiveItemType
 		}{
-			{desired: coverage.Issues, scan: ArchiveScanIssueInventory, column: "issues_coverage"},
-			{desired: coverage.MergeRequests, scan: ArchiveScanMergeRequestInventory, column: "merge_requests_coverage"},
+			{desired: coverage.Issues, itemType: ArchiveItemTypeIssue},
+			{desired: coverage.MergeRequests, itemType: ArchiveItemTypeMergeRequest},
 		} {
 			if inventory.desired != ArchiveCoverageSupported {
 				continue
 			}
-			result, err := tx.ExecContext(ctx, `
-				UPDATE forge_archive_repo_scans
-				SET scan_generation = `+nextEvenScanGenerationSQL+`,
-					next_cursor = NULL, last_input_cursor = NULL,
-					page_count = 0, status = 'pending',
-					last_error_code = NULL, last_error_detail = NULL,
-					updated_at = ?
-				WHERE repo_id = ? AND scan = ? AND status = 'complete'
-				  AND EXISTS (
-					SELECT 1 FROM forge_archive_repos
-					WHERE repo_id = ? AND `+inventory.column+` = 'unsupported'
-				  )`, now, repoID, inventory.scan, repoID)
-			if err != nil {
-				return fmt.Errorf("reopen %s archive inventory: %w", inventory.scan, err)
-			}
-			reopened, err := result.RowsAffected()
-			if err != nil {
-				return fmt.Errorf("reopen %s archive inventory rows affected: %w", inventory.scan, err)
-			}
-			if reopened == 0 {
-				continue
-			}
-			itemType := ArchiveItemTypeIssue
-			if inventory.scan == ArchiveScanMergeRequestInventory {
-				itemType = ArchiveItemTypeMergeRequest
-			}
-			if err := requeueArchiveKnownItemLookupsTx(
-				ctx, tx, repoID, itemType, now,
+			if _, err := reconcileArchiveInventoryAvailableTx(
+				ctx, tx, repoID, inventory.itemType, now,
 			); err != nil {
 				return err
-			}
-			if _, err := tx.ExecContext(ctx, `
-				UPDATE forge_archive_repos
-				SET `+inventory.column+` = 'unknown',
-					initial_completed_at = NULL,
-					updated_at = MAX(updated_at, ?)
-				WHERE repo_id = ?`, now, repoID); err != nil {
-				return fmt.Errorf("reset %s archive coverage: %w", inventory.scan, err)
 			}
 		}
 		_, err := tx.ExecContext(ctx, `
@@ -295,6 +294,56 @@ func (d *DB) ReconcileArchiveCoverage(ctx context.Context, repoID int64, coverag
 		}
 		return nil
 	})
+}
+
+func reconcileArchiveInventoryAvailableTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	repoID int64,
+	itemType ArchiveItemType,
+	now time.Time,
+) (bool, error) {
+	scan := ArchiveScanIssueInventory
+	column := "issues_coverage"
+	if itemType == ArchiveItemTypeMergeRequest {
+		scan = ArchiveScanMergeRequestInventory
+		column = "merge_requests_coverage"
+	}
+	result, err := tx.ExecContext(ctx, `
+		UPDATE forge_archive_repo_scans
+		SET scan_generation = `+nextEvenScanGenerationSQL+`,
+			next_cursor = NULL, last_input_cursor = NULL,
+			page_count = 0, status = 'pending',
+			last_error_code = NULL, last_error_detail = NULL,
+			updated_at = ?
+		WHERE repo_id = ? AND scan = ? AND status = 'complete'
+		  AND EXISTS (
+			SELECT 1 FROM forge_archive_repos
+			WHERE repo_id = ? AND `+column+` = 'unsupported'
+		  )`, now, repoID, scan, repoID)
+	if err != nil {
+		return false, fmt.Errorf("reopen %s archive inventory: %w", scan, err)
+	}
+	reopened, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("reopen %s archive inventory rows affected: %w", scan, err)
+	}
+	if reopened == 0 {
+		return false, nil
+	}
+	if err := requeueArchiveKnownItemLookupsTx(
+		ctx, tx, repoID, itemType, now,
+	); err != nil {
+		return false, err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE forge_archive_repos
+		SET `+column+` = 'unknown', initial_completed_at = NULL,
+			updated_at = MAX(updated_at, ?)
+		WHERE repo_id = ?`, now, repoID); err != nil {
+		return false, fmt.Errorf("reset %s archive coverage: %w", scan, err)
+	}
+	return true, nil
 }
 
 func requeueArchiveKnownItemLookupsTx(

--- a/internal/db/queries_archive.go
+++ b/internal/db/queries_archive.go
@@ -198,40 +198,6 @@ func (d *DB) PauseArchives(ctx context.Context, repoIDs []int64, now time.Time) 
 	})
 }
 
-// ReconcileArchiveInventoryAvailable reopens historical inventory after a
-// live maintenance read proves that a previously unsupported provider stream
-// is available. The active prompt boundary stays in place so the successful
-// maintenance response and the historical replay cover both sides of the
-// feature transition.
-func (d *DB) ReconcileArchiveInventoryAvailable(
-	ctx context.Context,
-	repoID int64,
-	itemType ArchiveItemType,
-	now time.Time,
-) error {
-	if repoID <= 0 {
-		return errors.New("reconcile archive inventory availability: repository is required")
-	}
-	if itemType != ArchiveItemTypeIssue && itemType != ArchiveItemTypeMergeRequest {
-		return fmt.Errorf(
-			"reconcile archive inventory availability: invalid item type %q",
-			itemType,
-		)
-	}
-	now = now.UTC()
-	return d.Tx(ctx, func(tx *sql.Tx) error {
-		if err := requireArchiveRepoIDs(
-			ctx, tx, "forge_archive_repos", []int64{repoID},
-		); err != nil {
-			return err
-		}
-		_, err := reconcileArchiveInventoryAvailableTx(
-			ctx, tx, repoID, itemType, now,
-		)
-		return err
-	})
-}
-
 // ReconcileArchiveCoverage records current provider capabilities and reopens
 // inventory that can now replace a previously unsupported result.
 func (d *DB) ReconcileArchiveCoverage(ctx context.Context, repoID int64, coverage ArchiveCoverageSet, now time.Time) error {
@@ -1324,6 +1290,13 @@ func (d *DB) CommitArchiveInventoryPage(ctx context.Context, commit ArchiveInven
 			typedErr = outcome.typedErr
 			return nil
 		}
+		if commit.InventoryAvailable {
+			if _, err := reconcileArchiveInventoryAvailableTx(
+				ctx, tx, commit.RepoID, commit.ItemType, commit.Now,
+			); err != nil {
+				return err
+			}
+		}
 		for _, item := range commit.Items {
 			item.ProviderCreatedAt = canonicalUTCTime(item.ProviderCreatedAt)
 			item.ProviderUpdatedAt = canonicalUTCTime(item.ProviderUpdatedAt)
@@ -1483,6 +1456,9 @@ func validateInventoryCommit(commit ArchiveInventoryCommit) error {
 	if commit.Coverage != ArchiveCoverageUnknown &&
 		(commit.RefreshReason != ArchiveRefreshReasonInitial || !commit.Exhausted) {
 		return errors.New("commit archive inventory: coverage requires exhausted initial inventory")
+	}
+	if commit.InventoryAvailable && commit.RefreshReason != ArchiveRefreshReasonPrompt {
+		return errors.New("commit archive inventory: availability proof requires prompt maintenance")
 	}
 	return nil
 }

--- a/internal/db/queries_archive_test.go
+++ b/internal/db/queries_archive_test.go
@@ -1060,6 +1060,58 @@ func TestReconcileArchiveCoverageRequeuesKnownItemsWhenInventoryReturns(t *testi
 	require.Greater(progress.ScanGeneration, archiveLifecycleDetailsGeneration)
 }
 
+func TestReconcileArchiveInventoryAvailablePreservesPromptBoundary(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := openTestDB(t)
+	ctx := t.Context()
+	now := archiveTestTime()
+	repoID := insertTestRepo(t, database, "acme", "reenabled-issues")
+	require.NoError(database.EnsureDiscoveryArchives(ctx, []int64{repoID}, now))
+	require.NoError(database.StartFullArchives(ctx, []int64{repoID}, now))
+	require.NoError(database.CommitArchiveInventoryPage(ctx, ArchiveInventoryCommit{
+		RepoID: repoID, ItemType: ArchiveItemTypeIssue,
+		RefreshReason: ArchiveRefreshReasonInitial, ScanGeneration: 1,
+		Exhausted: true, Coverage: ArchiveCoverageUnsupported, Now: now,
+	}))
+	require.NoError(database.CommitArchiveInventoryPage(ctx, ArchiveInventoryCommit{
+		RepoID: repoID, ItemType: ArchiveItemTypeMergeRequest,
+		RefreshReason: ArchiveRefreshReasonInitial, ScanGeneration: 1,
+		Exhausted: true, Coverage: ArchiveCoverageSupported, Now: now,
+	}))
+	insertArchiveItemForTest(t, database, repoID, ArchiveItemTypeIssue, 7, now)
+	insertArchiveProgressForTest(
+		t, database, repoID, ArchiveItemTypeIssue, 7,
+		ArchiveDatasetLookup, ArchiveDatasetProgressComplete,
+	)
+	promptAt := now.Add(time.Hour)
+	before, err := database.BeginArchivePromptMaintenance(ctx, repoID, now, promptAt)
+	require.NoError(err)
+	require.NotNil(before.PromptScanStartedAt)
+
+	require.NoError(database.ReconcileArchiveInventoryAvailable(
+		ctx, repoID, ArchiveItemTypeIssue, promptAt,
+	))
+
+	states, err := database.ListArchiveRepoStates(ctx, []int64{repoID})
+	require.NoError(err)
+	require.Len(states, 1)
+	state := states[0]
+	assert.False(state.IssueInventory.Complete())
+	assert.Greater(state.IssueInventory.Generation, before.IssueInventory.Generation)
+	assert.Equal(ArchiveCoverageUnknown, state.IssuesCoverage)
+	assert.Nil(state.InitialCompletedAt)
+	require.NotNil(state.PromptScanStartedAt)
+	assert.Equal(promptAt, *state.PromptScanStartedAt)
+	assert.Equal(before.MaintenanceIssues.Generation, state.MaintenanceIssues.Generation)
+	assert.Equal(
+		ArchiveDatasetProgressPending,
+		archiveProgressStatusForTest(
+			t, database, repoID, ArchiveItemTypeIssue, 7, ArchiveDatasetLookup,
+		),
+	)
+}
+
 func prepareLifecycleArchiveCoverage(
 	t *testing.T,
 	database *DB,

--- a/internal/db/queries_archive_test.go
+++ b/internal/db/queries_archive_test.go
@@ -1089,9 +1089,13 @@ func TestReconcileArchiveInventoryAvailablePreservesPromptBoundary(t *testing.T)
 	require.NoError(err)
 	require.NotNil(before.PromptScanStartedAt)
 
-	require.NoError(database.ReconcileArchiveInventoryAvailable(
-		ctx, repoID, ArchiveItemTypeIssue, promptAt,
-	))
+	require.NoError(database.CommitArchiveInventoryPage(ctx, ArchiveInventoryCommit{
+		RepoID: repoID, ItemType: ArchiveItemTypeIssue,
+		RefreshReason:  ArchiveRefreshReasonPrompt,
+		ScanGeneration: before.MaintenanceIssues.Generation,
+		InputCursor:    before.MaintenanceIssues.Cursor(), Exhausted: true,
+		InventoryAvailable: true, Now: promptAt,
+	}))
 
 	states, err := database.ListArchiveRepoStates(ctx, []int64{repoID})
 	require.NoError(err)

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -463,7 +463,11 @@ type ArchiveInventoryCommit struct {
 	NextCursor     string
 	Exhausted      bool
 	Coverage       ArchiveCoverage
-	Now            time.Time
+	// InventoryAvailable records that a successful prompt-maintenance read
+	// proved a previously unsupported historical stream is available. The
+	// page commit reconciles that state under the same operator and scan fence.
+	InventoryAvailable bool
+	Now                time.Time
 }
 
 // ArchiveItemWork is one claimable archive hydration operation.

--- a/internal/github/archive_lifecycle_test.go
+++ b/internal/github/archive_lifecycle_test.go
@@ -574,8 +574,9 @@ func TestArchiveDisabledIssueInventoryCompletesUnsupportedWithoutBlockingMergeRe
 	require.NoError(service.RunEligible(t.Context()))
 	require.NoError(service.RunEligible(t.Context()))
 
-	assert.Equal(int32(1), issueCalls.Load())
 	assert.Equal(int32(1), issueInventoryCalls.Load())
+	assert.Greater(issueCalls.Load(), issueInventoryCalls.Load(),
+		"maintenance must verify the provider stream despite the inventory cooldown")
 	assert.GreaterOrEqual(mergeRequestCalls.Load(), int32(1))
 	repo, err := database.GetRepoByIdentity(t.Context(), platform.DBRepoIdentity(ref))
 	require.NoError(err)

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -1295,6 +1295,11 @@ func (s *Syncer) Admit(
 		Owner: ref.Owner, Name: ref.Name, RepoPath: ref.RepoPath,
 		PlatformExternalID: ref.PlatformExternalID,
 	}
+	if archive.InventoryProbeRequested(ctx) {
+		ctx = withRepositoryFeatureCooldownBypass(
+			ctx, s.featureCooldowns.currentGeneration(),
+		)
+	}
 	probe, due, featureRetryAt := s.beginRepositoryFeatureProbeWithRetry(ctx, repo, feature)
 	if !due {
 		return archive.AdmissionResult{FeatureDeferred: &archive.FeatureDeferral{

--- a/internal/server/e2etest/archive_disabled_feature_test.go
+++ b/internal/server/e2etest/archive_disabled_feature_test.go
@@ -49,15 +49,26 @@ func TestArchiveAPIRecoversWhenGitHubIssuesAreReenabledE2E(t *testing.T) {
 		now: time.Now().UTC().Truncate(time.Second),
 	}
 	issueTimestamp := clock.Now().Add(30 * time.Second).Format(time.RFC3339)
-	var issueListCalls atomic.Int32
+	var historicalIssueListCalls atomic.Int32
+	var updatedIssueListCalls atomic.Int32
 	var issueDetailCalls atomic.Int32
+	updatedIssueStarted := make(chan struct{})
+	releaseUpdatedIssue := make(chan struct{})
+	updatedIssueSucceeded := make(chan struct{})
+	var releaseUpdatedIssueOnce sync.Once
+	var updatedIssueStartedOnce sync.Once
+	var updatedIssueSucceededOnce sync.Once
+	t.Cleanup(func() {
+		releaseUpdatedIssueOnce.Do(func() { close(releaseUpdatedIssue) })
+	})
 
 	providerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/api/graphql":
 			var request struct {
-				Query string `json:"query"`
+				Query     string         `json:"query"`
+				Variables map[string]any `json:"variables"`
 			}
 			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 				http.Error(w, `{"message":"invalid GraphQL request"}`, http.StatusBadRequest)
@@ -71,18 +82,32 @@ func TestArchiveAPIRecoversWhenGitHubIssuesAreReenabledE2E(t *testing.T) {
 				http.Error(w, `{"message":"unexpected GraphQL query"}`, http.StatusBadRequest)
 				return
 			}
-			if issueListCalls.Add(1) == 1 {
-				w.WriteHeader(http.StatusGone)
-				_, _ = w.Write([]byte(`{"message":"Issues are disabled for this repo"}`))
+			orderField, _ := request.Variables["orderField"].(string)
+			switch orderField {
+			case "CREATED_AT":
+				if historicalIssueListCalls.Add(1) == 1 {
+					w.WriteHeader(http.StatusGone)
+					_, _ = w.Write([]byte(`{"message":"Issues are disabled for this repo"}`))
+					return
+				}
+			case "UPDATED_AT":
+				updatedIssueListCalls.Add(1)
+				updatedIssueStartedOnce.Do(func() { close(updatedIssueStarted) })
+				<-releaseUpdatedIssue
+			default:
+				http.Error(w, `{"message":"unexpected issue order"}`, http.StatusBadRequest)
 				return
 			}
-			_, _ = w.Write([]byte(`{"data":{"repository":{"issues":{"nodes":[{
+			_, writeErr := w.Write([]byte(`{"data":{"repository":{"issues":{"nodes":[{
 				"id":"I_17","databaseId":17,"number":17,"title":"enabled issue",
 				"state":"CLOSED","body":"","url":"https://github.com/acme/widget/issues/17",
 				"author":{"login":"author"},"createdAt":"` + issueTimestamp + `",
 				"updatedAt":"` + issueTimestamp + `","closedAt":"` + issueTimestamp + `",
 				"comments":{"totalCount":0},"labels":{"nodes":[]},"assignees":{"nodes":[]}
 			}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}`))
+			if orderField == "UPDATED_AT" && writeErr == nil {
+				updatedIssueSucceededOnce.Do(func() { close(updatedIssueSucceeded) })
+			}
 		case "/api/v3/repos/acme/widget/pulls":
 			_, _ = w.Write([]byte(`[]`))
 		case "/api/v3/rate_limit":
@@ -156,23 +181,6 @@ func TestArchiveAPIRecoversWhenGitHubIssuesAreReenabledE2E(t *testing.T) {
 	syncer.SetArchiveService(archiveService)
 	syncer.SetArchivePollIntervalForTesting(time.Millisecond)
 
-	initialSyncDone := make(chan struct{}, 1)
-	syncer.SetOnStatusChange(func(status *ghclient.SyncStatus) {
-		if !status.Running {
-			select {
-			case initialSyncDone <- struct{}{}:
-			default:
-			}
-		}
-	})
-	syncer.Start(ctx)
-	t.Cleanup(syncer.Stop)
-	select {
-	case <-initialSyncDone:
-	case <-time.After(time.Second):
-		require.Fail("empty initial sync did not finish")
-	}
-
 	repo := ghclient.RepoRef{
 		Platform: ref.Platform, PlatformHost: ref.Host,
 		Owner: ref.Owner, Name: ref.Name, RepoPath: ref.RepoPath,
@@ -199,9 +207,33 @@ func TestArchiveAPIRecoversWhenGitHubIssuesAreReenabledE2E(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(started.JSON200)
 
+	// Start the worker only after the API has promoted the repository to full
+	// archive mode. This makes the first CREATED_AT request unambiguously part
+	// of the full initial scan rather than discovery work woken by SetRepos.
+	syncer.Start(ctx)
+	t.Cleanup(syncer.Stop)
+
+	storedRepo, err := database.GetRepoByIdentity(ctx, platform.DBRepoIdentity(ref))
+	require.NoError(err)
+	require.NotNil(storedRepo)
+
+	select {
+	case <-updatedIssueStarted:
+	case <-time.After(3 * time.Second):
+		require.Fail("maintenance did not issue an UPDATED_AT request")
+	}
+	var unsupportedGeneration int64
 	require.Eventually(func() bool {
-		return issueListCalls.Load() >= 1
-	}, time.Second, 5*time.Millisecond)
+		states, stateErr := database.ListArchiveRepoStates(ctx, []int64{storedRepo.ID})
+		ready := stateErr == nil && len(states) == 1 &&
+			historicalIssueListCalls.Load() >= 1 &&
+			states[0].IssuesCoverage == db.ArchiveCoverageUnsupported &&
+			states[0].IssueInventory.Complete() && states[0].InitialCompletedAt != nil
+		if ready {
+			unsupportedGeneration = states[0].IssueInventory.Generation
+		}
+		return ready
+	}, 3*time.Second, 5*time.Millisecond)
 	clock.Advance(time.Minute)
 	quotaRegistry.UpdateSnapshot(identity, ghclient.QuotaResourceREST, ghclient.Rate{
 		Limit: 5000, Remaining: 4999, Reset: clock.Now().Add(time.Hour),
@@ -209,11 +241,14 @@ func TestArchiveAPIRecoversWhenGitHubIssuesAreReenabledE2E(t *testing.T) {
 	quotaRegistry.UpdateSnapshot(identity, ghclient.QuotaResourceGraphQL, ghclient.Rate{
 		Limit: 5000, Remaining: 4999, Reset: clock.Now().Add(time.Hour),
 	})
+	releaseUpdatedIssueOnce.Do(func() { close(releaseUpdatedIssue) })
 	syncer.WakeArchive()
+	select {
+	case <-updatedIssueSucceeded:
+	case <-time.After(3 * time.Second):
+		require.Fail("UPDATED_AT maintenance request did not succeed")
+	}
 
-	storedRepo, err := database.GetRepoByIdentity(ctx, platform.DBRepoIdentity(ref))
-	require.NoError(err)
-	require.NotNil(storedRepo)
 	require.Eventually(func() bool {
 		stored, getErr := database.GetIssueByRepoIDAndNumber(ctx, storedRepo.ID, 17)
 		return getErr == nil && stored != nil && stored.Title == "enabled issue"
@@ -224,10 +259,11 @@ func TestArchiveAPIRecoversWhenGitHubIssuesAreReenabledE2E(t *testing.T) {
 	require.Len(states, 1)
 	assert.Equal(db.ArchiveCoverageSupported, states[0].IssuesCoverage)
 	assert.True(states[0].IssueInventory.Complete())
-	assert.Greater(states[0].IssueInventory.Generation, int64(1),
+	assert.Greater(states[0].IssueInventory.Generation, unsupportedGeneration,
 		"successful maintenance must reopen the unsupported historical inventory")
-	assert.GreaterOrEqual(issueListCalls.Load(), int32(2),
-		"recovery must make a provider read despite the disabled-feature cooldown")
+	assert.GreaterOrEqual(historicalIssueListCalls.Load(), int32(2),
+		"maintenance recovery must replay the historical inventory")
+	assert.GreaterOrEqual(updatedIssueListCalls.Load(), int32(1))
 	assert.GreaterOrEqual(issueDetailCalls.Load(), int32(1))
 
 	require.Eventually(func() bool {

--- a/internal/server/e2etest/archive_disabled_feature_test.go
+++ b/internal/server/e2etest/archive_disabled_feature_test.go
@@ -1,0 +1,238 @@
+package e2etest
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/forge/internal/apiclient"
+	"go.kenn.io/forge/internal/apiclient/generated"
+	"go.kenn.io/forge/internal/archive"
+	"go.kenn.io/forge/internal/db"
+	ghclient "go.kenn.io/forge/internal/github"
+	"go.kenn.io/forge/internal/platform"
+	"go.kenn.io/forge/internal/server"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+	"go.kenn.io/forge/internal/testutil/servertest"
+)
+
+type archiveFeatureClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *archiveFeatureClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *archiveFeatureClock) Advance(duration time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(duration)
+	c.mu.Unlock()
+}
+
+func TestArchiveAPIRecoversWhenGitHubIssuesAreReenabledE2E(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	clock := &archiveFeatureClock{
+		now: time.Now().UTC().Truncate(time.Second),
+	}
+	issueTimestamp := clock.Now().Add(30 * time.Second).Format(time.RFC3339)
+	var issueListCalls atomic.Int32
+	var issueDetailCalls atomic.Int32
+
+	providerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/graphql":
+			var request struct {
+				Query string `json:"query"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				http.Error(w, `{"message":"invalid GraphQL request"}`, http.StatusBadRequest)
+				return
+			}
+			if strings.Contains(request.Query, "timelineItems") {
+				_, _ = w.Write([]byte(`{"data":{"repository":{"issue":{"timelineItems":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`))
+				return
+			}
+			if !strings.Contains(request.Query, "issues(first: 100") {
+				http.Error(w, `{"message":"unexpected GraphQL query"}`, http.StatusBadRequest)
+				return
+			}
+			if issueListCalls.Add(1) == 1 {
+				w.WriteHeader(http.StatusGone)
+				_, _ = w.Write([]byte(`{"message":"Issues are disabled for this repo"}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"data":{"repository":{"issues":{"nodes":[{
+				"id":"I_17","databaseId":17,"number":17,"title":"enabled issue",
+				"state":"CLOSED","body":"","url":"https://github.com/acme/widget/issues/17",
+				"author":{"login":"author"},"createdAt":"` + issueTimestamp + `",
+				"updatedAt":"` + issueTimestamp + `","closedAt":"` + issueTimestamp + `",
+				"comments":{"totalCount":0},"labels":{"nodes":[]},"assignees":{"nodes":[]}
+			}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}`))
+		case "/api/v3/repos/acme/widget/pulls":
+			_, _ = w.Write([]byte(`[]`))
+		case "/api/v3/rate_limit":
+			_, _ = w.Write([]byte(`{"resources":{"core":{"limit":5000,"remaining":4999,"reset":4102444800}}}`))
+		case "/api/v3/repos/acme/widget":
+			_, _ = w.Write([]byte(`{
+				"id":1,"node_id":"R_widget","name":"widget","full_name":"acme/widget",
+				"owner":{"login":"acme"}
+			}`))
+		case "/api/v3/repos/acme/widget/issues/17":
+			issueDetailCalls.Add(1)
+			_, _ = w.Write([]byte(`{
+				"id":17,"node_id":"I_17","number":17,"title":"enabled issue","state":"closed",
+				"body":"","html_url":"https://github.com/acme/widget/issues/17",
+				"user":{"login":"author"},"created_at":"` + issueTimestamp + `",
+				"updated_at":"` + issueTimestamp + `","closed_at":"` + issueTimestamp + `",
+				"comments":0
+			}`))
+		case "/api/v3/repos/acme/widget/issues/17/comments":
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(providerServer.Close)
+
+	ref := platform.RepoRef{
+		Platform: platform.KindGitHub, Host: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		PlatformExternalID: "R_widget",
+	}
+	quotaRegistry := ghclient.NewQuotaRegistry()
+	identity := ghclient.IdentityKey{Host: "github.com", Principal: "user:7"}
+	rateKey := ghclient.RateBucketKey("github", ref.Host, identity.Principal)
+	budget := ghclient.NewSyncBudget(5000)
+	providerClient, err := ghclient.NewClient(
+		staticTokenSource("archive-token"), "github.com", nil, nil,
+		ghclient.WithBaseURLForTesting(providerServer.URL),
+		ghclient.WithQuotaAccounting(quotaRegistry, identity, identity),
+	)
+	require.NoError(err)
+	registry, err := ghclient.NewProviderRegistry(map[string]ghclient.Client{
+		"github.com": providerClient,
+	})
+	require.NoError(err)
+	database := dbtest.Open(t)
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry, database, nil, nil, time.Hour,
+		nil, map[string]*ghclient.SyncBudget{rateKey: budget},
+	)
+	router, err := ghclient.NewHostRouter(ref.Host, &ghclient.Route{
+		Key: ghclient.RouteKey{Host: ref.Host, Owner: ref.Owner}, Client: providerClient,
+		ReadIdentity: identity, WriteIdentity: identity,
+	})
+	require.NoError(err)
+	syncer.SetGitHubRouters(map[string]*ghclient.HostRouter{ref.Host: router})
+	syncer.SetQuotaRegistry(quotaRegistry)
+	quotaRegistry.UpdateSnapshot(identity, ghclient.QuotaResourceREST, ghclient.Rate{
+		Limit: 5000, Remaining: 4999, Reset: clock.Now().Add(time.Hour),
+	})
+	quotaRegistry.UpdateSnapshot(identity, ghclient.QuotaResourceGraphQL, ghclient.Rate{
+		Limit: 5000, Remaining: 4999, Reset: clock.Now().Add(time.Hour),
+	})
+	syncer.SetClock(clock.Now)
+	archiveService, err := archive.NewService(
+		database, registry, syncer, syncer, nil, clock,
+	)
+	require.NoError(err)
+	archiveService.SetMaintenanceInterval(time.Second)
+	archiveService.SetWake(syncer.WakeArchive)
+	syncer.SetArchiveService(archiveService)
+	syncer.SetArchivePollIntervalForTesting(time.Millisecond)
+
+	initialSyncDone := make(chan struct{}, 1)
+	syncer.SetOnStatusChange(func(status *ghclient.SyncStatus) {
+		if !status.Running {
+			select {
+			case initialSyncDone <- struct{}{}:
+			default:
+			}
+		}
+	})
+	syncer.Start(ctx)
+	t.Cleanup(syncer.Stop)
+	select {
+	case <-initialSyncDone:
+	case <-time.After(time.Second):
+		require.Fail("empty initial sync did not finish")
+	}
+
+	repo := ghclient.RepoRef{
+		Platform: ref.Platform, PlatformHost: ref.Host,
+		Owner: ref.Owner, Name: ref.Name, RepoPath: ref.RepoPath,
+		PlatformExternalID: ref.PlatformExternalID,
+	}
+	require.NoError(syncer.SetReposWithContext(ctx, []ghclient.RepoRef{repo}, false))
+
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{
+		Archive:                       archiveService,
+		HostCheckAllowLoopbackAnyPort: true,
+	})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	forgeServer := httptest.NewServer(srv)
+	t.Cleanup(forgeServer.Close)
+	api, err := apiclient.NewWithHTTPClient(forgeServer.URL, forgeServer.Client())
+	require.NoError(err)
+	repositories := []generated.ArchiveRepositoryRef{{
+		Provider: "github", PlatformHost: ref.Host,
+		Owner: ref.Owner, Name: ref.Name, RepoPath: ref.RepoPath,
+	}}
+	started, err := api.HTTP.StartArchivesWithResponse(
+		ctx, generated.ArchiveMutationBody{Repositories: &repositories},
+	)
+	require.NoError(err)
+	require.NotNil(started.JSON200)
+
+	require.Eventually(func() bool {
+		return issueListCalls.Load() >= 1
+	}, time.Second, 5*time.Millisecond)
+	clock.Advance(time.Minute)
+	quotaRegistry.UpdateSnapshot(identity, ghclient.QuotaResourceREST, ghclient.Rate{
+		Limit: 5000, Remaining: 4999, Reset: clock.Now().Add(time.Hour),
+	})
+	quotaRegistry.UpdateSnapshot(identity, ghclient.QuotaResourceGraphQL, ghclient.Rate{
+		Limit: 5000, Remaining: 4999, Reset: clock.Now().Add(time.Hour),
+	})
+	syncer.WakeArchive()
+
+	storedRepo, err := database.GetRepoByIdentity(ctx, platform.DBRepoIdentity(ref))
+	require.NoError(err)
+	require.NotNil(storedRepo)
+	require.Eventually(func() bool {
+		stored, getErr := database.GetIssueByRepoIDAndNumber(ctx, storedRepo.ID, 17)
+		return getErr == nil && stored != nil && stored.Title == "enabled issue"
+	}, 3*time.Second, 10*time.Millisecond)
+
+	states, err := database.ListArchiveRepoStates(ctx, []int64{storedRepo.ID})
+	require.NoError(err)
+	require.Len(states, 1)
+	assert.Equal(db.ArchiveCoverageSupported, states[0].IssuesCoverage)
+	assert.True(states[0].IssueInventory.Complete())
+	assert.Greater(states[0].IssueInventory.Generation, int64(1),
+		"successful maintenance must reopen the unsupported historical inventory")
+	assert.GreaterOrEqual(issueListCalls.Load(), int32(2),
+		"recovery must make a provider read despite the disabled-feature cooldown")
+	assert.GreaterOrEqual(issueDetailCalls.Load(), int32(1))
+
+	require.Eventually(func() bool {
+		status, statusErr := api.HTTP.ListArchiveStatusWithResponse(ctx, nil)
+		return statusErr == nil && status.JSON200 != nil && len(*status.JSON200) == 1 &&
+			(*status.JSON200)[0].Status == generated.ArchiveStatusResponseStatusCurrent
+	}, 3*time.Second, 10*time.Millisecond)
+}

--- a/internal/server/repobrowserapi/handler_test.go
+++ b/internal/server/repobrowserapi/handler_test.go
@@ -1047,7 +1047,10 @@ func setupServerRepoBrowserGitRepo(t *testing.T) (remote string, work string) {
 
 func serverRepoBrowserGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	runner := gitcmd.New().WithConfig("init.defaultBranch", "main")
+	runner := gitcmd.New().
+		WithConfig("init.defaultBranch", "main").
+		WithConfig("gc.auto", "0").
+		WithConfig("maintenance.auto", "false")
 	out, stderr, err := runner.Run(t.Context(), dir, nil, args...)
 	require.NoError(t, err, "git %v failed: %s%s", args, out, stderr)
 }


### PR DESCRIPTION
## Problem

Forge caches disabled repository features to avoid repeatedly calling endpoints that cannot succeed. That cache cannot prove a feature is still disabled, so archive scans could either stall or miss updates after re-enablement.

Recovery also ran before the maintenance page commit. A pause or competing page could invalidate that commit while historical progress still changed.

The same CI investigation exposed a repository-browser fixture race between Git maintenance and local cloning.

## Change

- Probe disabled inventory streams before advancing durable archive state.
- Carry successful maintenance recovery into the page transaction. Reopen historical inventory only after the transaction validates the active operator state, generation, and cursor.
- Reopen history only for providers that declare the corresponding historical capability.
- Disable Git auto-maintenance while repository-browser fixtures mutate local remotes.

## Outcome

Disabled features can complete without blocking the archive. Re-enabled features recover without crossing pause or stale-page boundaries, and parallel fixture clones remain stable.