### PR TITLE
fix(activity): keep PR timelines and recency authoritative

### DIFF
--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -299,6 +299,22 @@ func gitLabReadOnlyRepoRef(cloneURL string) platform.RepoRef {
 	}
 }
 
+func activityIdentityRepoRef(repo db.Repo, configuredRepoPath string) ghclient.RepoRef {
+	return ghclient.RepoRef{
+		Platform:           platform.Kind(repo.Platform),
+		RepoID:             repo.ID,
+		Owner:              repo.Owner,
+		Name:               repo.Name,
+		PlatformHost:       repo.PlatformHost,
+		RepoPath:           repo.RepoPath,
+		PlatformExternalID: repo.PlatformRepoID,
+		WebURL:             repo.WebURL,
+		CloneURL:           repo.CloneURL,
+		DefaultBranch:      repo.DefaultBranch,
+		ConfiguredRepoPath: configuredRepoPath,
+	}
+}
+
 func gitLabReadOnlyIssueFixture(
 	now time.Time,
 	cloneURL string,
@@ -1865,37 +1881,125 @@ func buildAppState(
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
-		if r.Method == http.MethodPost && r.URL.Path == "/__e2e/activity/pr-comment" {
+		if r.Method == http.MethodPost && r.URL.Path == "/__e2e/activity/item-comment" {
 			if r.URL.Query().Get("require_subscriber") != "false" && srv.SubscriberCount() == 0 {
 				http.Error(w, "event stream not connected", http.StatusConflict)
+				return
+			}
+			itemType := r.URL.Query().Get("item_type")
+			number := 1
+			if itemType == "issue" {
+				number = 10
+			} else if itemType != "pr" {
+				http.Error(w, "item_type must be pr or issue", http.StatusBadRequest)
 				return
 			}
 			body := r.URL.Query().Get("body")
 			if body == "" {
 				body = "Persisted live Activity comment"
 			}
+			comment, err := fc.CreateIssueComment(
+				r.Context(), "acme", "widgets", number, body,
+			)
+			if err != nil {
+				http.Error(w, "create fixture item comment", http.StatusInternalServerError)
+				return
+			}
+			if itemType == "pr" {
+				mr, err := database.GetMergeRequest(
+					r.Context(), "github", "github.com", "acme", "widgets", number,
+				)
+				if err != nil || mr == nil {
+					http.Error(w, "pull request not found", http.StatusNotFound)
+					return
+				}
+				if err := database.UpsertMREvents(r.Context(), []db.MREvent{
+					ghclient.NormalizeCommentEvent(mr.ID, comment),
+				}); err != nil {
+					http.Error(w, "persist pull request event", http.StatusInternalServerError)
+					return
+				}
+			} else {
+				issue, err := database.GetIssue(
+					r.Context(), "github", "github.com", "acme", "widgets", number,
+				)
+				if err != nil || issue == nil {
+					http.Error(w, "issue not found", http.StatusNotFound)
+					return
+				}
+				if err := database.UpsertIssueEvents(r.Context(), []db.IssueEvent{
+					ghclient.NormalizeIssueCommentEvent(issue.ID, comment),
+				}); err != nil {
+					http.Error(w, "persist issue event", http.StatusInternalServerError)
+					return
+				}
+			}
+			eventID := srv.Hub().Broadcast(server.Event{Type: "data_changed", Data: struct{}{}})
+			w.Header().Set("X-Kenn-E2E-Event-ID", strconv.FormatUint(eventID, 10))
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method == http.MethodPost &&
+			r.URL.Path == "/__e2e/activity/stage-filtered-parent-recency" {
 			mr, err := database.GetMergeRequest(
-				r.Context(), "github", "github.com", "acme", "widgets", 1,
+				r.Context(), "github", "github.com", "acme", "widgets", 6,
 			)
 			if err != nil || mr == nil {
 				http.Error(w, "pull request not found", http.StatusNotFound)
 				return
 			}
-			comment, err := fc.CreateIssueComment(
-				r.Context(), "acme", "widgets", 1, body,
-			)
-			if err != nil {
-				http.Error(w, "create fixture pull request comment", http.StatusInternalServerError)
+			outsideRange := time.Now().UTC().Add(-45 * 24 * time.Hour).Truncate(time.Second)
+			if _, err := database.WriteDB().ExecContext(r.Context(), `
+				UPDATE forge_merge_requests
+				SET created_at = ?, updated_at = ?, last_activity_at = ?
+				WHERE id = ?`, outsideRange, outsideRange, outsideRange, mr.ID); err != nil {
+				http.Error(w, "age pull request activity", http.StatusInternalServerError)
 				return
 			}
+			if _, err := database.WriteDB().ExecContext(r.Context(), `
+				UPDATE forge_mr_events SET created_at = ? WHERE merge_request_id = ?`,
+				outsideRange, mr.ID,
+			); err != nil {
+				http.Error(w, "age pull request events", http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method == http.MethodPost &&
+			r.URL.Path == "/__e2e/activity/filtered-parent-recency" {
+			if srv.SubscriberCount() == 0 {
+				http.Error(w, "event stream not connected", http.StatusConflict)
+				return
+			}
+			mr, err := database.GetMergeRequest(
+				r.Context(), "github", "github.com", "acme", "widgets", 6,
+			)
+			if err != nil || mr == nil {
+				http.Error(w, "pull request not found", http.StatusNotFound)
+				return
+			}
+			// The comment is the ledger event that defines Activity recency.
+			// The provider's updated_at is bumped further ahead, the way GitHub
+			// does after mergeability recomputes, and must not win.
+			activityAt := time.Now().UTC().Truncate(time.Second)
+			comment := fc.SeedIssueComment("acme", "widgets", 6, "Filtered parent comment", activityAt)
 			if err := database.UpsertMREvents(r.Context(), []db.MREvent{
 				ghclient.NormalizeCommentEvent(mr.ID, comment),
 			}); err != nil {
-				http.Error(w, "persist pull request event", http.StatusInternalServerError)
+				http.Error(w, "persist filtered pull request event", http.StatusInternalServerError)
 				return
 			}
-			eventID := srv.Hub().Broadcast(server.Event{Type: "data_changed", Data: struct{}{}})
-			w.Header().Set("X-Kenn-E2E-Event-ID", strconv.FormatUint(eventID, 10))
+			providerBumpAt := activityAt.Add(10 * time.Minute)
+			if _, err := database.WriteDB().ExecContext(r.Context(), `
+				UPDATE forge_merge_requests
+				SET updated_at = ?, last_activity_at = ?
+				WHERE id = ?`, providerBumpAt, providerBumpAt, mr.ID); err != nil {
+				http.Error(w, "advance pull request activity", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("X-Kenn-E2E-Parent-Activity-At", activityAt.Format(time.RFC3339Nano))
+			srv.Hub().Broadcast(server.Event{Type: "data_changed", Data: struct{}{}})
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
@@ -2057,6 +2161,86 @@ func buildAppState(
 				return
 			}
 			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method == http.MethodPost &&
+			r.URL.Path == "/__e2e/activity/repository-identity" {
+			const (
+				originalRepoPath    = "acme/widgets"
+				renamedRepoPath     = "acme/widgets-renamed"
+				replacementProvider = "e2e-replacement-widgets"
+			)
+			observedAt := time.Now().UTC().Add(time.Minute)
+			var entry *db.RepositoryCatalogEntry
+			var err error
+			switch r.URL.Query().Get("phase") {
+			case "rename":
+				original, getErr := database.GetRepoByIdentity(
+					r.Context(), db.GitHubRepoIdentity("github.com", "acme", "widgets"),
+				)
+				if getErr != nil || original == nil {
+					http.Error(w, "original repository not found", http.StatusNotFound)
+					return
+				}
+				entry, _, err = database.ReconcileRepositoryObservation(r.Context(), db.RepoIdentity{
+					Platform:       original.Platform,
+					PlatformHost:   original.PlatformHost,
+					PlatformRepoID: original.PlatformRepoID,
+					Owner:          "acme",
+					Name:           "widgets-renamed",
+					RepoPath:       renamedRepoPath,
+				}, observedAt)
+				if err == nil && entry != nil {
+					_, err = database.WriteDB().ExecContext(r.Context(), `
+						UPDATE forge_merge_requests
+						SET url = ?
+						WHERE repo_id = ? AND number = 1`,
+						"https://github.com/acme/widgets-renamed/pull/1", entry.Repository.ID,
+					)
+				}
+			case "reuse":
+				entry, _, err = database.ReconcileRepositoryObservation(r.Context(), db.RepoIdentity{
+					Platform:       "github",
+					PlatformHost:   "github.com",
+					PlatformRepoID: replacementProvider,
+					Owner:          "acme",
+					Name:           "widgets",
+					RepoPath:       originalRepoPath,
+				}, observedAt.Add(time.Minute))
+				if err == nil && entry != nil {
+					now := time.Now().UTC().Truncate(time.Second)
+					_, err = database.UpsertMergeRequest(r.Context(), &db.MergeRequest{
+						RepoID:             entry.Repository.ID,
+						PlatformID:         990001,
+						PlatformExternalID: "e2e-replacement-pull",
+						Number:             1,
+						URL:                "https://github.com/acme/widgets/pull/1",
+						Title:              "Replacement route pull request",
+						Author:             "replacement-author",
+						State:              db.MergeRequestStateOpen,
+						CreatedAt:          now,
+						UpdatedAt:          now,
+						LastActivityAt:     now,
+					})
+				}
+			default:
+				http.Error(w, "phase must be rename or reuse", http.StatusBadRequest)
+				return
+			}
+			if err != nil || entry == nil {
+				http.Error(w, "reconcile repository identity", http.StatusInternalServerError)
+				return
+			}
+			syncer.SetRepos([]ghclient.RepoRef{
+				activityIdentityRepoRef(entry.Repository, originalRepoPath),
+			})
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(map[string]string{
+				"platform_repo_id": entry.Repository.PlatformRepoID,
+				"repo_path":        entry.Repository.RepoPath,
+			}); err != nil {
+				slog.Warn("write repository identity fixture response", "err", err)
+			}
 			return
 		}
 		if r.Method == http.MethodPost && r.URL.Path == "/__e2e/repo-browser/tree/fail-next" {

--- a/context/notifications-in-activity.md
+++ b/context/notifications-in-activity.md
@@ -203,6 +203,7 @@ Rules:
 - API payload remains GitHub-shaped for now where existing clients depend on fields like `platform_thread_id` and `github_*` timestamps.
 - Provider-neutral storage and DB naming must not leak through API accidentally; translate at server boundary.
 - Generated OpenAPI clients must be regenerated after API shape changes.
+- Activity notification rows take `item_title`, `item_url`, and `activity_url` from the linked PR/issue when it has synced and fall back to persisted `subject_title`/`web_url` only for unsynced subjects; persisted values are frozen at sync time, and the frontend parent reconciliation is capped, so it cannot be the only rename repair (`internal/db/queries_activity.go::ListActivity`).
 - Activity notification rows carry the linked PR/issue lifecycle state in `subject_state` (allowed values `open` | `closed` | `merged`). `item_state` keeps carrying the notification's own `unread`/`read` triage state. `listActivity` populates `subject_state` via a `LEFT JOIN` to the merge-request/issue tables on `(repo_id, item_number)`, so the Hide closed/merged filter works in a notifications-only feed with no sibling PR/issue row present. The field is `omitempty`: when the subject is unanchored or has not synced, clients receive it absent rather than as `""`. Consumers must treat missing and empty string identically — both mean "lifecycle unknown / not applicable" — and must not treat unknown as `open`. Non-notification rows omit `subject_state` entirely; use `item_state` for them.
 
 ## Testing Expectations

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -896,7 +896,8 @@ Not every visibility control means "remove this entity entirely."
   issue opening rows
   (`frontend/src/lib/stores/activity.svelte.ts::buildActivityFilterTypes`).
 - Activity recency for a PR or issue is derived from the event ledger the feed can
-  render (opening, comments, reviews, commits, force pushes, merge, close), never from
+  render plus lifecycle transitions (opening, comments, reviews, commits, force pushes,
+  reopen, merge, close), never from
   provider `updated_at`/`last_activity_at`: GitHub bumps those for mergeability recomputes
   and branch deletion, which read as phantom activity. Event visibility filters must not
   redefine that recency (`internal/db/queries_activity.go::prActivityAtExpr`).

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -216,6 +216,11 @@ Persisted controls must state their scope clearly.
 - Activity filters remain URL-backed and session-scoped. Missing filter params on a
   partial Activity URL inherit the last validated route before store hydration, while
   explicit URL values win (`frontend/src/lib/stores/router.svelte.ts::restoreMissingActivityFilters`).
+- Activity URLs persist item scope (`item_types`) and event toggles (`event_types`)
+  independently. Legacy `types` migrates both dimensions and owns them during session
+  restoration; only exact `types=notification` means default item scope with no events,
+  and `commit` alone controls the old Commits toggle (ignore stale `default_branch_commit`)
+  (`frontend/src/lib/stores/activity.svelte.ts::readLegacyFilterSelections`).
 - Activity's Author filter follows GitHub `author:` semantics: it matches the parent PR
   or issue author, never a child event actor; its URL/API key remains `author`
   (`internal/db/queries_activity.go::ListActivity`).
@@ -884,11 +889,37 @@ Not every visibility control means "remove this entity entirely."
 
 - Controls that toggle detail visibility should preserve the parent row unless
   the feature explicitly removes that category from the result set.
+- Activity's Commits filter controls top-level default-branch commits only; it
+  neither selects PR or issue opening rows nor hides PR timeline commits while
+  PRs are enabled. Opening rows follow only the timeline events that can occur
+  on that item kind (issues: comments), so Reviews or Force pushes never toggle
+  issue opening rows
+  (`frontend/src/lib/stores/activity.svelte.ts::buildActivityFilterTypes`).
+- Activity recency for a PR or issue is derived from the event ledger the feed can
+  render (opening, comments, reviews, commits, force pushes, merge, close), never from
+  provider `updated_at`/`last_activity_at`: GitHub bumps those for mergeability recomputes
+  and branch deletion, which read as phantom activity. Event visibility filters must not
+  redefine that recency (`internal/db/queries_activity.go::prActivityAtExpr`).
+- Activity presentation filters apply to event, parent, and workspace projections;
+  "Hide bots" tests event actors on events and item authors on parent/workspace subjects
+  (`frontend/src/lib/components/ActivityFeed.svelte::visibleItemActivity`).
+- Activity `capped` reports event overflow; only it triggers event reloads and the
+  event warning. `item_activity_capped` drives only the independent parent-truncation
+  notice; a search whose event matches overflow the event page also reports it, because
+  event-matched parents are derived from that bounded page
+  (`frontend/src/lib/stores/activity.svelte.ts::createActivityStore`, `internal/server/huma_routes.go::Server.listActivity`).
+- Activity status totals deduplicate open subjects across event, parent, and workspace
+  snapshots; authoritative parent lifecycle state overrides event state
+  (`frontend/src/lib/components/layout/StatusBar.svelte::activityCounts`).
+- Authoritative Activity parents rewrite retained event parent metadata and notification provider
+  targets from the current parent URL; event-specific deep links stay event-owned. Key by stable
+  identity so mutable routes cannot split renames or route reuse (`frontend/src/lib/stores/activity.svelte.ts::reconcileItemsWithParentSubjects`).
 - When two data sources race, prefer the source that matches the user's current
   filter/scope rather than a stale but faster preview.
-- Detail sync convergence must directly reconcile visible PR, issue, and Activity
-  lists; Activity's forward cursor cannot surface newly persisted events older than
-  unrelated leading rows. Selection generations gate only detail installation, not
+- Successful initial detail reads and detail sync convergence must directly
+  reconcile visible PR, issue, and Activity lists; Activity's forward cursor
+  cannot surface newly persisted events older than unrelated leading rows.
+  Selection generations gate only detail installation, not successful-read or
   successful-sync invalidation (`frontend/src/lib/stores/detail.svelte.ts::reconcileListsAfterDetailSync`, `frontend/src/lib/stores/issues.svelte.ts::reconcileListsAfterDetailSync`).
 - Activity full-snapshot projections are latest-successful-request-wins across
   foreground and convergence reads. Incremental polling neither claims snapshot
@@ -900,6 +931,9 @@ Not every visibility control means "remove this entity entirely."
   successful snapshots, and a logical filter-scope change still fences the old result.
   A later successful snapshot fences older foreground failures; without one, a fenced
   foreground owner still settles loading (`frontend/src/lib/stores/activity-workflow.ts::ActivityWorkflowLive`).
+  Every fourth scheduled Activity poll is an authoritative full-snapshot
+  replacement so events hidden behind the forward cursor self-heal even without
+  detail navigation or SSE (`frontend/src/lib/stores/activity.svelte.ts::refreshActivityProgram`).
   Every authoritative snapshot projection clears an earlier error banner
   (`frontend/src/lib/stores/activity.svelte.ts::createActivityStore`).
 - After a sync trigger is accepted, retain optimistic running state through the

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -93,9 +93,9 @@ embedder protocol for arbitrary host state.
   candidates include eventless subjects in the same repository and time scope,
   while provider-event matching preserves workspace recency only for text search
   (`internal/server/huma_routes.go::mergeWorkspaceActivityAuthors`).
-- Activity event references key that snapshot by stable repo ID: issues use
-  own identity and PRs use resolved identity, so route reuse stays fail-closed
-  (`internal/server/helpers.go::workspaceRefForActivityItem`).
+- Activity events and parent summaries key that snapshot by stable repo ID and
+  canonical item type; normalize wire `"pr"` to workspace `"pull_request"`
+  before lookup so route reuse stays fail-closed (`internal/server/helpers.go::workspaceItemTypeFromActivity`).
 - The shared subject snapshot holds the repository-reconciliation read barrier
   across both its workspace-summary and subject-metadata reads, so a route move
   cannot split one response across repository identities

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -112,6 +112,9 @@ components:
           type: string
         item_author:
           type: string
+        item_last_activity_at:
+          format: date-time
+          type: string
         item_number:
           format: int64
           type: integer
@@ -164,6 +167,14 @@ components:
           type: string
         capped:
           type: boolean
+        item_activity:
+          items:
+            $ref: "#/components/schemas/ActivitySubjectResponse"
+          type:
+            - array
+            - "null"
+        item_activity_capped:
+          type: boolean
         items:
           items:
             $ref: "#/components/schemas/ActivityItemResponse"
@@ -178,8 +189,51 @@ components:
             - "null"
       required:
         - items
+        - item_activity
         - workspace_activity
         - capped
+        - item_activity_capped
+      type: object
+    ActivitySubjectResponse:
+      additionalProperties: false
+      properties:
+        activity_at:
+          format: date-time
+          type: string
+        item_author:
+          type: string
+        item_number:
+          format: int64
+          type: integer
+        item_state:
+          type: string
+        item_title:
+          type: string
+        item_type:
+          type: string
+        item_url:
+          type: string
+        platform_host:
+          type: string
+        repo:
+          $ref: "#/components/schemas/RepoRefResponse"
+        repo_name:
+          type: string
+        repo_owner:
+          type: string
+        workspace:
+          $ref: "#/components/schemas/WorkspaceRef"
+      required:
+        - repo
+        - platform_host
+        - repo_owner
+        - repo_name
+        - item_type
+        - item_number
+        - item_title
+        - item_url
+        - item_state
+        - activity_at
       type: object
     AddRepoInputBody:
       additionalProperties: false

--- a/frontend/src/lib/api/generated/schema.ts
+++ b/frontend/src/lib/api/generated/schema.ts
@@ -4664,6 +4664,8 @@ export interface components {
             cursor: string;
             id: string;
             item_author?: string;
+            /** Format: date-time */
+            item_last_activity_at?: string;
             /** Format: int64 */
             item_number: number;
             item_state: string;
@@ -4685,8 +4687,26 @@ export interface components {
              */
             readonly $schema?: string;
             capped: boolean;
+            item_activity: components["schemas"]["ActivitySubjectResponse"][] | null;
+            item_activity_capped: boolean;
             items: components["schemas"]["ActivityItemResponse"][] | null;
             workspace_activity: components["schemas"]["WorkspaceActivitySubjectResponse"][] | null;
+        };
+        ActivitySubjectResponse: {
+            /** Format: date-time */
+            activity_at: string;
+            item_author?: string;
+            /** Format: int64 */
+            item_number: number;
+            item_state: string;
+            item_title: string;
+            item_type: string;
+            item_url: string;
+            platform_host: string;
+            repo: components["schemas"]["RepoRefResponse"];
+            repo_name: string;
+            repo_owner: string;
+            workspace?: components["schemas"]["WorkspaceRef"];
         };
         AddRepoInputBody: {
             /**

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -24,6 +24,7 @@ export type LocalSyncCeilingStatus = components["schemas"]["LocalSyncCeilingStat
 export type RateLimitsResponse = components["schemas"]["RateLimitsResponse"];
 export type ActivityItem = components["schemas"]["ActivityItemResponse"];
 export type ActivityResponse = components["schemas"]["ActivityResponse"];
+export type ActivitySubject = components["schemas"]["ActivitySubjectResponse"];
 export type WorkspaceActivitySubject = components["schemas"]["WorkspaceActivitySubjectResponse"];
 export type ActivityAuthorsResponse = components["schemas"]["ActivityAuthorsResponse"];
 export type NotificationItem = components["schemas"]["NotificationResponse"];

--- a/frontend/src/lib/components/ActivityFeed.svelte
+++ b/frontend/src/lib/components/ActivityFeed.svelte
@@ -8,7 +8,7 @@
   } from "@kenn-io/kit-ui";
   import { Effect } from "effect";
   import { onMount, onDestroy } from "svelte";
-  import type { ActivityItem, WorkspaceActivitySubject } from "../api/types.js";
+  import type { ActivityItem, ActivitySubject, WorkspaceActivitySubject } from "../api/types.js";
   import type { AppExecution } from "../app/runtime.js";
   import { getAppRuntime } from "../app/runtime-context.js";
   import {
@@ -170,11 +170,11 @@
   function toggleEvent(evt: EventType): void {
     const current = activity.getEnabledEvents();
     const next = new Set(current);
-    // Deselecting the last event type is valid: it hides every event row
-    // while PR/issue rows and the separate Notifications toggle still
-    // govern their own rows. buildActivityFilterTypes encodes the empty
-    // set as an explicit type list, so the state round-trips through the
-    // URL rather than collapsing back to "show everything".
+    // Deselecting the last event type is valid: it hides every filterable
+    // event row while PR timeline commits and the separate Notifications
+    // toggle remain independent. buildActivityFilterTypes encodes the empty
+    // set explicitly so the state round-trips through the URL rather than
+    // collapsing back to "show everything".
     if (next.has(evt)) next.delete(evt);
     else next.add(evt);
     activity.setEnabledEvents(next);
@@ -314,6 +314,22 @@
     );
     if (activity.getHideClosedMerged()) {
       result = result.filter((subject) => subject.item_state !== "closed" && subject.item_state !== "merged");
+    }
+    if (activity.getHideBots()) {
+      result = result.filter((subject) => !isBot(subject.item_author ?? ""));
+    }
+    return result;
+  });
+
+  const visibleItemActivity = $derived.by(() => {
+    let result: ActivitySubject[] = activity.getItemActivity().filter((subject) =>
+      isActivityItemTypeEnabled(subject.item_type, activity.getEnabledItemTypes())
+    );
+    if (activity.getHideClosedMerged()) {
+      result = result.filter((subject) => subject.item_state !== "closed" && subject.item_state !== "merged");
+    }
+    if (activity.getHideBots()) {
+      result = result.filter((subject) => !isBot(subject.item_author ?? ""));
     }
     return result;
   });
@@ -716,7 +732,7 @@
     </div>
     </ScrollBox>
   {:else if activity.getViewMode() === "threaded"}
-    {#if displayItems.length === 0 && visibleWorkspaceActivity.length === 0 && activity.isActivityLoading()}
+    {#if displayItems.length === 0 && visibleItemActivity.length === 0 && visibleWorkspaceActivity.length === 0 && activity.isActivityLoading()}
       <ScrollBox label="Activity feed">
       <div class="table-container">
         <div class="loading-placeholder">
@@ -728,6 +744,7 @@
     {:else}
       <ActivityThreaded
         items={displayItems}
+        itemActivity={visibleItemActivity}
         workspaceActivity={visibleWorkspaceActivity}
         {onSelectItem}
         {onSelectBranchCommit}
@@ -1004,8 +1021,15 @@
   {/if}
 
   {#if activity.isActivityCapped()}
-    <div class="capped-notice">
+    <div class="capped-notice event-capped-notice">
       Showing most recent 5,000 events. Narrow the time range or use filters to see more.
+    </div>
+  {/if}
+
+  {#if activity.isItemActivityCapped()}
+    <div class="capped-notice item-activity-capped-notice">
+      Showing the 5,000 most recently active pull requests and issues. Item totals may be incomplete; narrow the time
+      range or item filters to see fewer results.
     </div>
   {/if}
 

--- a/frontend/src/lib/components/ActivityFeed.test.ts
+++ b/frontend/src/lib/components/ActivityFeed.test.ts
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/svelte";
 import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
-import type { ActivityItem, WorkspaceActivitySubject } from "../api/types.js";
+import type { ActivityItem, ActivitySubject, WorkspaceActivitySubject } from "../api/types.js";
 import { makeAppRuntime, type OwnedAppRuntime } from "../app/runtime.js";
 
 const runtimeCapture = vi.hoisted(() => ({ current: undefined as OwnedAppRuntime | undefined }));
@@ -18,7 +18,9 @@ import ActivityFeed from "./ActivityFeed.svelte";
 
 beforeEach(() => {
   runtimeCapture.current = makeAppRuntime();
+  itemActivity.value = [];
   workspaceActivity.value = [];
+  hideBots.value = false;
 });
 
 afterEach(async () => {
@@ -91,6 +93,7 @@ function workspaceSubject(overrides: Partial<WorkspaceActivitySubject> = {}): Wo
 }
 
 const items = vi.hoisted(() => ({ value: [] as ActivityItem[] }));
+const itemActivity = vi.hoisted(() => ({ value: [] as ActivitySubject[] }));
 const workspaceActivity = vi.hoisted(() => ({ value: [] as WorkspaceActivitySubject[] }));
 const viewMode = vi.hoisted(() => ({
   value: "flat" as "flat" | "threaded",
@@ -101,6 +104,7 @@ const expandAllThreads = vi.hoisted(() => vi.fn());
 const rollUpCommits = vi.hoisted(() => ({ value: false }));
 const hideDefaultBranchActivity = vi.hoisted(() => ({ value: false }));
 const hideClosedMerged = vi.hoisted(() => ({ value: false }));
+const hideBots = vi.hoisted(() => ({ value: false }));
 const hideOrgName = vi.hoisted(() => ({ value: false }));
 const setActivityFilterTypes = vi.hoisted(() => vi.fn());
 const enabledItemTypes = vi.hoisted(() => ({
@@ -110,6 +114,8 @@ const enabledEvents = vi.hoisted(() => ({
   value: new Set(["comment", "review", "commit", "force_push"]),
 }));
 const showNotifications = vi.hoisted(() => ({ value: true }));
+const activityCapped = vi.hoisted(() => ({ value: false }));
+const itemActivityCapped = vi.hoisted(() => ({ value: false }));
 const involvesMe = vi.hoisted(() => ({ value: false }));
 const markNotificationSeen = vi.hoisted(() => vi.fn(async () => undefined));
 const selectedAuthor = vi.hoisted(() => ({ value: undefined as string | undefined }));
@@ -137,16 +143,18 @@ vi.mock("../context.js", () => ({
       getShowNotifications: () => showNotifications.value,
       getInvolvesMe: () => involvesMe.value,
       getHideClosedMerged: () => hideClosedMerged.value,
-      getHideBots: () => false,
+      getHideBots: () => hideBots.value,
       getHideDefaultBranchActivity: () => hideDefaultBranchActivity.value,
       getEnabledItemTypes: () => enabledItemTypes.value,
       getActivityItems: () => items.value,
+      getItemActivity: () => itemActivity.value,
       getWorkspaceActivity: () => workspaceActivity.value,
       getActivityError: () => null,
       getViewMode: () => viewMode.value,
       getTimeRange: () => "7d",
       isActivityLoading: () => false,
-      isActivityCapped: () => false,
+      isActivityCapped: () => activityCapped.value,
+      isItemActivityCapped: () => itemActivityCapped.value,
       getCollapseThreads: () => collapseThreads.value,
       collapseAllThreads,
       expandAllThreads,
@@ -210,6 +218,8 @@ describe("ActivityFeed compact mode", () => {
     enabledItemTypes.value = new Set(["pr", "issue"]);
     enabledEvents.value = new Set(["comment", "review", "commit", "force_push"]);
     showNotifications.value = true;
+    activityCapped.value = false;
+    itemActivityCapped.value = false;
     selectedAuthor.value = undefined;
     setActivityAuthor.mockClear();
     setActivityFilterTypes.mockClear();
@@ -246,6 +256,15 @@ describe("ActivityFeed compact mode", () => {
     expect(screen.getByText("Add widget caching layer")).toBeTruthy();
   });
 
+  it("warns about parent truncation separately from event truncation", () => {
+    itemActivityCapped.value = true;
+
+    render(ActivityFeed, { props: { compact: true } });
+
+    expect(screen.getByText(/5,000 most recently active pull requests and issues/)).toBeTruthy();
+    expect(screen.queryByText(/most recent 5,000 events/)).toBeNull();
+  });
+
   it("shows workspace-only subjects only in threaded mode", () => {
     items.value = [];
     workspaceActivity.value = [workspaceSubject()];
@@ -267,6 +286,32 @@ describe("ActivityFeed compact mode", () => {
 
     const { container } = render(ActivityFeed, { props: { compact: true } });
     expect(container.textContent).not.toContain("Workspace-only work");
+  });
+
+  it("hides bot-authored parent and workspace summaries in threaded mode", () => {
+    viewMode.value = "threaded";
+    items.value = [];
+    itemActivity.value = [
+      workspaceSubject({
+        item_author: "renovate[bot]",
+        item_number: 8,
+        item_title: "Bot-authored parent",
+        workspace: undefined,
+      }),
+    ];
+    workspaceActivity.value = [
+      workspaceSubject({
+        item_author: "release-bot",
+        item_number: 9,
+        item_title: "Bot-authored workspace",
+      }),
+    ];
+    hideBots.value = true;
+
+    const { container } = render(ActivityFeed, { props: { compact: true } });
+
+    expect(container.textContent).not.toContain("Bot-authored parent");
+    expect(container.textContent).not.toContain("Bot-authored workspace");
   });
 
   it("selects a single PR or issue author from the typeahead", async () => {
@@ -376,7 +421,6 @@ describe("ActivityFeed compact mode", () => {
       "default_branch_force_push",
       "comment",
       "review",
-      "commit",
       "force_push",
       "notification",
     ]);
@@ -668,7 +712,7 @@ describe("ActivityFeed compact mode", () => {
     expect(row?.querySelector(".chip--kind-issue")).toBeNull();
   });
 
-  it("deselecting Commits also hides default-branch commit activity", async () => {
+  it("deselecting Commits hides default-branch commits but keeps PR commits", async () => {
     render(ActivityFeed, { props: { compact: true } });
 
     await fireEvent.click(screen.getByRole("button", { name: /^Filters/ }));
@@ -680,6 +724,7 @@ describe("ActivityFeed compact mode", () => {
       "default_branch_force_push",
       "comment",
       "review",
+      "commit",
       "force_push",
       "notification",
     ]);
@@ -759,10 +804,10 @@ describe("ActivityFeed compact mode", () => {
     await fireEvent.click(screen.getByRole("button", { name: /^Filters/ }));
     await fireEvent.click(screen.getByRole("button", { name: "Comments" }));
 
-    // Removing the last content event preserves the established
-    // notification-only view without leaking PR/issue opening rows.
+    // Removing the last top-level event keeps PR timeline commits and
+    // notifications without leaking PR/issue opening rows.
     expect(enabledEvents.value.size).toBe(0);
-    expect(setActivityFilterTypes).toHaveBeenCalledWith(["notification"]);
+    expect(setActivityFilterTypes).toHaveBeenCalledWith(["commit", "notification"]);
   });
 
   it("hides notifications on merged PRs even in a notifications-only feed", () => {

--- a/frontend/src/lib/components/ActivityThreaded.svelte
+++ b/frontend/src/lib/components/ActivityThreaded.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { EmptyState } from "@kenn-io/kit-ui";
   import { ScrollBox } from "@kenn-io/kit-ui";
-  import type { ActivityItem, WorkspaceActivitySubject } from "../api/types.js";
+  import type { ActivityItem, ActivitySubject, WorkspaceActivitySubject } from "../api/types.js";
   import { getStores } from "../context.js";
   import {
     collapseActivityRuns,
@@ -19,6 +19,7 @@
     localDateLabel,
     parseAPITimestamp,
   } from "../utils/time.js";
+  import { latestActivityAt } from "../utils/effective-activity.js";
   import {
     createRepoLabelFormatter,
     type RepoLabelIdentity,
@@ -37,6 +38,7 @@
 
   interface Props {
     items: ActivityItem[];
+    itemActivity?: ActivitySubject[];
     workspaceActivity?: WorkspaceActivitySubject[];
     onSelectItem: ((item: ActivityItem) => void) | undefined;
     onSelectBranchCommit?: ((item: ActivityItem) => void) | undefined;
@@ -66,6 +68,7 @@
 
   let {
     items,
+    itemActivity = [],
     workspaceActivity = [],
     onSelectItem,
     onSelectBranchCommit,
@@ -107,6 +110,7 @@
     kind: "branch";
     row: ActivityRow;
     provider: string;
+    platformRepoId: string;
     repoOwner: string;
     repoName: string;
     repoPath: string;
@@ -130,6 +134,7 @@
     createRepoLabelFormatter(
       [
         ...items.map(activityRepoIdentity),
+        ...itemActivity.map(activitySubjectRepoIdentity),
         ...workspaceActivity.map(workspaceRepoIdentity),
       ],
       { showOrgNames: !grouping.getHideOrgName() },
@@ -153,6 +158,7 @@
       const itemKey = activityItemKey({
         provider: item.repo?.provider ?? "",
         platformHost: item.platform_host ?? "",
+        platformRepoId: item.repo?.platform_repo_id,
         owner: item.repo_owner,
         name: item.repo_name,
         itemType: item.item_type,
@@ -192,7 +198,7 @@
           repoName: first.repo.name,
           repoPath: first.repo.repo_path,
           platformHost: first.repo.platform_host,
-          latestTime: first.created_at,
+          latestTime: latestActivityAt(first.created_at, first.item_last_activity_at),
           itemAuthor: itemAuthor(first),
           workspace: first.workspace,
           repo: first.repo,
@@ -203,10 +209,62 @@
       });
     }
 
+    for (const subject of itemActivity) {
+      const itemKey = activityItemKey({
+        provider: subject.repo.provider,
+        platformHost: subject.repo.platform_host,
+        platformRepoId: subject.repo.platform_repo_id,
+        owner: subject.repo.owner,
+        name: subject.repo.name,
+        repoPath: subject.repo.repo_path,
+        itemType: subject.item_type,
+        itemNumber: subject.item_number,
+      });
+      const existing = itemGroups.get(itemKey);
+      if (existing) {
+        existing.itemTitle = subject.item_title;
+        existing.itemUrl = subject.item_url;
+        existing.itemState = subject.item_state;
+        existing.itemAuthor = subject.item_author || existing.itemAuthor;
+        existing.workspace = subject.workspace ?? existing.workspace;
+        existing.repo = subject.repo;
+        existing.provider = subject.repo.provider;
+        existing.platformHost = subject.repo.platform_host;
+        existing.repoOwner = subject.repo.owner;
+        existing.repoName = subject.repo.name;
+        existing.repoPath = subject.repo.repo_path;
+        if (parseAPITimestamp(subject.activity_at).getTime() > parseAPITimestamp(existing.latestTime).getTime()) {
+          existing.latestTime = subject.activity_at;
+        }
+        continue;
+      }
+      itemGroups.set(itemKey, {
+        kind: "item",
+        itemType: subject.item_type,
+        itemNumber: subject.item_number,
+        itemTitle: subject.item_title,
+        itemUrl: subject.item_url,
+        itemState: subject.item_state,
+        branchName: "",
+        provider: subject.repo.provider,
+        repoOwner: subject.repo.owner,
+        repoName: subject.repo.name,
+        repoPath: subject.repo.repo_path,
+        platformHost: subject.repo.platform_host,
+        latestTime: subject.activity_at,
+        itemAuthor: subject.item_author ?? "",
+        workspace: subject.workspace,
+        repo: subject.repo,
+        events: [],
+        displayEvents: [],
+      });
+    }
+
     for (const subject of workspaceActivity) {
       const itemKey = activityItemKey({
         provider: subject.repo.provider,
         platformHost: subject.repo.platform_host,
+        platformRepoId: subject.repo.platform_repo_id,
         owner: subject.repo.owner,
         name: subject.repo.name,
         repoPath: subject.repo.repo_path,
@@ -281,12 +339,7 @@
     const repoMap = new Map<string, ThreadedEntry[]>();
     const repoLabels = new Map<string, string>();
     for (const entry of allEntries) {
-      const repoKey = activityRepoKey({
-        provider: entryProvider(entry),
-        platformHost: entryPlatformHost(entry),
-        owner: entryRepoOwner(entry),
-        name: entryRepoName(entry),
-      });
+      const repoKey = activityRepoKey(entryRepoIdentity(entry));
       repoLabels.set(repoKey, repoLabel(entryRepoIdentity(entry)));
       let bucket = repoMap.get(repoKey);
       if (!bucket) {
@@ -323,6 +376,7 @@
       kind: "branch",
       row,
       provider: item.repo.provider,
+      platformRepoId: item.repo.platform_repo_id ?? "",
       repoOwner: item.repo.owner,
       repoName: item.repo.name,
       repoPath: item.repo.repo_path,
@@ -391,6 +445,7 @@
     return activityItemKey({
       provider: g.provider,
       platformHost: g.platformHost,
+      platformRepoId: g.repo.platform_repo_id,
       owner: g.repoOwner,
       name: g.repoName,
       itemType: g.itemType,
@@ -404,6 +459,7 @@
     return `${activityRepoKey({
       provider: entry.provider,
       platformHost: entry.platformHost,
+      platformRepoId: entry.platformRepoId,
       owner: entry.repoOwner,
       name: entry.repoName,
     })}:branch-activity:${entry.row.id}`;
@@ -576,6 +632,7 @@
     return {
       provider: item.repo?.provider ?? "",
       platformHost: item.repo?.platform_host ?? item.platform_host,
+      platformRepoId: item.repo?.platform_repo_id,
       owner: item.repo?.owner ?? item.repo_owner,
       name: item.repo?.name ?? item.repo_name,
       repoPath: item.repo?.repo_path,
@@ -586,6 +643,18 @@
     return {
       provider: subject.repo.provider,
       platformHost: subject.repo.platform_host,
+      platformRepoId: subject.repo.platform_repo_id,
+      owner: subject.repo.owner,
+      name: subject.repo.name,
+      repoPath: subject.repo.repo_path,
+    };
+  }
+
+  function activitySubjectRepoIdentity(subject: ActivitySubject): RepoLabelIdentity {
+    return {
+      provider: subject.repo.provider,
+      platformHost: subject.repo.platform_host,
+      platformRepoId: subject.repo.platform_repo_id,
       owner: subject.repo.owner,
       name: subject.repo.name,
       repoPath: subject.repo.repo_path,
@@ -596,6 +665,7 @@
     return {
       provider: entry.kind === "item" ? entry.group.provider : entry.provider,
       platformHost: entryPlatformHost(entry),
+      platformRepoId: entry.kind === "item" ? entry.group.repo.platform_repo_id : entry.platformRepoId,
       owner: entryRepoOwner(entry),
       name: entryRepoName(entry),
       repoPath: entryRepoPath(entry),

--- a/frontend/src/lib/components/ActivityThreaded.test.ts
+++ b/frontend/src/lib/components/ActivityThreaded.test.ts
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render } from "@testing-library/svelte";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
-import type { ActivityItem, WorkspaceActivitySubject } from "../api/types.js";
+import type { ActivityItem, ActivitySubject, WorkspaceActivitySubject } from "../api/types.js";
 import ActivityThreaded from "./ActivityThreaded.svelte";
 
 function activityItem(id: string, overrides: Partial<ActivityItem> = {}): ActivityItem {
@@ -68,6 +68,17 @@ function workspaceSubject(overrides: Partial<WorkspaceActivitySubject> = {}): Wo
   };
 }
 
+function itemSubject(overrides: Partial<ActivitySubject> = {}): ActivitySubject {
+  const { workspace: _workspace, ...subject } = workspaceSubject();
+  return {
+    ...subject,
+    item_number: 8,
+    item_title: "Old pull with recent hidden activity",
+    item_url: "https://github.com/acme/widgets/pull/8",
+    ...overrides,
+  };
+}
+
 const expanded = vi.hoisted(() => ({ value: true }));
 const groupByRepo = vi.hoisted(() => ({ value: false }));
 const hideOrgName = vi.hoisted(() => ({ value: false }));
@@ -93,6 +104,7 @@ vi.mock("../context.js", () => ({
 describe("ActivityThreaded collapse", () => {
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
     expanded.value = true;
     groupByRepo.value = false;
     hideOrgName.value = false;
@@ -128,6 +140,36 @@ describe("ActivityThreaded collapse", () => {
     expect(onSelectItem).toHaveBeenCalledWith(expect.objectContaining({ item_number: 7, item_type: "pr" }));
   });
 
+  it("renders a recently active parent without inventing a visible event", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T14:05:00Z"));
+    const { container } = render(ActivityThreaded, {
+      props: {
+        items: [],
+        itemActivity: [itemSubject()],
+        onSelectItem: undefined,
+      },
+    });
+
+    const row = container.querySelector(".item-row");
+    expect(row?.textContent).toContain("Old pull with recent hidden activity");
+    expect(row?.querySelector(".cell--time")?.textContent).toBe("5m ago");
+    expect(container.querySelector(".thread-caret")).toBeNull();
+    expect(container.querySelector(".event-row")).toBeNull();
+  });
+
+  it("keeps the event actor as thread author when the parent summary has no author", () => {
+    const { container } = render(ActivityThreaded, {
+      props: {
+        items: [activityItem("authorless-parent-event", { item_number: 8, item_author: "", author: "alice" })],
+        itemActivity: [itemSubject({ item_author: undefined })],
+        onSelectItem: undefined,
+      },
+    });
+
+    expect(container.querySelector(".item-row .cell--author")?.textContent).toBe("alice");
+  });
+
   it("sorts existing threads by workspace activity without adding an event", () => {
     const { container } = render(ActivityThreaded, {
       props: {
@@ -151,6 +193,35 @@ describe("ActivityThreaded collapse", () => {
     const rows = Array.from(container.querySelectorAll(".item-row:not(.branch-activity-row)"));
     expect(rows[0]?.textContent).toContain("Workspace-active thread");
     expect(container.querySelectorAll(".event-row")).toHaveLength(2);
+  });
+
+  it("sorts and timestamps threads by parent recency when newer events are filtered", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T14:05:00Z"));
+    const { container } = render(ActivityThreaded, {
+      props: {
+        items: [
+          activityItem("older-visible-event", {
+            item_number: 1,
+            item_title: "Recently committed pull",
+            created_at: "2026-04-27T12:00:00Z",
+            item_last_activity_at: "2026-04-27T14:00:00Z",
+          }),
+          activityItem("newer-visible-event", {
+            item_number: 2,
+            item_title: "Recently commented pull",
+            created_at: "2026-04-27T13:00:00Z",
+            item_last_activity_at: "2026-04-27T13:00:00Z",
+          }),
+        ],
+        onSelectItem: undefined,
+      },
+    });
+
+    const rows = Array.from(container.querySelectorAll(".item-row:not(.branch-activity-row)"));
+    expect(rows[0]?.textContent).toContain("Recently committed pull");
+    expect(rows[0]?.querySelector(".cell--time")?.textContent).toBe("5m ago");
+    expect(container.querySelector(".event-row .event-time")?.textContent).toBe("2h ago");
   });
 
   it("hides events but keeps the item row when collapsed", () => {

--- a/frontend/src/lib/components/activityRows.ts
+++ b/frontend/src/lib/components/activityRows.ts
@@ -94,6 +94,7 @@ function repoKeyForItem(item: ActivityItem): string {
   return activityRepoKey({
     provider: item.repo?.provider ?? "",
     platformHost: item.platform_host ?? item.repo?.platform_host ?? "",
+    platformRepoId: item.repo?.platform_repo_id,
     owner: item.repo_owner,
     name: item.repo_name,
   });

--- a/frontend/src/lib/components/layout/StatusBar.svelte
+++ b/frontend/src/lib/components/layout/StatusBar.svelte
@@ -7,6 +7,7 @@
   import { getStores } from "../../context.js";
   import type { ActivityItem } from "../../api/types.js";
   import { isActivityItemTypeEnabled } from "../../stores/activity.svelte.js";
+  import { repoIdentityKey } from "../../utils/repo-label.js";
   import BudgetBars from "./BudgetBars.svelte";
   import BudgetPopover from "./BudgetPopover.svelte";
   import { formatCompact } from "./budget-utils";
@@ -70,6 +71,7 @@
     repo?: {
       provider?: string | undefined;
       platform_host?: string | undefined;
+      platform_repo_id?: string | undefined;
       repo_path?: string | undefined;
       owner?: string | undefined;
       name?: string | undefined;
@@ -77,6 +79,12 @@
     platform_host?: string | undefined;
     repo_owner?: string | undefined;
     repo_name?: string | undefined;
+  }
+
+  interface ActivityCountSubject extends RepoBackedItem {
+    item_number: number;
+    item_state: string;
+    item_type: string;
   }
 
   interface StatusCounts {
@@ -94,10 +102,17 @@
       ?? [item.repo?.owner ?? item.repo_owner, item.repo?.name ?? item.repo_name]
         .filter(Boolean)
         .join("/");
-    return `${provider}|${platformHost}/${repoPath}`;
+    return repoIdentityKey({
+      provider,
+      platformHost,
+      platformRepoId: item.repo?.platform_repo_id,
+      owner: item.repo?.owner ?? item.repo_owner ?? "",
+      name: item.repo?.name ?? item.repo_name ?? "",
+      repoPath,
+    });
   }
 
-  function activityItemKey(item: ActivityItem): string {
+  function activityItemKey(item: ActivityCountSubject): string {
     return `${repoKey(item)}|${item.item_type}|${item.item_number}`;
   }
 
@@ -125,6 +140,7 @@
   });
 
   const activityCounts = $derived.by((): StatusCounts => {
+    const subjects = new Map<string, { item: ActivityCountSubject; lifecycleState: string }>();
     const pullRequests = new Set<string>();
     const issueKeys = new Set<string>();
     const repos = new Set<string>();
@@ -135,17 +151,48 @@
       if (hideBots && isBot(item.author)) continue;
       if (!isActivityItemTypeEnabled(item.item_type, enabledItemTypes)) continue;
 
-      const lifecycleState = activityLifecycleState(item);
+      subjects.set(activityItemKey(item), {
+        item,
+        lifecycleState: activityLifecycleState(item),
+      });
+    }
+
+    // Parent summaries carry the authoritative lifecycle state and replace any
+    // event-backed snapshot for the same item.
+    for (const subject of activity.getItemActivity()) {
+      if (hideBots && isBot(subject.item_author ?? "")) continue;
+      if (!isActivityItemTypeEnabled(subject.item_type, enabledItemTypes)) continue;
+      subjects.set(activityItemKey(subject), {
+        item: subject,
+        lifecycleState: subject.item_state,
+      });
+    }
+
+    // Workspace-only subjects are visible threads too, but must not override
+    // an authoritative parent or an existing event-backed lifecycle state.
+    for (const subject of activity.getWorkspaceActivity()) {
+      if (hideBots && isBot(subject.item_author ?? "")) continue;
+      if (!isActivityItemTypeEnabled(subject.item_type, enabledItemTypes)) continue;
+      const key = activityItemKey(subject);
+      if (!subjects.has(key)) {
+        subjects.set(key, {
+          item: subject,
+          lifecycleState: subject.item_state,
+        });
+      }
+    }
+
+    for (const [key, { item, lifecycleState }] of subjects) {
       const isOpenPullRequest = item.item_type === "pr"
         && lifecycleState === "open";
       const isOpenIssue = item.item_type === "issue"
         && lifecycleState === "open";
 
       if (isOpenPullRequest) {
-        pullRequests.add(activityItemKey(item));
+        pullRequests.add(key);
         repos.add(repoKey(item));
       } else if (isOpenIssue) {
-        issueKeys.add(activityItemKey(item));
+        issueKeys.add(key);
         repos.add(repoKey(item));
       }
     }

--- a/frontend/src/lib/components/layout/StatusBar.test.ts
+++ b/frontend/src/lib/components/layout/StatusBar.test.ts
@@ -1,0 +1,150 @@
+import { cleanup, render, screen } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { ActivityItem, ActivitySubject, WorkspaceActivitySubject } from "../../api/types.js";
+
+const activityState = vi.hoisted(() => ({
+  items: [] as ActivityItem[],
+  itemActivity: [] as ActivitySubject[],
+  workspaceActivity: [] as WorkspaceActivitySubject[],
+  enabledItemTypes: new Set<"pr" | "issue">(["pr", "issue"]),
+  hideBots: false,
+}));
+
+const runtime = vi.hoisted(() => ({
+  runCommand: vi.fn(() => ({ interrupt: vi.fn() })),
+}));
+
+vi.mock("../../app/runtime-context.js", () => ({
+  getAppRuntime: () => runtime,
+}));
+
+vi.mock("../../stores/router.svelte.ts", () => ({
+  getPage: () => "activity",
+}));
+
+vi.mock("../../context.js", () => ({
+  getStores: () => ({
+    activity: {
+      getActivityItems: () => activityState.items,
+      getItemActivity: () => activityState.itemActivity,
+      getWorkspaceActivity: () => activityState.workspaceActivity,
+      getEnabledItemTypes: () => activityState.enabledItemTypes,
+      getHideBots: () => activityState.hideBots,
+    },
+    pulls: { getPulls: () => [] },
+    issues: { getIssues: () => [] },
+    sync: {
+      getSyncState: () => null,
+      getRateLimits: () => ({ provider_pools: {}, local_ceilings: {} }),
+    },
+    events: {
+      getConnectionState: () => "connected",
+      getLastError: () => null,
+      reconnect: vi.fn(),
+    },
+  }),
+}));
+
+import StatusBar from "./StatusBar.svelte";
+
+const repo = {
+  provider: "github",
+  platform_host: "github.com",
+  owner: "acme",
+  name: "widgets",
+  repo_path: "acme/widgets",
+};
+
+function parentSubject(itemType: "pr" | "issue", itemNumber: number, itemState = "open"): ActivitySubject {
+  return {
+    activity_at: "2026-08-14T12:00:00Z",
+    item_number: itemNumber,
+    item_state: itemState,
+    item_title: `${itemType} ${itemNumber}`,
+    item_type: itemType,
+    item_url: `https://github.com/acme/widgets/${itemType === "pr" ? "pull" : "issues"}/${itemNumber}`,
+    platform_host: "github.com",
+    repo,
+    repo_name: "widgets",
+    repo_owner: "acme",
+  } as ActivitySubject;
+}
+
+function workspaceSubject(itemType: "pr" | "issue", itemNumber: number): WorkspaceActivitySubject {
+  return {
+    ...parentSubject(itemType, itemNumber),
+    workspace: { id: `workspace-${itemNumber}`, status: "ready" },
+  } as WorkspaceActivitySubject;
+}
+
+function activityItem(itemType: "pr" | "issue", itemNumber: number, itemState = "open"): ActivityItem {
+  return {
+    ...parentSubject(itemType, itemNumber, itemState),
+    id: `event-${itemType}-${itemNumber}`,
+    cursor: `cursor-${itemType}-${itemNumber}`,
+    activity_type: "comment",
+    author: "alice",
+    body_preview: "",
+    created_at: "2026-08-14T12:00:00Z",
+  } as ActivityItem;
+}
+
+describe("StatusBar Activity counts", () => {
+  beforeEach(() => {
+    activityState.items = [];
+    activityState.itemActivity = [];
+    activityState.workspaceActivity = [];
+    activityState.enabledItemTypes = new Set(["pr", "issue"]);
+    activityState.hideBots = false;
+    runtime.runCommand.mockClear();
+  });
+
+  afterEach(() => cleanup());
+
+  it("counts open parent-only subjects from the authoritative snapshot", () => {
+    activityState.itemActivity = [parentSubject("pr", 7), parentSubject("issue", 8), parentSubject("pr", 9, "merged")];
+
+    render(StatusBar);
+
+    expect(screen.getByText("1 PRs")).toBeTruthy();
+    expect(screen.getByText("1 issues")).toBeTruthy();
+    expect(screen.getByText("1 repos")).toBeTruthy();
+  });
+
+  it("deduplicates subjects represented by events, parents, and workspaces", () => {
+    activityState.items = [activityItem("pr", 7)];
+    activityState.itemActivity = [parentSubject("pr", 7)];
+    activityState.workspaceActivity = [workspaceSubject("pr", 7), workspaceSubject("issue", 8)];
+
+    render(StatusBar);
+
+    expect(screen.getByText("1 PRs")).toBeTruthy();
+    expect(screen.getByText("1 issues")).toBeTruthy();
+    expect(screen.getByText("1 repos")).toBeTruthy();
+  });
+
+  it("uses authoritative parent lifecycle state over an event snapshot", () => {
+    activityState.items = [activityItem("pr", 7)];
+    activityState.itemActivity = [parentSubject("pr", 7, "merged")];
+
+    render(StatusBar);
+
+    expect(screen.getByText("0 PRs")).toBeTruthy();
+    expect(screen.getByText("0 repos")).toBeTruthy();
+  });
+
+  it("excludes bot-authored parent and workspace-only subjects", () => {
+    activityState.hideBots = true;
+    activityState.itemActivity = [
+      { ...parentSubject("pr", 7), item_author: "renovate[bot]" },
+      { ...parentSubject("pr", 9), item_author: "alice" },
+    ];
+    activityState.workspaceActivity = [{ ...workspaceSubject("issue", 8), item_author: "release-bot" }];
+
+    render(StatusBar);
+
+    expect(screen.getByText("1 PRs")).toBeTruthy();
+    expect(screen.getByText("0 issues")).toBeTruthy();
+    expect(screen.getByText("1 repos")).toBeTruthy();
+  });
+});

--- a/frontend/src/lib/stores/activity.svelte.test.ts
+++ b/frontend/src/lib/stores/activity.svelte.test.ts
@@ -2,7 +2,7 @@ import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { GeneratedClient } from "../api/generated-api.js";
 import type { OwnedAppRuntime } from "../app/runtime.js";
-import type { ActivityItem, ActivitySettings, WorkspaceActivitySubject } from "../api/types.js";
+import type { ActivityItem, ActivitySettings, ActivitySubject, WorkspaceActivitySubject } from "../api/types.js";
 import { makeTestAppRuntime } from "../testing/effect-layers.js";
 import {
   buildActivityItemTypeFilter,
@@ -66,6 +66,21 @@ function workspaceActivity(itemNumber: number): WorkspaceActivitySubject {
   };
 }
 
+function itemActivity(itemNumber: number): ActivitySubject {
+  return {
+    activity_at: `2026-08-09T12:00:0${itemNumber}Z`,
+    item_number: itemNumber,
+    item_state: "open",
+    item_title: `PR ${itemNumber}`,
+    item_type: "pr",
+    item_url: `https://github.com/acme/widgets/pull/${itemNumber}`,
+    platform_host: "github.com",
+    repo: { host: "github.com", owner: "acme", name: "widgets" },
+    repo_name: "widgets",
+    repo_owner: "acme",
+  };
+}
+
 beforeEach(() => {
   runtime = undefined;
   localStorage.clear();
@@ -106,6 +121,35 @@ describe("activity store workspace activity", () => {
     await vi.waitFor(() => expect(store.isActivityLoading()).toBe(false));
 
     expect(store.getWorkspaceActivity()).toEqual(snapshot);
+  });
+
+  it("retains the authoritative item snapshot returned with an activity read", async () => {
+    const snapshot = [itemActivity(7)];
+    const client = {
+      GET: async () => ({ data: { items: [], capped: false, item_activity: snapshot }, error: null }),
+    } as unknown as GeneratedClient;
+    const store = createActivityStore({ client });
+
+    store.loadActivity();
+    await vi.waitFor(() => expect(store.isActivityLoading()).toBe(false));
+
+    expect(store.getItemActivity()).toEqual(snapshot);
+  });
+
+  it("retains parent-snapshot truncation independently from event truncation", async () => {
+    const client = {
+      GET: async () => ({
+        data: { items: [], capped: false, item_activity: [itemActivity(7)], item_activity_capped: true },
+        error: null,
+      }),
+    } as unknown as GeneratedClient;
+    const store = createActivityStore({ client });
+
+    store.loadActivity();
+    await vi.waitFor(() => expect(store.isActivityLoading()).toBe(false));
+
+    expect(store.isActivityCapped()).toBe(false);
+    expect(store.isItemActivityCapped()).toBe(true);
   });
 });
 
@@ -209,7 +253,7 @@ describe("buildActivityFilterTypes", () => {
     expect(buildActivityFilterTypes(allItemTypes, allEvents, false)).toEqual([]);
   });
 
-  it("drops default-branch commits when the commit event is deselected", () => {
+  it("drops default-branch commits but keeps PR commits when Commits is deselected", () => {
     const enabled = new Set(["comment", "review", "force_push"]);
     expect(buildActivityFilterTypes(allItemTypes, enabled, false)).toEqual([
       "new_pr",
@@ -217,6 +261,7 @@ describe("buildActivityFilterTypes", () => {
       "default_branch_force_push",
       "comment",
       "review",
+      "commit",
       "force_push",
       "notification",
     ]);
@@ -254,7 +299,6 @@ describe("buildActivityFilterTypes", () => {
       "default_branch_force_push",
       "comment",
       "review",
-      "commit",
       "force_push",
       "notification",
     ]);
@@ -277,15 +321,70 @@ describe("buildActivityFilterTypes", () => {
     ]);
   });
 
-  it("preserves notification-only filtering for the default item scope", () => {
-    expect(buildActivityFilterTypes(allItemTypes, new Set(), false, true)).toEqual(["notification"]);
+  it("gates issue opening rows on comments, the only issue timeline event", () => {
+    expect(buildActivityFilterTypes(allItemTypes, new Set(["review"]), true, false)).toEqual([
+      "new_pr",
+      "review",
+      "commit",
+    ]);
+    expect(buildActivityFilterTypes(allItemTypes, new Set(["force_push"]), true, false)).toEqual([
+      "new_pr",
+      "commit",
+      "force_push",
+    ]);
+    expect(buildActivityFilterTypes(allItemTypes, new Set(["comment"]), true, false)).toEqual([
+      "new_pr",
+      "new_issue",
+      "comment",
+      "commit",
+    ]);
+  });
+
+  it("keeps PR commits when every top-level event filter is deselected", () => {
+    expect(buildActivityFilterTypes(allItemTypes, new Set(), false, true)).toEqual(["commit", "notification"]);
+  });
+
+  it("does not include opening events when only default-branch commits are selected", () => {
+    expect(buildActivityFilterTypes(allItemTypes, new Set(["commit"]), false, true)).toEqual([
+      "default_branch_commit",
+      "commit",
+      "notification",
+    ]);
+  });
+
+  it.each([
+    {
+      name: "notifications off",
+      itemTypes: allItemTypes,
+      showNotifications: false,
+      expected: ["commit"],
+    },
+    {
+      name: "pull requests only",
+      itemTypes: new Set<"pr" | "issue">(["pr"]),
+      showNotifications: true,
+      expected: ["commit", "notification"],
+    },
+    {
+      name: "issues only with notifications",
+      itemTypes: new Set<"pr" | "issue">(["issue"]),
+      showNotifications: true,
+      expected: ["notification"],
+    },
+    {
+      name: "issues only without notifications",
+      itemTypes: new Set<"pr" | "issue">(["issue"]),
+      showNotifications: false,
+      expected: ["none"],
+    },
+  ])("keeps opening events hidden with no event toggles when $name", ({ itemTypes, showNotifications, expected }) => {
+    expect(buildActivityFilterTypes(itemTypes, new Set(), false, showNotifications)).toEqual(expected);
   });
 
   it("supports repository-level commits with both item types hidden", () => {
     expect(buildActivityFilterTypes(new Set(), new Set(["commit"]), false, false)).toEqual([
       "none",
       "default_branch_commit",
-      "commit",
     ]);
   });
 
@@ -326,18 +425,159 @@ describe("activity store URL hydration", () => {
     expect(new URLSearchParams(window.location.search).has("author")).toBe(false);
   });
 
-  it("normalizes legacy URLs that kept default-branch commits while commit was deselected", () => {
-    window.history.replaceState(
-      null,
-      "",
-      "/?types=new_pr,new_issue,default_branch_commit,default_branch_force_push,comment,review,force_push",
-    );
+  it("restores mandatory PR commits without re-enabling default-branch commits", () => {
+    window.history.replaceState(null, "", "/?event_types=comment,review,force_push");
     const s = makeStore();
     s.initializeFromMount();
-    // Notifications default on, so a legacy filtered URL (no notif=0)
-    // gains the notification type on hydration.
     expect(s.getActivityFilterTypes()).toEqual([
       "new_pr",
+      "new_issue",
+      "default_branch_force_push",
+      "comment",
+      "review",
+      "commit",
+      "force_push",
+      "notification",
+    ]);
+    expect(new URLSearchParams(window.location.search).get("event_types")).toBe("comment,review,force_push");
+    expect(new URLSearchParams(window.location.search).has("types")).toBe(false);
+    expect(s.getEnabledEvents().has("commit")).toBe(false);
+  });
+
+  it.each([
+    {
+      name: "the all-items empty-event encoding",
+      legacyTypes: "notification",
+      expectedItems: ["pr", "issue"],
+      expectedEvents: [],
+      expectedItemParam: null,
+      expectedEventParam: "none",
+    },
+    {
+      name: "a notified commit-only filter",
+      legacyTypes: "commit,notification",
+      expectedItems: [],
+      expectedEvents: ["commit"],
+      expectedItemParam: "none",
+      expectedEventParam: "commit",
+    },
+    {
+      name: "a manually bookmarked commit-only filter",
+      legacyTypes: "commit",
+      expectedItems: [],
+      expectedEvents: ["commit"],
+      expectedItemParam: "none",
+      expectedEventParam: "commit",
+    },
+    {
+      name: "an issue-only comment filter",
+      legacyTypes: "new_issue,comment,notification",
+      expectedItems: ["issue"],
+      expectedEvents: ["comment"],
+      expectedItemParam: "issue",
+      expectedEventParam: "comment",
+    },
+    {
+      name: "a pull-request filter with default-branch commits enabled",
+      legacyTypes: "new_pr,default_branch_commit,comment,commit",
+      expectedItems: ["pr"],
+      expectedEvents: ["comment", "commit"],
+      expectedItemParam: "pr",
+      expectedEventParam: "comment,commit",
+    },
+  ])(
+    "migrates bookmarked legacy types for $name",
+    ({ legacyTypes, expectedItems, expectedEvents, expectedItemParam, expectedEventParam }) => {
+      window.history.replaceState(null, "", `/?types=${legacyTypes}`);
+      const first = makeStore();
+      first.initializeFromMount();
+
+      expect([...first.getEnabledItemTypes()]).toEqual(expectedItems);
+      expect([...first.getEnabledEvents()]).toEqual(expectedEvents);
+      const normalized = new URLSearchParams(window.location.search);
+      expect(normalized.has("types")).toBe(false);
+      expect(normalized.get("item_types")).toBe(expectedItemParam);
+      expect(normalized.get("event_types")).toBe(expectedEventParam);
+
+      const fresh = makeStore();
+      fresh.initializeFromMount();
+      expect([...fresh.getEnabledItemTypes()]).toEqual(expectedItems);
+      expect([...fresh.getEnabledEvents()]).toEqual(expectedEvents);
+    },
+  );
+
+  it("normalizes explicit default item and event selections out of the URL", () => {
+    window.history.replaceState(null, "", "/?item_types=pr,issue&event_types=comment,review,commit,force_push");
+    const s = makeStore();
+    s.initializeFromMount();
+    expect(s.getActivityFilterTypes()).toEqual([]);
+    const normalized = new URLSearchParams(window.location.search);
+    expect(normalized.has("item_types")).toBe(false);
+    expect(normalized.has("event_types")).toBe(false);
+  });
+
+  it.each([
+    {
+      name: "PRs only",
+      itemTypes: "pr",
+      eventTypes: "comment",
+      expected: ["pr"],
+      filterTypes: ["new_pr", "comment", "commit", "notification"],
+    },
+    {
+      name: "issues only",
+      itemTypes: "issue",
+      eventTypes: "comment",
+      expected: ["issue"],
+      filterTypes: ["new_issue", "comment", "notification"],
+    },
+    {
+      name: "neither item type",
+      itemTypes: "none",
+      eventTypes: "commit",
+      expected: [],
+      filterTypes: ["none", "default_branch_commit", "notification"],
+    },
+  ])("hydrates $name independently from event selections", ({ itemTypes, eventTypes, expected, filterTypes }) => {
+    window.history.replaceState(null, "", `/?item_types=${itemTypes}&event_types=${eventTypes}`);
+    const s = makeStore();
+    s.initializeFromMount();
+    expect([...s.getEnabledItemTypes()]).toEqual(expected);
+    expect(s.getActivityFilterTypes()).toEqual(filterTypes);
+    const normalized = new URLSearchParams(window.location.search);
+    expect(normalized.get("item_types")).toBe(itemTypes);
+    expect(normalized.get("event_types")).toBe(eventTypes);
+    expect(normalized.has("types")).toBe(false);
+  });
+
+  it("round trips default item scope with every event toggle disabled after URL normalization", () => {
+    window.history.replaceState(null, "", "/?item_types=pr,issue&event_types=none");
+    const first = makeStore();
+    first.initializeFromMount();
+
+    expect([...first.getEnabledItemTypes()]).toEqual(DEFAULT_ACTIVITY_ITEM_TYPES);
+    expect([...first.getEnabledEvents()]).toEqual([]);
+    expect(first.getActivityFilterTypes()).toEqual(["commit", "notification"]);
+    const normalized = new URLSearchParams(window.location.search);
+    expect(normalized.has("item_types")).toBe(false);
+    expect(normalized.get("event_types")).toBe("none");
+    expect(normalized.has("types")).toBe(false);
+
+    const fresh = makeStore();
+    fresh.initializeFromMount();
+    expect([...fresh.getEnabledItemTypes()]).toEqual(DEFAULT_ACTIVITY_ITEM_TYPES);
+    expect([...fresh.getEnabledEvents()]).toEqual([]);
+    expect(fresh.getActivityFilterTypes()).toEqual(["commit", "notification"]);
+  });
+
+  it("round trips item scope independently from the default-branch commit toggle", () => {
+    window.history.replaceState(null, "", "/?item_types=issue&event_types=comment,review,force_push");
+    const first = makeStore();
+    first.initializeFromMount();
+
+    expect([...first.getEnabledItemTypes()]).toEqual(["issue"]);
+    expect([...first.getEnabledEvents()]).toEqual(["comment", "review", "force_push"]);
+    expect(first.getActivityFilterTypes()).toEqual([
       "new_issue",
       "default_branch_force_push",
       "comment",
@@ -345,63 +585,15 @@ describe("activity store URL hydration", () => {
       "force_push",
       "notification",
     ]);
-    expect(new URLSearchParams(window.location.search).get("types")).toBe(
-      "new_pr,new_issue,default_branch_force_push,comment,review,force_push,notification",
-    );
-  });
 
-  it("normalizes a legacy all-selected types list back to no filter", () => {
-    window.history.replaceState(
-      null,
-      "",
-      "/?types=new_pr,new_issue,default_branch_commit,default_branch_force_push,comment,review,commit,force_push",
-    );
-    const s = makeStore();
-    s.initializeFromMount();
-    expect(s.getActivityFilterTypes()).toEqual([]);
-    expect(new URLSearchParams(window.location.search).has("types")).toBe(false);
-  });
-
-  it.each([
-    {
-      name: "PRs only",
-      types: "new_pr,comment",
-      expected: ["pr"],
-      normalized: "new_pr,comment,notification",
-    },
-    {
-      name: "issues only",
-      types: "new_issue,comment",
-      expected: ["issue"],
-      normalized: "new_issue,comment,notification",
-    },
-    {
-      name: "neither item type",
-      types: "default_branch_commit,commit",
-      expected: [],
-      normalized: "none,default_branch_commit,commit,notification",
-    },
-  ])("hydrates $name from the types parameter", ({ types, expected, normalized }) => {
-    window.history.replaceState(null, "", `/?types=${types}`);
-    const s = makeStore();
-    s.initializeFromMount();
-    expect([...s.getEnabledItemTypes()]).toEqual(expected);
-    expect(new URLSearchParams(window.location.search).get("types")).toBe(normalized);
-  });
-
-  it("hydrates notification-only URLs with the default item scope", () => {
-    window.history.replaceState(null, "", "/?types=notification");
-    const s = makeStore();
-    s.initializeFromMount();
-
-    expect([...s.getEnabledItemTypes()]).toEqual(DEFAULT_ACTIVITY_ITEM_TYPES);
-    expect([...s.getEnabledEvents()]).toEqual([]);
-    expect(s.getActivityFilterTypes()).toEqual(["notification"]);
-    expect(new URLSearchParams(window.location.search).get("types")).toBe("notification");
+    const fresh = makeStore();
+    fresh.initializeFromMount();
+    expect([...fresh.getEnabledItemTypes()]).toEqual(["issue"]);
+    expect([...fresh.getEnabledEvents()]).toEqual(["comment", "review", "force_push"]);
   });
 
   it("round trips a fully empty selection without restoring defaults", () => {
-    window.history.replaceState(null, "", "/?types=none&notif=0&hide_branch=1");
+    window.history.replaceState(null, "", "/?item_types=none&event_types=none&notif=0&hide_branch=1");
     const s = makeStore();
     s.initializeFromMount();
 
@@ -410,7 +602,10 @@ describe("activity store URL hydration", () => {
     expect(s.getShowNotifications()).toBe(false);
     expect(s.getHideDefaultBranchActivity()).toBe(true);
     expect(s.getActivityFilterTypes()).toEqual(["none"]);
-    expect(new URLSearchParams(window.location.search).get("types")).toBe("none");
+    const normalized = new URLSearchParams(window.location.search);
+    expect(normalized.get("item_types")).toBe("none");
+    expect(normalized.get("event_types")).toBe("none");
+    expect(normalized.has("types")).toBe(false);
   });
 });
 
@@ -771,6 +966,63 @@ describe("activity store default-branch visibility", () => {
     next.syncToURL();
     expect(new URLSearchParams(window.location.search).has("hide_branch")).toBe(false);
   });
+
+  it("keeps the Commits toggle enabled while default-branch activity is hidden", () => {
+    window.history.replaceState(null, "", "/?hide_branch=1&notif=0");
+    const first = makeStore();
+    first.initializeFromMount();
+    expect(first.getEnabledEvents().has("commit")).toBe(true);
+    expect(first.getActivityFilterTypes()).not.toContain("default_branch_commit");
+
+    const fresh = makeStore();
+    fresh.initializeFromMount();
+    expect(fresh.getEnabledEvents().has("commit")).toBe(true);
+    fresh.setHideDefaultBranchActivity(false);
+    fresh.syncToURL();
+    expect(fresh.getActivityFilterTypes()).toContain("default_branch_commit");
+  });
+
+  it("migrates a legacy hidden-branch URL without disabling the Commits toggle", () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/?types=new_pr,new_issue,comment,review,commit,force_push,notification&hide_branch=1",
+    );
+    const first = makeStore();
+    first.initializeFromMount();
+
+    expect(first.getHideDefaultBranchActivity()).toBe(true);
+    expect(first.getEnabledEvents()).toEqual(new Set(DEFAULT_EVENT_TYPES));
+    const normalized = new URLSearchParams(window.location.search);
+    expect(normalized.has("types")).toBe(false);
+    expect(normalized.has("event_types")).toBe(false);
+    expect(normalized.get("hide_branch")).toBe("1");
+
+    const fresh = makeStore();
+    fresh.initializeFromMount();
+    expect(fresh.getEnabledEvents()).toEqual(new Set(DEFAULT_EVENT_TYPES));
+  });
+
+  it("drops a stale default-branch token when the legacy Commits toggle is absent", () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/?types=new_pr,new_issue,default_branch_commit,comment,review,force_push,notification&hide_branch=1",
+    );
+    const first = makeStore();
+    first.initializeFromMount();
+
+    expect(first.getHideDefaultBranchActivity()).toBe(true);
+    expect(first.getEnabledEvents()).toEqual(new Set(["comment", "review", "force_push"]));
+    const normalized = new URLSearchParams(window.location.search);
+    expect(normalized.has("types")).toBe(false);
+    expect(normalized.get("event_types")).toBe("comment,review,force_push");
+    expect(normalized.get("hide_branch")).toBe("1");
+
+    const fresh = makeStore();
+    fresh.initializeFromMount();
+    expect(fresh.getEnabledEvents()).toEqual(new Set(["comment", "review", "force_push"]));
+  });
 });
 
 describe("activity store commit roll-up", () => {
@@ -986,6 +1238,159 @@ describe("activity store markNotificationSeen", () => {
 });
 
 describe("activity polling recovery", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reconciles retained item events from stable authoritative parent identities", async () => {
+    const now = new Date().toISOString();
+    const retained = {
+      id: "pre:7",
+      cursor: "pre:7",
+      activity_type: "comment",
+      activity_url: "https://github.com/acme/widgets/pull/7#issuecomment-42",
+      author: "event-author",
+      body_preview: "Existing comment",
+      created_at: now,
+      item_author: "old-parent-author",
+      item_number: 7,
+      item_state: "open",
+      item_title: "Old title",
+      item_type: "pr",
+      item_url: "https://github.com/acme/widgets/pull/7",
+      platform_host: "github.com",
+      repo_owner: "acme",
+      repo_name: "widgets",
+      repo: {
+        provider: "github",
+        platform_host: "github.com",
+        platform_repo_id: "repo-original",
+        owner: "acme",
+        name: "widgets",
+        repo_path: "acme/widgets",
+      },
+      workspace: { id: "old-workspace", status: "ready" },
+    } as ActivityItem;
+    const retainedNotification = {
+      ...retained,
+      id: "ntf:7",
+      cursor: "ntf:7",
+      activity_type: "notification",
+      activity_url: "https://github.com/acme/widgets/pull/7",
+      item_state: "unread",
+    } as ActivityItem;
+    const renamed = {
+      activity_at: now,
+      item_author: "current-parent-author",
+      item_number: 7,
+      item_state: "merged",
+      item_title: "Current title",
+      item_type: "pr",
+      item_url: "https://github.com/acme/widgets-renamed/pull/7",
+      platform_host: "github.com",
+      repo_owner: "acme",
+      repo_name: "widgets-renamed",
+      repo: {
+        provider: "github",
+        platform_host: "github.com",
+        platform_repo_id: "repo-original",
+        owner: "acme",
+        name: "widgets-renamed",
+        repo_path: "acme/widgets-renamed",
+      },
+      workspace: { id: "current-workspace", status: "ready" },
+    } as ActivitySubject;
+    const replacement = {
+      ...renamed,
+      item_title: "Replacement title",
+      item_url: "https://github.com/acme/widgets/pull/7",
+      repo_name: "widgets",
+      repo: {
+        ...renamed.repo,
+        platform_repo_id: "repo-replacement",
+        name: "widgets",
+        repo_path: "acme/widgets",
+      },
+    } as ActivitySubject;
+    let feedReads = 0;
+    const client = {
+      GET: vi.fn(async (path: string) => {
+        if (path === "/activity/authors") return { data: { authors: [] }, error: null };
+        feedReads += 1;
+        if (feedReads === 1) {
+          return { data: { items: [retained, retainedNotification], capped: false }, error: null };
+        }
+        return {
+          data: { items: [], item_activity: [renamed, replacement], capped: false },
+          error: null,
+        };
+      }),
+    } as unknown as GeneratedClient;
+    const store = createActivityStore({ client });
+    store.loadActivity();
+    await vi.waitFor(() => expect(store.getActivityItems()).toEqual([retained, retainedNotification]));
+
+    store.startActivityPolling();
+
+    await vi.waitFor(() =>
+      expect(store.getActivityItems().map((item) => item.repo.repo_path)).toEqual([
+        "acme/widgets-renamed",
+        "acme/widgets-renamed",
+      ]),
+    );
+    const reconciledEvent = store.getActivityItems().find((item) => item.id === retained.id);
+    const reconciledNotification = store.getActivityItems().find((item) => item.id === retainedNotification.id);
+    expect(reconciledEvent).toEqual(
+      expect.objectContaining({
+        activity_url: retained.activity_url,
+        author: "event-author",
+        item_author: "current-parent-author",
+        item_state: "merged",
+        item_title: "Current title",
+        item_url: "https://github.com/acme/widgets-renamed/pull/7",
+        platform_host: "github.com",
+        repo_owner: "acme",
+        repo_name: "widgets-renamed",
+        repo: renamed.repo,
+        workspace: renamed.workspace,
+      }),
+    );
+    expect(reconciledNotification).toEqual(
+      expect.objectContaining({
+        activity_url: renamed.item_url,
+        item_url: renamed.item_url,
+        repo: renamed.repo,
+      }),
+    );
+  });
+
+  it("replaces the feed on the scheduled full poll so cursor-behind activity becomes visible", async () => {
+    vi.useFakeTimers();
+    const now = new Date().toISOString();
+    const stale = { ...notificationItem("ntf:stale", "unread"), created_at: now };
+    const persistedBehindCursor = { ...notificationItem("ntf:persisted", "unread"), created_at: now };
+    let feedReads = 0;
+    const client = {
+      GET: vi.fn(async (path: string) => {
+        if (path === "/activity/authors") return { data: { authors: [] }, error: null };
+        feedReads += 1;
+        if (feedReads === 1) return { data: { items: [stale], capped: false }, error: null };
+        if (feedReads <= 4) return { data: { items: [], capped: false }, error: null };
+        if (feedReads === 5) return { data: { items: [persistedBehindCursor], capped: false }, error: null };
+        throw new Error(`unexpected activity request ${feedReads}`);
+      }),
+    } as unknown as GeneratedClient;
+    const store = createActivityStore({ client });
+    store.loadActivity();
+    await vi.waitFor(() => expect(store.getActivityItems()).toEqual([stale]));
+
+    store.startActivityPolling();
+    await vi.advanceTimersByTimeAsync(45_000);
+    await vi.waitFor(() => expect(feedReads).toBe(5));
+
+    expect(store.getActivityItems()).toEqual([persistedBehindCursor]);
+  });
+
   it("clears a foreground error when a replacement poll succeeds afterward", async () => {
     const pendingPoll = Promise.withResolvers<{
       data: { items: ActivityItem[]; capped: boolean };
@@ -1154,5 +1559,41 @@ describe("activity polling recovery", () => {
     await vi.waitFor(() => expect(feedReads).toBe(3));
 
     expect(store.isActivityLoading()).toBe(false);
+  });
+
+  it("does not reload events when only the parent snapshot is capped", async () => {
+    const initial = { ...notificationItem("ntf:42", "unread"), created_at: new Date().toISOString() };
+    let feedReads = 0;
+    const client = {
+      GET: vi.fn(async (path: string) => {
+        if (path === "/activity/authors") return { data: { authors: [] }, error: null };
+        feedReads += 1;
+        if (feedReads === 1) {
+          return { data: { items: [initial], capped: false, item_activity_capped: false }, error: null };
+        }
+        if (feedReads === 2) {
+          return {
+            data: {
+              items: [],
+              capped: false,
+              item_activity: [itemActivity(7)],
+              item_activity_capped: true,
+            },
+            error: null,
+          };
+        }
+        throw new Error(`unexpected activity request ${feedReads}`);
+      }),
+    } as unknown as GeneratedClient;
+    const store = createActivityStore({ client });
+    store.loadActivity();
+    await vi.waitFor(() => expect(store.getActivityItems()).toEqual([initial]));
+
+    store.startActivityPolling();
+    await vi.waitFor(() => expect(store.isItemActivityCapped()).toBe(true));
+
+    expect(feedReads).toBe(2);
+    expect(store.isActivityCapped()).toBe(false);
+    expect(store.getActivityItems()).toEqual([initial]);
   });
 });

--- a/frontend/src/lib/stores/activity.svelte.ts
+++ b/frontend/src/lib/stores/activity.svelte.ts
@@ -9,9 +9,11 @@ import type {
   ActivityParams,
   ActivityResponse,
   ActivitySettings,
+  ActivitySubject,
   NotificationBulkResponse,
   WorkspaceActivitySubject,
 } from "../api/types.js";
+import { activityItemKey } from "../components/activityRows.js";
 import { ActivityWorkflow } from "./activity-workflow.js";
 import { showFlash } from "./flash.svelte.js";
 import { ProviderMutations, providerMutationFailureMessage } from "./ordered-mutations.js";
@@ -24,10 +26,15 @@ export type ActivityAPIItemType = ActivityItemType | "repo";
 
 export const DEFAULT_ACTIVITY_ITEM_TYPES = ["pr", "issue"] as const;
 export const DEFAULT_EVENT_TYPES = ["comment", "review", "commit", "force_push"] as const;
+const PR_TIMELINE_EVENT_TYPES = ["comment", "review", "force_push"] as const;
+const ISSUE_TIMELINE_EVENT_TYPES = ["comment"] as const;
 const NO_ACTIVITY_FILTER_TYPE = "none";
+const ACTIVITY_ITEM_TYPES_PARAM = "item_types";
+const ACTIVITY_EVENT_TYPES_PARAM = "event_types";
 
-// Default-branch activity rows render as "Commit"/"Force-pushed" just like
-// their PR counterparts, so the event-type toggles must govern both kinds.
+// Default-branch force pushes and PR force pushes share a filter. Commits are
+// intentionally different: the Commits filter controls only top-level branch
+// activity, while commits inside PR timelines are always part of the PR.
 const BRANCH_TYPE_FOR_EVENT: Partial<Record<string, string>> = {
   commit: "default_branch_commit",
   force_push: "default_branch_force_push",
@@ -50,16 +57,20 @@ export function buildActivityFilterTypes(
   // to build the explicit list that omits "notification".
   if (allSelected) return [];
 
-  // Keep the established notification-only representation free of opening
-  // events when both item scopes remain at their default.
-  if (enabledItemTypes.size === DEFAULT_ACTIVITY_ITEM_TYPES.length && enabledEvents.size === 0 && showNotifications) {
-    return ["notification"];
-  }
-
   const types: string[] = [];
   if (enabledItemTypes.size === 0) types.push(NO_ACTIVITY_FILTER_TYPE);
-  if (enabledItemTypes.has("pr")) types.push("new_pr");
-  if (enabledItemTypes.has("issue")) types.push("new_issue");
+  // Opening rows are timeline events, not parent anchors. Authoritative parent
+  // summaries are projected separately, so opening rows follow only the
+  // timeline events that can occur on that item kind: an issue timeline has
+  // comments alone, so Reviews or Force pushes must not toggle issue opening
+  // rows. The Commits toggle controls top-level default-branch commits only,
+  // so it does not opt into PR or issue opening rows either.
+  if (enabledItemTypes.has("pr") && PR_TIMELINE_EVENT_TYPES.some((eventType) => enabledEvents.has(eventType))) {
+    types.push("new_pr");
+  }
+  if (enabledItemTypes.has("issue") && ISSUE_TIMELINE_EVENT_TYPES.some((eventType) => enabledEvents.has(eventType))) {
+    types.push("new_issue");
+  }
   if (!hideDefaultBranchActivity) {
     for (const evt of DEFAULT_EVENT_TYPES) {
       const branchType = BRANCH_TYPE_FOR_EVENT[evt];
@@ -67,7 +78,11 @@ export function buildActivityFilterTypes(
     }
   }
   for (const evt of DEFAULT_EVENT_TYPES) {
-    if (enabledEvents.has(evt)) types.push(evt);
+    if (evt === "commit") {
+      if (enabledItemTypes.has("pr")) types.push(evt);
+    } else if (enabledEvents.has(evt)) {
+      types.push(evt);
+    }
   }
   if (showNotifications) types.push("notification");
   return types.length > 0 ? types : [NO_ACTIVITY_FILTER_TYPE];
@@ -80,6 +95,50 @@ export function buildActivityItemTypeFilter(enabledItemTypes: ReadonlySet<Activi
 export function isActivityItemTypeEnabled(itemType: string, enabledItemTypes: ReadonlySet<ActivityItemType>): boolean {
   if (itemType !== "pr" && itemType !== "issue") return true;
   return enabledItemTypes.has(itemType);
+}
+
+function readSelectedFilters<T extends string>(value: string | null, defaults: readonly T[]): Set<T> {
+  if (value === null) return new Set(defaults);
+  const selected = value === NO_ACTIVITY_FILTER_TYPE ? [] : value.split(",");
+  return new Set(defaults.filter((candidate) => selected.includes(candidate)));
+}
+
+function writeSelectedFilters<T extends string>(
+  searchParams: URLSearchParams,
+  name: string,
+  selected: ReadonlySet<T>,
+  defaults: readonly T[],
+): void {
+  const ordered = defaults.filter((candidate) => selected.has(candidate));
+  if (ordered.length === defaults.length) {
+    searchParams.delete(name);
+  } else {
+    searchParams.set(name, ordered.length > 0 ? ordered.join(",") : NO_ACTIVITY_FILTER_TYPE);
+  }
+}
+
+function readLegacyFilterSelections(value: string): {
+  itemTypes: Set<ActivityItemType>;
+  events: Set<string>;
+} {
+  const types = value ? value.split(",") : [];
+  if (types.length === 0) {
+    return {
+      itemTypes: new Set(DEFAULT_ACTIVITY_ITEM_TYPES),
+      events: new Set(DEFAULT_EVENT_TYPES),
+    };
+  }
+
+  const encodedEmptyEventDefaultScope = types.length === 1 && types[0] === "notification";
+  const itemTypes = encodedEmptyEventDefaultScope
+    ? new Set(DEFAULT_ACTIVITY_ITEM_TYPES)
+    : new Set(
+        DEFAULT_ACTIVITY_ITEM_TYPES.filter((itemType) => types.includes(itemType === "pr" ? "new_pr" : "new_issue")),
+      );
+  const events = encodedEmptyEventDefaultScope
+    ? new Set<string>()
+    : new Set(DEFAULT_EVENT_TYPES.filter((eventType) => types.includes(eventType)));
+  return { itemTypes, events };
 }
 
 // Activity item ids are "<source>:<source_id>"; notification rows use
@@ -135,10 +194,12 @@ export function createActivityStore(opts: ActivityStoreOptions) {
   // --- state ---
 
   let items = $state<ActivityItem[]>([]);
+  let itemActivity = $state.raw<ActivitySubject[]>([]);
   let workspaceActivity = $state.raw<WorkspaceActivitySubject[]>([]);
   let loading = $state(false);
   let storeError = $state<string | null>(null);
   let capped = $state(false);
+  let itemActivityCapped = $state(false);
   let filterTypes = $state<string[]>([]);
   let searchQuery = $state<string | undefined>(undefined);
   let authorFilter = $state<string | undefined>(undefined);
@@ -172,6 +233,9 @@ export function createActivityStore(opts: ActivityStoreOptions) {
   function getActivityItems(): ActivityItem[] {
     return items;
   }
+  function getItemActivity(): ActivitySubject[] {
+    return itemActivity;
+  }
   function getWorkspaceActivity(): WorkspaceActivitySubject[] {
     return workspaceActivity;
   }
@@ -183,6 +247,9 @@ export function createActivityStore(opts: ActivityStoreOptions) {
   }
   function isActivityCapped(): boolean {
     return capped;
+  }
+  function isItemActivityCapped(): boolean {
+    return itemActivityCapped;
   }
   function getActivityFilterTypes(): string[] {
     return filterTypes;
@@ -451,19 +518,74 @@ export function createActivityStore(opts: ActivityStoreOptions) {
     return projected;
   }
 
+  function stableParentKey(item: ActivityItem | ActivitySubject): string | undefined {
+    const repo = item.repo;
+    if (!repo) return undefined;
+    const platformRepoId = repo.platform_repo_id?.trim();
+    if (!platformRepoId || (item.item_type !== "pr" && item.item_type !== "issue")) return undefined;
+    return activityItemKey({
+      provider: repo.provider,
+      platformHost: repo.platform_host,
+      platformRepoId,
+      owner: repo.owner,
+      name: repo.name,
+      repoPath: repo.repo_path,
+      itemType: item.item_type,
+      itemNumber: item.item_number,
+    });
+  }
+
+  function reconcileItemsWithParentSubjects(subjects: ActivitySubject[]): void {
+    const subjectsByKey = new Map<string, ActivitySubject>();
+    for (const subject of subjects) {
+      const key = stableParentKey(subject);
+      if (key) subjectsByKey.set(key, subject);
+    }
+    items = items.map((item) => {
+      const key = stableParentKey(item);
+      const subject = key ? subjectsByKey.get(key) : undefined;
+      if (!subject) return item;
+      const { workspace: _staleWorkspace, ...retainedEvent } = item;
+      return {
+        ...retainedEvent,
+        ...(item.activity_type === "notification" ? { activity_url: subject.item_url } : {}),
+        item_author: subject.item_author ?? "",
+        item_last_activity_at: subject.activity_at,
+        item_state: item.activity_type === "notification" ? item.item_state : subject.item_state,
+        item_title: subject.item_title,
+        item_url: subject.item_url,
+        platform_host: subject.repo.platform_host,
+        repo_owner: subject.repo.owner,
+        repo_name: subject.repo.name,
+        repo: subject.repo,
+        ...(item.activity_type === "notification" ? { subject_state: subject.item_state } : {}),
+        ...(subject.workspace ? { workspace: subject.workspace } : {}),
+      };
+    });
+  }
+
+  function projectActivitySubjects(response: ActivityResponse): void {
+    const subjects = response.item_activity ?? [];
+    reconcileItemsWithParentSubjects(subjects);
+    itemActivity = subjects;
+    workspaceActivity = response.workspace_activity ?? [];
+    itemActivityCapped = response.item_activity_capped ?? false;
+  }
+
+  function projectActivitySnapshot(result: OwnedActivityResponse): void {
+    items = projectOwnedNotificationStates(result);
+    projectActivitySubjects(result.response);
+    capped = result.response.capped;
+    loading = false;
+    storeError = null;
+  }
+
   function loadActivityProgram(params: ActivityParams, owner: "foreground" | "poll" = "foreground") {
     return Effect.gen(function* () {
       const workflow = yield* ActivityWorkflow;
       const scope = activityProjectionScope(params);
       const read = activityRead(params);
-      const project = (result: OwnedActivityResponse) =>
-        Effect.sync(() => {
-          items = projectOwnedNotificationStates(result);
-          workspaceActivity = result.response.workspace_activity ?? [];
-          capped = result.response.capped;
-          loading = false;
-          storeError = null;
-        });
+      const project = (result: OwnedActivityResponse) => Effect.sync(() => projectActivitySnapshot(result));
       const clearLoading = Effect.sync(() => {
         loading = false;
       });
@@ -493,14 +615,7 @@ export function createActivityStore(opts: ActivityStoreOptions) {
       const params = buildParams();
       const scope = activityProjectionScope(params);
       const read = activityRead(params);
-      const project = (result: OwnedActivityResponse) =>
-        Effect.sync(() => {
-          items = projectOwnedNotificationStates(result);
-          workspaceActivity = result.response.workspace_activity ?? [];
-          capped = result.response.capped;
-          loading = false;
-          storeError = null;
-        });
+      const project = (result: OwnedActivityResponse) => Effect.sync(() => projectActivitySnapshot(result));
       return Effect.gen(function* () {
         const workflow = yield* ActivityWorkflow;
         yield* Effect.all([workflow.reconcileRead(scope, read, project), loadActivityAuthorsEffect(true)], {
@@ -526,20 +641,14 @@ export function createActivityStore(opts: ActivityStoreOptions) {
   function refreshActivityProgram(params: ActivityParams) {
     return Effect.gen(function* () {
       const workflow = yield* ActivityWorkflow;
-      yield* workflow.pollRead(activityProjectionScope(params), activityRead(params), (result) => {
-        const fresh = projectOwnedNotificationStates(result);
-        return Effect.sync(() => {
-          workspaceActivity = result.response.workspace_activity ?? [];
-          if (fresh.length === 0) return;
-          const freshById = new Map(fresh.map((item) => [item.id, item]));
-          items = items.map((item) => {
-            const updated = freshById.get(item.id);
-            return updated && updated.item_state !== item.item_state
-              ? { ...item, item_state: updated.item_state }
-              : item;
-          });
-        });
-      });
+      yield* workflow.pollSnapshotRead(
+        activityProjectionScope(params),
+        activityRead(params),
+        (result) => Effect.sync(() => projectActivitySnapshot(result)),
+        Effect.sync(() => {
+          loading = false;
+        }),
+      );
     });
   }
 
@@ -620,19 +729,15 @@ export function createActivityStore(opts: ActivityStoreOptions) {
         Effect.gen(function* () {
           const activityChanged = yield* Effect.sync(() => {
             if (mode === "replace") {
-              items = projectOwnedNotificationStates(result);
-              workspaceActivity = result.response.workspace_activity ?? [];
-              capped = result.response.capped;
-              loading = false;
-              storeError = null;
+              projectActivitySnapshot(result);
               return true;
             }
-            workspaceActivity = result.response.workspace_activity ?? [];
             const existingIds = new Set(items.map((item) => item.id));
             const newItems = projectOwnedNotificationStates(result, false).filter((item) => !existingIds.has(item.id));
             if (newItems.length > 0) {
               items = [...newItems, ...items];
             }
+            projectActivitySubjects(result.response);
             const cutoff = new Date(Date.now() - RANGE_MS[timeRange]);
             items = items.filter((item) => new Date(item.created_at) >= cutoff);
             return newItems.length > 0;
@@ -685,31 +790,7 @@ export function createActivityStore(opts: ActivityStoreOptions) {
     });
   }
 
-  // deriveFiltersFromTypes reconstructs the dropdown state from the
-  // persisted `types` list. The notification toggle is NOT inferred
-  // from list membership: a legacy URL listing every event type but no
-  // "notification" must still mean "show everything" rather than
-  // "notifications hidden", so showNotifications is carried by its own
-  // `notif` URL param (read in syncFromURL) instead.
-  function deriveFiltersFromTypes(): void {
-    if (filterTypes.length === 0) {
-      enabledItemTypes = new Set(DEFAULT_ACTIVITY_ITEM_TYPES);
-      enabledEvents = new Set(DEFAULT_EVENT_TYPES);
-    } else {
-      const notificationOnly = filterTypes.length === 1 && filterTypes[0] === "notification";
-      enabledItemTypes = notificationOnly
-        ? new Set(DEFAULT_ACTIVITY_ITEM_TYPES)
-        : new Set(
-            DEFAULT_ACTIVITY_ITEM_TYPES.filter((itemType) =>
-              filterTypes.includes(itemType === "pr" ? "new_pr" : "new_issue"),
-            ),
-          );
-      enabledEvents = new Set(DEFAULT_EVENT_TYPES.filter((t) => filterTypes.includes(t)));
-    }
-    // Rebuild so the request matches the filter state the dropdown
-    // shows: legacy URLs can list default_branch_commit while commit is
-    // deselected, and an empty list with notifications hidden must
-    // become the explicit exclusion list a bare `[]` cannot express.
+  function rebuildFilterTypes(): void {
     filterTypes = buildActivityFilterTypes(
       enabledItemTypes,
       enabledEvents,
@@ -737,10 +818,13 @@ export function createActivityStore(opts: ActivityStoreOptions) {
 
   function syncFromURL(): void {
     const sp = new URLSearchParams(window.location.search);
-    if (sp.has("types")) {
-      const typesParam = sp.get("types");
-      filterTypes = typesParam ? typesParam.split(",") : [];
-    }
+    const legacySelections = sp.has("types") ? readLegacyFilterSelections(sp.get("types") ?? "") : undefined;
+    enabledItemTypes = sp.has(ACTIVITY_ITEM_TYPES_PARAM)
+      ? readSelectedFilters(sp.get(ACTIVITY_ITEM_TYPES_PARAM), DEFAULT_ACTIVITY_ITEM_TYPES)
+      : (legacySelections?.itemTypes ?? new Set(DEFAULT_ACTIVITY_ITEM_TYPES));
+    enabledEvents = sp.has(ACTIVITY_EVENT_TYPES_PARAM)
+      ? readSelectedFilters(sp.get(ACTIVITY_EVENT_TYPES_PARAM), DEFAULT_EVENT_TYPES)
+      : (legacySelections?.events ?? new Set(DEFAULT_EVENT_TYPES));
     if (sp.has("search")) searchQuery = sp.get("search") ?? undefined;
     authorFilter = sp.get("author")?.trim() || undefined;
     if (sp.has("range")) {
@@ -755,13 +839,15 @@ export function createActivityStore(opts: ActivityStoreOptions) {
     hideDefaultBranchActivity = sp.get("hide_branch") === "1";
     showNotifications = sp.get("notif") !== "0";
     applyCollapsedFromURL();
-    deriveFiltersFromTypes();
+    rebuildFilterTypes();
   }
 
   function syncToURL(): void {
     const sp = new URLSearchParams(window.location.search);
-    if (filterTypes.length > 0) sp.set("types", filterTypes.join(","));
-    else sp.delete("types");
+    rebuildFilterTypes();
+    sp.delete("types");
+    writeSelectedFilters(sp, ACTIVITY_ITEM_TYPES_PARAM, enabledItemTypes, DEFAULT_ACTIVITY_ITEM_TYPES);
+    writeSelectedFilters(sp, ACTIVITY_EVENT_TYPES_PARAM, enabledEvents, DEFAULT_EVENT_TYPES);
     if (searchQuery) sp.set("search", searchQuery);
     else sp.delete("search");
     if (authorFilter) sp.set("author", authorFilter);
@@ -789,10 +875,12 @@ export function createActivityStore(opts: ActivityStoreOptions) {
 
   return {
     getActivityItems,
+    getItemActivity,
     getWorkspaceActivity,
     isActivityLoading,
     getActivityError,
     isActivityCapped,
+    isItemActivityCapped,
     getActivityFilterTypes,
     getActivitySearch,
     getActivityAuthor,

--- a/frontend/src/lib/stores/detail.svelte.test.ts
+++ b/frontend/src/lib/stores/detail.svelte.test.ts
@@ -690,7 +690,7 @@ describe("createDetailStore", () => {
     store.setPullState(routeRef, 7, "closed");
 
     await vi.waitFor(() => expect(get).toHaveBeenCalledTimes(2));
-    await vi.waitFor(() => expect(pulls.loadPulls).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(pulls.loadPulls).toHaveBeenCalledTimes(2));
   });
 
   it("syncs detail and resolves after applying the refreshed head", async () => {
@@ -715,6 +715,61 @@ describe("createDetailStore", () => {
     expect(refreshed).toBe(true);
     expect(store.getDetail()?.platform_head_sha).toBe("fresh-head");
     expect(pulls.loadPulls).toHaveBeenCalledTimes(1);
+  });
+
+  it("reconciles visible lists after the initial detail read exposes persisted activity", async () => {
+    const loadPulls = vi.fn();
+    const onDetailSynchronized = vi.fn();
+    const store = createDetailStore({
+      client: mockClient({ GET: vi.fn().mockResolvedValue({ data: pullDetail("persisted-head") }) }),
+      getPage: () => "pulls",
+      pulls: { loadPulls },
+      onDetailSynchronized,
+    });
+
+    await loadDetail(store, "acme", "widget", 7, {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widget",
+      sync: false,
+    });
+
+    expect(loadPulls).toHaveBeenCalledOnce();
+    expect(onDetailSynchronized).toHaveBeenCalledOnce();
+  });
+
+  it("reconciles a successful initial read after its presentation generation is superseded", async () => {
+    const detailRead = Promise.withResolvers<{ data: PullDetail }>();
+    const get = vi.fn(() => detailRead.promise);
+    const post = vi.fn(() => new Promise<never>(() => {}));
+    const loadPulls = vi.fn();
+    const onDetailSynchronized = vi.fn();
+    const store = createDetailStore({
+      client: mockClient({ GET: get, POST: post }),
+      getPage: () => "pulls",
+      pulls: { loadPulls },
+      onDetailSynchronized,
+    });
+
+    store.loadDetail("acme", "widget", 7, {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widget",
+      sync: false,
+    });
+    await vi.waitFor(() => expect(get).toHaveBeenCalledOnce());
+
+    detailRead.resolve({ data: pullDetail("persisted-head") });
+    store.syncDetailNow("acme", "widget", 7, {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widget",
+    });
+
+    await vi.waitFor(() => expect(onDetailSynchronized).toHaveBeenCalledOnce());
+    expect(post).toHaveBeenCalledOnce();
+    expect(loadPulls).toHaveBeenCalledOnce();
+    expect(store.getDetail()).toBeNull();
   });
 
   it("reconciles visible lists when selection closes during an explicit detail sync", async () => {
@@ -819,8 +874,8 @@ describe("createDetailStore", () => {
     await vi.advanceTimersByTimeAsync(300);
 
     await vi.waitFor(() => expect(store.getDetail()?.merge_request.platform_head_sha).toBe("fresh-head"));
-    expect(loadPulls).toHaveBeenCalledOnce();
-    expect(onDetailSynchronized).toHaveBeenCalledOnce();
+    expect(loadPulls).toHaveBeenCalledTimes(2);
+    expect(onDetailSynchronized).toHaveBeenCalledTimes(2);
   });
 
   it("reconciles visible lists when selection changes during a background detail sync", async () => {
@@ -861,8 +916,8 @@ describe("createDetailStore", () => {
     syncPost.resolve({ data: undefined, error: undefined });
     await vi.advanceTimersByTimeAsync(300);
 
-    await vi.waitFor(() => expect(onDetailSynchronized).toHaveBeenCalledOnce());
-    expect(loadPulls).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(onDetailSynchronized).toHaveBeenCalledTimes(3));
+    expect(loadPulls).toHaveBeenCalledTimes(3);
     expect(store.getDetail()?.repo_name).toBe("widget-b");
     expect(store.getDetail()?.merge_request.platform_head_sha).toBe("other-head");
   });

--- a/frontend/src/lib/stores/detail.svelte.ts
+++ b/frontend/src/lib/stores/detail.svelte.ts
@@ -979,6 +979,7 @@ export function createDetailStore(opts: DetailStoreOptions) {
     const program = Effect.gen(function* () {
       const workflow = yield* DetailWorkflow;
       const data = yield* workflow.read(key, read);
+      reconcileListsAfterDetailSync();
       if (gen !== syncGeneration) return;
       const applied = yield* rebasePullMutations(requestRef, data, () => {
         if (gen !== syncGeneration || activeSelectionKey !== key) return false;

--- a/frontend/src/lib/stores/issues.svelte.test.ts
+++ b/frontend/src/lib/stores/issues.svelte.test.ts
@@ -230,6 +230,56 @@ describe("createIssuesStore", () => {
     vi.useRealTimers();
   });
 
+  it("reconciles visible lists after the initial detail read exposes persisted activity", async () => {
+    const get = vi.fn(async (path: string) =>
+      path === "/issues" ? { data: [], error: undefined } : { data: issueDetail(), error: undefined },
+    );
+    const onDetailSynchronized = vi.fn();
+    const store = createIssuesStore({
+      client: mockClient({ GET: get }),
+      getPage: () => "issues",
+      onDetailSynchronized,
+    });
+
+    await loadIssueDetail(store, "acme", "widget", 7, {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widget",
+      sync: false,
+    });
+
+    expect(get.mock.calls.filter(([path]) => path === "/issues")).toHaveLength(1);
+    expect(onDetailSynchronized).toHaveBeenCalledOnce();
+  });
+
+  it("reconciles visible lists when selection closes as the initial detail read succeeds", async () => {
+    const detailRead = Promise.withResolvers<{ data: IssueDetail; error: undefined }>();
+    const get = vi.fn((path: string) =>
+      path === "/issues" ? Promise.resolve({ data: [], error: undefined }) : detailRead.promise,
+    );
+    const onDetailSynchronized = vi.fn();
+    const store = createIssuesStore({
+      client: mockClient({ GET: get }),
+      getPage: () => "issues",
+      onDetailSynchronized,
+    });
+
+    store.loadIssueDetail("acme", "widget", 7, {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widget",
+      sync: false,
+    });
+    await vi.waitFor(() => expect(get).toHaveBeenCalledOnce());
+
+    detailRead.resolve({ data: issueDetail(), error: undefined });
+    store.clearIssueDetail();
+
+    await vi.waitFor(() => expect(onDetailSynchronized).toHaveBeenCalledOnce());
+    expect(get.mock.calls.filter(([path]) => path === "/issues")).toHaveLength(1);
+    expect(store.getIssueDetail()).toBeNull();
+  });
+
   it("reconciles visible activity and issue lists after a background detail sync converges", async () => {
     vi.useFakeTimers();
     const cached = issueDetail();
@@ -262,8 +312,8 @@ describe("createIssuesStore", () => {
     await vi.advanceTimersByTimeAsync(300);
 
     await vi.waitFor(() => expect(store.getIssueDetail()?.issue.Title).toBe("Fresh issue detail"));
-    expect(get.mock.calls.filter(([path]) => path === "/issues")).toHaveLength(1);
-    expect(onDetailSynchronized).toHaveBeenCalledOnce();
+    expect(get.mock.calls.filter(([path]) => path === "/issues")).toHaveLength(2);
+    expect(onDetailSynchronized).toHaveBeenCalledTimes(2);
   });
 
   it("reconciles visible lists when selection closes during a synchronous detail sync", async () => {
@@ -290,8 +340,8 @@ describe("createIssuesStore", () => {
 
     syncPost.resolve({ data: issueDetail(), error: undefined });
 
-    await vi.waitFor(() => expect(onDetailSynchronized).toHaveBeenCalledOnce());
-    expect(get.mock.calls.filter(([path]) => path === "/issues")).toHaveLength(1);
+    await vi.waitFor(() => expect(onDetailSynchronized).toHaveBeenCalledTimes(2));
+    expect(get.mock.calls.filter(([path]) => path === "/issues")).toHaveLength(2);
     expect(store.getIssueDetail()).toBeNull();
   });
 
@@ -326,8 +376,8 @@ describe("createIssuesStore", () => {
     syncPost.resolve({ data: undefined, error: undefined });
     await vi.advanceTimersByTimeAsync(300);
 
-    await vi.waitFor(() => expect(onDetailSynchronized).toHaveBeenCalledOnce());
-    expect(get.mock.calls.filter(([path]) => path === "/issues")).toHaveLength(1);
+    await vi.waitFor(() => expect(onDetailSynchronized).toHaveBeenCalledTimes(2));
+    expect(get.mock.calls.filter(([path]) => path === "/issues")).toHaveLength(2);
     expect(store.getIssueDetail()).toBeNull();
   });
 

--- a/frontend/src/lib/stores/issues.svelte.ts
+++ b/frontend/src/lib/stores/issues.svelte.ts
@@ -864,6 +864,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
     const program = Effect.gen(function* () {
       const workflow = yield* IssuesWorkflow;
       const result = yield* workflow.detail(issueDetailKey(ref), syncMode, readIssueDetail(ref, "GET issue detail"));
+      reconcileListsAfterDetailSync();
       const applied = yield* installIssueDetail(ref, result.detail, envelopeTick, generation, false);
       if (generation === issueSyncGeneration) detailLoading = false;
       if (!applied || generation !== issueSyncGeneration) return;

--- a/frontend/src/lib/stores/router.initialization.test.ts
+++ b/frontend/src/lib/stores/router.initialization.test.ts
@@ -93,7 +93,7 @@ describe("router initialization", () => {
   });
 
   it("restores the last Activity route after reloading on Workspaces", async () => {
-    const activityRoute = "/?types=new_pr,comment,review,force_push,notification";
+    const activityRoute = "/?item_types=pr&event_types=comment,review,force_push";
     const router = await importRouterAt(activityRoute);
     router.navigate("/workspaces");
 
@@ -106,7 +106,7 @@ describe("router initialization", () => {
     window.__BASE_PATH__ = "/kenn-forge/";
     window.sessionStorage.setItem(
       "kenn-forge:last-activity-route",
-      "/?view=flat&types=new_pr,comment,review,force_push&notif=0&hide_branch=1&author=Alice%20Smith",
+      "/?view=flat&item_types=pr&event_types=comment,review,force_push&notif=0&hide_branch=1&author=Alice%20Smith",
     );
 
     const router = await importRouterAt("/kenn-forge/?view=threaded");
@@ -114,7 +114,8 @@ describe("router initialization", () => {
 
     expect(restoredURL.pathname).toBe("/kenn-forge/");
     expect(restoredURL.searchParams.get("view")).toBe("threaded");
-    expect(restoredURL.searchParams.get("types")).toBe("new_pr,comment,review,force_push");
+    expect(restoredURL.searchParams.get("item_types")).toBe("pr");
+    expect(restoredURL.searchParams.get("event_types")).toBe("comment,review,force_push");
     expect(restoredURL.searchParams.get("notif")).toBe("0");
     expect(restoredURL.searchParams.get("hide_branch")).toBe("1");
     expect(restoredURL.searchParams.get("author")).toBe("Alice Smith");
@@ -125,7 +126,7 @@ describe("router initialization", () => {
     window.__BASE_PATH__ = "/kenn-forge/";
     window.sessionStorage.setItem(
       "kenn-forge:last-activity-route",
-      "/?types=new_pr,comment,review,force_push&notif=0&hide_branch=1&author=Alice",
+      "/?item_types=pr&event_types=comment,review,force_push&notif=0&hide_branch=1&author=Alice",
     );
     const router = await importRouterAt("/kenn-forge/settings");
 
@@ -134,15 +135,50 @@ describe("router initialization", () => {
 
     expect(restoredURL.pathname).toBe("/kenn-forge/");
     expect(restoredURL.searchParams.get("view")).toBe("threaded");
-    expect(restoredURL.searchParams.get("types")).toBe("new_pr,comment,review,force_push");
+    expect(restoredURL.searchParams.get("item_types")).toBe("pr");
+    expect(restoredURL.searchParams.get("event_types")).toBe("comment,review,force_push");
     expect(restoredURL.searchParams.get("notif")).toBe("0");
     expect(restoredURL.searchParams.get("hide_branch")).toBe("1");
     expect(restoredURL.searchParams.get("author")).toBe("Bob");
   });
 
+  it("restores a stored legacy Activity filter for migration during store hydration", async () => {
+    window.__BASE_PATH__ = "/kenn-forge/";
+    window.sessionStorage.setItem("kenn-forge:last-activity-route", "/?types=new_issue,comment,notification&notif=0");
+    const router = await importRouterAt("/kenn-forge/settings");
+
+    router.navigate("/?view=threaded");
+    const restoredURL = new URL(window.location.href);
+
+    expect(restoredURL.pathname).toBe("/kenn-forge/");
+    expect(restoredURL.searchParams.get("view")).toBe("threaded");
+    expect(restoredURL.searchParams.get("types")).toBe("new_issue,comment,notification");
+    expect(restoredURL.searchParams.get("notif")).toBe("0");
+  });
+
+  it("keeps an explicit legacy Activity bookmark ahead of canonical session filters", async () => {
+    window.__BASE_PATH__ = "/kenn-forge/";
+    window.sessionStorage.setItem("kenn-forge:last-activity-route", "/?item_types=pr&event_types=comment&notif=0");
+
+    await importRouterAt("/kenn-forge/?types=new_issue,review,notification");
+    const { createActivityStore } = await import("./activity.svelte.js");
+    const store = createActivityStore({ runtime: {} as never });
+    store.initializeFromMount();
+
+    expect([...store.getEnabledItemTypes()]).toEqual(["issue"]);
+    expect([...store.getEnabledEvents()]).toEqual(["review"]);
+    const normalizedURL = new URL(window.location.href);
+    expect(normalizedURL.searchParams.has("types")).toBe(false);
+    expect(normalizedURL.searchParams.get("item_types")).toBe("issue");
+    expect(normalizedURL.searchParams.get("event_types")).toBe("review");
+  });
+
   it("restores stored Activity filters when Back or Forward enters Activity", async () => {
     window.__BASE_PATH__ = "/kenn-forge/";
-    window.sessionStorage.setItem("kenn-forge:last-activity-route", "/?types=new_pr,comment,review,force_push");
+    window.sessionStorage.setItem(
+      "kenn-forge:last-activity-route",
+      "/?item_types=pr&event_types=comment,review,force_push",
+    );
     await importRouterAt("/kenn-forge/settings");
 
     window.history.pushState(null, "", "/kenn-forge/?view=threaded");
@@ -150,10 +186,11 @@ describe("router initialization", () => {
     const restoredURL = new URL(window.location.href);
 
     expect(restoredURL.searchParams.get("view")).toBe("threaded");
-    expect(restoredURL.searchParams.get("types")).toBe("new_pr,comment,review,force_push");
+    expect(restoredURL.searchParams.get("item_types")).toBe("pr");
+    expect(restoredURL.searchParams.get("event_types")).toBe("comment,review,force_push");
   });
 
-  it.each(["/workspaces", "/unexpected", "//", "///?types=new_pr", "//example.com/?types=new_pr"])(
+  it.each(["/workspaces", "/unexpected", "//", "///?item_types=pr", "//example.com/?item_types=pr"])(
     "ignores an invalid stored Activity route: %s",
     async (storedRoute) => {
       window.sessionStorage.setItem("kenn-forge:last-activity-route", storedRoute);
@@ -175,7 +212,7 @@ describe("router initialization", () => {
   });
 
   it("keeps the in-memory Activity route when session storage writes are blocked", async () => {
-    const activityRoute = "/?types=new_pr,comment,review,force_push,notification";
+    const activityRoute = "/?item_types=pr&event_types=comment,review,force_push";
     const router = await importRouterAt(activityRoute);
     vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
       throw new DOMException("blocked", "SecurityError");

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -553,7 +553,14 @@ let route = $state<Route>(parseRoute(configuredInitialRoute ?? currentLocationPa
 // Back/Forward), and initial load — so it stays current regardless of how
 // Activity is entered or left.
 const LAST_ACTIVITY_ROUTE_STORAGE_KEY = "kenn-forge:last-activity-route";
-const RESTORABLE_ACTIVITY_FILTER_PARAMS = ["types", "notif", "hide_branch", "author"] as const;
+const RESTORABLE_ACTIVITY_FILTER_PARAMS = [
+  "item_types",
+  "event_types",
+  "types",
+  "notif",
+  "hide_branch",
+  "author",
+] as const;
 
 function isRestorableActivityRoute(routePath: string): boolean {
   if (!routePath.startsWith("/") || routePath.startsWith("//")) return false;
@@ -592,9 +599,11 @@ function restoreMissingActivityFilters(): void {
 
   const currentURL = new URL(currentRoute, "https://example.invalid");
   const storedURL = new URL(lastActivityRoute, "https://example.invalid");
+  const currentHasLegacyTypes = currentURL.searchParams.has("types");
   let restored = false;
   for (const param of RESTORABLE_ACTIVITY_FILTER_PARAMS) {
-    if (!currentURL.searchParams.has(param) && storedURL.searchParams.has(param)) {
+    const representedByLegacyTypes = currentHasLegacyTypes && (param === "item_types" || param === "event_types");
+    if (!currentURL.searchParams.has(param) && !representedByLegacyTypes && storedURL.searchParams.has(param)) {
       currentURL.searchParams.set(param, storedURL.searchParams.get(param)!);
       restored = true;
     }

--- a/frontend/src/lib/utils/effective-activity.ts
+++ b/frontend/src/lib/utils/effective-activity.ts
@@ -9,3 +9,10 @@ export function effectiveActivity(providerAt: string, workspaceAt?: string): Eff
   }
   return { at: providerAt, fromWorkspace: false };
 }
+
+export function latestActivityAt(eventAt: string, itemAt?: string): string {
+  if (itemAt && Date.parse(itemAt) > Date.parse(eventAt)) {
+    return itemAt;
+  }
+  return eventAt;
+}

--- a/frontend/src/lib/utils/repo-label.test.ts
+++ b/frontend/src/lib/utils/repo-label.test.ts
@@ -133,4 +133,18 @@ describe("repo labels", () => {
     expect(repoIdentityKey(repos[0]!)).not.toBe(repoIdentityKey(repos[2]!));
     expect(repoIdentityKey(repos[0]!)).toBe(repoIdentityKey({ ...repos[0]! }));
   });
+
+  it("uses stable repository ids across renames and route reuse", () => {
+    const original = { ...repos[0]!, platformRepoId: "repo-widgets" };
+    const renamed = {
+      ...original,
+      owner: "platform",
+      name: "widgets-next",
+      repoPath: "platform/widgets-next",
+    };
+    const replacement = { ...repos[0]!, platformRepoId: "repo-replacement" };
+
+    expect(repoIdentityKey(original)).toBe(repoIdentityKey(renamed));
+    expect(repoIdentityKey(original)).not.toBe(repoIdentityKey(replacement));
+  });
 });

--- a/frontend/src/lib/utils/repo-label.ts
+++ b/frontend/src/lib/utils/repo-label.ts
@@ -1,6 +1,7 @@
 export interface RepoLabelIdentity {
   provider: string;
   platformHost: string;
+  platformRepoId?: string | undefined;
   owner: string;
   name: string;
   repoPath?: string | undefined;
@@ -88,12 +89,9 @@ export function repoPath(repo: RepoLabelIdentity): string {
 }
 
 export function repoIdentityKey(repo: RepoLabelIdentity): string {
-  // The "|" delimiter is the established thread/grouping key format
-  // (provider|host|owner/name); activity item and branch keys append
-  // ":type:number" to it and ActivityThreaded relies on that shape.
-  // None of provider, host, or repo path contains "|", so segments
-  // stay unambiguous.
-  return [repo.provider.trim(), repo.platformHost.trim(), repoPath(repo)].join("|");
+  const platformRepoId = repo.platformRepoId?.trim();
+  const prefix = [repo.provider.trim(), repo.platformHost.trim()];
+  return platformRepoId ? [...prefix, "id", platformRepoId].join("|") : [...prefix, repoPath(repo)].join("|");
 }
 
 function hostNeeded(hostsByRepoPath: ReadonlyMap<string, ReadonlySet<string>>, path: string): boolean {

--- a/frontend/src/lib/views/MobileActivityView.svelte
+++ b/frontend/src/lib/views/MobileActivityView.svelte
@@ -4,7 +4,7 @@
   import { SvelteMap, SvelteSet } from "svelte/reactivity";
   import { getAppRuntime } from "../app/runtime-context.js";
   import type { AppExecution } from "../app/runtime.js";
-  import type { ActivityItem, WorkspaceActivitySubject } from "../api/types.js";
+  import type { ActivityItem, ActivitySubject, WorkspaceActivitySubject } from "../api/types.js";
   import { getStores } from "../context.js";
   import {
     buildActivityFilterTypes,
@@ -25,6 +25,7 @@
     type TimelineTone,
   } from "@kenn-io/kit-ui";
   import { parseAPITimestamp } from "../utils/time.js";
+  import { latestActivityAt } from "../utils/effective-activity.js";
   import ItemKindChip from "../components/shared/ItemKindChip.svelte";
   import ItemStateChip from "../components/shared/ItemStateChip.svelte";
   import { SelectDropdown } from "@kenn-io/kit-ui";
@@ -137,6 +138,23 @@
       );
     }
 
+    if (activity.getHideBots()) {
+      result = result.filter((subject) => !isBot(subject.item_author ?? ""));
+    }
+
+    return result;
+  });
+
+  const visibleItemActivity = $derived.by(() => {
+    let result = activity.getItemActivity().filter((subject) =>
+      isActivityItemTypeEnabled(subject.item_type, activity.getEnabledItemTypes())
+    );
+    if (activity.getHideClosedMerged()) {
+      result = result.filter((subject) => subject.item_state !== "closed" && subject.item_state !== "merged");
+    }
+    if (activity.getHideBots()) {
+      result = result.filter((subject) => !isBot(subject.item_author ?? ""));
+    }
     return result;
   });
 
@@ -148,6 +166,7 @@
         ? activityBranchKey({
             provider: item.repo.provider,
             platformHost: item.repo.platform_host,
+            platformRepoId: item.repo.platform_repo_id,
             owner: item.repo.owner,
             name: item.repo.name,
             repoPath: item.repo.repo_path,
@@ -156,6 +175,7 @@
         : activityItemKey({
             provider: item.repo.provider,
             platformHost: item.repo.platform_host,
+            platformRepoId: item.repo.platform_repo_id,
             owner: item.repo.owner,
             name: item.repo.name,
             repoPath: item.repo.repo_path,
@@ -181,7 +201,52 @@
         representative,
         events,
         eventCount: events.length,
-        latestTime: representative.created_at,
+        latestTime: latestActivityAt(
+          representative.created_at,
+          representative.item_last_activity_at,
+        ),
+      });
+    }
+
+    for (const subject of visibleItemActivity) {
+      const key = activityItemKey({
+        provider: subject.repo.provider,
+        platformHost: subject.repo.platform_host,
+        platformRepoId: subject.repo.platform_repo_id,
+        owner: subject.repo.owner,
+        name: subject.repo.name,
+        repoPath: subject.repo.repo_path,
+        itemType: subject.item_type,
+        itemNumber: subject.item_number,
+      });
+      const existing = groupsByKey.get(key);
+      if (existing) {
+        if (
+          parseAPITimestamp(subject.activity_at).getTime()
+          > parseAPITimestamp(existing.latestTime).getTime()
+        ) {
+          existing.latestTime = subject.activity_at;
+        }
+        existing.representative = {
+          ...existing.representative,
+          item_title: subject.item_title,
+          item_url: subject.item_url,
+          item_state: subject.item_state,
+          item_author: subject.item_author || existing.representative.item_author || "",
+          platform_host: subject.repo.platform_host,
+          repo_owner: subject.repo.owner,
+          repo_name: subject.repo.name,
+          repo: subject.repo,
+          ...(subject.workspace ? { workspace: subject.workspace } : {}),
+        };
+        continue;
+      }
+      groupsByKey.set(key, {
+        key,
+        representative: subjectSelectionItem(subject, "parent"),
+        events: [],
+        eventCount: 0,
+        latestTime: subject.activity_at,
       });
     }
 
@@ -189,6 +254,7 @@
       const key = activityItemKey({
         provider: subject.repo.provider,
         platformHost: subject.repo.platform_host,
+        platformRepoId: subject.repo.platform_repo_id,
         owner: subject.repo.owner,
         name: subject.repo.name,
         repoPath: subject.repo.repo_path,
@@ -216,7 +282,7 @@
       }
       groupsByKey.set(key, {
         key,
-        representative: subjectSelectionItem(subject),
+        representative: subjectSelectionItem(subject, "workspace"),
         events: [],
         eventCount: 0,
         latestTime: subject.activity_at,
@@ -259,7 +325,8 @@
     createRepoLabelFormatter(
       [
         ...displayItems.map(activityRepoIdentity),
-        ...visibleWorkspaceActivity.map(workspaceRepoIdentity),
+        ...visibleItemActivity.map(subjectRepoIdentity),
+        ...visibleWorkspaceActivity.map(subjectRepoIdentity),
       ],
       { showOrgNames: !grouping.getHideOrgName() },
     ),
@@ -359,10 +426,14 @@
     onSelectItem?.(group.representative);
   }
 
-  function subjectSelectionItem(subject: WorkspaceActivitySubject): ActivityItem {
-    const id = `workspace:${activityItemKey({
+  function subjectSelectionItem(
+    subject: ActivitySubject | WorkspaceActivitySubject,
+    activityType: "parent" | "workspace",
+  ): ActivityItem {
+    const id = `${activityType}:${activityItemKey({
       provider: subject.repo.provider,
       platformHost: subject.repo.platform_host,
+      platformRepoId: subject.repo.platform_repo_id,
       owner: subject.repo.owner,
       name: subject.repo.name,
       repoPath: subject.repo.repo_path,
@@ -372,7 +443,7 @@
     return {
       id,
       cursor: id,
-      activity_type: "workspace",
+      activity_type: activityType,
       author: subject.item_author ?? "",
       body_preview: "",
       created_at: subject.activity_at,
@@ -466,16 +537,18 @@
     return {
       provider: item.repo.provider,
       platformHost: item.repo.platform_host,
+      platformRepoId: item.repo.platform_repo_id,
       owner: item.repo.owner,
       name: item.repo.name,
       repoPath: item.repo.repo_path,
     };
   }
 
-  function workspaceRepoIdentity(subject: WorkspaceActivitySubject): RepoLabelIdentity {
+  function subjectRepoIdentity(subject: ActivitySubject | WorkspaceActivitySubject): RepoLabelIdentity {
     return {
       provider: subject.repo.provider,
       platformHost: subject.repo.platform_host,
+      platformRepoId: subject.repo.platform_repo_id,
       owner: subject.repo.owner,
       name: subject.repo.name,
       repoPath: subject.repo.repo_path,
@@ -749,8 +822,15 @@
     {/if}
 
     {#if activity.isActivityCapped()}
-      <div class="mobile-activity-capped">
+      <div class="mobile-activity-capped event-capped-notice">
         Showing most recent 5,000 events. Narrow the range or filters to see more.
+      </div>
+    {/if}
+
+    {#if activity.isItemActivityCapped()}
+      <div class="mobile-activity-capped item-activity-capped-notice">
+        Showing the 5,000 most recently active pull requests and issues. Item totals may be incomplete; narrow the
+        range or item filters to see fewer results.
       </div>
     {/if}
   </div>

--- a/frontend/src/lib/views/MobileActivityView.test.ts
+++ b/frontend/src/lib/views/MobileActivityView.test.ts
@@ -1,6 +1,6 @@
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
-import type { ActivityItem, WorkspaceActivitySubject } from "../api/types.js";
+import type { ActivityItem, ActivitySubject, WorkspaceActivitySubject } from "../api/types.js";
 import MobileActivityView from "./MobileActivityViewRuntimeHarness.svelte";
 
 function branchActivityItem(id: string, overrides: Partial<ActivityItem> = {}): ActivityItem {
@@ -36,11 +36,15 @@ function branchActivityItem(id: string, overrides: Partial<ActivityItem> = {}): 
 }
 
 const items = vi.hoisted(() => ({ value: [] as ActivityItem[] }));
+const itemActivity = vi.hoisted(() => ({ value: [] as ActivitySubject[] }));
 const workspaceActivity = vi.hoisted(() => ({ value: [] as WorkspaceActivitySubject[] }));
 const onSelectItem = vi.hoisted(() => vi.fn());
 const hideClosedMerged = vi.hoisted(() => ({ value: false }));
+const hideBots = vi.hoisted(() => ({ value: false }));
 const hideOrgName = vi.hoisted(() => ({ value: false }));
 const showNotifications = vi.hoisted(() => ({ value: true }));
+const activityCapped = vi.hoisted(() => ({ value: false }));
+const itemActivityCapped = vi.hoisted(() => ({ value: false }));
 const involvesMe = vi.hoisted(() => ({ value: false }));
 const enabledItemTypes = vi.hoisted(() => ({
   value: new Set<"pr" | "issue">(["pr", "issue"]),
@@ -81,6 +85,7 @@ vi.mock("../context.js", () => ({
       isActivityAuthorsLoading: () => false,
       getActivityAuthorsError: () => null,
       getActivityItems: () => items.value,
+      getItemActivity: () => itemActivity.value,
       getWorkspaceActivity: () => workspaceActivity.value,
       getActivityError: () => null,
       getTimeRange: () => "7d",
@@ -89,10 +94,11 @@ vi.mock("../context.js", () => ({
       getShowNotifications: () => showNotifications.value,
       getInvolvesMe: () => involvesMe.value,
       getHideClosedMerged: () => hideClosedMerged.value,
-      getHideBots: () => false,
+      getHideBots: () => hideBots.value,
       getHideDefaultBranchActivity: () => false,
       isActivityLoading: () => false,
-      isActivityCapped: () => false,
+      isActivityCapped: () => activityCapped.value,
+      isItemActivityCapped: () => itemActivityCapped.value,
       setActivityFilterTypes: vi.fn(),
       setActivitySearch: vi.fn(),
       setActivityAuthor,
@@ -122,12 +128,19 @@ vi.mock("../context.js", () => ({
   }),
 }));
 
+beforeEach(() => {
+  hideBots.value = false;
+});
+
 describe("MobileActivityView branch activity", () => {
   beforeEach(() => {
     items.value = [branchActivityItem("branch-commit")];
+    itemActivity.value = [];
     workspaceActivity.value = [];
     hideOrgName.value = false;
     hideClosedMerged.value = false;
+    activityCapped.value = false;
+    itemActivityCapped.value = false;
     enabledItemTypes.value = new Set(["pr", "issue"]);
     onSelectItem.mockClear();
     setEnabledItemTypes.mockClear();
@@ -153,6 +166,15 @@ describe("MobileActivityView branch activity", () => {
     expect(article?.textContent).not.toContain("#0");
     expect(article?.querySelector(".chip--kind-pr")).toBeNull();
     expect(article?.querySelector(".chip--kind-issue")).toBeNull();
+  });
+
+  it("warns about parent truncation separately from event truncation", () => {
+    itemActivityCapped.value = true;
+
+    render(MobileActivityView, { props: { onSelectItem } });
+
+    expect(screen.getByText(/5,000 most recently active pull requests and issues/)).toBeTruthy();
+    expect(screen.queryByText(/most recent 5,000 events/)).toBeNull();
   });
 
   it("exposes independent PR and issue toggles", async () => {
@@ -351,9 +373,15 @@ function workspaceSubject(
   } as WorkspaceActivitySubject;
 }
 
+function itemSubject(number: number, title: string, activityAt: string): ActivitySubject {
+  const { workspace: _workspace, ...subject } = workspaceSubject(number, title, activityAt);
+  return subject;
+}
+
 describe("MobileActivityView workspace activity", () => {
   beforeEach(() => {
     items.value = [];
+    itemActivity.value = [];
     workspaceActivity.value = [];
     hideClosedMerged.value = false;
     enabledItemTypes.value = new Set(["pr", "issue"]);
@@ -362,6 +390,7 @@ describe("MobileActivityView workspace activity", () => {
 
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
   });
 
   it("orders an existing thread by its newer workspace activity", () => {
@@ -375,6 +404,31 @@ describe("MobileActivityView workspace activity", () => {
 
     const cards = Array.from(container.querySelectorAll(".mobile-activity-card__title"));
     expect(cards.map((card) => card.textContent?.trim())).toEqual(["Workspace-active pull", "Provider-newer pull"]);
+  });
+
+  it("orders a thread by parent recency when its newer event is filtered", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T14:05:00Z"));
+    items.value = [
+      {
+        ...pullActivityItem("older-visible-event", "Recently committed pull", "2026-04-27T12:00:00Z", 1),
+        item_last_activity_at: "2026-04-27T14:00:00Z",
+      },
+      {
+        ...pullActivityItem("newer-visible-event", "Recently commented pull", "2026-04-27T13:00:00Z", 2),
+        item_last_activity_at: "2026-04-27T13:00:00Z",
+      },
+    ];
+
+    const { container } = render(MobileActivityView, { props: { onSelectItem } });
+
+    const cards = Array.from(container.querySelectorAll(".mobile-activity-card__title"));
+    expect(cards.map((card) => card.textContent?.trim())).toEqual([
+      "Recently committed pull",
+      "Recently commented pull",
+    ]);
+    expect(container.querySelector(".mobile-activity-card time")?.textContent).toBe("5m ago");
+    expect(container.querySelector(".mobile-activity-events time")?.textContent).toBe("2h ago");
   });
 
   it("renders a workspace-only subject without inventing a timeline event", async () => {
@@ -395,6 +449,76 @@ describe("MobileActivityView workspace activity", () => {
         item_type: "pr",
       }),
     );
+  });
+
+  it("renders a recently active parent without inventing a timeline event", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T14:05:00Z"));
+    itemActivity.value = [itemSubject(8, "Old pull with recent hidden activity", "2026-04-27T14:00:00Z")];
+
+    const { container } = render(MobileActivityView, { props: { onSelectItem } });
+
+    expect(screen.getByText("Old pull with recent hidden activity")).toBeTruthy();
+    expect(screen.getByText("0 events")).toBeTruthy();
+    expect(container.querySelector(".mobile-activity-card time")?.textContent).toBe("5m ago");
+    expect(container.querySelector(".mobile-activity-events")).toBeNull();
+  });
+
+  it("hides bot-authored parent and workspace-only cards", () => {
+    itemActivity.value = [
+      {
+        ...itemSubject(8, "Bot-authored parent", "2026-04-27T14:00:00Z"),
+        item_author: "renovate[bot]",
+      },
+    ];
+    workspaceActivity.value = [
+      {
+        ...workspaceSubject(9, "Bot-authored workspace", "2026-04-27T13:00:00Z"),
+        item_author: "release-bot",
+      },
+    ];
+    hideBots.value = true;
+
+    const { container } = render(MobileActivityView, { props: { onSelectItem } });
+
+    expect(container.textContent).not.toContain("Bot-authored parent");
+    expect(container.textContent).not.toContain("Bot-authored workspace");
+  });
+
+  it("disambiguates repository labels for parent-only cards", () => {
+    hideOrgName.value = true;
+    itemActivity.value = [
+      {
+        ...itemSubject(8, "First parent", "2026-04-27T14:00:00Z"),
+        repo: {
+          provider: "github",
+          platform_host: "github.com",
+          platform_repo_id: "repo-acme-widgets",
+          owner: "acme",
+          name: "widgets",
+          repo_path: "acme/widgets",
+        },
+      },
+      {
+        ...itemSubject(9, "Second parent", "2026-04-27T13:00:00Z"),
+        repo_owner: "platform",
+        repo: {
+          provider: "gitlab",
+          platform_host: "gitlab.example.com",
+          platform_repo_id: "repo-platform-widgets",
+          owner: "platform",
+          name: "widgets",
+          repo_path: "platform/widgets",
+        },
+      },
+    ];
+
+    const { container } = render(MobileActivityView, { props: { onSelectItem } });
+
+    const repoLabels = Array.from(container.querySelectorAll(".mobile-activity-card__meta span:first-child")).map(
+      (element) => element.textContent?.trim(),
+    );
+    expect(repoLabels).toEqual(["acme/widgets", "platform/widgets"]);
   });
 });
 
@@ -429,6 +553,7 @@ function notificationItem(id: string, title: string, subjectState: string): Acti
 
 describe("MobileActivityView notifications", () => {
   beforeEach(() => {
+    itemActivity.value = [];
     workspaceActivity.value = [];
     hideClosedMerged.value = false;
     showNotifications.value = true;
@@ -486,6 +611,7 @@ describe("MobileActivityView notifications", () => {
 
 describe("MobileActivityView hide closed/merged", () => {
   beforeEach(() => {
+    itemActivity.value = [];
     workspaceActivity.value = [];
     hideClosedMerged.value = false;
     showNotifications.value = true;

--- a/frontend/tests/e2e-full/activity-filters.spec.ts
+++ b/frontend/tests/e2e-full/activity-filters.spec.ts
@@ -68,20 +68,28 @@ test.describe("activity feed filters", () => {
     });
   });
 
-  test("notification-only URLs retain the default item scope", async ({ page }) => {
+  test("URLs with no top-level event types retain PR commits and the default item scope", async ({ page }) => {
     const notificationResponse = page.waitForResponse((response) => {
       const url = new URL(response.url());
-      return url.pathname === "/api/v1/activity" && url.searchParams.getAll("types").includes("notification");
+      const types = (url.searchParams.get("types") ?? "").split(",");
+      return url.pathname === "/api/v1/activity" && types.includes("notification");
     });
 
-    await page.goto("/?types=notification");
-    const requestURL = new URL((await notificationResponse).url());
+    await page.goto("/?event_types=none");
+    const response = await notificationResponse;
+    const requestURL = new URL(response.url());
+    const snapshot = (await response.json()) as { items: Array<{ activity_type: string }> };
 
     expect(requestURL.searchParams.getAll("item_types")).toEqual([]);
+    expect(new Set(snapshot.items.map((item) => item.activity_type))).toEqual(new Set(["commit", "notification"]));
+    expect(new URL(page.url()).searchParams.get("event_types")).toBe("none");
     await expect(page.getByRole("switch", { name: "PRs" })).toBeChecked();
     await expect(page.getByRole("switch", { name: "Issues" })).toBeChecked();
     await expect(page.locator(".activity-row .evt-label.evt-notification").first()).toBeVisible();
-    await expect(page.locator(".activity-row .evt-label:not(.evt-notification)")).toHaveCount(0);
+    await expect(page.locator(".activity-row .evt-label.evt-commit").first()).toBeVisible();
+    await expect(page.locator(".activity-row .evt-label.evt-comment, .activity-row .evt-label.evt-review")).toHaveCount(
+      0,
+    );
   });
 
   test("Threaded item toggles hide the complete matching threads", async ({ page }) => {
@@ -93,8 +101,7 @@ test.describe("activity feed filters", () => {
 
     await expect(page.locator(".threaded-view .chip--kind-pr")).toHaveCount(0);
     await expect(page.locator(".threaded-view .chip--kind-issue").first()).toBeVisible();
-    await expect.poll(() => new URL(page.url()).searchParams.get("types") ?? "").not.toContain("new_pr");
-    await expect.poll(() => new URL(page.url()).searchParams.get("types") ?? "").toContain("new_issue");
+    await expect.poll(() => new URL(page.url()).searchParams.get("item_types")).toBe("issue");
   });
 
   test("disabling Comments hides comment rows", async ({ page }) => {

--- a/frontend/tests/e2e-full/activity-live-refresh.spec.ts
+++ b/frontend/tests/e2e-full/activity-live-refresh.spec.ts
@@ -27,10 +27,11 @@ async function persistActivityComment(
   baseURL: string,
   body: string,
   requireSubscriber = true,
+  itemType: "pr" | "issue" = "pr",
 ): Promise<number> {
-  const query = new URLSearchParams({ body });
+  const query = new URLSearchParams({ body, item_type: itemType });
   if (!requireSubscriber) query.set("require_subscriber", "false");
-  const response = await page.request.post(`${baseURL}/__e2e/activity/pr-comment?${query}`);
+  const response = await page.request.post(`${baseURL}/__e2e/activity/item-comment?${query}`);
   expect(response.status(), await response.text()).toBe(204);
   const eventID = Number(response.headers()["x-kenn-e2e-event-id"]);
   expect(eventID).toBeGreaterThan(0);
@@ -139,6 +140,136 @@ for (const item of olderDetailSyncCases) {
   });
 }
 
+for (const item of olderDetailSyncCases) {
+  test(`initial ${item.itemType} detail read reconciles already-persisted Activity behind the feed cursor`, async ({
+    page,
+  }, testInfo) => {
+    testInfo.setTimeout(60_000);
+    const server = await startIsolatedE2EServer();
+    const releaseDetailSync = Promise.withResolvers<void>();
+    try {
+      await page.route("**/api/v1/events**", async (route) => {
+        await route.abort("connectionfailed");
+      });
+      await page.route(`**${item.detailPath}/sync/async`, async (route) => {
+        await releaseDetailSync.promise;
+        await route.fulfill({ status: 202 });
+      });
+
+      const initialActivity = page.waitForResponse((response) => {
+        const url = new URL(response.url());
+        return (
+          response.request().method() === "GET" && url.pathname === "/api/v1/activity" && !url.searchParams.has("after")
+        );
+      });
+      await page.goto(`${server.info.base_url}/?view=threaded`);
+      await initialActivity;
+
+      const body = `Already-persisted ${item.itemType} Activity behind the feed cursor`;
+      await persistActivityComment(page, server.info.base_url, body, false, item.itemType);
+
+      const reconciledActivity = page.waitForResponse(
+        async (response) => {
+          const url = new URL(response.url());
+          if (
+            response.request().method() !== "GET" ||
+            url.pathname !== "/api/v1/activity" ||
+            url.searchParams.has("after")
+          ) {
+            return false;
+          }
+          const snapshot = (await response.json()) as { items: Array<{ body_preview: string }> };
+          return snapshot.items.some((event) => event.body_preview === body);
+        },
+        { timeout: 5_000 },
+      );
+
+      const itemRow = page.locator(".activity-feed .threaded-view .item-row", {
+        hasText: item.title,
+      });
+      const initialDetail = page.waitForResponse((response) => {
+        const url = new URL(response.url());
+        return response.request().method() === "GET" && url.pathname === item.detailPath;
+      });
+      await itemRow.click();
+
+      const detailResponse = (await (await initialDetail).json()) as { events?: Array<{ Body?: string }> };
+      expect(detailResponse.events?.some((event) => event.Body === body)).toBe(true);
+      await reconciledActivity;
+      await expect(page.locator(".activity-feed").getByText("fixture-bot", { exact: true })).toBeVisible();
+    } finally {
+      releaseDetailSync.resolve();
+      await page.unrouteAll({ behavior: "ignoreErrors" }).catch(() => {});
+      await server.stop();
+    }
+  });
+}
+
+test("a filtered newer event updates the parent ordering and timestamp", async ({ page }, testInfo) => {
+  testInfo.setTimeout(60_000);
+  const server = await startIsolatedE2EServer();
+  try {
+    const staged = await page.request.post(`${server.info.base_url}/__e2e/activity/stage-filtered-parent-recency`);
+    expect(staged.status(), await staged.text()).toBe(204);
+
+    const streamRequested = page.waitForRequest((request) => new URL(request.url()).pathname === "/api/v1/events");
+    const initialActivity = page.waitForResponse((response) => {
+      const url = new URL(response.url());
+      return response.request().method() === "GET" && url.pathname === "/api/v1/activity";
+    });
+    await page.goto(
+      `${server.info.base_url}/?view=threaded&range=30d&item_types=pr&event_types=none&notif=0&hide_branch=1`,
+    );
+    await streamRequested;
+    await initialActivity;
+
+    // Recency comes from the event ledger, not provider updated_at: widgets#1
+    // was "updated" two hours ago but its newest event is days old, so the
+    // dependabot pull opened six hours ago leads.
+    const rows = page.locator(".activity-feed .threaded-view .item-row");
+    await expect(rows.first()).toContainText("Bump lodash from 4.17.20 to 4.17.21");
+    await expect(rows.first().locator(".cell--time")).toHaveText("6h ago");
+    await expect(rows.filter({ hasText: "WIP: new dashboard layout" })).toHaveCount(0);
+
+    const refreshStartedAt = Math.floor(Date.now() / 1000) * 1000;
+    const refreshedActivity = page.waitForResponse(async (response) => {
+      const url = new URL(response.url());
+      if (response.request().method() !== "GET" || url.pathname !== "/api/v1/activity") return false;
+      const snapshot = (await response.json()) as {
+        item_activity: Array<{ item_number: number; activity_at: string }>;
+      };
+      return snapshot.item_activity.some(
+        (subject) => subject.item_number === 6 && Date.parse(subject.activity_at) >= refreshStartedAt,
+      );
+    });
+    const advanced = await page.request.post(`${server.info.base_url}/__e2e/activity/filtered-parent-recency`);
+    expect(advanced.status(), await advanced.text()).toBe(204);
+    const expectedActivityAt = advanced.headers()["x-kenn-e2e-parent-activity-at"];
+    expect(expectedActivityAt).toBeDefined();
+
+    const refreshedSnapshot = (await (await refreshedActivity).json()) as {
+      items: Array<{
+        activity_type: string;
+        body_preview: string;
+        item_number: number;
+      }>;
+      item_activity: Array<{ activity_at: string; item_number: number; item_title: string }>;
+    };
+    expect(
+      refreshedSnapshot.items.some((activityItem) => activityItem.body_preview === "Filtered parent comment"),
+    ).toBe(false);
+    expect(refreshedSnapshot.items.some((activityItem) => activityItem.item_number === 6)).toBe(false);
+    const updatedParent = refreshedSnapshot.item_activity.find((subject) => subject.item_number === 6);
+    expect(updatedParent?.item_title).toBe("WIP: new dashboard layout");
+    expect(Date.parse(updatedParent?.activity_at ?? "")).toBe(Date.parse(expectedActivityAt ?? ""));
+
+    await expect(rows.first()).toContainText("WIP: new dashboard layout");
+    await expect(rows.first().locator(".cell--time")).toHaveText("just now");
+  } finally {
+    await server.stop();
+  }
+});
+
 test("accepted detail sync reconciles Activity after its selection closes", async ({ page }, testInfo) => {
   testInfo.setTimeout(60_000);
   const server = await startIsolatedE2EServer();
@@ -230,8 +361,7 @@ test("persisted Activity events appear in the open PR timeline after SSE invalid
       { timeout: 5_000 },
     );
 
-    const persisted = await page.request.post(`${server.info.base_url}/__e2e/activity/pr-comment`);
-    expect(persisted.status()).toBe(204);
+    await persistActivityComment(page, server.info.base_url, newComment);
 
     const storedDetail = await page.request.get(`${server.info.base_url}/api/v1/pulls/github/acme/widgets/1`);
     expect(storedDetail.ok()).toBe(true);
@@ -293,6 +423,131 @@ test("SSE comment refresh does not promote the commenter to an Activity author c
     await authorTrigger.click();
     await expect(page.getByRole("option", { name: "alice" })).toBeVisible();
     await expect(page.getByRole("option", { name: "fixture-bot" })).toHaveCount(0);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("incremental Activity polling keeps renamed routes distinct and reconciles provider links", async ({
+  page,
+}, testInfo) => {
+  testInfo.setTimeout(75_000);
+  const server = await startIsolatedE2EServer();
+  try {
+    await page.goto(`${server.info.base_url}/?view=threaded&range=30d`);
+
+    const feed = page.locator(".activity-feed .threaded-view");
+    const original = feed.locator(".item-row", { hasText: "Add widget caching layer" });
+    await expect(original).toHaveCount(1);
+
+    const renamedActivity = page.waitForResponse(async (response) => {
+      const url = new URL(response.url());
+      if (
+        response.request().method() !== "GET" ||
+        url.pathname !== "/api/v1/activity" ||
+        !url.searchParams.has("after")
+      ) {
+        return false;
+      }
+      const snapshot = (await response.json()) as {
+        item_activity: Array<{ repo: { platform_repo_id?: string; repo_path?: string } }>;
+      };
+      return snapshot.item_activity.some(
+        (subject) => subject.repo.platform_repo_id && subject.repo.repo_path === "acme/widgets-renamed",
+      );
+    });
+    const rename = await page.request.post(`${server.info.base_url}/__e2e/activity/repository-identity?phase=rename`);
+    expect(rename.ok(), await rename.text()).toBe(true);
+    await renamedActivity;
+
+    await expect(original).toHaveCount(1);
+
+    const replacementActivity = page.waitForResponse(async (response) => {
+      const url = new URL(response.url());
+      if (
+        response.request().method() !== "GET" ||
+        url.pathname !== "/api/v1/activity" ||
+        !url.searchParams.has("after")
+      ) {
+        return false;
+      }
+      const snapshot = (await response.json()) as {
+        item_activity: Array<{
+          item_title: string;
+          repo: { platform_repo_id?: string; repo_path?: string };
+        }>;
+      };
+      return snapshot.item_activity.some(
+        (subject) =>
+          subject.item_title === "Replacement route pull request" &&
+          subject.repo.platform_repo_id === "e2e-replacement-widgets" &&
+          subject.repo.repo_path === "acme/widgets",
+      );
+    });
+    const reuse = await page.request.post(`${server.info.base_url}/__e2e/activity/repository-identity?phase=reuse`);
+    expect(reuse.ok(), await reuse.text()).toBe(true);
+    await replacementActivity;
+
+    await expect(original).toHaveCount(1);
+    const replacement = feed.locator(".item-row", { hasText: "Replacement route pull request" });
+    await expect(replacement).toHaveCount(1);
+
+    await page.getByRole("button", { name: /^Filters/ }).click();
+    await page.getByRole("radiogroup", { name: "View" }).getByRole("radio", { name: "Flat" }).click();
+    const notification = page.locator(".activity-row", { hasText: "Review requested" });
+    await expect(notification).toHaveCount(1);
+    await page.evaluate(() => {
+      window.open = ((url?: string | URL) => {
+        window.sessionStorage.setItem("e2e-opened-provider-url", String(url ?? ""));
+        return null;
+      }) as typeof window.open;
+    });
+    await notification.getByRole("button", { name: "Open activity in provider" }).click();
+    await expect
+      .poll(() => page.evaluate(() => window.sessionStorage.getItem("e2e-opened-provider-url")))
+      .toBe("https://github.com/acme/widgets-renamed/pull/1");
+
+    await page.getByRole("button", { name: /^Filters/ }).click();
+    await page.getByRole("radiogroup", { name: "View" }).getByRole("radio", { name: "Threaded" }).click();
+    await original.click();
+    await expect.poll(() => new URL(page.url()).searchParams.get("repo_path")).toBe("acme/widgets-renamed");
+
+    await replacement.click();
+    await expect.poll(() => new URL(page.url()).searchParams.get("repo_path")).toBe("acme/widgets");
+  } finally {
+    await server.stop();
+  }
+});
+
+test("legacy commit bookmark normalizes against the real Activity API", async ({ page }) => {
+  const server = await startIsolatedE2EServer();
+  try {
+    const seeded = await page.request.post(`${server.info.base_url}/__e2e/activity/default-branch-commit`);
+    expect(seeded.status(), await seeded.text()).toBe(204);
+
+    const activityResponse = page.waitForResponse((response) => {
+      const url = new URL(response.url());
+      return response.request().method() === "GET" && url.pathname === "/api/v1/activity";
+    });
+    await page.goto(`${server.info.base_url}/?view=flat&types=commit,notification`);
+    const snapshot = (await (await activityResponse).json()) as {
+      items: Array<{ activity_type: string; body_preview: string }>;
+    };
+    expect(
+      snapshot.items.some(
+        (item) =>
+          item.activity_type === "default_branch_commit" && item.body_preview === "Repository maintenance commit",
+      ),
+    ).toBe(true);
+
+    await expect(page.locator(".activity-row", { hasText: "Repository maintenance commit" })).toBeVisible();
+    await expect(page.locator(".activity-row", { hasText: "Add widget caching layer" })).toHaveCount(0);
+    await expect(page.locator(".activity-row", { hasText: "Widget rendering broken on Safari" })).toHaveCount(0);
+
+    const normalized = new URL(page.url());
+    expect(normalized.searchParams.has("types")).toBe(false);
+    expect(normalized.searchParams.get("item_types")).toBe("none");
+    expect(normalized.searchParams.get("event_types")).toBe("commit");
   } finally {
     await server.stop();
   }

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -315,7 +315,7 @@ test.describe("phone routes", () => {
 
     await page.getByRole("switch", { name: "Issues" }).click();
     await expect(page.getByRole("switch", { name: "Issues" })).not.toBeChecked();
-    await expect(page).toHaveURL(/types=new_pr/);
+    await expect(page).toHaveURL(/item_types=pr/);
 
     await page.getByRole("combobox", { name: /Time range/ }).click();
     await page.getByRole("option", { name: "24h" }).click();
@@ -333,7 +333,7 @@ test.describe("phone routes", () => {
 
     const repoLabels = page.locator(".mobile-activity-card__meta > span:first-child");
     await expect(repoLabels.first()).toBeVisible();
-    await expect(repoLabels).toHaveText(["acme/widgets"]);
+    expect(new Set(await repoLabels.allTextContents())).toEqual(new Set(["acme/widgets"]));
   });
 
   test("mobile activity filters by author without overflowing the phone viewport", async ({ page }) => {

--- a/frontend/tests/e2e-full/workspace-session-activity.spec.ts
+++ b/frontend/tests/e2e-full/workspace-session-activity.spec.ts
@@ -21,6 +21,8 @@ type WorkspaceResponse = {
 };
 
 type ActivityResponse = {
+  items: Array<{ item_number: number; item_type: string }> | null;
+  item_activity: Array<{ item_number: number; item_type: string }> | null;
   workspace_activity: Array<{ item_number: number; item_type: string; activity_at: string }> | null;
 };
 
@@ -85,6 +87,18 @@ async function selectActivityViewItem(page: Page, label: string): Promise<void> 
     await expect(panel).toBeVisible();
   }
   await panel.locator(".activity-filters__item", { hasText: label }).click();
+}
+
+async function activityStatusCount(page: Page, label: "PRs" | "issues"): Promise<number> {
+  const item = page
+    .getByRole("contentinfo")
+    .locator(".status-item")
+    .filter({ hasText: new RegExp(`^\\d+ ${label}$`) });
+  await expect(item).toBeVisible();
+  const text = await item.textContent();
+  const count = Number.parseInt(text ?? "", 10);
+  expect(count).not.toBeNaN();
+  return count;
 }
 
 test.describe("workspace session activity across item surfaces", () => {
@@ -273,7 +287,7 @@ test.describe("workspace session activity across item surfaces", () => {
       const phoneContext = await browser.newContext({ ...devices["iPhone 13"] });
       try {
         const phonePage = await phoneContext.newPage();
-        await phonePage.goto(`${server.info.base_url}/m?range=24h&types=notification`);
+        await phonePage.goto(`${server.info.base_url}/m?range=24h&event_types=none`);
 
         await expect(phonePage.locator(".mobile-shell")).toBeVisible();
         const mobileCards = phonePage.locator(".mobile-activity-card");
@@ -294,6 +308,121 @@ test.describe("workspace session activity across item surfaces", () => {
         await expect(phonePage).toHaveURL(/\/focus\/issues\/github\/acme\/widgets\/10$/);
       } finally {
         await phoneContext.close();
+      }
+
+      // Exercise bot filtering against the authoritative parent/workspace
+      // projections, not event rows. PR #7 has recent parent activity but no
+      // selected event, while issue #13 is outside 24h until workspace output
+      // gives it a current workspace-only activity timestamp.
+      rmSync(changeSignal, { force: true });
+      const seededSessionCount = readdirSync(activitySignalDir).filter((entry) => entry.startsWith("seeded.")).length;
+      const botIssueCreated = await api.post("/api/v1/issues/github/acme/widgets/13/workspace", { data: {} });
+      expect(botIssueCreated.status(), await botIssueCreated.text()).toBe(202);
+      const botIssueWorkspace = (await botIssueCreated.json()) as WorkspaceResponse;
+      await waitForWorkspaceReady(api, botIssueWorkspace.id);
+
+      const botIssueLaunched = await api.post(`/api/v1/workspaces/${botIssueWorkspace.id}/runtime/sessions`, {
+        data: { target_key: "activity-e2e", display_region: "terminal" },
+      });
+      expect(botIssueLaunched.ok(), await botIssueLaunched.text()).toBe(true);
+      await expect
+        .poll(() => readdirSync(activitySignalDir).filter((entry) => entry.startsWith("seeded.")).length)
+        .toBe(seededSessionCount + 1);
+      await expect
+        .poll(async () => {
+          const response = await api.get(`/api/v1/workspaces/${botIssueWorkspace.id}`);
+          expect(response.ok(), await response.text()).toBe(true);
+          return ((await response.json()) as WorkspaceResponse).tmux_activity_source;
+        })
+        .toBe("none");
+
+      writeFileSync(changeSignal, "change\n", "utf8");
+      await expect
+        .poll(
+          async () => {
+            const response = await api.get("/api/v1/activity?since=2026-01-01T00:00:00Z");
+            expect(response.ok(), await response.text()).toBe(true);
+            return ((await response.json()) as ActivityResponse).workspace_activity?.some(
+              (subject) => subject.item_type === "issue" && subject.item_number === 13,
+            );
+          },
+          { timeout: 20_000 },
+        )
+        .toBe(true);
+
+      const since24h = encodeURIComponent(new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString());
+      const botSubjectsResponse = await api.get(
+        `/api/v1/activity?since=${since24h}&types=commit&item_types=pr,issue,repo`,
+      );
+      expect(botSubjectsResponse.ok(), await botSubjectsResponse.text()).toBe(true);
+      const botSubjects = (await botSubjectsResponse.json()) as ActivityResponse;
+      expect(botSubjects.items ?? []).not.toContainEqual(expect.objectContaining({ item_type: "pr", item_number: 7 }));
+      expect(botSubjects.items ?? []).not.toContainEqual(
+        expect.objectContaining({ item_type: "issue", item_number: 13 }),
+      );
+      expect(botSubjects.item_activity ?? []).toContainEqual(
+        expect.objectContaining({ item_type: "pr", item_number: 7 }),
+      );
+      expect(botSubjects.item_activity ?? []).not.toContainEqual(
+        expect.objectContaining({ item_type: "issue", item_number: 13 }),
+      );
+      expect(botSubjects.workspace_activity ?? []).toContainEqual(
+        expect.objectContaining({ item_type: "issue", item_number: 13 }),
+      );
+
+      const settingsLoaded = page.waitForResponse((response) => {
+        const url = new URL(response.url());
+        return url.pathname === "/api/v1/settings" && response.request().method() === "GET";
+      });
+      await page.goto(`${server.info.base_url}/`);
+      await settingsLoaded;
+      await expect(page.locator(".activity-table .activity-row").first()).toBeVisible();
+      await selectActivityViewItem(page, "Threaded");
+      await selectActivityViewItem(page, "24h");
+      await expect(page.locator(".activity-filters__trigger")).toContainText("Threaded · 24h");
+      const botPullTitle = "Bump lodash from 4.17.20 to 4.17.21";
+      const botIssueTitle = "Security advisory: prototype pollution";
+      const botPullRow = page.locator(".threaded-view .item-row", { hasText: botPullTitle });
+      const botIssueRow = page.locator(".threaded-view .item-row", { hasText: botIssueTitle });
+      await expect(botPullRow).toBeVisible();
+      await expect(botIssueRow).toBeVisible();
+      const pullCountBefore = await activityStatusCount(page, "PRs");
+      const issueCountBefore = await activityStatusCount(page, "issues");
+
+      await selectActivityViewItem(page, "Hide bots");
+      await expect(botPullRow).toHaveCount(0);
+      await expect(botIssueRow).toHaveCount(0);
+      await expect(page.getByRole("contentinfo").locator(".status-item").filter({ hasText: /PRs$/ })).toHaveText(
+        `${pullCountBefore - 1} PRs`,
+      );
+      await expect(
+        page
+          .getByRole("contentinfo")
+          .locator(".status-item")
+          .filter({ hasText: /issues$/ }),
+      ).toHaveText(`${issueCountBefore - 1} issues`);
+
+      const botPhoneContext = await browser.newContext({ ...devices["iPhone 13"] });
+      try {
+        const botPhonePage = await botPhoneContext.newPage();
+        const mobileSettingsLoaded = botPhonePage.waitForResponse((response) => {
+          const url = new URL(response.url());
+          return url.pathname === "/api/v1/settings" && response.request().method() === "GET";
+        });
+        await botPhonePage.goto(`${server.info.base_url}/m`);
+        await mobileSettingsLoaded;
+        await botPhonePage.getByRole("button", { name: /^Filters/ }).click();
+        await botPhonePage.getByRole("combobox", { name: /Time range/ }).click();
+        await botPhonePage.getByRole("option", { name: "24h" }).click();
+        const botPullCard = botPhonePage.locator(".mobile-activity-card", { hasText: botPullTitle });
+        const botIssueCard = botPhonePage.locator(".mobile-activity-card", { hasText: botIssueTitle });
+        await expect(botPullCard).toBeVisible();
+        await expect(botIssueCard).toBeVisible();
+        await botPhonePage.getByRole("button", { name: "Hide bots", exact: true }).click();
+        await expect(botPullCard).toHaveCount(0);
+        await expect(botIssueCard).toHaveCount(0);
+      } finally {
+        await botPhoneContext.close();
       }
     } finally {
       await api.dispose();

--- a/frontend/tests/e2e/default-branch-activity.spec.ts
+++ b/frontend/tests/e2e/default-branch-activity.spec.ts
@@ -89,8 +89,36 @@ function prComment(): unknown {
   };
 }
 
+function openingItem(
+  activityType: "new_pr" | "new_issue",
+  itemType: "pr" | "issue",
+  itemNumber: number,
+  title: string,
+  createdAt: string,
+): unknown {
+  const path = itemType === "pr" ? "pull" : "issues";
+  return {
+    id: `${activityType}-${itemNumber}`,
+    cursor: `${activityType}-${itemNumber}`,
+    activity_type: activityType,
+    author: "alice",
+    body_preview: "",
+    created_at: createdAt,
+    item_number: itemNumber,
+    item_state: "open",
+    item_title: title,
+    item_type: itemType,
+    item_url: `https://github.com/acme/widgets/${path}/${itemNumber}`,
+    platform_host: "github.com",
+    repo_owner: "acme",
+    repo_name: "widgets",
+    repo,
+  };
+}
+
 const activityItems = [
   branchForcePush("2026-03-30T14:06:00Z"),
+  openingItem("new_pr", "pr", 43, "New pull request opening", "2026-03-30T14:05:30Z"),
   branchCommit(
     "commit-5",
     "5555555555555555555555555555555555555555",
@@ -109,6 +137,7 @@ const activityItems = [
     "Ship direct main commit 3",
     "2026-03-30T14:03:00Z",
   ),
+  openingItem("new_issue", "issue", 44, "New issue opening", "2026-03-30T14:02:45Z"),
   prComment(),
   branchCommit(
     "commit-2",
@@ -142,7 +171,10 @@ function sparseCommitPatch(): string {
   ].join("\n");
 }
 
-async function mockDefaultBranchActivity(page: Page): Promise<void> {
+async function mockDefaultBranchActivity(
+  page: Page,
+  options: { readonly itemActivityCapped?: boolean } = {},
+): Promise<void> {
   await page.addInitScript(() => {
     Object.defineProperty(window, "__kenn_forgeOpenedURL", {
       configurable: true,
@@ -199,6 +231,7 @@ async function mockDefaultBranchActivity(page: Page): Promise<void> {
       contentType: "application/json",
       body: JSON.stringify({
         capped: false,
+        item_activity_capped: options.itemActivityCapped ?? false,
         items,
       }),
     });
@@ -321,6 +354,16 @@ test.describe("default branch activity", () => {
     ).toBeVisible();
   });
 
+  test("warns when parent activity is capped without reporting event overflow", async ({ page }) => {
+    await mockDefaultBranchActivity(page, { itemActivityCapped: true });
+    await page.goto("/?view=flat");
+
+    await expect(page.locator(".item-activity-capped-notice")).toContainText(
+      "5,000 most recently active pull requests and issues",
+    );
+    await expect(page.locator(".event-capped-notice")).toHaveCount(0);
+  });
+
   test("deselecting Commits hides default-branch commit rows", async ({ page }) => {
     await mockDefaultBranchActivity(page);
     await page.goto("/?view=flat");
@@ -340,6 +383,25 @@ test.describe("default branch activity", () => {
         hasText: "Add browser regression coverage",
       }),
     ).toBeVisible();
+  });
+
+  test("selecting only Commits hides pull request and issue opening rows", async ({ page }) => {
+    await mockDefaultBranchActivity(page);
+    await page.goto("/?view=flat");
+
+    await expect(page.locator(".activity-row", { hasText: "New pull request opening" })).toBeVisible();
+    await expect(page.locator(".activity-row", { hasText: "New issue opening" })).toBeVisible();
+
+    await page.locator(".activity-feed .activity-filters__trigger").click();
+    const filterPanel = page.locator(".activity-filters__panel");
+    await expect(filterPanel).toBeVisible();
+    for (const label of ["Comments", "Reviews", "Force pushes"]) {
+      await filterPanel.getByRole("button", { name: label, exact: true }).click();
+    }
+
+    await expect(page.locator(".activity-row", { hasText: "Ship direct main commit 5" })).toBeVisible();
+    await expect(page.locator(".activity-row", { hasText: "New pull request opening" })).toHaveCount(0);
+    await expect(page.locator(".activity-row", { hasText: "New issue opening" })).toHaveCount(0);
   });
 
   test("roll-up toggle collapses commit runs in the flat feed", async ({ page }) => {
@@ -371,13 +433,9 @@ test.describe("default branch activity", () => {
     ).toBeVisible();
   });
 
-  test("legacy URL with stale default-branch commit types hides commit rows on load", async ({ page }) => {
+  test("URL event state keeps default-branch commits disabled on load", async ({ page }) => {
     await mockDefaultBranchActivity(page);
-    // URLs written before the fix kept default_branch_commit in the types
-    // param even with commit deselected; hydration must normalize it away.
-    await page.goto(
-      "/?view=flat&types=new_pr,new_issue,default_branch_commit,default_branch_force_push,comment,review,force_push",
-    );
+    await page.goto("/?view=flat&event_types=comment,review,force_push");
 
     await expect(page.locator(".activity-row", { hasText: "aaaaaaa -> bbbbbbb" })).toBeVisible();
     await expect(
@@ -385,6 +443,20 @@ test.describe("default branch activity", () => {
         hasText: "Ship direct main commit",
       }),
     ).toHaveCount(0);
+  });
+
+  test("legacy commit bookmarks keep default-branch commits enabled", async ({ page }) => {
+    await mockDefaultBranchActivity(page);
+    await page.goto("/?view=flat&types=commit,notification");
+
+    await expect(page.locator(".activity-row", { hasText: "Ship direct main commit 5" })).toBeVisible();
+    await expect(page.locator(".activity-row", { hasText: "New pull request opening" })).toHaveCount(0);
+    await expect(page.locator(".activity-row", { hasText: "New issue opening" })).toHaveCount(0);
+
+    const url = new URL(page.url());
+    expect(url.searchParams.has("types")).toBe(false);
+    expect(url.searchParams.get("item_types")).toBe("none");
+    expect(url.searchParams.get("event_types")).toBe("commit");
   });
 
   test("deselecting Force pushes hides default-branch force pushes", async ({ page }) => {

--- a/frontend/tests/e2e/workspaces.spec.ts
+++ b/frontend/tests/e2e/workspaces.spec.ts
@@ -268,7 +268,8 @@ test("Activity filters survive a reload while viewing Workspaces", async ({ page
   await expect(commitsFilter).not.toHaveClass(/\bactive\b/);
 
   const activitySearch = new URL(page.url()).search;
-  expect(activitySearch).toContain("types=");
+  expect(activitySearch).toContain("item_types=pr");
+  expect(activitySearch).toContain("event_types=comment%2Creview%2Cforce_push");
 
   await page.getByRole("button", { name: "Workspaces" }).click();
   await expect(page).toHaveURL(/\/workspaces$/);
@@ -290,12 +291,16 @@ test("Activity filters survive navigation to a URL that only sets the view", asy
 
   await page.locator(".activity-feed .activity-filters__trigger").click();
   await page.locator(".activity-filters__panel").getByRole("button", { name: "Commits", exact: true }).click();
-  const activityTypes = new URL(page.url()).searchParams.get("types");
-  expect(activityTypes).not.toBeNull();
+  const activityURL = new URL(page.url());
+  const itemTypes = activityURL.searchParams.get("item_types");
+  const eventTypes = activityURL.searchParams.get("event_types");
+  expect(itemTypes).toBe("pr");
+  expect(eventTypes).toBe("comment,review,force_push");
 
   await page.goto("/?view=threaded");
 
-  await expect.poll(() => new URL(page.url()).searchParams.get("types")).toBe(activityTypes);
+  await expect.poll(() => new URL(page.url()).searchParams.get("item_types")).toBe(itemTypes);
+  await expect.poll(() => new URL(page.url()).searchParams.get("event_types")).toBe(eventTypes);
   await expect(page.getByRole("switch", { name: "Issues" })).not.toBeChecked();
   await page.locator(".activity-feed .activity-filters__trigger").click();
   await expect(
@@ -308,15 +313,19 @@ test("Settings Back to app restores Activity filters after a reload", async ({ p
   await page.getByRole("switch", { name: "Issues" }).click();
   await page.locator(".activity-feed .activity-filters__trigger").click();
   await page.locator(".activity-filters__panel").getByRole("button", { name: "Commits", exact: true }).click();
-  const activityTypes = new URL(page.url()).searchParams.get("types");
-  expect(activityTypes).not.toBeNull();
+  const activityURL = new URL(page.url());
+  const itemTypes = activityURL.searchParams.get("item_types");
+  const eventTypes = activityURL.searchParams.get("event_types");
+  expect(itemTypes).toBe("pr");
+  expect(eventTypes).toBe("comment,review,force_push");
 
   await page.locator('button[title="Settings"]').click();
   await expect(page.getByRole("button", { name: "Back to app" })).toBeVisible();
   await page.reload();
   await page.getByRole("button", { name: "Back to app" }).click();
 
-  await expect.poll(() => new URL(page.url()).searchParams.get("types")).toBe(activityTypes);
+  await expect.poll(() => new URL(page.url()).searchParams.get("item_types")).toBe(itemTypes);
+  await expect.poll(() => new URL(page.url()).searchParams.get("event_types")).toBe(eventTypes);
   await expect(page.getByRole("switch", { name: "Issues" })).not.toBeChecked();
   await page.locator(".activity-feed .activity-filters__trigger").click();
   await expect(

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -1081,35 +1081,36 @@ type ActivityAuthorsResponse struct {
 
 // ActivityItemResponse defines model for ActivityItemResponse.
 type ActivityItemResponse struct {
-	ActivityType   string          `json:"activity_type"`
-	ActivityUrl    *string         `json:"activity_url,omitempty"`
-	AfterSha       *string         `json:"after_sha,omitempty"`
-	Author         string          `json:"author"`
-	AuthorEmail    *string         `json:"author_email,omitempty"`
-	AuthorName     *string         `json:"author_name,omitempty"`
-	AuthoredAt     *string         `json:"authored_at,omitempty"`
-	BeforeSha      *string         `json:"before_sha,omitempty"`
-	BodyPreview    string          `json:"body_preview"`
-	BranchName     *string         `json:"branch_name,omitempty"`
-	CommitSha      *string         `json:"commit_sha,omitempty"`
-	CommittedAt    *string         `json:"committed_at,omitempty"`
-	CommitterEmail *string         `json:"committer_email,omitempty"`
-	CommitterName  *string         `json:"committer_name,omitempty"`
-	CreatedAt      string          `json:"created_at"`
-	Cursor         string          `json:"cursor"`
-	Id             string          `json:"id"`
-	ItemAuthor     *string         `json:"item_author,omitempty"`
-	ItemNumber     int64           `json:"item_number"`
-	ItemState      string          `json:"item_state"`
-	ItemTitle      string          `json:"item_title"`
-	ItemType       string          `json:"item_type"`
-	ItemUrl        string          `json:"item_url"`
-	PlatformHost   string          `json:"platform_host"`
-	Repo           RepoRefResponse `json:"repo"`
-	RepoName       string          `json:"repo_name"`
-	RepoOwner      string          `json:"repo_owner"`
-	SubjectState   *string         `json:"subject_state,omitempty"`
-	Workspace      *WorkspaceRef   `json:"workspace,omitempty"`
+	ActivityType       string          `json:"activity_type"`
+	ActivityUrl        *string         `json:"activity_url,omitempty"`
+	AfterSha           *string         `json:"after_sha,omitempty"`
+	Author             string          `json:"author"`
+	AuthorEmail        *string         `json:"author_email,omitempty"`
+	AuthorName         *string         `json:"author_name,omitempty"`
+	AuthoredAt         *string         `json:"authored_at,omitempty"`
+	BeforeSha          *string         `json:"before_sha,omitempty"`
+	BodyPreview        string          `json:"body_preview"`
+	BranchName         *string         `json:"branch_name,omitempty"`
+	CommitSha          *string         `json:"commit_sha,omitempty"`
+	CommittedAt        *string         `json:"committed_at,omitempty"`
+	CommitterEmail     *string         `json:"committer_email,omitempty"`
+	CommitterName      *string         `json:"committer_name,omitempty"`
+	CreatedAt          string          `json:"created_at"`
+	Cursor             string          `json:"cursor"`
+	Id                 string          `json:"id"`
+	ItemAuthor         *string         `json:"item_author,omitempty"`
+	ItemLastActivityAt *time.Time      `json:"item_last_activity_at,omitempty"`
+	ItemNumber         int64           `json:"item_number"`
+	ItemState          string          `json:"item_state"`
+	ItemTitle          string          `json:"item_title"`
+	ItemType           string          `json:"item_type"`
+	ItemUrl            string          `json:"item_url"`
+	PlatformHost       string          `json:"platform_host"`
+	Repo               RepoRefResponse `json:"repo"`
+	RepoName           string          `json:"repo_name"`
+	RepoOwner          string          `json:"repo_owner"`
+	SubjectState       *string         `json:"subject_state,omitempty"`
+	Workspace          *WorkspaceRef   `json:"workspace,omitempty"`
 }
 
 // ActivityResponse defines model for ActivityResponse.
@@ -1117,10 +1118,28 @@ type ActivityResponse struct {
 	// Schema A URL to the JSON Schema for this object.
 	//
 	// Example: /api/v1/schemas/ActivityResponse.json
-	Schema            *string                             `json:"$schema,omitempty"`
-	Capped            bool                                `json:"capped"`
-	Items             *[]ActivityItemResponse             `json:"items"`
-	WorkspaceActivity *[]WorkspaceActivitySubjectResponse `json:"workspace_activity"`
+	Schema             *string                             `json:"$schema,omitempty"`
+	Capped             bool                                `json:"capped"`
+	ItemActivity       *[]ActivitySubjectResponse          `json:"item_activity"`
+	ItemActivityCapped bool                                `json:"item_activity_capped"`
+	Items              *[]ActivityItemResponse             `json:"items"`
+	WorkspaceActivity  *[]WorkspaceActivitySubjectResponse `json:"workspace_activity"`
+}
+
+// ActivitySubjectResponse defines model for ActivitySubjectResponse.
+type ActivitySubjectResponse struct {
+	ActivityAt   time.Time       `json:"activity_at"`
+	ItemAuthor   *string         `json:"item_author,omitempty"`
+	ItemNumber   int64           `json:"item_number"`
+	ItemState    string          `json:"item_state"`
+	ItemTitle    string          `json:"item_title"`
+	ItemType     string          `json:"item_type"`
+	ItemUrl      string          `json:"item_url"`
+	PlatformHost string          `json:"platform_host"`
+	Repo         RepoRefResponse `json:"repo"`
+	RepoName     string          `json:"repo_name"`
+	RepoOwner    string          `json:"repo_owner"`
+	Workspace    *WorkspaceRef   `json:"workspace,omitempty"`
 }
 
 // AddRepoInputBody defines model for AddRepoInputBody.

--- a/internal/db/queries_activity.go
+++ b/internal/db/queries_activity.go
@@ -11,7 +11,8 @@ import (
 )
 
 // prActivityAtExpr is a pull request's Activity recency: opening, the newest
-// ledger event the feed can render, merge, or close, whichever is latest.
+// ledger event the feed can render, reopen, merge, or close, whichever is
+// latest.
 // Provider updated_at is not activity: GitHub bumps it for mergeability
 // recomputation after base pushes, head-branch deletion after merge, and other
 // invisible bookkeeping, which surfaced phantom recency in the feed. The
@@ -21,18 +22,18 @@ func prActivityAtExpr(pr string) string {
 	return fmt.Sprintf(
 		"MAX(%[1]s.created_at, COALESCE((SELECT e.created_at FROM forge_mr_events e "+
 			"WHERE e.merge_request_id = %[1]s.id "+
-			"AND e.event_type IN ('issue_comment', 'review', 'commit', 'force_push') "+
+			"AND e.event_type IN ('issue_comment', 'review', 'commit', 'force_push', 'reopened') "+
 			"ORDER BY e.created_at DESC LIMIT 1), %[1]s.created_at), "+
 			"COALESCE(%[1]s.merged_at, %[1]s.created_at), COALESCE(%[1]s.closed_at, %[1]s.created_at))",
 		pr)
 }
 
 // issueActivityAtExpr is an issue's Activity recency: opening, the newest
-// rendered ledger event, or close, whichever is latest.
+// rendered ledger event, reopen, or close, whichever is latest.
 func issueActivityAtExpr(issue string) string {
 	return fmt.Sprintf(
 		"MAX(%[1]s.created_at, COALESCE((SELECT e.created_at FROM forge_issue_events e "+
-			"WHERE e.issue_id = %[1]s.id AND e.event_type = 'issue_comment' "+
+			"WHERE e.issue_id = %[1]s.id AND e.event_type IN ('issue_comment', 'reopened') "+
 			"ORDER BY e.created_at DESC LIMIT 1), %[1]s.created_at), "+
 			"COALESCE(%[1]s.closed_at, %[1]s.created_at))",
 		issue)
@@ -760,7 +761,7 @@ func (d *DB) ListActivityAuthors(
 			FROM forge_mr_events e
 			JOIN forge_merge_requests p ON e.merge_request_id = p.id
 			JOIN forge_repos r ON p.repo_id = r.id AND r.lifecycle_state = 'active'
-			WHERE e.event_type IN ('issue_comment', 'review', 'commit', 'force_push')
+			WHERE e.event_type IN ('issue_comment', 'review', 'commit', 'force_push', 'reopened')
 			  AND NOT EXISTS (
 			      SELECT 1 FROM forge_archive_items ai
 			      WHERE ai.repo_id = p.repo_id
@@ -774,7 +775,7 @@ func (d *DB) ListActivityAuthors(
 			FROM forge_issue_events e
 			JOIN forge_issues i ON e.issue_id = i.id
 			JOIN forge_repos r ON i.repo_id = r.id AND r.lifecycle_state = 'active'
-			WHERE e.event_type = 'issue_comment'
+			WHERE e.event_type IN ('issue_comment', 'reopened')
 			  AND NOT EXISTS (
 			      SELECT 1 FROM forge_archive_items ai
 			      WHERE ai.repo_id = i.repo_id

--- a/internal/db/queries_activity.go
+++ b/internal/db/queries_activity.go
@@ -10,6 +10,34 @@ import (
 	"time"
 )
 
+// prActivityAtExpr is a pull request's Activity recency: opening, the newest
+// ledger event the feed can render, merge, or close, whichever is latest.
+// Provider updated_at is not activity: GitHub bumps it for mergeability
+// recomputation after base pushes, head-branch deletion after merge, and other
+// invisible bookkeeping, which surfaced phantom recency in the feed. The
+// correlated lookup walks (merge_request_id, created_at DESC) and stops at the
+// first rendered event.
+func prActivityAtExpr(pr string) string {
+	return fmt.Sprintf(
+		"MAX(%[1]s.created_at, COALESCE((SELECT e.created_at FROM forge_mr_events e "+
+			"WHERE e.merge_request_id = %[1]s.id "+
+			"AND e.event_type IN ('issue_comment', 'review', 'commit', 'force_push') "+
+			"ORDER BY e.created_at DESC LIMIT 1), %[1]s.created_at), "+
+			"COALESCE(%[1]s.merged_at, %[1]s.created_at), COALESCE(%[1]s.closed_at, %[1]s.created_at))",
+		pr)
+}
+
+// issueActivityAtExpr is an issue's Activity recency: opening, the newest
+// rendered ledger event, or close, whichever is latest.
+func issueActivityAtExpr(issue string) string {
+	return fmt.Sprintf(
+		"MAX(%[1]s.created_at, COALESCE((SELECT e.created_at FROM forge_issue_events e "+
+			"WHERE e.issue_id = %[1]s.id AND e.event_type = 'issue_comment' "+
+			"ORDER BY e.created_at DESC LIMIT 1), %[1]s.created_at), "+
+			"COALESCE(%[1]s.closed_at, %[1]s.created_at))",
+		issue)
+}
+
 // ListActivity returns a unified, reverse-chronological feed of
 // activity across all repos. It merges new PRs, new issues, PR
 // events, issue events, default-branch commits/force-pushes, and
@@ -130,6 +158,9 @@ func (d *DB) ListActivity(
 	// PR/issue-anchored, non-author rows. Excluding the whole branch here
 	// (only when no config is loaded) rather than after the query keeps the
 	// LIMIT window from being spent on rows the caller will not serve.
+	// Title, URL, author, and state come from the linked PR or issue when it
+	// is synced: the persisted notification keeps the route and title from
+	// sync time, which go stale after a repository rename or title edit.
 	notificationUnion := ""
 	var notificationArgs []any
 	if !opts.ExcludeNotifications {
@@ -145,18 +176,22 @@ func (d *DB) ListActivity(
 		notificationUnion = `
 			UNION ALL
 			SELECT 'notification', 'ntf', n.id, r.id,
-			       r.platform, r.platform_host, r.owner, r.name, r.repo_path_key,
-			       n.item_type, COALESCE(n.item_number, 0), n.subject_title,
-			       n.web_url, CASE WHEN n.unread = 1 THEN 'unread' ELSE 'read' END,
+			       r.platform, r.platform_host, r.platform_repo_id, r.repo_path,
+			       r.owner, r.name, r.repo_path_key,
+			       n.item_type, COALESCE(n.item_number, 0),
+			       COALESCE(NULLIF(mr.title, ''), NULLIF(iss.title, ''), n.subject_title),
+			       COALESCE(NULLIF(mr.url, ''), NULLIF(iss.url, ''), n.web_url),
+			       CASE WHEN n.unread = 1 THEN 'unread' ELSE 'read' END,
 			       COALESCE(NULLIF(mr.author, ''), NULLIF(iss.author, ''), n.item_author),
 			       COALESCE(NULLIF(mr.author, ''), NULLIF(iss.author, ''), n.item_author),
 			       n.source_updated_at,
+			       COALESCE(mr.id, iss.id),
 			       substr(n.reason, 1, 200),
 			       '', '', '', '',
 			       '', '',
 			       '', '',
 			       NULL, NULL,
-			       n.web_url,
+			       COALESCE(NULLIF(mr.url, ''), NULLIF(iss.url, ''), n.web_url),
 			       COALESCE(mr.state, iss.state, '')
 			FROM forge_notification_items n
 			JOIN forge_repos r
@@ -185,12 +220,15 @@ func (d *DB) ListActivity(
 			      )` + notificationScope
 	}
 
+	// The page is materialized before parent recency is derived so the ledger
+	// lookup runs once per returned row rather than once per candidate row.
 	query := fmt.Sprintf(`
+		WITH page AS MATERIALIZED (
 		SELECT activity_type, source, source_id, repo_id, platform, platform_host,
-		       repo_owner, repo_name,
+		       platform_repo_id, repo_path, repo_owner, repo_name,
 		       item_type, item_number, item_title,
 		       item_url, item_state, author, item_author,
-		       created_at, body_preview,
+		       created_at, parent_id, body_preview,
 		       branch_name, commit_sha, before_sha, after_sha,
 		       author_name, author_email, committer_name, committer_email,
 		       authored_at, committed_at, activity_url,
@@ -199,12 +237,13 @@ func (d *DB) ListActivity(
 			SELECT 'new_pr' AS activity_type,
 			       'pr' AS source, p.id AS source_id,
 			       r.id AS repo_id,
-			       r.platform, r.platform_host, r.owner AS repo_owner, r.name AS repo_name,
-			       r.repo_path_key,
+			       r.platform, r.platform_host, r.platform_repo_id, r.repo_path,
+			       r.owner AS repo_owner, r.name AS repo_name, r.repo_path_key,
 			       'pr' AS item_type, p.number AS item_number,
 			       p.title AS item_title,
 			       p.url AS item_url, p.state AS item_state,
 			       p.author, p.author AS item_author, p.created_at,
+			       p.id AS parent_id,
 			       '' AS body_preview,
 			       '' AS branch_name, '' AS commit_sha, '' AS before_sha, '' AS after_sha,
 			       '' AS author_name, '' AS author_email,
@@ -223,10 +262,12 @@ func (d *DB) ListActivity(
 			)
 			UNION ALL
 			SELECT 'new_issue', 'issue', i.id, r.id,
-			       r.platform, r.platform_host, r.owner, r.name, r.repo_path_key,
+			       r.platform, r.platform_host, r.platform_repo_id, r.repo_path,
+			       r.owner, r.name, r.repo_path_key,
 			       'issue', i.number, i.title,
 			       i.url, i.state,
 			       i.author, i.author, i.created_at,
+			       i.id,
 			       '',
 			       '', '', '', '',
 			       '', '',
@@ -250,10 +291,12 @@ func (d *DB) ListActivity(
 			       END,
 			       'pre', e.id,
 			       r.id,
-			       r.platform, r.platform_host, r.owner, r.name, r.repo_path_key,
+			       r.platform, r.platform_host, r.platform_repo_id, r.repo_path,
+			       r.owner, r.name, r.repo_path_key,
 			       'pr', p.number, p.title,
 			       p.url, p.state,
 			       e.author, p.author, e.created_at,
+			       p.id,
 			       substr(COALESCE(e.body, ''), 1, 200),
 			       '', '', '', '',
 			       '', '',
@@ -275,10 +318,12 @@ func (d *DB) ListActivity(
 			  )
 			UNION ALL
 			SELECT 'comment', 'ise', e.id, r.id,
-			       r.platform, r.platform_host, r.owner, r.name, r.repo_path_key,
+			       r.platform, r.platform_host, r.platform_repo_id, r.repo_path,
+			       r.owner, r.name, r.repo_path_key,
 			       'issue', i.number, i.title,
 			       i.url, i.state,
 			       e.author, i.author, e.created_at,
+			       i.id,
 			       substr(COALESCE(e.body, ''), 1, 200),
 			       '', '', '', '',
 			       '', '',
@@ -299,10 +344,12 @@ func (d *DB) ListActivity(
 			  )
 			UNION ALL
 			SELECT 'default_branch_commit', 'bc', bc.id, r.id,
-			       r.platform, r.platform_host, r.owner, r.name, r.repo_path_key,
+			       r.platform, r.platform_host, r.platform_repo_id, r.repo_path,
+			       r.owner, r.name, r.repo_path_key,
 			       '', 0, '',
 			       '', '',
 			       substr(bc.author_name, 1, %[1]d), '', bc.committed_at,
+			       NULL,
 			       substr(bc.subject, 1, 200),
 			       bc.branch_name, bc.commit_sha, '', '',
 			       substr(bc.author_name, 1, %[1]d),
@@ -316,10 +363,12 @@ func (d *DB) ListActivity(
 			JOIN forge_repos r ON bc.repo_id = r.id AND r.lifecycle_state = 'active'
 			UNION ALL
 			SELECT 'default_branch_force_push', 'bfp', bfp.id, r.id,
-			       r.platform, r.platform_host, r.owner, r.name, r.repo_path_key,
+			       r.platform, r.platform_host, r.platform_repo_id, r.repo_path,
+			       r.owner, r.name, r.repo_path_key,
 			       '', 0, '',
 			       '', '',
 			       '', '', bfp.detected_at,
+			       NULL,
 			       bfp.before_sha || ' -> ' || bfp.after_sha,
 			       bfp.branch_name, '', bfp.before_sha, bfp.after_sha,
 			       '', '',
@@ -333,7 +382,26 @@ func (d *DB) ListActivity(
 		) unified
 		%[2]s
 		ORDER BY created_at DESC, source DESC, source_id DESC
-		LIMIT ?`, branchCommitIdentityMaxBytes, where, notificationUnion)
+		LIMIT ?
+		)
+		SELECT activity_type, source, source_id, repo_id, platform, platform_host,
+		       platform_repo_id, repo_path, repo_owner, repo_name,
+		       item_type, item_number, item_title,
+		       item_url, item_state, author, item_author,
+		       created_at,
+		       CASE item_type
+		           WHEN 'pr' THEN (SELECT %[4]s FROM forge_merge_requests p WHERE p.id = page.parent_id)
+		           WHEN 'issue' THEN (SELECT %[5]s FROM forge_issues i WHERE i.id = page.parent_id)
+		       END AS item_last_activity_at,
+		       body_preview,
+		       branch_name, commit_sha, before_sha, after_sha,
+		       author_name, author_email, committer_name, committer_email,
+		       authored_at, committed_at, activity_url,
+		       subject_state
+		FROM page
+		ORDER BY created_at DESC, source DESC, source_id DESC`,
+		branchCommitIdentityMaxBytes, where, notificationUnion,
+		prActivityAtExpr("p"), issueActivityAtExpr("i"))
 
 	queryArgs := make([]any, 0, len(notificationArgs)+len(args)+1)
 	queryArgs = append(queryArgs, notificationArgs...)
@@ -350,15 +418,17 @@ func (d *DB) ListActivity(
 	for rows.Next() {
 		var it ActivityItem
 		var createdAtStr string
+		var itemLastActivityAtStr sql.NullString
 		var authoredAtStr sql.NullString
 		var committedAtStr sql.NullString
 		if err := rows.Scan(
 			&it.ActivityType, &it.Source, &it.SourceID,
 			&it.RepoID,
-			&it.Platform, &it.PlatformHost, &it.RepoOwner, &it.RepoName,
+			&it.Platform, &it.PlatformHost, &it.PlatformRepoID, &it.RepoPath,
+			&it.RepoOwner, &it.RepoName,
 			&it.ItemType, &it.ItemNumber, &it.ItemTitle,
 			&it.ItemURL, &it.ItemState, &it.Author, &it.ItemAuthor,
-			&createdAtStr, &it.BodyPreview,
+			&createdAtStr, &itemLastActivityAtStr, &it.BodyPreview,
 			&it.BranchName, &it.CommitSHA, &it.BeforeSHA, &it.AfterSHA,
 			&it.AuthorName, &it.AuthorEmail,
 			&it.CommitterName, &it.CommitterEmail,
@@ -374,6 +444,15 @@ func (d *DB) ListActivity(
 				createdAtStr, err)
 		}
 		it.CreatedAt = t
+		if itemLastActivityAtStr.Valid && itemLastActivityAtStr.String != "" {
+			itemLastActivityAt, err := parseDBTime(itemLastActivityAtStr.String)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"parse activity item_last_activity_at %q: %w",
+					itemLastActivityAtStr.String, err)
+			}
+			it.ItemLastActivityAt = &itemLastActivityAt
+		}
 		if authoredAtStr.Valid && authoredAtStr.String != "" {
 			authoredAt, err := parseDBTime(authoredAtStr.String)
 			if err != nil {
@@ -397,8 +476,187 @@ func (d *DB) ListActivity(
 	return items, rows.Err()
 }
 
+// ListActivitySubjects returns a full parent snapshot ordered and filtered by
+// ledger-derived pull-request and issue recency (see prActivityAtExpr). Event
+// filters and cursors do not participate because a hidden or behind-cursor
+// event can still advance a parent's visible timestamp and position.
+func (d *DB) ListActivitySubjects(
+	ctx context.Context, opts ListActivitySubjectsOpts,
+) ([]ActivitySubject, error) {
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+
+	var whereClauses []string
+	var args []any
+	if opts.Repo != "" {
+		if cond := activityRepoFilterCondition(opts.RepoFilters, &args); cond != "" {
+			whereClauses = append(whereClauses, cond)
+		} else {
+			host, pathKey := repoFilterHostAndPathKey(opts.Repo)
+			if pathKey != "" {
+				if host != "" {
+					whereClauses = append(whereClauses, "platform_host = ?")
+					args = append(args, host)
+				}
+				whereClauses = append(whereClauses, "repo_path_key = ?")
+				args = append(args, pathKey)
+			}
+		}
+	}
+	if opts.AllowedRepoIDs != nil {
+		cond := activityRepoIDCondition(opts.AllowedRepoIDs, &args)
+		if cond == "" {
+			cond = "0 = 1"
+		}
+		whereClauses = append(whereClauses, cond)
+	}
+	if len(opts.ItemTypes) > 0 {
+		itemTypeClauses := make([]string, 0, len(opts.ItemTypes))
+		for _, itemType := range opts.ItemTypes {
+			if itemType != "pr" && itemType != "issue" {
+				continue
+			}
+			itemTypeClauses = append(itemTypeClauses, "item_type = ?")
+			args = append(args, itemType)
+		}
+		if len(itemTypeClauses) == 0 {
+			whereClauses = append(whereClauses, "0 = 1")
+		} else {
+			whereClauses = append(whereClauses, "("+strings.Join(itemTypeClauses, " OR ")+")")
+		}
+	}
+	if opts.Search != "" {
+		pattern := "%" + strings.ToLower(opts.Search) + "%"
+		searchClauses := []string{
+			"LOWER('#' || item_number || ' ' || item_title) LIKE ?",
+			"LOWER(item_title) LIKE ?",
+			"LOWER(item_author) LIKE ?",
+		}
+		args = append(args, pattern, pattern, pattern)
+
+		matchedSubjectPlaceholders := make([]string, 0, len(opts.SearchMatchedSubjectKeys))
+		seenMatchedSubjects := make(map[WorkspaceSubjectKey]struct{}, len(opts.SearchMatchedSubjectKeys))
+		for _, key := range opts.SearchMatchedSubjectKeys {
+			if key.ItemType != "pr" && key.ItemType != "issue" {
+				continue
+			}
+			if _, seen := seenMatchedSubjects[key]; seen {
+				continue
+			}
+			seenMatchedSubjects[key] = struct{}{}
+			matchedSubjectPlaceholders = append(matchedSubjectPlaceholders, "(?, ?, ?)")
+			args = append(args, key.RepoID, key.ItemType, key.ItemNumber)
+		}
+		if len(matchedSubjectPlaceholders) > 0 {
+			searchClauses = append(searchClauses,
+				"(repo_id, item_type, item_number) IN ("+
+					strings.Join(matchedSubjectPlaceholders, ", ")+")")
+		}
+		whereClauses = append(whereClauses, "("+strings.Join(searchClauses, " OR ")+")")
+	}
+	if opts.Author != "" {
+		whereClauses = append(whereClauses, "LOWER(item_author) = LOWER(?)")
+		args = append(args, opts.Author)
+	}
+	if opts.ViewerLogins != nil {
+		whereClauses = append(whereClauses, activityInvolvementCondition(opts.ViewerLogins, &args))
+	}
+	if opts.Since != nil {
+		whereClauses = append(whereClauses, "activity_at >= ?")
+		args = append(args, *opts.Since)
+	}
+
+	where := ""
+	if len(whereClauses) > 0 {
+		where = "WHERE " + strings.Join(whereClauses, " AND ")
+	}
+	query := `
+		SELECT repo_id, platform, platform_host, platform_repo_id, repo_path,
+		       repo_owner, repo_name,
+		       item_type, item_number, item_title, item_url, item_state,
+		       item_author, activity_at
+		FROM (
+			SELECT r.id AS repo_id, r.platform, r.platform_host,
+			       r.platform_repo_id, r.repo_path,
+			       r.owner AS repo_owner, r.name AS repo_name, r.repo_path_key,
+			       'pr' AS item_type, p.number AS item_number, p.title AS item_title,
+			       p.url AS item_url, p.state AS item_state, p.author AS item_author,
+			       ` + prActivityAtExpr("p") + ` AS activity_at
+			FROM forge_merge_requests p
+			JOIN forge_repos r ON p.repo_id = r.id AND r.lifecycle_state = 'active'
+			WHERE NOT EXISTS (
+			    SELECT 1 FROM forge_archive_items ai
+			    WHERE ai.repo_id = p.repo_id
+			      AND ai.item_type = 'merge_request'
+			      AND ai.item_number = p.number
+			      AND ai.lifecycle_state = 'removed_upstream'
+			)
+			UNION ALL
+			SELECT r.id, r.platform, r.platform_host, r.platform_repo_id, r.repo_path,
+			       r.owner, r.name, r.repo_path_key,
+			       'issue', i.number, i.title, i.url, i.state, i.author,
+			       ` + issueActivityAtExpr("i") + `
+			FROM forge_issues i
+			JOIN forge_repos r ON i.repo_id = r.id AND r.lifecycle_state = 'active'
+			WHERE NOT EXISTS (
+			    SELECT 1 FROM forge_archive_items ai
+			    WHERE ai.repo_id = i.repo_id
+			      AND ai.item_type = 'issue'
+			      AND ai.item_number = i.number
+			      AND ai.lifecycle_state = 'removed_upstream'
+			)
+		) unified
+		` + where + `
+		ORDER BY activity_at DESC, repo_id DESC, item_type DESC, item_number DESC
+		LIMIT ?`
+	args = append(args, limit)
+
+	rows, err := d.ro.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list activity subjects: %w", err)
+	}
+	defer rows.Close()
+
+	var subjects []ActivitySubject
+	for rows.Next() {
+		var subject ActivitySubject
+		var activityAt string
+		if err := rows.Scan(
+			&subject.Subject.Key.RepoID,
+			&subject.Subject.Platform,
+			&subject.Subject.PlatformHost,
+			&subject.Subject.PlatformRepoID,
+			&subject.Subject.RepoPath,
+			&subject.Subject.RepoOwner,
+			&subject.Subject.RepoName,
+			&subject.Subject.Key.ItemType,
+			&subject.Subject.Key.ItemNumber,
+			&subject.Subject.Title,
+			&subject.Subject.URL,
+			&subject.Subject.State,
+			&subject.Subject.Author,
+			&activityAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan activity subject: %w", err)
+		}
+		subject.ActivityAt, err = parseDBTime(activityAt)
+		if err != nil {
+			return nil, fmt.Errorf("parse activity subject activity_at %q: %w", activityAt, err)
+		}
+		subjects = append(subjects, subject)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list activity subjects rows: %w", err)
+	}
+	return subjects, nil
+}
+
 // ListActivityAuthors returns the distinct, non-empty PR and issue authors
-// available in an activity scope. Identity is case-insensitive; when casing
+// available in an activity scope. Candidates mirror Activity recency: opening,
+// rendered ledger events, merge, close, and notifications, so every parent the
+// feed can show offers its author. Identity is case-insensitive; when casing
 // differs, the most recently active subject's spelling wins. Results are
 // ordered by most recent activity so the typeahead puts currently active
 // authors first.
@@ -517,6 +775,32 @@ func (d *DB) ListActivityAuthors(
 			JOIN forge_issues i ON e.issue_id = i.id
 			JOIN forge_repos r ON i.repo_id = r.id AND r.lifecycle_state = 'active'
 			WHERE e.event_type = 'issue_comment'
+			  AND NOT EXISTS (
+			      SELECT 1 FROM forge_archive_items ai
+			      WHERE ai.repo_id = i.repo_id
+			        AND ai.item_type = 'issue'
+			        AND ai.item_number = i.number
+			        AND ai.lifecycle_state = 'removed_upstream'
+			  )
+			UNION ALL
+			SELECT r.id, r.platform, r.platform_host, r.owner, r.name, r.repo_path_key,
+			       p.author, MAX(COALESCE(p.merged_at, p.closed_at), COALESCE(p.closed_at, p.merged_at))
+			FROM forge_merge_requests p
+			JOIN forge_repos r ON p.repo_id = r.id AND r.lifecycle_state = 'active'
+			WHERE (p.merged_at IS NOT NULL OR p.closed_at IS NOT NULL)
+			  AND NOT EXISTS (
+			      SELECT 1 FROM forge_archive_items ai
+			      WHERE ai.repo_id = p.repo_id
+			        AND ai.item_type = 'merge_request'
+			        AND ai.item_number = p.number
+			        AND ai.lifecycle_state = 'removed_upstream'
+			  )
+			UNION ALL
+			SELECT r.id, r.platform, r.platform_host, r.owner, r.name, r.repo_path_key,
+			       i.author, i.closed_at
+			FROM forge_issues i
+			JOIN forge_repos r ON i.repo_id = r.id AND r.lifecycle_state = 'active'
+			WHERE i.closed_at IS NOT NULL
 			  AND NOT EXISTS (
 			      SELECT 1 FROM forge_archive_items ai
 			      WHERE ai.repo_id = i.repo_id

--- a/internal/db/queries_activity_test.go
+++ b/internal/db/queries_activity_test.go
@@ -1850,6 +1850,15 @@ func TestActivityRecencyDerivesFromRenderedEventLedger(t *testing.T) {
 	mergedPR.ClosedAt = &mergedAt
 	insertTestMRWithOptions(t, d, mergedPR)
 
+	// A reopen is a lifecycle action even though the feed renders no row for it.
+	reopenedAt := now.Add(-3 * time.Hour)
+	reopenedPRID := insertTestMRWithOptions(t, d, testMR(repoID, 5, withMRTitle("Reopened PR"),
+		withMRActivity(now.Add(-30*24*time.Hour))))
+	require.NoError(d.UpsertMREvents(ctx, []MREvent{{
+		MergeRequestID: reopenedPRID, EventType: "reopened", Author: "author",
+		CreatedAt: reopenedAt, DedupeKey: "reopened-pr",
+	}}))
+
 	issue := testIssue(repoID, 4, withIssueTitle("Issue"), withIssueActivity(now.Add(-9*24*time.Hour)))
 	issue.UpdatedAt = now.Add(-10 * time.Minute)
 	issue.LastActivityAt = now.Add(-10 * time.Minute)
@@ -1872,11 +1881,13 @@ func TestActivityRecencyDerivesFromRenderedEventLedger(t *testing.T) {
 		1347: lastComment,
 		3:    mergedAt,
 		4:    lastIssueComment,
+		5:    reopenedAt,
 	}, activityByNumber, "provider updated_at must not admit or date parents")
-	require.Len(subjects, 3)
+	require.Len(subjects, 4)
 	assert.Equal(3, subjects[0].Subject.Key.ItemNumber, "ordered by ledger recency")
-	assert.Equal(4, subjects[1].Subject.Key.ItemNumber)
-	assert.Equal(1347, subjects[2].Subject.Key.ItemNumber)
+	assert.Equal(5, subjects[1].Subject.Key.ItemNumber)
+	assert.Equal(4, subjects[2].Subject.Key.ItemNumber)
+	assert.Equal(1347, subjects[3].Subject.Key.ItemNumber)
 
 	items, err := d.ListActivity(ctx, ListActivityOpts{Since: &since, Limit: 50})
 	require.NoError(err)
@@ -1914,16 +1925,23 @@ func TestListActivityAuthorsIncludeParentsRecentOnlyByCloseOrMerge(t *testing.T)
 	closedIssue.ClosedAt = &closedAt
 	insertTestIssueWithOptions(t, d, closedIssue)
 
+	reopenedIssueID := insertTestIssueWithOptions(t, d, testIssue(repoID, 4, withIssueAuthor("Reopener"),
+		withIssueActivity(now.Add(-30*24*time.Hour))))
+	require.NoError(d.UpsertIssueEvents(ctx, []IssueEvent{{
+		IssueID: reopenedIssueID, EventType: "reopened", Author: "Reopener",
+		CreatedAt: now.Add(-3 * time.Hour), DedupeKey: "reopened-issue",
+	}}))
+
 	dormant := testMR(repoID, 3, withMRAuthor("Dormant"), withMRActivity(now.Add(-30*24*time.Hour)))
 	dormant.LastActivityAt = now.Add(-time.Minute)
 	insertTestMRWithOptions(t, d, dormant)
 
 	subjects, err := d.ListActivitySubjects(ctx, ListActivitySubjectsOpts{Since: &since, Limit: 50})
 	require.NoError(err)
-	require.Len(subjects, 2, "merge and close admit parents to the window")
+	require.Len(subjects, 3, "merge, close, and reopen admit parents to the window")
 
 	authors, err := d.ListActivityAuthors(ctx, ListActivityAuthorsOpts{Since: &since})
 	require.NoError(err)
-	assert.Equal([]string{"Merger", "Closer"}, authors,
+	assert.Equal([]string{"Merger", "Closer", "Reopener"}, authors,
 		"every parent visible in Activity must offer its author as a filter candidate")
 }

--- a/internal/db/queries_activity_test.go
+++ b/internal/db/queries_activity_test.go
@@ -858,6 +858,153 @@ func TestListActivityItemAuthor(t *testing.T) {
 	assert.Empty(branchCommit.ItemAuthor)
 }
 
+func TestListActivityCarriesParentRecencyWhenNewerEventsAreFiltered(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	base := baseTime()
+
+	repoID := insertTestRepo(t, d, "alice", "alpha")
+	// The filtered commit is the newest ledger event and must still define
+	// the parent's recency on the visible comment row.
+	prActivityAt := base.Add(19 * time.Minute)
+	prID := insertTestMRWithOptions(t, d, testMR(repoID, 1, withMRActivity(base)))
+	issueActivityAt := base.Add(11 * time.Minute)
+	issueID := insertTestIssueWithOptions(t, d, testIssue(repoID, 2, withIssueActivity(base)))
+
+	require.NoError(d.UpsertMREvents(ctx, []MREvent{
+		{
+			MergeRequestID: prID,
+			EventType:      "issue_comment",
+			Author:         "reviewer",
+			CreatedAt:      base.Add(10 * time.Minute),
+			DedupeKey:      "visible-comment",
+		},
+		{
+			MergeRequestID: prID,
+			EventType:      "commit",
+			Author:         "alice",
+			CreatedAt:      base.Add(19 * time.Minute),
+			DedupeKey:      "filtered-commit",
+		},
+	}))
+	require.NoError(d.UpsertIssueEvents(ctx, []IssueEvent{{
+		IssueID:   issueID,
+		EventType: "issue_comment",
+		Author:    "reporter",
+		CreatedAt: base.Add(11 * time.Minute),
+		DedupeKey: "issue-comment",
+	}}))
+
+	items, err := d.ListActivity(ctx, ListActivityOpts{
+		Types: []string{"comment"},
+		Limit: 50,
+	})
+	require.NoError(err)
+	require.Len(items, 2)
+
+	byType := make(map[string]ActivityItem, len(items))
+	for _, item := range items {
+		byType[item.ItemType] = item
+	}
+	require.NotNil(byType["pr"].ItemLastActivityAt)
+	assert.Equal(prActivityAt, *byType["pr"].ItemLastActivityAt)
+	require.NotNil(byType["issue"].ItemLastActivityAt)
+	assert.Equal(issueActivityAt, *byType["issue"].ItemLastActivityAt)
+	assert.NotContains(activityTypes(items), "commit")
+}
+
+func TestListActivitySubjectsUsesAuthoritativeRecencyForWindowAndLimit(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	now := baseTime()
+	since := now.Add(-7 * 24 * time.Hour)
+
+	repoID := insertTestRepo(t, d, "alice", "alpha")
+	oldCreatedAt := now.Add(-30 * 24 * time.Hour)
+	recentActivityAt := now.Add(-time.Hour)
+	recentParent := testMR(repoID, 1,
+		withMRTitle("Old pull with recent hidden activity"),
+		withMRActivity(oldCreatedAt),
+	)
+	recentParent.UpdatedAt = recentActivityAt
+	recentParent.LastActivityAt = recentActivityAt
+	recentParentID := insertTestMRWithOptions(t, d, recentParent)
+	require.NoError(d.UpsertMREvents(ctx, []MREvent{{
+		MergeRequestID: recentParentID,
+		EventType:      "issue_comment",
+		Author:         "reviewer",
+		CreatedAt:      recentActivityAt,
+		DedupeKey:      "recent-hidden-comment",
+	}}))
+
+	olderActivityAt := now.Add(-2 * time.Hour)
+	insertTestMRWithOptions(t, d, testMR(repoID, 2,
+		withMRTitle("Newer pull with older activity"),
+		withMRActivity(olderActivityAt),
+	))
+
+	visibleEvents, err := d.ListActivity(ctx, ListActivityOpts{
+		Types:     []string{"commit"},
+		ItemTypes: []string{"pr", "repo"},
+		Since:     &since,
+		Limit:     1,
+	})
+	require.NoError(err)
+	assert.Empty(visibleEvents, "the comment is hidden by the event filter")
+
+	subjects, err := d.ListActivitySubjects(ctx, ListActivitySubjectsOpts{
+		ItemTypes: []string{"pr", "repo"},
+		Since:     &since,
+		Limit:     1,
+	})
+	require.NoError(err)
+	require.Len(subjects, 1)
+	assert.Equal(1, subjects[0].Subject.Key.ItemNumber)
+	assert.Equal("pr", subjects[0].Subject.Key.ItemType)
+	assert.Equal("Old pull with recent hidden activity", subjects[0].Subject.Title)
+	assert.Equal(recentActivityAt, subjects[0].ActivityAt)
+}
+
+func TestListActivitySubjectsIncludesParentsWhoseEventsMatchSearch(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	now := baseTime()
+	repoID := insertTestRepo(t, d, "alice", "alpha")
+
+	insertTestMRWithOptions(t, d, testMR(repoID, 1,
+		withMRTitle("Unrelated parent matched through an event"),
+		withMRActivity(now.Add(-time.Hour)),
+	))
+	insertTestMRWithOptions(t, d, testMR(repoID, 2,
+		withMRTitle("Needle in the parent title"),
+		withMRActivity(now.Add(-2*time.Hour)),
+	))
+	insertTestMRWithOptions(t, d, testMR(repoID, 3,
+		withMRTitle("Unrelated parent without a matching event"),
+		withMRActivity(now.Add(-3*time.Hour)),
+	))
+
+	subjects, err := d.ListActivitySubjects(ctx, ListActivitySubjectsOpts{
+		Search: "needle",
+		SearchMatchedSubjectKeys: []WorkspaceSubjectKey{
+			{RepoID: repoID, ItemType: "pr", ItemNumber: 1},
+		},
+		Limit: 50,
+	})
+	require.NoError(err)
+	require.Len(subjects, 2)
+	assert.ElementsMatch([]int{1, 2}, []int{
+		subjects[0].Subject.Key.ItemNumber,
+		subjects[1].Subject.Key.ItemNumber,
+	})
+}
+
 func testBranchCommit(
 	repoID int64,
 	branch string,
@@ -1571,4 +1718,212 @@ func TestListActivityNotificationRepoFilterFollowsRename(t *testing.T) {
 	require.NoError(err)
 	assert.Empty(stale,
 		"linked notifications must not answer to historical routes")
+}
+
+func TestListActivityNotificationUsesLinkedParentMetadata(t *testing.T) {
+	tests := []struct {
+		name         string
+		itemType     string
+		staleURL     string
+		currentURL   string
+		insertParent func(t *testing.T, d *DB, repoID int64, number int, url string)
+	}{
+		{
+			name:       "pull request",
+			itemType:   "pr",
+			staleURL:   "https://github.com/acme/widget/pull/7",
+			currentURL: "https://github.com/acme/gadget/pull/7",
+			insertParent: func(t *testing.T, d *DB, repoID int64, number int, url string) {
+				mr := testMR(repoID, number, withMRTitle("Current parent title"))
+				mr.URL = url
+				insertTestMRWithOptions(t, d, mr)
+			},
+		},
+		{
+			name:       "issue",
+			itemType:   "issue",
+			staleURL:   "https://github.com/acme/widget/issues/7",
+			currentURL: "https://github.com/acme/gadget/issues/7",
+			insertParent: func(t *testing.T, d *DB, repoID int64, number int, url string) {
+				issue := testIssue(repoID, number, withIssueTitle("Current parent title"))
+				issue.URL = url
+				insertTestIssueWithOptions(t, d, issue)
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			d := openTestDB(t)
+			ctx := t.Context()
+			base := baseTime()
+			number := 7
+
+			entry, _, err := d.ReconcileRepositoryObservation(ctx, RepoIdentity{
+				Platform: "github", PlatformHost: "github.com",
+				PlatformRepoID: "R_widget", Owner: "acme", Name: "widget",
+			}, base)
+			require.NoError(err)
+			require.NoError(d.UpsertNotifications(ctx, []Notification{{
+				Platform:               "github",
+				PlatformHost:           "github.com",
+				PlatformNotificationID: "ntf-stale-parent",
+				RepoOwner:              "acme",
+				RepoName:               "widget",
+				SubjectType:            "PullRequest",
+				SubjectTitle:           "Title at notification time",
+				WebURL:                 tc.staleURL,
+				ItemNumber:             &number,
+				ItemType:               tc.itemType,
+				ItemAuthor:             "carol",
+				Reason:                 "mention",
+				Unread:                 true,
+				SourceUpdatedAt:        base.Add(10 * time.Minute),
+				SyncedAt:               base.Add(10 * time.Minute),
+			}}))
+			_, _, err = d.ReconcileRepositoryObservation(ctx, RepoIdentity{
+				Platform: "github", PlatformHost: "github.com",
+				PlatformRepoID: "R_widget", Owner: "acme", Name: "gadget",
+			}, base.Add(time.Hour))
+			require.NoError(err)
+			tc.insertParent(t, d, entry.Repository.ID, number, tc.currentURL)
+
+			items, err := d.ListActivity(ctx, ListActivityOpts{Limit: 50, Types: []string{"notification"}})
+			require.NoError(err)
+			require.Len(items, 1)
+			// The persisted notification keeps the route and title from when
+			// it was synced. The feed row must report the linked parent's
+			// current metadata so a renamed or reused route never leaks
+			// through the notification, whether or not the frontend later
+			// reconciles it against the capped parent snapshot.
+			assert.Equal("gadget", items[0].RepoName)
+			assert.Equal("Current parent title", items[0].ItemTitle)
+			assert.Equal(tc.currentURL, items[0].ItemURL)
+			assert.Equal(tc.currentURL, items[0].ActivityURL)
+			assert.Equal("unread", items[0].ItemState)
+			assert.Equal("open", items[0].SubjectState)
+		})
+	}
+}
+
+func TestActivityRecencyDerivesFromRenderedEventLedger(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	now := baseTime()
+	since := now.Add(-7 * 24 * time.Hour)
+	repoID := insertTestRepo(t, d, "acme", "widget")
+
+	// The provider bumped updated_at 16 minutes ago (mergeability recompute
+	// after a base push), but the last visible timeline entry is a comment
+	// from 14 hours ago. A cross reference an hour ago is in the ledger but
+	// never renders in the feed, so it must not count either.
+	stackedPR := testMR(repoID, 1347, withMRTitle("Stacked PR"), withMRActivity(now.Add(-10*24*time.Hour)))
+	stackedPR.UpdatedAt = now.Add(-16 * time.Minute)
+	stackedPR.LastActivityAt = now.Add(-16 * time.Minute)
+	stackedPRID := insertTestMRWithOptions(t, d, stackedPR)
+	lastComment := now.Add(-14 * time.Hour)
+	require.NoError(d.UpsertMREvents(ctx, []MREvent{
+		{MergeRequestID: stackedPRID, EventType: "issue_comment", Author: "reviewer",
+			CreatedAt: lastComment, DedupeKey: "stack-comment"},
+		{MergeRequestID: stackedPRID, EventType: "cross_referenced", Author: "bot",
+			CreatedAt: now.Add(-time.Hour), DedupeKey: "stack-xref"},
+	}))
+
+	// Only the provider timestamp is inside the window; the ledger is stale.
+	dormantPR := testMR(repoID, 2, withMRTitle("Dormant PR"), withMRActivity(now.Add(-30*24*time.Hour)))
+	dormantPR.UpdatedAt = now.Add(-time.Hour)
+	dormantPR.LastActivityAt = now.Add(-time.Hour)
+	dormantPRID := insertTestMRWithOptions(t, d, dormantPR)
+	require.NoError(d.UpsertMREvents(ctx, []MREvent{{
+		MergeRequestID: dormantPRID, EventType: "issue_comment", Author: "reviewer",
+		CreatedAt: now.Add(-20 * 24 * time.Hour), DedupeKey: "dormant-comment",
+	}}))
+
+	// A merge is activity even without a rendered event row.
+	mergedAt := now.Add(-2 * time.Hour)
+	mergedPR := testMR(repoID, 3, withMRTitle("Merged PR"), withMRState(MergeRequestStateMerged),
+		withMRActivity(now.Add(-30*24*time.Hour)))
+	mergedPR.MergedAt = &mergedAt
+	mergedPR.ClosedAt = &mergedAt
+	insertTestMRWithOptions(t, d, mergedPR)
+
+	issue := testIssue(repoID, 4, withIssueTitle("Issue"), withIssueActivity(now.Add(-9*24*time.Hour)))
+	issue.UpdatedAt = now.Add(-10 * time.Minute)
+	issue.LastActivityAt = now.Add(-10 * time.Minute)
+	issueID := insertTestIssueWithOptions(t, d, issue)
+	lastIssueComment := now.Add(-5 * time.Hour)
+	require.NoError(d.UpsertIssueEvents(ctx, []IssueEvent{
+		{IssueID: issueID, EventType: "issue_comment", Author: "reporter",
+			CreatedAt: lastIssueComment, DedupeKey: "issue-comment"},
+		{IssueID: issueID, EventType: "assigned", Author: "triager",
+			CreatedAt: now.Add(-30 * time.Minute), DedupeKey: "issue-assigned"},
+	}))
+
+	subjects, err := d.ListActivitySubjects(ctx, ListActivitySubjectsOpts{Since: &since, Limit: 50})
+	require.NoError(err)
+	activityByNumber := make(map[int]time.Time, len(subjects))
+	for _, subject := range subjects {
+		activityByNumber[subject.Subject.Key.ItemNumber] = subject.ActivityAt
+	}
+	assert.Equal(map[int]time.Time{
+		1347: lastComment,
+		3:    mergedAt,
+		4:    lastIssueComment,
+	}, activityByNumber, "provider updated_at must not admit or date parents")
+	require.Len(subjects, 3)
+	assert.Equal(3, subjects[0].Subject.Key.ItemNumber, "ordered by ledger recency")
+	assert.Equal(4, subjects[1].Subject.Key.ItemNumber)
+	assert.Equal(1347, subjects[2].Subject.Key.ItemNumber)
+
+	items, err := d.ListActivity(ctx, ListActivityOpts{Since: &since, Limit: 50})
+	require.NoError(err)
+	for _, item := range items {
+		switch item.ItemNumber {
+		case 1347:
+			require.NotNil(item.ItemLastActivityAt, "%s row", item.ActivityType)
+			assert.Equal(lastComment, *item.ItemLastActivityAt, "%s row", item.ActivityType)
+		case 4:
+			require.NotNil(item.ItemLastActivityAt, "%s row", item.ActivityType)
+			assert.Equal(lastIssueComment, *item.ItemLastActivityAt, "%s row", item.ActivityType)
+		}
+	}
+}
+
+func TestListActivityAuthorsIncludeParentsRecentOnlyByCloseOrMerge(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	now := baseTime()
+	since := now.Add(-7 * 24 * time.Hour)
+	repoID := insertTestRepo(t, d, "acme", "widget")
+
+	mergedAt := now.Add(-time.Hour)
+	mergedPR := testMR(repoID, 1, withMRAuthor("Merger"), withMRState(MergeRequestStateMerged),
+		withMRActivity(now.Add(-30*24*time.Hour)))
+	mergedPR.MergedAt = &mergedAt
+	mergedPR.ClosedAt = &mergedAt
+	insertTestMRWithOptions(t, d, mergedPR)
+
+	closedAt := now.Add(-2 * time.Hour)
+	closedIssue := testIssue(repoID, 2, withIssueAuthor("Closer"), withIssueActivity(now.Add(-30*24*time.Hour)))
+	closedIssue.State = "closed"
+	closedIssue.ClosedAt = &closedAt
+	insertTestIssueWithOptions(t, d, closedIssue)
+
+	dormant := testMR(repoID, 3, withMRAuthor("Dormant"), withMRActivity(now.Add(-30*24*time.Hour)))
+	dormant.LastActivityAt = now.Add(-time.Minute)
+	insertTestMRWithOptions(t, d, dormant)
+
+	subjects, err := d.ListActivitySubjects(ctx, ListActivitySubjectsOpts{Since: &since, Limit: 50})
+	require.NoError(err)
+	require.Len(subjects, 2, "merge and close admit parents to the window")
+
+	authors, err := d.ListActivityAuthors(ctx, ListActivityAuthorsOpts{Since: &since})
+	require.NoError(err)
+	assert.Equal([]string{"Merger", "Closer"}, authors,
+		"every parent visible in Activity must offer its author as a filter candidate")
 }

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -906,16 +906,17 @@ type WorkspaceSubjectKey struct {
 }
 
 type WorkspaceSubjectMetadata struct {
-	Key          WorkspaceSubjectKey
-	Platform     string
-	PlatformHost string
-	RepoOwner    string
-	RepoName     string
-	RepoPath     string
-	Title        string
-	State        string
-	URL          string
-	Author       string
+	Key            WorkspaceSubjectKey
+	Platform       string
+	PlatformHost   string
+	PlatformRepoID string
+	RepoOwner      string
+	RepoName       string
+	RepoPath       string
+	Title          string
+	State          string
+	URL            string
+	Author         string
 }
 
 // RepoViewerLogin binds a provider-authenticated login to the stable local
@@ -1117,20 +1118,22 @@ type RateLimit struct {
 
 // ActivityItem represents one row in the unified activity feed.
 type ActivityItem struct {
-	ActivityType string // new_pr, new_issue, comment, review, commit, default_branch_*
-	Source       string // pr, issue, pre, ise, bc, bfp
-	SourceID     int64  // PK from the source table
-	RepoID       int64
-	Platform     string
-	PlatformHost string
-	RepoOwner    string
-	RepoName     string
-	ItemType     string // pr, issue, or empty for repo-level activity
-	ItemNumber   int
-	ItemTitle    string
-	ItemURL      string
-	ItemState    string // open, merged, closed
-	Author       string
+	ActivityType   string // new_pr, new_issue, comment, review, commit, default_branch_*
+	Source         string // pr, issue, pre, ise, bc, bfp
+	SourceID       int64  // PK from the source table
+	RepoID         int64
+	Platform       string
+	PlatformHost   string
+	PlatformRepoID string
+	RepoOwner      string
+	RepoName       string
+	RepoPath       string
+	ItemType       string // pr, issue, or empty for repo-level activity
+	ItemNumber     int
+	ItemTitle      string
+	ItemURL        string
+	ItemState      string // open, merged, closed
+	Author         string
 	// ItemAuthor is the author of the parent PR/issue, carried on every
 	// PR/issue row (open, comment, review, commit, force_push) so the
 	// threaded feed can show the item's author rather than the latest
@@ -1149,11 +1152,23 @@ type ActivityItem struct {
 	AuthoredAt     *time.Time
 	CommittedAt    *time.Time
 	ActivityURL    string
+	// ItemLastActivityAt is the parent PR or issue's Activity recency, derived
+	// from the event ledger the feed can render rather than provider
+	// updated_at. It is independent of Activity filters, which may hide the
+	// event responsible for that timestamp.
+	ItemLastActivityAt *time.Time
 	// SubjectState is the open/closed/merged state of a notification row's
 	// linked PR/issue. Empty for non-notification rows, which carry their
 	// own state in ItemState. Lets the feed apply Hide closed/merged to
 	// notifications, whose ItemState holds unread/read instead.
 	SubjectState string
+}
+
+// ActivitySubject is the authoritative parent projection for one pull request
+// or issue in the Activity time range. It is independent of event visibility.
+type ActivitySubject struct {
+	Subject    WorkspaceSubjectMetadata
+	ActivityAt time.Time
 }
 
 // Stack represents a detected chain of dependent PRs.
@@ -1386,6 +1401,23 @@ type ListActivityOpts struct {
 	AfterTime      *time.Time
 	AfterSource    string
 	AfterSourceID  int64
+}
+
+// ListActivitySubjectsOpts holds parent-level filters for the Activity feed.
+// Event-type filters and cursors do not apply to this authoritative snapshot.
+type ListActivitySubjectsOpts struct {
+	Repo           string
+	RepoFilters    []RepoFilter
+	AllowedRepoIDs []int64
+	ItemTypes      []string
+	Search         string
+	// SearchMatchedSubjectKeys identifies parents whose provider events matched
+	// Search. The parent title and author do not necessarily contain that term.
+	SearchMatchedSubjectKeys []WorkspaceSubjectKey
+	Author                   string
+	ViewerLogins             []RepoViewerLogin
+	Limit                    int
+	Since                    *time.Time
 }
 
 // ListActivityAuthorsOpts holds the repository and time scopes used to build

--- a/internal/db/workspace_subjects.go
+++ b/internal/db/workspace_subjects.go
@@ -40,7 +40,7 @@ func (d *DB) ListWorkspaceSubjectMetadata(
 			FROM json_each(?)
 		)
 		SELECT q.repo_id, q.item_type, q.item_number,
-		       r.platform, r.platform_host, r.owner, r.name, r.repo_path,
+		       r.platform, r.platform_host, r.platform_repo_id, r.owner, r.name, r.repo_path,
 		       p.title, p.state, p.url, p.author
 		FROM requested q
 		JOIN forge_repos r ON r.id = q.repo_id AND r.lifecycle_state = 'active'
@@ -55,7 +55,7 @@ func (d *DB) ListWorkspaceSubjectMetadata(
 		)
 		UNION ALL
 		SELECT q.repo_id, q.item_type, q.item_number,
-		       r.platform, r.platform_host, r.owner, r.name, r.repo_path,
+		       r.platform, r.platform_host, r.platform_repo_id, r.owner, r.name, r.repo_path,
 		       i.title, i.state, i.url, i.author
 		FROM requested q
 		JOIN forge_repos r ON r.id = q.repo_id AND r.lifecycle_state = 'active'
@@ -77,7 +77,7 @@ func (d *DB) ListWorkspaceSubjectMetadata(
 		var item WorkspaceSubjectMetadata
 		if err := rows.Scan(
 			&item.Key.RepoID, &item.Key.ItemType, &item.Key.ItemNumber,
-			&item.Platform, &item.PlatformHost, &item.RepoOwner, &item.RepoName,
+			&item.Platform, &item.PlatformHost, &item.PlatformRepoID, &item.RepoOwner, &item.RepoName,
 			&item.RepoPath, &item.Title, &item.State, &item.URL, &item.Author,
 		); err != nil {
 			return nil, fmt.Errorf("scan workspace subject metadata: %w", err)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -9091,6 +9091,7 @@ func TestOpenAPIEndpointReflectsHumaContract(t *testing.T) {
 	require.Contains(body, `"/activity"`)
 	require.Contains(body, `"name":"since"`)
 	require.Contains(body, `"capped"`)
+	require.Contains(body, `"item_activity_capped"`)
 	require.NotContains(body, `"name":"before"`)
 	require.NotContains(body, `"has_more"`)
 }
@@ -23821,6 +23822,179 @@ func TestAPIListActivity(t *testing.T) {
 	assert.Len(*unfiltered.JSON200.Items, len(*resp.JSON200.Items))
 }
 
+func TestAPIListActivityReturnsRecentParentWhenItsVisibleEventsAreFiltered(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv, database := setupTestServer(t)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+	createdAt := now.Add(-30 * 24 * time.Hour)
+	activityAt := now.Add(-time.Hour)
+
+	prID := seedPR(
+		t, database, "acme", "widget", 77,
+		withSeedPRTitle("Old pull with recent hidden activity"),
+		withSeedPRTimes(createdAt, activityAt, activityAt),
+	)
+	require.NoError(database.InsertWorkspace(ctx, &db.Workspace{
+		ID: "ws-hidden-parent", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget", ItemType: db.WorkspaceItemTypePullRequest,
+		ItemNumber: 77, WorktreePath: t.TempDir(), Status: "ready",
+	}))
+	require.NoError(database.UpsertMREvents(ctx, []db.MREvent{{
+		MergeRequestID: prID,
+		EventType:      "issue_comment",
+		Author:         "reviewer",
+		CreatedAt:      activityAt,
+		DedupeKey:      "api-hidden-parent-comment",
+	}}))
+
+	since := url.QueryEscape(now.Add(-7 * 24 * time.Hour).Format(time.RFC3339))
+	rr := doJSON(
+		t,
+		srv,
+		http.MethodGet,
+		"/api/v1/activity?since="+since+"&types=commit&item_types=pr,repo",
+		nil,
+	)
+	require.Equal(http.StatusOK, rr.Code)
+	var body struct {
+		Items        []activityItemResponse    `json:"items"`
+		ItemActivity []activitySubjectResponse `json:"item_activity"`
+	}
+	require.NoError(json.NewDecoder(rr.Body).Decode(&body))
+	assert.Empty(body.Items, "the comment must remain hidden by the event filter")
+	require.Len(body.ItemActivity, 1)
+	assert.Equal(77, body.ItemActivity[0].ItemNumber)
+	assert.Equal("pr", body.ItemActivity[0].ItemType)
+	assert.Equal("Old pull with recent hidden activity", body.ItemActivity[0].ItemTitle)
+	assert.Equal(formatUTCRFC3339(activityAt), body.ItemActivity[0].ActivityAt)
+	require.NotNil(body.ItemActivity[0].Workspace)
+	assert.Equal("ws-hidden-parent", body.ItemActivity[0].Workspace.ID)
+}
+
+func TestAPIListActivityIncrementalSearchReturnsParentsMatchedByProviderEvents(t *testing.T) {
+	req := require.New(t)
+	srv, database := setupTestServer(t)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+	activityAt := now.Add(-time.Hour)
+
+	bodyMatchID := seedPR(
+		t, database, "acme", "widget", 78,
+		withSeedPRTitle("Parent with an unrelated title"),
+		withSeedPRTimes(activityAt, activityAt, activityAt),
+	)
+	actorMatchID := seedPR(
+		t, database, "acme", "widget", 79,
+		withSeedPRTitle("Another unrelated parent"),
+		withSeedPRTimes(activityAt, activityAt, activityAt),
+	)
+	req.NoError(database.UpsertMREvents(ctx, []db.MREvent{
+		{
+			MergeRequestID: bodyMatchID,
+			EventType:      "issue_comment",
+			Author:         "reviewer",
+			Body:           "contains body-match-term",
+			CreatedAt:      activityAt,
+			DedupeKey:      "incremental-search-body-match",
+		},
+		{
+			MergeRequestID: actorMatchID,
+			EventType:      "issue_comment",
+			Author:         "actor-match-term",
+			Body:           "unrelated comment",
+			CreatedAt:      activityAt,
+			DedupeKey:      "incremental-search-actor-match",
+		},
+	}))
+
+	since := url.QueryEscape(now.Add(-7 * 24 * time.Hour).Format(time.RFC3339))
+	after := url.QueryEscape(db.EncodeCursor(now, "mr_event", 1))
+	for _, tc := range []struct {
+		name       string
+		search     string
+		itemNumber int
+	}{
+		{name: "event body", search: "body-match-term", itemNumber: 78},
+		{name: "event actor", search: "actor-match-term", itemNumber: 79},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			rr := doJSON(
+				t,
+				srv,
+				http.MethodGet,
+				"/api/v1/activity?since="+since+"&after="+after+"&search="+url.QueryEscape(tc.search),
+				nil,
+			)
+			require.Equal(http.StatusOK, rr.Code)
+			var body struct {
+				Items        []activityItemResponse    `json:"items"`
+				ItemActivity []activitySubjectResponse `json:"item_activity"`
+			}
+			require.NoError(json.NewDecoder(rr.Body).Decode(&body))
+			require.Empty(body.Items, "the matching event is behind the incremental cursor")
+			require.Len(body.ItemActivity, 1)
+			require.Equal(tc.itemNumber, body.ItemActivity[0].ItemNumber)
+		})
+	}
+}
+
+func TestAPIListActivitySeparatesEventAndParentSnapshotCaps(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv, database := setupTestServer(t)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+	repoID, err := database.UpsertRepo(ctx, verifiedGitHubRepoIdentity("github.com", "acme", "many-parents"))
+	require.NoError(err)
+
+	_, err = database.WriteDB().ExecContext(ctx, `
+		WITH digits(n) AS (
+			VALUES (0), (1), (2), (3), (4), (5), (6), (7), (8), (9)
+		), numbers(n) AS (
+			SELECT ones.n + 10 * tens.n + 100 * hundreds.n + 1000 * thousands.n + 1
+			FROM digits AS ones
+			CROSS JOIN digits AS tens
+			CROSS JOIN digits AS hundreds
+			CROSS JOIN digits AS thousands
+		)
+		INSERT INTO forge_merge_requests (
+			repo_id, platform_id, number, url, title, author, state,
+			created_at, updated_at, last_activity_at
+		)
+		SELECT ?, n, n,
+		       'https://github.com/acme/many-parents/pull/' || n,
+		       'Parent ' || n, 'testuser', 'open', ?, ?, ?
+		FROM numbers
+		WHERE n <= ?`,
+		repoID, now, now, now, activitySafetyCap+1,
+	)
+	require.NoError(err)
+
+	since := url.QueryEscape(now.Add(-time.Minute).Format(time.RFC3339))
+	rr := doJSON(
+		t,
+		srv,
+		http.MethodGet,
+		"/api/v1/activity?since="+since+"&types=commit&item_types=pr,repo",
+		nil,
+	)
+	require.Equal(http.StatusOK, rr.Code)
+	var body struct {
+		Items              []activityItemResponse    `json:"items"`
+		ItemActivity       []activitySubjectResponse `json:"item_activity"`
+		Capped             bool                      `json:"capped"`
+		ItemActivityCapped bool                      `json:"item_activity_capped"`
+	}
+	require.NoError(json.NewDecoder(rr.Body).Decode(&body))
+	assert.Empty(body.Items)
+	require.Len(body.ItemActivity, activitySafetyCap)
+	assert.False(body.Capped, "parent snapshot overflow must not report event overflow")
+	assert.True(body.ItemActivityCapped)
+}
+
 func TestWorkspaceActivitySearchKeepsSubjectsWithMatchingProviderEvents(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -24055,6 +24229,52 @@ func TestAPIListActivityFiltersByAuthorAndListsScopedCandidates(t *testing.T) {
 	assert.NotContains(candidateBody.Authors, "Hidden Actor")
 }
 
+func TestAPIListActivityReturnsParentRecencyWhenCommitEventsAreFiltered(t *testing.T) {
+	require := require.New(t)
+	srv, database := setupTestServer(t)
+	ctx := t.Context()
+	base := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	// The hidden commit is the newest rendered ledger event, so it defines
+	// the parent's recency; the provider's later updated_at does not.
+	parentActivityAt := base.Add(19 * time.Minute)
+
+	prID := seedPR(
+		t, database, "acme", "widget", 1,
+		withSeedPRTimes(base, base.Add(20*time.Minute), base.Add(20*time.Minute)),
+	)
+	require.NoError(database.UpsertMREvents(ctx, []db.MREvent{
+		{
+			MergeRequestID: prID,
+			EventType:      "issue_comment",
+			Author:         "reviewer",
+			CreatedAt:      base.Add(10 * time.Minute),
+			DedupeKey:      "visible-comment",
+		},
+		{
+			MergeRequestID: prID,
+			EventType:      "commit",
+			Author:         "owner",
+			CreatedAt:      base.Add(19 * time.Minute),
+			DedupeKey:      "filtered-commit",
+		},
+	}))
+
+	since := base.Add(-time.Minute).Format(time.RFC3339)
+	rr := doJSON(
+		t,
+		srv,
+		http.MethodGet,
+		"/api/v1/activity?since="+url.QueryEscape(since)+"&types=comment",
+		nil,
+	)
+	require.Equal(http.StatusOK, rr.Code)
+	var body activityResponse
+	require.NoError(json.Unmarshal(rr.Body.Bytes(), &body))
+	require.Len(body.Items, 1)
+	require.Equal("comment", body.Items[0].ActivityType)
+	require.Equal(parentActivityAt.Format(time.RFC3339), body.Items[0].ItemLastActivityAt)
+}
+
 func TestAPIActivityScopesFollowTrackedRepositoryIDAcrossRename(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -24098,6 +24318,9 @@ func TestAPIActivityScopesFollowTrackedRepositoryIDAcrossRename(t *testing.T) {
 	require.NoError(json.Unmarshal(feed.Body.Bytes(), &feedBody))
 	require.Len(feedBody.Items, 1)
 	assert.Equal("gadget", feedBody.Items[0].RepoName)
+	assert.Equal(repo.PlatformRepoID, feedBody.Items[0].Repo.PlatformRepoID)
+	require.Len(feedBody.ItemActivity, 1)
+	assert.Equal(repo.PlatformRepoID, feedBody.ItemActivity[0].Repo.PlatformRepoID)
 
 	candidates := doJSON(
 		t, srv, http.MethodGet,
@@ -24166,6 +24389,65 @@ func TestAPIListActivityAppliesTrackedRepoScopeBeforeAuthorLimit(t *testing.T) {
 		assert.Equal("Item Owner", item.ItemAuthor)
 	}
 	assert.False(feedBody.Capped)
+}
+
+func TestAPIListActivitySearchReportsParentTruncationWhenMatchesOverflowEventCap(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv, database := setupTestServer(t)
+	ctx := t.Context()
+	base := time.Now().UTC().Add(-2 * time.Hour).Truncate(time.Second)
+
+	// The older parent matches the search only through its event body, and
+	// that event sits behind more than a full event page of newer matches on
+	// another parent, so it can only be recognised as a truncated parent.
+	olderPRID := seedPR(
+		t, database, "acme", "widget", 1,
+		withSeedPRTitle("Unrelated older parent"),
+		withSeedPRTimes(base, base, base),
+	)
+	require.NoError(database.UpsertMREvents(ctx, []db.MREvent{{
+		MergeRequestID: olderPRID,
+		EventType:      "issue_comment",
+		Author:         "reviewer",
+		Body:           "needle in an older event",
+		CreatedAt:      base.Add(time.Minute),
+		DedupeKey:      "older-needle",
+	}}))
+	noisyPRID := seedPR(
+		t, database, "acme", "widget", 2,
+		withSeedPRTitle("Unrelated noisy parent"),
+		withSeedPRTimes(base, base, base),
+	)
+	noisyEvents := make([]db.MREvent, activitySafetyCap+1)
+	for i := range noisyEvents {
+		noisyEvents[i] = db.MREvent{
+			MergeRequestID: noisyPRID,
+			EventType:      "issue_comment",
+			Author:         "reviewer",
+			Body:           "needle repeated",
+			CreatedAt:      base.Add(2*time.Minute + time.Duration(i)*time.Second),
+			DedupeKey:      fmt.Sprintf("noisy-needle-%d", i),
+		}
+	}
+	require.NoError(database.UpsertMREvents(ctx, noisyEvents))
+
+	since := url.QueryEscape(base.Add(-time.Minute).Format(time.RFC3339))
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/activity?since="+since+"&search=needle", nil)
+	require.Equal(http.StatusOK, rr.Code)
+	var body struct {
+		Items              []activityItemResponse    `json:"items"`
+		ItemActivity       []activitySubjectResponse `json:"item_activity"`
+		Capped             bool                      `json:"capped"`
+		ItemActivityCapped bool                      `json:"item_activity_capped"`
+	}
+	require.NoError(json.NewDecoder(rr.Body).Decode(&body))
+	require.Len(body.Items, activitySafetyCap)
+	assert.True(body.Capped)
+	assert.True(body.ItemActivityCapped,
+		"parents matched only through truncated events must be reported as truncated")
+	require.Len(body.ItemActivity, 1)
+	assert.Equal(2, body.ItemActivity[0].ItemNumber)
 }
 
 func TestAPIListActivityIncludesNotificationSyncedBeforeRepo(t *testing.T) {

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -215,9 +215,26 @@ type rateLimitsResponse struct {
 const activitySafetyCap = 5000
 
 type activityResponse struct {
-	Items             []activityItemResponse             `json:"items"`
-	WorkspaceActivity []workspaceActivitySubjectResponse `json:"workspace_activity"`
-	Capped            bool                               `json:"capped"`
+	Items              []activityItemResponse             `json:"items"`
+	ItemActivity       []activitySubjectResponse          `json:"item_activity"`
+	WorkspaceActivity  []workspaceActivitySubjectResponse `json:"workspace_activity"`
+	Capped             bool                               `json:"capped"`
+	ItemActivityCapped bool                               `json:"item_activity_capped"`
+}
+
+type activitySubjectResponse struct {
+	Repo         httpapi.RepoRefResponse    `json:"repo"`
+	PlatformHost string                     `json:"platform_host"`
+	RepoOwner    string                     `json:"repo_owner"`
+	RepoName     string                     `json:"repo_name"`
+	ItemType     string                     `json:"item_type"`
+	ItemNumber   int                        `json:"item_number"`
+	ItemTitle    string                     `json:"item_title"`
+	ItemURL      string                     `json:"item_url"`
+	ItemState    string                     `json:"item_state"`
+	ItemAuthor   string                     `json:"item_author,omitempty"`
+	Workspace    *workspaceapi.WorkspaceRef `json:"workspace,omitempty"`
+	ActivityAt   string                     `json:"activity_at" format:"date-time"`
 }
 
 type workspaceActivitySubjectResponse struct {
@@ -240,33 +257,34 @@ type activityAuthorsResponse struct {
 }
 
 type activityItemResponse struct {
-	ID             string                     `json:"id"`
-	Cursor         string                     `json:"cursor"`
-	ActivityType   string                     `json:"activity_type"`
-	Repo           httpapi.RepoRefResponse    `json:"repo"`
-	PlatformHost   string                     `json:"platform_host"`
-	RepoOwner      string                     `json:"repo_owner"`
-	RepoName       string                     `json:"repo_name"`
-	ItemType       string                     `json:"item_type"`
-	ItemNumber     int                        `json:"item_number"`
-	ItemTitle      string                     `json:"item_title"`
-	ItemURL        string                     `json:"item_url"`
-	ItemState      string                     `json:"item_state"`
-	Workspace      *workspaceapi.WorkspaceRef `json:"workspace,omitempty"`
-	Author         string                     `json:"author"`
-	ItemAuthor     string                     `json:"item_author,omitempty"`
-	CreatedAt      string                     `json:"created_at"`
-	BodyPreview    string                     `json:"body_preview"`
-	BranchName     string                     `json:"branch_name,omitempty"`
-	CommitSHA      string                     `json:"commit_sha,omitempty"`
-	BeforeSHA      string                     `json:"before_sha,omitempty"`
-	AfterSHA       string                     `json:"after_sha,omitempty"`
-	AuthorName     string                     `json:"author_name,omitempty"`
-	AuthorEmail    string                     `json:"author_email,omitempty"`
-	CommitterName  string                     `json:"committer_name,omitempty"`
-	CommitterEmail string                     `json:"committer_email,omitempty"`
-	AuthoredAt     string                     `json:"authored_at,omitempty"`
-	CommittedAt    string                     `json:"committed_at,omitempty"`
-	ActivityURL    string                     `json:"activity_url,omitempty"`
-	SubjectState   string                     `json:"subject_state,omitempty"`
+	ID                 string                     `json:"id"`
+	Cursor             string                     `json:"cursor"`
+	ActivityType       string                     `json:"activity_type"`
+	Repo               httpapi.RepoRefResponse    `json:"repo"`
+	PlatformHost       string                     `json:"platform_host"`
+	RepoOwner          string                     `json:"repo_owner"`
+	RepoName           string                     `json:"repo_name"`
+	ItemType           string                     `json:"item_type"`
+	ItemNumber         int                        `json:"item_number"`
+	ItemTitle          string                     `json:"item_title"`
+	ItemURL            string                     `json:"item_url"`
+	ItemState          string                     `json:"item_state"`
+	Workspace          *workspaceapi.WorkspaceRef `json:"workspace,omitempty"`
+	Author             string                     `json:"author"`
+	ItemAuthor         string                     `json:"item_author,omitempty"`
+	CreatedAt          string                     `json:"created_at"`
+	ItemLastActivityAt string                     `json:"item_last_activity_at,omitempty" format:"date-time"`
+	BodyPreview        string                     `json:"body_preview"`
+	BranchName         string                     `json:"branch_name,omitempty"`
+	CommitSHA          string                     `json:"commit_sha,omitempty"`
+	BeforeSHA          string                     `json:"before_sha,omitempty"`
+	AfterSHA           string                     `json:"after_sha,omitempty"`
+	AuthorName         string                     `json:"author_name,omitempty"`
+	AuthorEmail        string                     `json:"author_email,omitempty"`
+	CommitterName      string                     `json:"committer_name,omitempty"`
+	CommitterEmail     string                     `json:"committer_email,omitempty"`
+	AuthoredAt         string                     `json:"authored_at,omitempty"`
+	CommittedAt        string                     `json:"committed_at,omitempty"`
+	ActivityURL        string                     `json:"activity_url,omitempty"`
+	SubjectState       string                     `json:"subject_state,omitempty"`
 }

--- a/internal/server/apitest/api_test.go
+++ b/internal/server/apitest/api_test.go
@@ -243,6 +243,12 @@ func TestAPIActivityAndRepoSummariesHideRemovedUpstreamArchiveRows(t *testing.T)
 		require.NotEqualValues(2, item.ItemNumber)
 		require.NotEqualValues(4, item.ItemNumber)
 	}
+	require.NotNil(activity.JSON200.ItemActivity)
+	require.NotEmpty(*activity.JSON200.ItemActivity)
+	for _, subject := range *activity.JSON200.ItemActivity {
+		require.NotEqualValues(2, subject.ItemNumber, "removed parents must not surface as parent-only threads")
+		require.NotEqualValues(4, subject.ItemNumber, "removed parents must not surface as parent-only threads")
+	}
 	authors, err := client.HTTP.ListActivityAuthorsWithResponse(
 		ctx, &generated.ListActivityAuthorsParams{Since: &since},
 	)

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -41,12 +41,18 @@ func workspaceRefForActivityItem(
 	if workspaceItemType == "" {
 		return nil
 	}
-	key := db.WorkspaceSubjectKey{
+	return workspaceRefForActivitySubjectKey(snapshot, db.WorkspaceSubjectKey{
 		RepoID: item.RepoID, ItemType: workspaceItemType, ItemNumber: item.ItemNumber,
-	}
+	})
+}
+
+func workspaceRefForActivitySubjectKey(
+	snapshot workspaceapi.WorkspaceSubjectSnapshot,
+	key db.WorkspaceSubjectKey,
+) *workspaceapi.WorkspaceRef {
 	var ref workspaceapi.WorkspaceRef
 	var ok bool
-	if workspaceItemType == db.WorkspaceItemTypeIssue {
+	if key.ItemType == db.WorkspaceItemTypeIssue {
 		ref, ok = snapshot.OwnReferences[key]
 	} else if subject, exists := snapshot.Subjects[key]; exists {
 		ref, ok = subject.Workspace, true

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1376,7 +1376,7 @@ func (s *Server) listActivity(ctx context.Context, input *listActivityInput) (*l
 		slog.Error("list activity failed", "err", err)
 		return nil, httpapi.Internal("list activity failed")
 	}
-	var workspaceEventItems []db.ActivityItem
+	workspaceEventItems := items
 	hasFullWorkspaceEventItems := opts.Search != "" && opts.AfterTime != nil
 	if hasFullWorkspaceEventItems {
 		workspaceOpts := opts
@@ -1388,6 +1388,38 @@ func (s *Server) listActivity(ctx context.Context, input *listActivityInput) (*l
 			slog.Error("list activity search subjects failed", "err", err)
 			return nil, httpapi.Internal("list activity failed")
 		}
+	}
+	// Search-matched parents are derived from the bounded event read, so an
+	// event page that overflowed can hide parents whose only matches fell off
+	// it; report that as parent truncation rather than a complete snapshot.
+	searchMatchesTruncated := opts.Search != "" && len(workspaceEventItems) > activitySafetyCap
+	var searchMatchedSubjectKeys []db.WorkspaceSubjectKey
+	if opts.Search != "" {
+		searchMatchedSubjectKeys = make([]db.WorkspaceSubjectKey, 0, len(workspaceEventItems))
+		for _, item := range workspaceEventItems {
+			if item.ItemType != "pr" && item.ItemType != "issue" {
+				continue
+			}
+			searchMatchedSubjectKeys = append(searchMatchedSubjectKeys, db.WorkspaceSubjectKey{
+				RepoID: item.RepoID, ItemType: item.ItemType, ItemNumber: item.ItemNumber,
+			})
+		}
+	}
+	itemActivity, err := s.db.ListActivitySubjects(ctx, db.ListActivitySubjectsOpts{
+		Repo:                     opts.Repo,
+		RepoFilters:              opts.RepoFilters,
+		AllowedRepoIDs:           opts.AllowedRepoIDs,
+		ItemTypes:                opts.ItemTypes,
+		Search:                   opts.Search,
+		SearchMatchedSubjectKeys: searchMatchedSubjectKeys,
+		Author:                   opts.Author,
+		ViewerLogins:             opts.ViewerLogins,
+		Limit:                    activitySafetyCap + 1,
+		Since:                    opts.Since,
+	})
+	if err != nil {
+		slog.Error("list activity subjects failed", "err", err)
+		return nil, httpapi.Internal("list activity failed")
 	}
 	if s.activityAfterItemsForTest != nil {
 		s.activityAfterItemsForTest()
@@ -1425,9 +1457,13 @@ func (s *Server) listActivity(ctx context.Context, input *listActivityInput) (*l
 		}
 	}
 
-	capped := len(items) > activitySafetyCap
-	if capped {
+	eventsCapped := len(items) > activitySafetyCap
+	itemActivityCapped := len(itemActivity) > activitySafetyCap || searchMatchesTruncated
+	if len(items) > activitySafetyCap {
 		items = items[:activitySafetyCap]
+	}
+	if len(itemActivity) > activitySafetyCap {
+		itemActivity = itemActivity[:activitySafetyCap]
 	}
 	if hasFullWorkspaceEventItems {
 		if len(workspaceEventItems) > activitySafetyCap {
@@ -1443,9 +1479,11 @@ func (s *Server) listActivity(ctx context.Context, input *listActivityInput) (*l
 			ID:           it.Source + ":" + strconv.FormatInt(it.SourceID, 10),
 			Cursor:       db.EncodeCursor(it.CreatedAt, it.Source, it.SourceID),
 			ActivityType: it.ActivityType,
-			Repo: s.repoResolver.RefFromParts(
-				it.Platform, it.PlatformHost, it.RepoOwner, it.RepoName,
-			),
+			Repo: s.repoResolver.Ref(db.Repo{
+				Platform: it.Platform, PlatformHost: it.PlatformHost,
+				PlatformRepoID: it.PlatformRepoID, Owner: it.RepoOwner,
+				Name: it.RepoName, RepoPath: it.RepoPath,
+			}),
 			PlatformHost: it.PlatformHost,
 			RepoOwner:    it.RepoOwner,
 			RepoName:     it.RepoName,
@@ -1459,6 +1497,9 @@ func (s *Server) listActivity(ctx context.Context, input *listActivityInput) (*l
 			ItemAuthor:   it.ItemAuthor,
 			CreatedAt:    formatUTCRFC3339(it.CreatedAt),
 			BodyPreview:  it.BodyPreview,
+		}
+		if it.ItemLastActivityAt != nil {
+			item.ItemLastActivityAt = formatUTCRFC3339(*it.ItemLastActivityAt)
 		}
 		item.BranchName = it.BranchName
 		item.CommitSHA = it.CommitSHA
@@ -1482,9 +1523,40 @@ func (s *Server) listActivity(ctx context.Context, input *listActivityInput) (*l
 		out[i] = item
 	}
 
+	itemActivityOut := make([]activitySubjectResponse, len(itemActivity))
+	for i, activity := range itemActivity {
+		subject := activity.Subject
+		workspaceSubjectKey := subject.Key
+		workspaceSubjectKey.ItemType = workspaceItemTypeFromActivity(subject.Key.ItemType)
+		itemActivityOut[i] = activitySubjectResponse{
+			Repo: s.repoResolver.Ref(db.Repo{
+				Platform: subject.Platform, PlatformHost: subject.PlatformHost,
+				PlatformRepoID: subject.PlatformRepoID, Owner: subject.RepoOwner,
+				Name: subject.RepoName, RepoPath: subject.RepoPath,
+			}),
+			PlatformHost: subject.PlatformHost,
+			RepoOwner:    subject.RepoOwner,
+			RepoName:     subject.RepoName,
+			ItemType:     subject.Key.ItemType,
+			ItemNumber:   subject.Key.ItemNumber,
+			ItemTitle:    subject.Title,
+			ItemURL:      subject.URL,
+			ItemState:    subject.State,
+			ItemAuthor:   subject.Author,
+			Workspace:    workspaceRefForActivitySubjectKey(workspaceSnapshot, workspaceSubjectKey),
+			ActivityAt:   formatUTCRFC3339(activity.ActivityAt),
+		}
+	}
+
 	workspaceActivity := s.workspaceActivityResponse(input, opts, workspaceSnapshot, workspaceEventItems)
 	return &listActivityOutput{
-		Body: activityResponse{Items: out, WorkspaceActivity: workspaceActivity, Capped: capped},
+		Body: activityResponse{
+			Items:              out,
+			ItemActivity:       itemActivityOut,
+			WorkspaceActivity:  workspaceActivity,
+			Capped:             eventsCapped,
+			ItemActivityCapped: itemActivityCapped,
+		},
 	}, nil
 }
 
@@ -1552,9 +1624,11 @@ func (s *Server) workspaceActivityResponse(
 		}
 		ref := activity.Workspace
 		result = append(result, workspaceActivitySubjectResponse{
-			Repo: s.repoResolver.RefFromParts(
-				subject.Platform, subject.PlatformHost, subject.RepoOwner, subject.RepoName,
-			),
+			Repo: s.repoResolver.Ref(db.Repo{
+				Platform: subject.Platform, PlatformHost: subject.PlatformHost,
+				PlatformRepoID: subject.PlatformRepoID, Owner: subject.RepoOwner,
+				Name: subject.RepoName, RepoPath: subject.RepoPath,
+			}),
 			PlatformHost: subject.PlatformHost, RepoOwner: subject.RepoOwner, RepoName: subject.RepoName,
 			ItemType: wireType, ItemNumber: key.ItemNumber, ItemTitle: subject.Title,
 			ItemURL: subject.URL, ItemState: subject.State, ItemAuthor: subject.Author,

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -317,8 +317,10 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 		return nil, fmt.Errorf("upsert widgets#6: %w", err)
 	}
 
-	// widgets#7: open, dependabot[bot]
-	w7Created := now.Add(-1 * 24 * time.Hour)
+	// widgets#7: open, dependabot[bot], opened recently with no other ledger
+	// events so Activity treats it as recent parent activity without a
+	// selectable event row.
+	w7Created := now.Add(-6 * time.Hour)
 	_, err = d.UpsertMergeRequest(ctx, &db.MergeRequest{
 		RepoID:            widgetsID,
 		PlatformID:        1007,


### PR DESCRIPTION
Activity could show an old parent time while detail already contained newer activity because filter state and feed recency were coupled.

- Treat Commits as a top-level default-branch filter; PR commits remain in PR timelines.
- Carry each PR or issue authoritative last activity through Activity and use it for desktop and mobile grouping and ordering.
- Reconcile visible PR, issue, and Activity lists after every successful initial detail read, even if selection changes before display.
- Keep periodic full Activity snapshots authoritative for cursor-hidden events.