### PR TITLE
fix(archive): hide items removed upstream

### DIFF
--- a/context/fleet-architecture.md
+++ b/context/fleet-architecture.md
@@ -15,6 +15,9 @@ peer transports, or remote workspace and session operations.
   Workspace managers or root mutable config
   (`internal/server/workspaceapi/fleet_snapshot.go::FleetSnapshot`,
   `internal/server/fleetapi/handler.go::ConfigSnapshot`).
+- Workspace overlays keep the local shell but omit links and metadata for
+  removed source or associated items; inaccessible items remain visible
+  (`internal/server/fleetapi/fleet_adapter.go::worktreeFromWorkspace`).
 
 ## Snapshot And Routing Contracts
 

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -422,6 +422,9 @@ Repository import requests and route/query shapes should carry
   characters exactly once, via shared provider route helpers.
 - New provider-aware routes should not require ad hoc URL construction in
   stores/components.
+- Archive items marked `removed_upstream` remain stored for sync repair but are
+  hidden from public item reads, stacks, activity, repository summaries, and
+  archive reports; `inaccessible` items remain visible. (`internal/server/pullapi/helpers.go::visibleMergeRequest`)
 - Embedded navigation events for repo-bound routes must publish identity from
   parsed route state, not from global embed config. When a route carries repo
   identity, event payloads should include `provider`, `platform_host`, and

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -425,7 +425,9 @@ Repository import requests and route/query shapes should carry
 - Archive items marked `removed_upstream` remain stored for sync repair but are
   hidden from public item reads, resolution, autocomplete, stacks, activity,
   workspace subject metadata, repository summaries, archive reports, and
-  provider mutations; `inaccessible` items remain visible.
+  provider mutations; synchronous public item sync rejects known tombstones
+  before provider access and uses visibility-filtered response reads.
+  `inaccessible` items remain visible.
   (`internal/server/pullapi/helpers.go::visibleMergeRequest`,
   `internal/server/issueapi/mutation_handlers.go::requireVisibleIssue`)
 - Embedded navigation events for repo-bound routes must publish identity from

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -428,6 +428,10 @@ Repository import requests and route/query shapes should carry
   links, repository summaries, archive reports, and provider mutations;
   synchronous and queued public item sync rejects known tombstones before
   provider access, with queued work rechecking visibility when it executes.
+  Watched fast-sync and priority detail-drain work perform that recheck after
+  stable repository resolution; archive-budget hydration bypasses it so a
+  terminal item can be repaired when it reappears upstream. Deferred PR and
+  issue workspace setup rechecks its source before any Git or provider access.
   Periodic repository sync excludes tombstones from closed-item and
   merged-actor repair candidates, then rechecks before each provider fetch.
   Secondary workflows such as label validation, automatic assignment,

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -424,9 +424,12 @@ Repository import requests and route/query shapes should carry
   stores/components.
 - Archive items marked `removed_upstream` remain stored for sync repair but are
   hidden from public item reads, resolution, autocomplete, stacks, activity,
-  workspace subject metadata, repository summaries, archive reports, and
-  provider mutations; synchronous public item sync rejects known tombstones
-  before provider access and uses visibility-filtered response reads.
+  workspace creation and subject metadata, project worktree imports, Kata
+  links, repository summaries, archive reports, and provider mutations;
+  synchronous public item sync rejects known tombstones before provider access
+  and uses visibility-filtered response reads. Secondary workflows such as
+  label validation, automatic assignment, and on-demand worktree sync must
+  check item visibility before provider access.
   `inaccessible` items remain visible.
   (`internal/server/pullapi/helpers.go::visibleMergeRequest`,
   `internal/server/issueapi/mutation_handlers.go::requireVisibleIssue`)

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -431,7 +431,8 @@ Repository import requests and route/query shapes should carry
   Watched fast-sync and priority detail-drain work perform that recheck after
   stable repository resolution; archive-budget hydration bypasses it so a
   terminal item can be repaired when it reappears upstream. Deferred PR and
-  issue workspace setup rechecks its source before any Git or provider access.
+  issue comment drains recheck their parent before provider access, and
+  workspace setup rechecks its source before any Git or provider access.
   Periodic repository sync excludes tombstones from closed-item and
   merged-actor repair candidates, then rechecks before each provider fetch.
   Secondary workflows such as label validation, automatic assignment,

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -278,7 +278,9 @@ registry helpers return typed errors for missing providers or capabilities.
 
 - Archive is a scheduling and progress mode over normal sync, not a second sync engine; completeness is repository and item progress scoped by full repository identity. (`internal/db/queries_archive.go::GetArchiveProgress`)
 - Created-order inventory calls require the historical capability; updated-order maintenance traversal does not. Each returns one bounded identity page with an advancing opaque cursor or explicit exhaustion. (`internal/platform/reader_validation.go::pageReaderValidation.prepare`)
-- Hydration admits one item and invokes canonical item sync; only a successful complete sync records an archive outcome. Do not add archive-specific content paths. (`internal/archive/hydrate.go::hydrateItem`)
+- Hydration admits one item and invokes canonical item sync; only a successful complete
+  sync records an archive outcome, and provider finalizers run after that commit so they
+  observe lifecycle reactivation. (`internal/archive/hydrate.go::hydrateItem`)
 - Only parent lookups explicitly classified as removed, moved, or inaccessible are terminal. Generic and child-dataset not-found responses remain retries; a successful non-GitHub feature-metadata confirmation doubles as repository-accessibility evidence and must not be repeated before marking the parent absent. Canonical item content stays untouched. (`internal/archive/hydrate.go::archiveTerminalSyncOutcome`, `internal/platform/gitealike/feature_disabled.go::Provider.repositoryItemLookupError`,
   `internal/platform/gitlab/feature_disabled.go::Client.repositoryItemLookupError`)
 - Removed-upstream parents stay stored for rediscovery but are excluded from public

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -428,8 +428,9 @@ Repository import requests and route/query shapes should carry
   links, repository summaries, archive reports, and provider mutations;
   synchronous public item sync rejects known tombstones before provider access
   and uses visibility-filtered response reads. Secondary workflows such as
-  label validation, automatic assignment, and on-demand worktree sync must
-  check item visibility before provider access.
+  label validation, automatic assignment, pushed-head refresh, and on-demand
+  worktree sync must check item visibility before provider access. Workspace
+  and Fleet projections retain local records but omit removed parent metadata.
   `inaccessible` items remain visible.
   (`internal/server/pullapi/helpers.go::visibleMergeRequest`,
   `internal/server/issueapi/mutation_handlers.go::requireVisibleIssue`)

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -426,11 +426,13 @@ Repository import requests and route/query shapes should carry
   hidden from public item reads, resolution, autocomplete, stacks, activity,
   workspace creation and subject metadata, project worktree imports, Kata
   links, repository summaries, archive reports, and provider mutations;
-  synchronous public item sync rejects known tombstones before provider access
-  and uses visibility-filtered response reads. Secondary workflows such as
-  label validation, automatic assignment, pushed-head refresh, and on-demand
-  worktree sync must check item visibility before provider access. Workspace
-  and Fleet projections retain local records but omit removed parent metadata.
+  synchronous and queued public item sync rejects known tombstones before
+  provider access, with queued work rechecking visibility when it executes.
+  Secondary workflows such as label validation, automatic assignment,
+  pushed-head refresh, manual workspace refresh, and on-demand worktree sync
+  must check item visibility before item-specific provider access. Workspace and
+  Fleet projections retain local records but omit removed parent metadata;
+  visible stack members are renumbered contiguously after filtering.
   `inaccessible` items remain visible.
   (`internal/server/pullapi/helpers.go::visibleMergeRequest`,
   `internal/server/issueapi/mutation_handlers.go::requireVisibleIssue`)

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -281,6 +281,9 @@ registry helpers return typed errors for missing providers or capabilities.
 - Hydration admits one item and invokes canonical item sync; only a successful complete sync records an archive outcome. Do not add archive-specific content paths. (`internal/archive/hydrate.go::hydrateItem`)
 - Only parent lookups explicitly classified as removed, moved, or inaccessible are terminal. Generic and child-dataset not-found responses remain retries; a successful non-GitHub feature-metadata confirmation doubles as repository-accessibility evidence and must not be repeated before marking the parent absent. Canonical item content stays untouched. (`internal/archive/hydrate.go::archiveTerminalSyncOutcome`, `internal/platform/gitealike/feature_disabled.go::Provider.repositoryItemLookupError`,
   `internal/platform/gitlab/feature_disabled.go::Client.repositoryItemLookupError`)
+- Removed-upstream parents stay stored for rediscovery but are excluded from public
+  item list/detail reads and archive reports; inaccessible rows remain visible because
+  authorization loss does not prove removal. (`internal/db/queries_archive_report.go::archiveReportActivityQuery`)
 - Maintenance rediscovery reopens terminal item progress for hydration; unsupported and blocked items remain excluded. (`internal/db/queries_dataset_progress.go::reopenArchiveItemProgressTx`)
 - Issue and merge-request inventory coverage is explicit and independent from child-dataset coverage. Exhausted supported scans record `supported`; declared or repository-specific feature absence records `unsupported` and completes only that stream. (`internal/archive/inventory.go::inventoryPage`, `internal/db/queries_archive.go::CommitArchiveInventoryPage`)
 - Repository-specific feature absence also exhausts the current maintenance stream without replacing established historical coverage. (`internal/archive/maintenance.go::promptPages`)

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -428,6 +428,8 @@ Repository import requests and route/query shapes should carry
   links, repository summaries, archive reports, and provider mutations;
   synchronous and queued public item sync rejects known tombstones before
   provider access, with queued work rechecking visibility when it executes.
+  Periodic repository sync excludes tombstones from closed-item and
+  merged-actor repair candidates, then rechecks before each provider fetch.
   Secondary workflows such as label validation, automatic assignment,
   pushed-head refresh, manual workspace refresh, and on-demand worktree sync
   must check item visibility before item-specific provider access. Workspace and

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -423,8 +423,11 @@ Repository import requests and route/query shapes should carry
 - New provider-aware routes should not require ad hoc URL construction in
   stores/components.
 - Archive items marked `removed_upstream` remain stored for sync repair but are
-  hidden from public item reads, stacks, activity, repository summaries, and
-  archive reports; `inaccessible` items remain visible. (`internal/server/pullapi/helpers.go::visibleMergeRequest`)
+  hidden from public item reads, resolution, autocomplete, stacks, activity,
+  workspace subject metadata, repository summaries, archive reports, and
+  provider mutations; `inaccessible` items remain visible.
+  (`internal/server/pullapi/helpers.go::visibleMergeRequest`,
+  `internal/server/issueapi/mutation_handlers.go::requireVisibleIssue`)
 - Embedded navigation events for repo-bound routes must publish identity from
   parsed route state, not from global embed config. When a route carries repo
   identity, event payloads should include `provider`, `platform_host`, and

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -10,6 +10,8 @@ fixtures, or changing shell-script coverage.
   ordered priority groups; keep the shared Go cache across worktrees (`scripts/run-hook-go.sh`, `prek.toml:53`).
 - `-short` must skip tests that build and launch real kenn-forge daemons or run
   load-sensitive sync E2Es; those flows belong in full Go lanes (`cmd/kenn-forge/lock_e2e_test.go::buildForgeWithLDFlags`, `internal/server/e2etest/sync_cooldown_test.go::TestTriggerSyncE2EPrioritizesNonDefaultHostFilter`).
+- Race tests must synchronize at the narrow boundary under test; do not put a short
+  wall-clock deadline around an entire sync pipeline (`internal/github/sync_test.go::TestResolveDisplayNameDedupsConcurrentLookups`).
 - Pre-commit runs frontend core checks without full-project Effect diagnostics;
   explicit frontend checks and CI retain Effect coverage (`Makefile::frontend-check-no-deps`).
 - Do not use `-v` unless the user requests it or a particular failure genuinely

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -314,9 +314,9 @@ commit (`internal/db/db.go::LockMergeRequestSnapshot`,
 Persisted-workspace refreshes reload by workspace ID while holding that same
 barrier through classification persistence, so repository renames cannot turn
 a known head into `unknown` (`internal/workspace/manager.go::RefreshWorkspaceHeadRepoSnapshot`).
-The revision guard also fences removed-upstream visibility; removed PRs persist
-unknown head trust so generated launch context never advertises a stale push
-target (`internal/db/queries.go::UpdateWorkspaceMRHeadRepoForSnapshot`).
+Head-trust refresh and generated-context rendering both recheck removed-upstream
+visibility; removed PRs contribute no provider title, URL, branch, or push target
+(`internal/workspace/agent_context.go::PrepareAgentLaunchContext`).
 
 Workspace creation launches an agent only after an explicit target choice on
 the create split button. The one-shot target is reactive session state keyed by

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -317,6 +317,9 @@ a known head into `unknown` (`internal/workspace/manager.go::RefreshWorkspaceHea
 Head-trust refresh and generated-context rendering both recheck removed-upstream
 visibility; removed PRs contribute no provider title, URL, branch, or push target
 (`internal/workspace/agent_context.go::PrepareAgentLaunchContext`).
+Workspace summaries expose provider links and head metadata only when the mutable
+route resolves to one active repository; unresolved or reused routes keep local
+workspace state but hide provider projections (`internal/db/queries.go::workspaceSummaryColumns`).
 
 Workspace creation launches an agent only after an explicit target choice on
 the create split button. The one-shot target is reactive session state keyed by

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -314,6 +314,9 @@ commit (`internal/db/db.go::LockMergeRequestSnapshot`,
 Persisted-workspace refreshes reload by workspace ID while holding that same
 barrier through classification persistence, so repository renames cannot turn
 a known head into `unknown` (`internal/workspace/manager.go::RefreshWorkspaceHeadRepoSnapshot`).
+The revision guard also fences removed-upstream visibility; removed PRs persist
+unknown head trust so generated launch context never advertises a stale push
+target (`internal/db/queries.go::UpdateWorkspaceMRHeadRepoForSnapshot`).
 
 Workspace creation launches an agent only after an explicit target choice on
 the create split button. The one-shot target is reactive session state keyed by

--- a/internal/archive/hydrate.go
+++ b/internal/archive/hydrate.go
@@ -51,6 +51,11 @@ func (s *Service) hydrateItem(
 			}
 			return err
 		}
+		if finalizer, ok := s.items.(ItemSyncFinalizer); ok {
+			finalizer.FinalizeArchiveItemSync(
+				ctx, work.RepoID, work.ItemType, work.ItemNumber,
+			)
+		}
 		return nil
 	}
 

--- a/internal/archive/service.go
+++ b/internal/archive/service.go
@@ -27,6 +27,14 @@ type ItemSyncer interface {
 	) (ItemSyncResult, error)
 }
 
+// ItemSyncFinalizer applies provider-specific persistence that must observe a
+// successful archive lifecycle commit. Most item sources need no finalizer.
+type ItemSyncFinalizer interface {
+	FinalizeArchiveItemSync(
+		context.Context, int64, db.ArchiveItemType, int,
+	)
+}
+
 // ItemSyncResult carries provider work accounting and any canonical evidence
 // that archive progress must revalidate atomically after domain persistence.
 type ItemSyncResult struct {

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -1842,6 +1842,13 @@ func (d *DB) GetMergeRequest(
 		WHERE r.platform = ? AND r.platform_host = ?
 		  AND r.owner_key = ? AND r.name_key = ?
 		  AND r.lifecycle_state = 'active'
+		  AND NOT EXISTS (
+			SELECT 1 FROM forge_archive_items ai
+			WHERE ai.repo_id = p.repo_id
+			  AND ai.item_type = 'merge_request'
+			  AND ai.item_number = p.number
+			  AND ai.lifecycle_state = 'removed_upstream'
+		  )
 		  AND p.number = ?`,
 		platform, platformHost, owner, name, number,
 	).Scan(
@@ -1879,7 +1886,32 @@ func (d *DB) GetMergeRequest(
 
 // GetMergeRequestByRepoIDAndNumber returns a merge request by repo ID and number.
 func (d *DB) GetMergeRequestByRepoIDAndNumber(ctx context.Context, repoID int64, number int) (*MergeRequest, error) {
+	return d.getMergeRequestByRepoIDAndNumber(ctx, repoID, number, true)
+}
+
+// GetVisibleMergeRequestByRepoIDAndNumber returns a merge request unless its
+// archive parent was removed upstream. Internal sync paths use the unfiltered
+// query above so maintenance can reactivate and repair retained canonical data.
+func (d *DB) GetVisibleMergeRequestByRepoIDAndNumber(
+	ctx context.Context, repoID int64, number int,
+) (*MergeRequest, error) {
+	return d.getMergeRequestByRepoIDAndNumber(ctx, repoID, number, false)
+}
+
+func (d *DB) getMergeRequestByRepoIDAndNumber(
+	ctx context.Context, repoID int64, number int, includeRemoved bool,
+) (*MergeRequest, error) {
 	var mr MergeRequest
+	removedFilter := ""
+	if !includeRemoved {
+		removedFilter = ` AND NOT EXISTS (
+			SELECT 1 FROM forge_archive_items ai
+			WHERE ai.repo_id = p.repo_id
+			  AND ai.item_type = 'merge_request'
+			  AND ai.item_number = p.number
+			  AND ai.lifecycle_state = 'removed_upstream'
+		)`
+	}
 	err := d.ro.QueryRowContext(ctx, `
 		SELECT p.id, p.snapshot_revision, p.repo_id, p.platform_id, p.platform_external_id, p.number, p.url, p.title,
 		       p.author, p.author_display_name, p.state, p.is_draft, p.is_locked,
@@ -1903,7 +1935,7 @@ func (d *DB) GetMergeRequestByRepoIDAndNumber(ctx context.Context, repoID int64,
 		    ON k.repo_id = p.repo_id AND k.item_type = 'pr' AND k.item_number = p.number
 		LEFT JOIN forge_starred_items s
 		    ON s.item_type = 'pr' AND s.repo_id = p.repo_id AND s.number = p.number
-		WHERE p.repo_id = ? AND p.number = ?`,
+		WHERE p.repo_id = ? AND p.number = ?`+removedFilter,
 		repoID, number,
 	).Scan(
 		&mr.ID, &mr.SnapshotRevision, &mr.RepoID, &mr.PlatformID, &mr.PlatformExternalID, &mr.Number, &mr.URL, &mr.Title,
@@ -1947,6 +1979,13 @@ func (d *DB) ListMergeRequests(ctx context.Context, opts ListMergeRequestsOpts) 
 	}
 	var conds []string
 	var args []any
+	conds = append(conds, `NOT EXISTS (
+		SELECT 1 FROM forge_archive_items ai
+		WHERE ai.repo_id = p.repo_id
+		  AND ai.item_type = 'merge_request'
+		  AND ai.item_number = p.number
+		  AND ai.lifecycle_state = 'removed_upstream'
+	)`)
 
 	switch state {
 	case "all":
@@ -3130,6 +3169,13 @@ func (d *DB) GetIssue(
 		WHERE r.platform = ? AND r.platform_host = ?
 		  AND r.owner_key = ? AND r.name_key = ?
 		  AND r.lifecycle_state = 'active'
+		  AND NOT EXISTS (
+			SELECT 1 FROM forge_archive_items ai
+			WHERE ai.repo_id = i.repo_id
+			  AND ai.item_type = 'issue'
+			  AND ai.item_number = i.number
+			  AND ai.lifecycle_state = 'removed_upstream'
+		  )
 		  AND i.number = ?`,
 		platform, platformHost, owner, name, number,
 	).Scan(
@@ -3162,7 +3208,31 @@ func (d *DB) GetIssue(
 
 // GetIssueByRepoIDAndNumber returns an issue by repo ID and number.
 func (d *DB) GetIssueByRepoIDAndNumber(ctx context.Context, repoID int64, number int) (*Issue, error) {
+	return d.getIssueByRepoIDAndNumber(ctx, repoID, number, true)
+}
+
+// GetVisibleIssueByRepoIDAndNumber returns an issue unless its archive parent
+// was removed upstream. Internal sync paths retain access for rediscovery.
+func (d *DB) GetVisibleIssueByRepoIDAndNumber(
+	ctx context.Context, repoID int64, number int,
+) (*Issue, error) {
+	return d.getIssueByRepoIDAndNumber(ctx, repoID, number, false)
+}
+
+func (d *DB) getIssueByRepoIDAndNumber(
+	ctx context.Context, repoID int64, number int, includeRemoved bool,
+) (*Issue, error) {
 	var issue Issue
+	removedFilter := ""
+	if !includeRemoved {
+		removedFilter = ` AND NOT EXISTS (
+			SELECT 1 FROM forge_archive_items ai
+			WHERE ai.repo_id = i.repo_id
+			  AND ai.item_type = 'issue'
+			  AND ai.item_number = i.number
+			  AND ai.lifecycle_state = 'removed_upstream'
+		)`
+	}
 	err := d.ro.QueryRowContext(ctx, `
 		SELECT i.id, i.snapshot_revision, i.repo_id, i.platform_id, i.platform_external_id, i.number, i.url, i.title,
 		       i.author, i.state, i.body, i.comment_count, i.labels_json, i.assignees_json,
@@ -3175,7 +3245,7 @@ func (d *DB) GetIssueByRepoIDAndNumber(ctx context.Context, repoID int64, number
 		    ON s.item_type = 'issue' AND s.repo_id = i.repo_id AND s.number = i.number
 		LEFT JOIN forge_item_workflow_state w
 		    ON w.repo_id = i.repo_id AND w.item_type = 'issue' AND w.item_number = i.number
-		WHERE i.repo_id = ? AND i.number = ?`,
+		WHERE i.repo_id = ? AND i.number = ?`+removedFilter,
 		repoID, number,
 	).Scan(
 		&issue.ID, &issue.SnapshotRevision, &issue.RepoID, &issue.PlatformID, &issue.PlatformExternalID, &issue.Number,
@@ -3215,6 +3285,13 @@ func (d *DB) ListIssues(
 	}
 	var conds []string
 	var args []any
+	conds = append(conds, `NOT EXISTS (
+		SELECT 1 FROM forge_archive_items ai
+		WHERE ai.repo_id = i.repo_id
+		  AND ai.item_type = 'issue'
+		  AND ai.item_number = i.number
+		  AND ai.lifecycle_state = 'removed_upstream'
+	)`)
 
 	switch state {
 	case "all":

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -5209,14 +5209,15 @@ func (d *DB) UpdateWorkspaceMRHeadRepoForMissingRepo(
 }
 
 // UpdateWorkspaceMRHeadRepoForSnapshot persists a classification only while
-// the merge-request revision that produced it remains current. A false result
-// tells the caller to reread and retry against the newer snapshot.
+// the merge-request revision and removed-upstream visibility that produced it
+// remain current. A false result tells the caller to reread and retry.
 func (d *DB) UpdateWorkspaceMRHeadRepoForSnapshot(
 	ctx context.Context,
 	id string,
 	repoID int64,
 	mrNumber int,
 	expectedRevision int64,
+	expectedRemoved bool,
 	mrHeadRepo *string,
 ) (bool, error) {
 	result, err := d.execContext(ctx, `
@@ -5227,12 +5228,23 @@ func (d *DB) UpdateWorkspaceMRHeadRepoForSnapshot(
 		      SELECT snapshot_revision
 		      FROM forge_merge_requests
 		      WHERE repo_id = ? AND number = ?
-		  ), 0) = ?`,
+		  ), 0) = ?
+		  AND EXISTS (
+		      SELECT 1
+		      FROM forge_archive_items
+		      WHERE repo_id = ?
+		        AND item_type = 'merge_request'
+		        AND item_number = ?
+		        AND lifecycle_state = 'removed_upstream'
+		  ) = ?`,
 		mrHeadRepo,
 		id,
 		repoID,
 		mrNumber,
 		expectedRevision,
+		repoID,
+		mrNumber,
+		expectedRemoved,
 	)
 	if err != nil {
 		return false, fmt.Errorf(
@@ -5608,6 +5620,36 @@ const workspaceSummaryColumns = `
 	w.error_message, w.created_at, w.kata_metadata,
 	r.id, r.platform_repo_id,
 	CASE
+	    WHEN w.item_type = 'pull_request' THEN NOT EXISTS (
+	        SELECT 1
+	        FROM forge_archive_items source_a
+	        WHERE source_a.repo_id = r.id
+	          AND source_a.item_type = 'merge_request'
+	          AND source_a.item_number = w.item_number
+	          AND source_a.lifecycle_state = 'removed_upstream'
+	    )
+	    WHEN w.item_type = 'issue' THEN NOT EXISTS (
+	        SELECT 1
+	        FROM forge_archive_items source_a
+	        WHERE source_a.repo_id = r.id
+	          AND source_a.item_type = 'issue'
+	          AND source_a.item_number = w.item_number
+	          AND source_a.lifecycle_state = 'removed_upstream'
+	    )
+	    ELSE 1
+	END,
+	CASE
+	    WHEN w.associated_pr_number IS NULL THEN 0
+	    ELSE NOT EXISTS (
+	        SELECT 1
+	        FROM forge_archive_items associated_a
+	        WHERE associated_a.repo_id = r.id
+	          AND associated_a.item_type = 'merge_request'
+	          AND associated_a.item_number = w.associated_pr_number
+	          AND associated_a.lifecycle_state = 'removed_upstream'
+	    )
+	END,
+	CASE
 	    WHEN w.item_type = 'issue' THEN i.title
 	    ELSE m.title
 	END,
@@ -5687,6 +5729,7 @@ func scanWorkspaceSummary(
 		&s.WorktreePath, &s.TmuxSession, &s.TerminalBackend, &s.Status,
 		&s.ErrorMessage, &s.CreatedAt, &kataMetadataJSON,
 		&repoID, &repoPlatformID,
+		&s.SourceItemVisible, &s.AssociatedPRVisible,
 		&s.SourceTitle, &s.SourceState, &s.SourceURL,
 		&s.MRIsDraft, &s.MRCIStatus,
 		&s.MRReviewDecision, &s.MRAdditions, &s.MRDeletions,

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -2576,8 +2576,15 @@ func (d *DB) GetPreviouslyOpenMRNumbers(
 	stillOpen map[int]bool,
 ) ([]int, error) {
 	rows, err := d.ro.QueryContext(ctx,
-		`SELECT number FROM forge_merge_requests
-		 WHERE repo_id = ? AND state = 'open'`,
+		`SELECT mr.number FROM forge_merge_requests mr
+		 WHERE mr.repo_id = ? AND mr.state = 'open'
+		   AND NOT EXISTS (
+		     SELECT 1 FROM forge_archive_items ai
+		     WHERE ai.repo_id = mr.repo_id
+		       AND ai.item_type = 'merge_request'
+		       AND ai.item_number = mr.number
+		       AND ai.lifecycle_state = 'removed_upstream'
+		   )`,
 		repoID,
 	)
 	if err != nil {
@@ -2636,6 +2643,13 @@ func (d *DB) GetMergedMRNumbersMissingMergedActor(
 		 WHERE mr.repo_id = ? AND mr.state = 'merged'
 		   AND mr.merged_at >= ?
 		   AND (mr.merged_at < ? OR (mr.merged_at = ? AND mr.id < ?))
+		   AND NOT EXISTS (
+		     SELECT 1 FROM forge_archive_items ai
+		     WHERE ai.repo_id = mr.repo_id
+		       AND ai.item_type = 'merge_request'
+		       AND ai.item_number = mr.number
+		       AND ai.lifecycle_state = 'removed_upstream'
+		   )
 		   AND NOT EXISTS (
 		     SELECT 1 FROM forge_mr_events e
 		     WHERE e.merge_request_id = mr.id
@@ -3533,8 +3547,15 @@ func (d *DB) GetPreviouslyOpenIssueNumbers(
 	stillOpen map[int]bool,
 ) ([]int, error) {
 	rows, err := d.ro.QueryContext(ctx,
-		`SELECT number FROM forge_issues
-		 WHERE repo_id = ? AND state = 'open'`,
+		`SELECT i.number FROM forge_issues i
+		 WHERE i.repo_id = ? AND i.state = 'open'
+		   AND NOT EXISTS (
+		     SELECT 1 FROM forge_archive_items ai
+		     WHERE ai.repo_id = i.repo_id
+		       AND ai.item_type = 'issue'
+		       AND ai.item_number = i.number
+		       AND ai.lifecycle_state = 'removed_upstream'
+		   )`,
 		repoID,
 	)
 	if err != nil {

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -5620,6 +5620,7 @@ const workspaceSummaryColumns = `
 	w.error_message, w.created_at, w.kata_metadata,
 	r.id, r.platform_repo_id,
 	CASE
+	    WHEN r.id IS NULL THEN 0
 	    WHEN w.item_type = 'pull_request' THEN NOT EXISTS (
 	        SELECT 1
 	        FROM forge_archive_items source_a
@@ -5639,7 +5640,7 @@ const workspaceSummaryColumns = `
 	    ELSE 1
 	END,
 	CASE
-	    WHEN w.associated_pr_number IS NULL THEN 0
+	    WHEN r.id IS NULL OR w.associated_pr_number IS NULL THEN 0
 	    ELSE NOT EXISTS (
 	        SELECT 1
 	        FROM forge_archive_items associated_a

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -3959,20 +3959,48 @@ func (d *DB) ListCommentAutocompleteUsers(
 			SELECT mr.author AS login, mr.last_activity_at AS last_seen
 			FROM forge_merge_requests mr
 			WHERE mr.repo_id = (SELECT id FROM repo)
+			  AND NOT EXISTS (
+				SELECT 1 FROM forge_archive_items a
+				WHERE a.repo_id = mr.repo_id
+				  AND a.item_type = 'merge_request'
+				  AND a.item_number = mr.number
+				  AND a.lifecycle_state = 'removed_upstream'
+			  )
 			UNION ALL
 			SELECT i.author AS login, i.last_activity_at AS last_seen
 			FROM forge_issues i
 			WHERE i.repo_id = (SELECT id FROM repo)
+			  AND NOT EXISTS (
+				SELECT 1 FROM forge_archive_items a
+				WHERE a.repo_id = i.repo_id
+				  AND a.item_type = 'issue'
+				  AND a.item_number = i.number
+				  AND a.lifecycle_state = 'removed_upstream'
+			  )
 			UNION ALL
 			SELECT e.author AS login, e.created_at AS last_seen
 			FROM forge_mr_events e
 			JOIN forge_merge_requests mr ON mr.id = e.merge_request_id
 			WHERE mr.repo_id = (SELECT id FROM repo)
+			  AND NOT EXISTS (
+				SELECT 1 FROM forge_archive_items a
+				WHERE a.repo_id = mr.repo_id
+				  AND a.item_type = 'merge_request'
+				  AND a.item_number = mr.number
+				  AND a.lifecycle_state = 'removed_upstream'
+			  )
 			UNION ALL
 			SELECT e.author AS login, e.created_at AS last_seen
 			FROM forge_issue_events e
 			JOIN forge_issues i ON i.id = e.issue_id
 			WHERE i.repo_id = (SELECT id FROM repo)
+			  AND NOT EXISTS (
+				SELECT 1 FROM forge_archive_items a
+				WHERE a.repo_id = i.repo_id
+				  AND a.item_type = 'issue'
+				  AND a.item_number = i.number
+				  AND a.lifecycle_state = 'removed_upstream'
+			  )
 		), ranked AS (
 			SELECT login, MAX(last_seen) AS last_seen
 			FROM candidates

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -5630,10 +5630,26 @@ const workspaceSummaryJoins = `
 	    ON m.repo_id = r.id
 	   AND m.number = w.item_number
 	   AND w.item_type = 'pull_request'
+	   AND NOT EXISTS (
+	       SELECT 1
+	       FROM forge_archive_items a
+	       WHERE a.repo_id = m.repo_id
+	         AND a.item_type = 'merge_request'
+	         AND a.item_number = m.number
+	         AND a.lifecycle_state = 'removed_upstream'
+	   )
 	LEFT JOIN forge_issues i
 	    ON i.repo_id = r.id
 	   AND i.number = w.item_number
-	   AND w.item_type = 'issue'`
+	   AND w.item_type = 'issue'
+	   AND NOT EXISTS (
+	       SELECT 1
+	       FROM forge_archive_items a
+	       WHERE a.repo_id = i.repo_id
+	         AND a.item_type = 'issue'
+	         AND a.item_number = i.number
+	         AND a.lifecycle_state = 'removed_upstream'
+	   )`
 
 func scanWorkspaceSummary(
 	scanner interface{ Scan(...any) error },

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -3424,7 +3424,14 @@ func (d *DB) ResolveItemNumber(
 	var exists int
 	err = d.ro.QueryRowContext(ctx,
 		`SELECT 1 FROM forge_merge_requests
-		 WHERE repo_id = ? AND number = ?`,
+		 WHERE repo_id = ? AND number = ?
+		   AND NOT EXISTS (
+		       SELECT 1 FROM forge_archive_items ai
+		       WHERE ai.repo_id = forge_merge_requests.repo_id
+		         AND ai.item_type = 'merge_request'
+		         AND ai.item_number = forge_merge_requests.number
+		         AND ai.lifecycle_state = 'removed_upstream'
+		   )`,
 		repoID, number,
 	).Scan(&exists)
 	if err == nil {
@@ -3436,7 +3443,14 @@ func (d *DB) ResolveItemNumber(
 
 	err = d.ro.QueryRowContext(ctx,
 		`SELECT 1 FROM forge_issues
-		 WHERE repo_id = ? AND number = ?`,
+		 WHERE repo_id = ? AND number = ?
+		   AND NOT EXISTS (
+		       SELECT 1 FROM forge_archive_items ai
+		       WHERE ai.repo_id = forge_issues.repo_id
+		         AND ai.item_type = 'issue'
+		         AND ai.item_number = forge_issues.number
+		         AND ai.lifecycle_state = 'removed_upstream'
+		   )`,
 		repoID, number,
 	).Scan(&exists)
 	if err == nil {
@@ -3457,10 +3471,24 @@ func (d *DB) ResolveItemNumberOfType(
 	switch itemType {
 	case "pr":
 		query = `SELECT 1 FROM forge_merge_requests
-		         WHERE repo_id = ? AND number = ?`
+		         WHERE repo_id = ? AND number = ?
+		           AND NOT EXISTS (
+		               SELECT 1 FROM forge_archive_items ai
+		               WHERE ai.repo_id = forge_merge_requests.repo_id
+		                 AND ai.item_type = 'merge_request'
+		                 AND ai.item_number = forge_merge_requests.number
+		                 AND ai.lifecycle_state = 'removed_upstream'
+		           )`
 	case "issue":
 		query = `SELECT 1 FROM forge_issues
-		         WHERE repo_id = ? AND number = ?`
+		         WHERE repo_id = ? AND number = ?
+		           AND NOT EXISTS (
+		               SELECT 1 FROM forge_archive_items ai
+		               WHERE ai.repo_id = forge_issues.repo_id
+		                 AND ai.item_type = 'issue'
+		                 AND ai.item_number = forge_issues.number
+		                 AND ai.lifecycle_state = 'removed_upstream'
+		           )`
 	default:
 		return "", false, fmt.Errorf("unsupported item type %q", itemType)
 	}
@@ -4009,10 +4037,24 @@ func (d *DB) ListCommentAutocompleteReferences(
 			SELECT 'pull' AS kind, mr.number, mr.title, mr.state, mr.last_activity_at
 			FROM forge_merge_requests mr
 			WHERE mr.repo_id = (SELECT id FROM repo)
+			  AND NOT EXISTS (
+			      SELECT 1 FROM forge_archive_items ai
+			      WHERE ai.repo_id = mr.repo_id
+			        AND ai.item_type = 'merge_request'
+			        AND ai.item_number = mr.number
+			        AND ai.lifecycle_state = 'removed_upstream'
+			  )
 			UNION ALL
 			SELECT 'issue' AS kind, i.number, i.title, i.state, i.last_activity_at
 			FROM forge_issues i
 			WHERE i.repo_id = (SELECT id FROM repo)
+			  AND NOT EXISTS (
+			      SELECT 1 FROM forge_archive_items ai
+			      WHERE ai.repo_id = i.repo_id
+			        AND ai.item_type = 'issue'
+			        AND ai.item_number = i.number
+			        AND ai.lifecycle_state = 'removed_upstream'
+			  )
 		)
 		SELECT kind, number, title, state
 		FROM candidates

--- a/internal/db/queries_activity.go
+++ b/internal/db/queries_activity.go
@@ -174,7 +174,15 @@ func (d *DB) ListActivity(
 			LEFT JOIN forge_issues iss
 			       ON n.item_type = 'issue' AND iss.repo_id = r.id AND iss.number = n.item_number
 			WHERE n.item_type IN ('pr', 'issue') AND n.item_number IS NOT NULL
-			      AND n.reason != 'author'` + notificationScope
+			      AND n.reason != 'author'
+			      AND NOT EXISTS (
+			          SELECT 1 FROM forge_archive_items ai
+			          WHERE ai.repo_id = r.id
+			            AND ai.item_type = CASE n.item_type
+			                WHEN 'pr' THEN 'merge_request' ELSE 'issue' END
+			            AND ai.item_number = n.item_number
+			            AND ai.lifecycle_state = 'removed_upstream'
+			      )` + notificationScope
 	}
 
 	query := fmt.Sprintf(`
@@ -206,6 +214,13 @@ func (d *DB) ListActivity(
 			       '' AS subject_state
 			FROM forge_merge_requests p
 			JOIN forge_repos r ON p.repo_id = r.id AND r.lifecycle_state = 'active'
+			WHERE NOT EXISTS (
+			    SELECT 1 FROM forge_archive_items ai
+			    WHERE ai.repo_id = p.repo_id
+			      AND ai.item_type = 'merge_request'
+			      AND ai.item_number = p.number
+			      AND ai.lifecycle_state = 'removed_upstream'
+			)
 			UNION ALL
 			SELECT 'new_issue', 'issue', i.id, r.id,
 			       r.platform, r.platform_host, r.owner, r.name, r.repo_path_key,
@@ -221,6 +236,13 @@ func (d *DB) ListActivity(
 			       ''
 			FROM forge_issues i
 			JOIN forge_repos r ON i.repo_id = r.id AND r.lifecycle_state = 'active'
+			WHERE NOT EXISTS (
+			    SELECT 1 FROM forge_archive_items ai
+			    WHERE ai.repo_id = i.repo_id
+			      AND ai.item_type = 'issue'
+			      AND ai.item_number = i.number
+			      AND ai.lifecycle_state = 'removed_upstream'
+			)
 			UNION ALL
 			SELECT CASE e.event_type
 			           WHEN 'issue_comment' THEN 'comment'
@@ -244,6 +266,13 @@ func (d *DB) ListActivity(
 			JOIN forge_repos r ON p.repo_id = r.id AND r.lifecycle_state = 'active'
 			WHERE e.event_type IN (
 				'issue_comment', 'review', 'commit', 'force_push')
+			  AND NOT EXISTS (
+			      SELECT 1 FROM forge_archive_items ai
+			      WHERE ai.repo_id = p.repo_id
+			        AND ai.item_type = 'merge_request'
+			        AND ai.item_number = p.number
+			        AND ai.lifecycle_state = 'removed_upstream'
+			  )
 			UNION ALL
 			SELECT 'comment', 'ise', e.id, r.id,
 			       r.platform, r.platform_host, r.owner, r.name, r.repo_path_key,
@@ -261,6 +290,13 @@ func (d *DB) ListActivity(
 			JOIN forge_issues i ON e.issue_id = i.id
 			JOIN forge_repos r ON i.repo_id = r.id AND r.lifecycle_state = 'active'
 			WHERE e.event_type = 'issue_comment'
+			  AND NOT EXISTS (
+			      SELECT 1 FROM forge_archive_items ai
+			      WHERE ai.repo_id = i.repo_id
+			        AND ai.item_type = 'issue'
+			        AND ai.item_number = i.number
+			        AND ai.lifecycle_state = 'removed_upstream'
+			  )
 			UNION ALL
 			SELECT 'default_branch_commit', 'bc', bc.id, r.id,
 			       r.platform, r.platform_host, r.owner, r.name, r.repo_path_key,
@@ -423,7 +459,15 @@ func (d *DB) ListActivityAuthors(
 			LEFT JOIN forge_issues iss
 			       ON n.item_type = 'issue' AND iss.repo_id = r.id AND iss.number = n.item_number
 			WHERE n.item_type IN ('pr', 'issue') AND n.item_number IS NOT NULL
-			      AND n.reason != 'author'` + notificationScope
+			      AND n.reason != 'author'
+			      AND NOT EXISTS (
+			          SELECT 1 FROM forge_archive_items ai
+			          WHERE ai.repo_id = r.id
+			            AND ai.item_type = CASE n.item_type
+			                WHEN 'pr' THEN 'merge_request' ELSE 'issue' END
+			            AND ai.item_number = n.item_number
+			            AND ai.lifecycle_state = 'removed_upstream'
+			      )` + notificationScope
 	}
 
 	query := fmt.Sprintf(`
@@ -433,11 +477,25 @@ func (d *DB) ListActivityAuthors(
 			       p.author, p.created_at
 			FROM forge_merge_requests p
 			JOIN forge_repos r ON p.repo_id = r.id AND r.lifecycle_state = 'active'
+			WHERE NOT EXISTS (
+			    SELECT 1 FROM forge_archive_items ai
+			    WHERE ai.repo_id = p.repo_id
+			      AND ai.item_type = 'merge_request'
+			      AND ai.item_number = p.number
+			      AND ai.lifecycle_state = 'removed_upstream'
+			)
 			UNION ALL
 			SELECT r.id, r.platform, r.platform_host, r.owner, r.name, r.repo_path_key,
 			       i.author, i.created_at
 			FROM forge_issues i
 			JOIN forge_repos r ON i.repo_id = r.id AND r.lifecycle_state = 'active'
+			WHERE NOT EXISTS (
+			    SELECT 1 FROM forge_archive_items ai
+			    WHERE ai.repo_id = i.repo_id
+			      AND ai.item_type = 'issue'
+			      AND ai.item_number = i.number
+			      AND ai.lifecycle_state = 'removed_upstream'
+			)
 			UNION ALL
 			SELECT r.id, r.platform, r.platform_host, r.owner, r.name, r.repo_path_key,
 			       p.author, e.created_at
@@ -445,6 +503,13 @@ func (d *DB) ListActivityAuthors(
 			JOIN forge_merge_requests p ON e.merge_request_id = p.id
 			JOIN forge_repos r ON p.repo_id = r.id AND r.lifecycle_state = 'active'
 			WHERE e.event_type IN ('issue_comment', 'review', 'commit', 'force_push')
+			  AND NOT EXISTS (
+			      SELECT 1 FROM forge_archive_items ai
+			      WHERE ai.repo_id = p.repo_id
+			        AND ai.item_type = 'merge_request'
+			        AND ai.item_number = p.number
+			        AND ai.lifecycle_state = 'removed_upstream'
+			  )
 			UNION ALL
 			SELECT r.id, r.platform, r.platform_host, r.owner, r.name, r.repo_path_key,
 			       i.author, e.created_at
@@ -452,6 +517,13 @@ func (d *DB) ListActivityAuthors(
 			JOIN forge_issues i ON e.issue_id = i.id
 			JOIN forge_repos r ON i.repo_id = r.id AND r.lifecycle_state = 'active'
 			WHERE e.event_type = 'issue_comment'
+			  AND NOT EXISTS (
+			      SELECT 1 FROM forge_archive_items ai
+			      WHERE ai.repo_id = i.repo_id
+			        AND ai.item_type = 'issue'
+			        AND ai.item_number = i.number
+			        AND ai.lifecycle_state = 'removed_upstream'
+			  )
 			%[1]s
 		), scoped AS (
 			SELECT author, created_at

--- a/internal/db/queries_archive.go
+++ b/internal/db/queries_archive.go
@@ -917,6 +917,31 @@ type ArchiveItemTerminal struct {
 	At         time.Time
 }
 
+// IsArchiveItemRemovedUpstream reports whether retained canonical data is
+// hidden by a durable provider-removal tombstone.
+func (d *DB) IsArchiveItemRemovedUpstream(
+	ctx context.Context,
+	repoID int64,
+	itemType ArchiveItemType,
+	itemNumber int,
+) (bool, error) {
+	var exists int
+	err := d.ro.QueryRowContext(ctx, `
+		SELECT 1
+		FROM forge_archive_items
+		WHERE repo_id = ? AND item_type = ? AND item_number = ?
+		  AND lifecycle_state = 'removed_upstream'`,
+		repoID, itemType, itemNumber,
+	).Scan(&exists)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("check removed archive item: %w", err)
+	}
+	return true, nil
+}
+
 func markArchiveItemTerminalTx(ctx context.Context, tx *sql.Tx, t ArchiveItemTerminal) error {
 	result, err := tx.ExecContext(ctx, `
 		UPDATE forge_archive_items

--- a/internal/db/queries_archive_report.go
+++ b/internal/db/queries_archive_report.go
@@ -282,6 +282,12 @@ func archiveReportActivityQuery(
 			JOIN forge_repos r ON r.id = i.repo_id
 			CROSS JOIN bounds b
 			WHERE i.created_at >= b.start_at AND i.created_at < b.end_at
+			  AND NOT EXISTS (
+				SELECT 1 FROM forge_archive_items ai
+				WHERE ai.repo_id = i.repo_id AND ai.item_type = 'issue'
+				  AND ai.item_number = i.number
+				  AND ai.lifecycle_state = 'removed_upstream'
+			  )
 			UNION ALL
 			SELECT r.id, r.platform, r.platform_host, r.owner, r.name, r.repo_path,
 				'issue_closed', i.number,
@@ -301,6 +307,12 @@ func archiveReportActivityQuery(
 			JOIN forge_repos r ON r.id = i.repo_id
 			CROSS JOIN bounds b
 			WHERE i.closed_at >= b.start_at AND i.closed_at < b.end_at
+			  AND NOT EXISTS (
+				SELECT 1 FROM forge_archive_items ai
+				WHERE ai.repo_id = i.repo_id AND ai.item_type = 'issue'
+				  AND ai.item_number = i.number
+				  AND ai.lifecycle_state = 'removed_upstream'
+			  )
 			UNION ALL
 			SELECT r.id, r.platform, r.platform_host, r.owner, r.name, r.repo_path,
 				'merge_request', mr.number,
@@ -313,6 +325,12 @@ func archiveReportActivityQuery(
 			JOIN forge_repos r ON r.id = mr.repo_id
 			CROSS JOIN bounds b
 			WHERE mr.created_at >= b.start_at AND mr.created_at < b.end_at
+			  AND NOT EXISTS (
+				SELECT 1 FROM forge_archive_items ai
+				WHERE ai.repo_id = mr.repo_id AND ai.item_type = 'merge_request'
+				  AND ai.item_number = mr.number
+				  AND ai.lifecycle_state = 'removed_upstream'
+			  )
 			UNION ALL
 			SELECT r.id, r.platform, r.platform_host, r.owner, r.name, r.repo_path,
 				'merge_request_merged', mr.number,
@@ -333,6 +351,12 @@ func archiveReportActivityQuery(
 			JOIN forge_repos r ON r.id = mr.repo_id
 			CROSS JOIN bounds b
 			WHERE mr.merged_at >= b.start_at AND mr.merged_at < b.end_at
+			  AND NOT EXISTS (
+				SELECT 1 FROM forge_archive_items ai
+				WHERE ai.repo_id = mr.repo_id AND ai.item_type = 'merge_request'
+				  AND ai.item_number = mr.number
+				  AND ai.lifecycle_state = 'removed_upstream'
+			  )
 			UNION ALL
 			SELECT r.id, r.platform, r.platform_host, r.owner, r.name, r.repo_path,
 				'ordinary_comment', i.number,
@@ -348,6 +372,12 @@ func archiveReportActivityQuery(
 			CROSS JOIN bounds b
 			WHERE e.event_type = 'issue_comment'
 			  AND e.created_at >= b.start_at AND e.created_at < b.end_at
+			  AND NOT EXISTS (
+				SELECT 1 FROM forge_archive_items ai
+				WHERE ai.repo_id = i.repo_id AND ai.item_type = 'issue'
+				  AND ai.item_number = i.number
+				  AND ai.lifecycle_state = 'removed_upstream'
+			  )
 			UNION ALL
 			SELECT r.id, r.platform, r.platform_host, r.owner, r.name, r.repo_path,
 				CASE e.event_type
@@ -367,6 +397,12 @@ func archiveReportActivityQuery(
 			CROSS JOIN bounds b
 			WHERE e.event_type IN ('issue_comment', 'review', 'review_comment')
 			  AND e.created_at >= b.start_at AND e.created_at < b.end_at
+			  AND NOT EXISTS (
+				SELECT 1 FROM forge_archive_items ai
+				WHERE ai.repo_id = mr.repo_id AND ai.item_type = 'merge_request'
+				  AND ai.item_number = mr.number
+				  AND ai.lifecycle_state = 'removed_upstream'
+			  )
 		),
 		deduplicated AS (
 			SELECT activity.*,

--- a/internal/db/queries_archive_report_test.go
+++ b/internal/db/queries_archive_report_test.go
@@ -59,6 +59,58 @@ func TestArchiveReportActivityUsesHalfOpenAttributionAndProviderIdentity(t *test
 		"equal logins on different providers remain distinct report inputs")
 }
 
+func TestArchiveReportActivityHidesRemovedUpstreamParents(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	start := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(24 * time.Hour)
+	repoID := insertArchiveReportRepo(t, database, RepoIdentity{
+		Platform: "github", PlatformHost: "github.example", Owner: "acme", Name: "widget",
+	})
+
+	issueID := insertArchiveReportIssue(
+		t, database, repoID, 1, "issue-1", "Removed issue", "sam", start,
+	)
+	mrID := insertArchiveReportMR(
+		t, database, repoID, 2, "mr-2", "Removed merge request", "sam", start,
+	)
+	insertArchiveReportIssueEvent(
+		t, database, issueID, "issue_comment", "comment-1", "removed", "sam", start,
+	)
+	insertArchiveReportMREvent(
+		t, database, mrID, "review", "review-2", "removed", "sam", start,
+	)
+	visibleID := insertArchiveReportMR(
+		t, database, repoID, 3, "mr-3", "Inaccessible merge request", "sam", start,
+	)
+	insertArchiveReportMREvent(
+		t, database, visibleID, "review", "review-3", "cached", "sam", start,
+	)
+	_, err := database.WriteDB().ExecContext(t.Context(), `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES
+			(?, 'issue', 1, 'issue-1', ?, ?, 'removed_upstream'),
+			(?, 'merge_request', 2, 'mr-2', ?, ?, 'removed_upstream'),
+			(?, 'merge_request', 3, 'mr-3', ?, ?, 'inaccessible')`,
+		repoID, start, start, repoID, start, start, repoID, start, start,
+	)
+	require.NoError(err)
+
+	tx, err := database.ReadDB().BeginTx(t.Context(), &sql.TxOptions{ReadOnly: true})
+	require.NoError(err)
+	t.Cleanup(func() { _ = tx.Rollback() })
+	rows, err := LoadArchiveReportActivity(t.Context(), tx, []int64{repoID}, start, end)
+	require.NoError(err)
+	require.NoError(tx.Commit())
+	require.Len(rows, 2)
+	require.Equal([]ArchiveReportActivityKind{
+		ArchiveReportActivityMergeRequest,
+		ArchiveReportActivityReview,
+	}, archiveReportKinds(rows))
+}
+
 func TestArchiveReportActivityMeasuresUTF8Bytes(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/db/queries_branch_match.go
+++ b/internal/db/queries_branch_match.go
@@ -98,6 +98,14 @@ func (d *DB) ListWorktreeLinkPRs(ctx context.Context) ([]WorktreeLinkPR, error) 
 		       m.review_decision, m.mergeable_state, m.additions, m.deletions, m.comment_count
 		FROM forge_mr_worktree_links l
 		JOIN forge_merge_requests m ON m.id = l.merge_request_id
+		WHERE NOT EXISTS (
+			SELECT 1
+			FROM forge_archive_items a
+			WHERE a.repo_id = m.repo_id
+			  AND a.item_type = 'merge_request'
+			  AND a.item_number = m.number
+			  AND a.lifecycle_state = 'removed_upstream'
+		)
 		ORDER BY l.worktree_key`)
 	if err != nil {
 		return nil, fmt.Errorf("list worktree link PRs: %w", err)

--- a/internal/db/queries_branch_match_test.go
+++ b/internal/db/queries_branch_match_test.go
@@ -127,6 +127,36 @@ func TestListWorktreeLinkPRs_EmptyWhenNoLinks(t *testing.T) {
 	assert.Empty(t, prs)
 }
 
+func TestListWorktreeLinkPRs_OmitsRemovedPullRequestMetadata(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	repoID := insertTestRepo(t, d, "acme", "widget")
+	mrID := insertTestMRWithOptions(t, d, testMR(
+		repoID, 7, withMRTitle("Removed pull"), withMRBranches("feature", "main"),
+	))
+	require.NoError(d.SetWorktreeLinks(ctx, []WorktreeLink{{
+		MergeRequestID: mrID,
+		WorktreeKey:    "worktree:/work/wt-feature",
+		WorktreePath:   "/work/wt-feature",
+		WorktreeBranch: "feature",
+		LinkedAt:       baseTime(),
+	}}))
+	now := baseTime()
+	_, err := d.WriteDB().ExecContext(ctx, `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES (?, 'merge_request', 7, 'pull-7', ?, ?, 'removed_upstream')`,
+		repoID, now, now,
+	)
+	require.NoError(err)
+
+	prs, err := d.ListWorktreeLinkPRs(ctx)
+	require.NoError(err)
+	require.Empty(prs)
+}
+
 // TestListWorktreesForBranchMatch_ExcludesStaleAndEmptyBranch verifies the
 // enumeration excludes worktrees that cannot branch-match: a stale worktree
 // (its checkout vanished) and detached-HEAD worktrees, both in the synthetic

--- a/internal/db/queries_repo_summaries.go
+++ b/internal/db/queries_repo_summaries.go
@@ -51,6 +51,13 @@ func (d *DB) loadRepoSummaryStats(
 			       SUM(CASE WHEN state = 'open' AND is_draft THEN 1 ELSE 0 END) AS draft_pr_count,
 			       MAX(last_activity_at) AS last_pr_activity_at
 			FROM forge_merge_requests
+			WHERE NOT EXISTS (
+			    SELECT 1 FROM forge_archive_items ai
+			    WHERE ai.repo_id = forge_merge_requests.repo_id
+			      AND ai.item_type = 'merge_request'
+			      AND ai.item_number = forge_merge_requests.number
+			      AND ai.lifecycle_state = 'removed_upstream'
+			)
 			GROUP BY repo_id
 		),
 		issue_stats AS (
@@ -59,6 +66,13 @@ func (d *DB) loadRepoSummaryStats(
 			       SUM(CASE WHEN state = 'open' THEN 1 ELSE 0 END) AS open_issue_count,
 			       MAX(last_activity_at) AS last_issue_activity_at
 			FROM forge_issues
+			WHERE NOT EXISTS (
+			    SELECT 1 FROM forge_archive_items ai
+			    WHERE ai.repo_id = forge_issues.repo_id
+			      AND ai.item_type = 'issue'
+			      AND ai.item_number = forge_issues.number
+			      AND ai.lifecycle_state = 'removed_upstream'
+			)
 			GROUP BY repo_id
 		)
 		SELECT r.id,
@@ -422,10 +436,24 @@ func (d *DB) loadRepoSummaryAuthors(
 			SELECT repo_id, author, last_activity_at
 			FROM forge_merge_requests
 			WHERE author <> ''
+			  AND NOT EXISTS (
+			      SELECT 1 FROM forge_archive_items ai
+			      WHERE ai.repo_id = forge_merge_requests.repo_id
+			        AND ai.item_type = 'merge_request'
+			        AND ai.item_number = forge_merge_requests.number
+			        AND ai.lifecycle_state = 'removed_upstream'
+			  )
 			UNION ALL
 			SELECT repo_id, author, last_activity_at
 			FROM forge_issues
 			WHERE author <> ''
+			  AND NOT EXISTS (
+			      SELECT 1 FROM forge_archive_items ai
+			      WHERE ai.repo_id = forge_issues.repo_id
+			        AND ai.item_type = 'issue'
+			        AND ai.item_number = forge_issues.number
+			        AND ai.lifecycle_state = 'removed_upstream'
+			  )
 		),
 		author_totals AS (
 			SELECT repo_id,
@@ -497,6 +525,13 @@ func (d *DB) loadRepoSummaryIssues(
 			       ) AS rank
 			FROM forge_issues
 			WHERE state = 'open'
+			  AND NOT EXISTS (
+			      SELECT 1 FROM forge_archive_items ai
+			      WHERE ai.repo_id = forge_issues.repo_id
+			        AND ai.item_type = 'issue'
+			        AND ai.item_number = forge_issues.number
+			        AND ai.lifecycle_state = 'removed_upstream'
+			  )
 		)
 		SELECT repo_id, number, title, author, state, url, last_activity_at
 		FROM ranked

--- a/internal/db/queries_resolve_test.go
+++ b/internal/db/queries_resolve_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -51,4 +52,66 @@ func TestResolveItemNumber(t *testing.T) {
 	require.NoError(err)
 	assert.False(found)
 	assert.Empty(itemType)
+}
+
+func TestResolveItemNumberHidesOnlyRemovedUpstreamItems(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	ctx := t.Context()
+	repoID := insertTestRepo(t, database, "acme", "widget")
+	now := time.Now().UTC().Truncate(time.Second)
+
+	insertTestMR(t, database, repoID, 1, "inaccessible pull", now)
+	insertTestMR(t, database, repoID, 2, "removed pull", now)
+	insertTestIssue(t, database, repoID, 3, "inaccessible issue", now)
+	insertTestIssue(t, database, repoID, 4, "removed issue", now)
+	_, err := database.WriteDB().ExecContext(ctx, `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES
+			(?, 'merge_request', 1, 'pr-1', ?, ?, 'inaccessible'),
+			(?, 'merge_request', 2, 'pr-2', ?, ?, 'removed_upstream'),
+			(?, 'issue', 3, 'issue-3', ?, ?, 'inaccessible'),
+			(?, 'issue', 4, 'issue-4', ?, ?, 'removed_upstream')`,
+		repoID, now, now, repoID, now, now,
+		repoID, now, now, repoID, now, now,
+	)
+	require.NoError(err)
+
+	for _, tc := range []struct {
+		number int
+		kind   string
+		found  bool
+	}{
+		{number: 1, kind: "pr", found: true},
+		{number: 2, found: false},
+		{number: 3, kind: "issue", found: true},
+		{number: 4, found: false},
+	} {
+		kind, found, resolveErr := database.ResolveItemNumber(ctx, repoID, tc.number)
+		require.NoError(resolveErr)
+		require.Equal(tc.found, found)
+		require.Equal(tc.kind, kind)
+	}
+
+	for _, tc := range []struct {
+		number int
+		kind   string
+		found  bool
+	}{
+		{number: 1, kind: "pr", found: true},
+		{number: 2, kind: "pr", found: false},
+		{number: 3, kind: "issue", found: true},
+		{number: 4, kind: "issue", found: false},
+	} {
+		kind, found, resolveErr := database.ResolveItemNumberOfType(ctx, repoID, tc.number, tc.kind)
+		require.NoError(resolveErr)
+		require.Equal(tc.found, found)
+		if tc.found {
+			require.Equal(tc.kind, kind)
+		} else {
+			require.Empty(kind)
+		}
+	}
 }

--- a/internal/db/queries_stacks.go
+++ b/internal/db/queries_stacks.go
@@ -232,6 +232,7 @@ func (d *DB) ListStacksWithMembers(ctx context.Context, repoFilter string) ([]St
 		); err != nil {
 			return nil, nil, fmt.Errorf("scan stack member: %w", err)
 		}
+		m.Position = len(memberMap[m.StackID]) + 1
 		memberMap[m.StackID] = append(memberMap[m.StackID], m)
 	}
 	return stacks, memberMap, mRows.Err()
@@ -353,6 +354,7 @@ func (d *DB) getStackForPRWhere(ctx context.Context, where string, args ...any) 
 		); err != nil {
 			return nil, nil, fmt.Errorf("scan stack member: %w", err)
 		}
+		m.Position = len(members) + 1
 		members = append(members, m)
 	}
 	return &stack, members, rows.Err()

--- a/internal/db/queries_stacks.go
+++ b/internal/db/queries_stacks.go
@@ -25,7 +25,14 @@ func (d *DB) listPRsForStacks(ctx context.Context, repoID int64, stateFilter str
 		SELECT id, number, title, head_branch, base_branch, state, ci_status, review_decision,
 		       head_repo_clone_url
 		FROM forge_merge_requests
-		WHERE repo_id = ? `+stateFilter+`
+		WHERE repo_id = ?
+		  AND NOT EXISTS (
+		      SELECT 1 FROM forge_archive_items ai
+		      WHERE ai.repo_id = forge_merge_requests.repo_id
+		        AND ai.item_type = 'merge_request'
+		        AND ai.item_number = forge_merge_requests.number
+		        AND ai.lifecycle_state = 'removed_upstream'
+		  ) `+stateFilter+`
 		ORDER BY number`,
 		repoID,
 	)
@@ -143,7 +150,14 @@ func (d *DB) ListStacksWithMembers(ctx context.Context, repoFilter string) ([]St
 	conds = append(conds, `EXISTS (
 		SELECT 1 FROM forge_stack_members sm2
 		JOIN forge_merge_requests p2 ON p2.id = sm2.merge_request_id
-		WHERE sm2.stack_id = s.id AND p2.state = 'open')`)
+		WHERE sm2.stack_id = s.id AND p2.state = 'open'
+		  AND NOT EXISTS (
+		      SELECT 1 FROM forge_archive_items ai
+		      WHERE ai.repo_id = p2.repo_id
+		        AND ai.item_type = 'merge_request'
+		        AND ai.item_number = p2.number
+		        AND ai.lifecycle_state = 'removed_upstream'
+		  ))`)
 	conds = append(conds, "r.lifecycle_state = 'active'")
 
 	where := "WHERE " + strings.Join(conds, " AND ")
@@ -193,6 +207,13 @@ func (d *DB) ListStacksWithMembers(ctx context.Context, repoFilter string) ([]St
 		FROM forge_stack_members sm
 		JOIN forge_merge_requests p ON p.id = sm.merge_request_id
 		WHERE sm.stack_id IN (` + sqlPlaceholders(len(stackIDs)) + `)
+		  AND NOT EXISTS (
+		      SELECT 1 FROM forge_archive_items ai
+		      WHERE ai.repo_id = p.repo_id
+		        AND ai.item_type = 'merge_request'
+		        AND ai.item_number = p.number
+		        AND ai.lifecycle_state = 'removed_upstream'
+		  )
 		ORDER BY sm.stack_id, sm.position`
 
 	mRows, err := d.ro.QueryContext(ctx, memberQuery, memberArgs...)
@@ -254,7 +275,14 @@ func (d *DB) GetStackForPR(
 		ctx,
 		`WHERE r.platform = ? AND r.platform_host = ?
 		    AND r.owner_key = ? AND r.name_key = ?
-		    AND p.number = ?`,
+		    AND p.number = ?
+		    AND NOT EXISTS (
+		        SELECT 1 FROM forge_archive_items ai
+		        WHERE ai.repo_id = p.repo_id
+		          AND ai.item_type = 'merge_request'
+		          AND ai.item_number = p.number
+		          AND ai.lifecycle_state = 'removed_upstream'
+		    )`,
 		platform, platformHost, owner, name, number,
 	)
 }
@@ -264,7 +292,14 @@ func (d *DB) GetStackForPR(
 func (d *DB) GetStackForPRByRepoID(ctx context.Context, repoID int64, number int) (*Stack, []StackMemberWithPR, error) {
 	return d.getStackForPRWhere(
 		ctx,
-		`WHERE p.repo_id = ? AND p.number = ?`,
+		`WHERE p.repo_id = ? AND p.number = ?
+		    AND NOT EXISTS (
+		        SELECT 1 FROM forge_archive_items ai
+		        WHERE ai.repo_id = p.repo_id
+		          AND ai.item_type = 'merge_request'
+		          AND ai.item_number = p.number
+		          AND ai.lifecycle_state = 'removed_upstream'
+		    )`,
 		repoID, number,
 	)
 }
@@ -294,6 +329,13 @@ func (d *DB) getStackForPRWhere(ctx context.Context, where string, args ...any) 
 		FROM forge_stack_members sm
 		JOIN forge_merge_requests p ON p.id = sm.merge_request_id
 		WHERE sm.stack_id = ?
+		  AND NOT EXISTS (
+		      SELECT 1 FROM forge_archive_items ai
+		      WHERE ai.repo_id = p.repo_id
+		        AND ai.item_type = 'merge_request'
+		        AND ai.item_number = p.number
+		        AND ai.lifecycle_state = 'removed_upstream'
+		  )
 		ORDER BY sm.position`, stack.ID,
 	)
 	if err != nil {
@@ -341,7 +383,21 @@ func (d *DB) ListMRsBlockedByStackConflicts(ctx context.Context, mrIDs []int64) 
 		WHERE target.merge_request_id IN (`+sqlPlaceholders(len(mrIDs))+`)
 		  AND target_pr.state = 'open'
 		  AND blocker_pr.state != 'merged'
-		  AND blocker_pr.mergeable_state = 'dirty'`,
+		  AND blocker_pr.mergeable_state = 'dirty'
+		  AND NOT EXISTS (
+		      SELECT 1 FROM forge_archive_items ai
+		      WHERE ai.repo_id = target_pr.repo_id
+		        AND ai.item_type = 'merge_request'
+		        AND ai.item_number = target_pr.number
+		        AND ai.lifecycle_state = 'removed_upstream'
+		  )
+		  AND NOT EXISTS (
+		      SELECT 1 FROM forge_archive_items ai
+		      WHERE ai.repo_id = blocker_pr.repo_id
+		        AND ai.item_type = 'merge_request'
+		        AND ai.item_number = blocker_pr.number
+		        AND ai.lifecycle_state = 'removed_upstream'
+		  )`,
 		args...,
 	)
 	if err != nil {

--- a/internal/db/queries_stacks_test.go
+++ b/internal/db/queries_stacks_test.go
@@ -1,7 +1,9 @@
 package db
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -79,6 +81,71 @@ func TestUpsertStackAndReplaceMembers(t *testing.T) {
 	assert.Len(memberMap[stackID], 2)
 	assert.Equal(1, memberMap[stackID][0].Position)
 	assert.Equal(2, memberMap[stackID][1].Position)
+}
+
+func TestStackMembersRenumberAfterRemovedMembersAreFiltered(t *testing.T) {
+	tests := []struct {
+		name          string
+		removedNumber int
+		wantNumbers   []int
+	}{
+		{name: "first member", removedNumber: 1, wantNumbers: []int{2, 3}},
+		{name: "middle member", removedNumber: 2, wantNumbers: []int{1, 3}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			d := openTestDB(t)
+			ctx := t.Context()
+			repoID := insertTestRepo(t, d, "org", "repo")
+
+			memberIDs := make([]int64, 0, 3)
+			for number := 1; number <= 3; number++ {
+				memberIDs = append(memberIDs, insertTestMRWithBranches(
+					t, d, repoID, number,
+					fmt.Sprintf("feature/%d", number), "main", MergeRequestStateOpen,
+				))
+			}
+			stackID, err := d.UpsertStack(ctx, repoID, 1, "feature")
+			require.NoError(err)
+			require.NoError(d.ReplaceStackMembers(ctx, stackID, []StackMember{
+				{MergeRequestID: memberIDs[0], Position: 1},
+				{MergeRequestID: memberIDs[1], Position: 2},
+				{MergeRequestID: memberIDs[2], Position: 3},
+			}))
+
+			now := time.Now().UTC().Truncate(time.Second)
+			_, err = d.WriteDB().ExecContext(ctx, `
+				INSERT INTO forge_archive_items (
+					repo_id, item_type, item_number, provider_item_id,
+					provider_created_at, provider_updated_at, lifecycle_state
+				) VALUES (?, 'merge_request', ?, ?, ?, ?, 'removed_upstream')`,
+				repoID, tt.removedNumber,
+				fmt.Sprintf("pull-%d", tt.removedNumber), now, now,
+			)
+			require.NoError(err)
+
+			_, memberMap, err := d.ListStacksWithMembers(ctx, "")
+			require.NoError(err)
+			require.Len(memberMap[stackID], 2)
+			for i, member := range memberMap[stackID] {
+				require.Equal(tt.wantNumbers[i], member.Number)
+				require.Equal(i+1, member.Position)
+			}
+
+			stack, members, err := d.GetStackForPRByRepoID(
+				ctx, repoID, tt.wantNumbers[1],
+			)
+			require.NoError(err)
+			require.NotNil(stack)
+			require.Len(members, 2)
+			for i, member := range members {
+				require.Equal(tt.wantNumbers[i], member.Number)
+				require.Equal(i+1, member.Position)
+			}
+		})
+	}
 }
 
 func TestStackMembersIncludeMergeableState(t *testing.T) {

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -3678,6 +3678,52 @@ func TestListCommentAutocompleteUsersScopesByProvider(t *testing.T) {
 	assert.Equal([]string{"alice"}, users)
 }
 
+func TestListCommentAutocompleteUsersHidesOnlyRemovedUpstreamItems(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	now := baseTime()
+	repoID := insertTestRepo(t, d, "acme", "widget")
+	inaccessibleMRID := insertTestMR(t, d, repoID, 1, "inaccessible pull", now)
+	removedMRID := insertTestMR(t, d, repoID, 2, "removed pull", now)
+	inaccessibleIssueID := insertTestIssue(t, d, repoID, 3, "inaccessible issue", now)
+	removedIssueID := insertTestIssue(t, d, repoID, 4, "removed issue", now)
+	_, err := d.WriteDB().ExecContext(ctx, `
+		UPDATE forge_merge_requests SET author = CASE number
+			WHEN 1 THEN 'visible-pull-author' ELSE 'removed-pull-author' END;
+		UPDATE forge_issues SET author = CASE number
+			WHEN 3 THEN 'visible-issue-author' ELSE 'removed-issue-author' END;
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES
+			(?, 'merge_request', 1, 'pr-1', ?, ?, 'inaccessible'),
+			(?, 'merge_request', 2, 'pr-2', ?, ?, 'removed_upstream'),
+			(?, 'issue', 3, 'issue-3', ?, ?, 'inaccessible'),
+			(?, 'issue', 4, 'issue-4', ?, ?, 'removed_upstream')`,
+		repoID, now, now, repoID, now, now,
+		repoID, now, now, repoID, now, now,
+	)
+	require.NoError(err)
+	require.NoError(d.UpsertMREvents(ctx, []MREvent{
+		{MergeRequestID: inaccessibleMRID, EventType: "comment", Author: "visible-pull-event", CreatedAt: now, DedupeKey: "visible-pull-event"},
+		{MergeRequestID: removedMRID, EventType: "comment", Author: "removed-pull-event", CreatedAt: now, DedupeKey: "removed-pull-event"},
+	}))
+	require.NoError(d.UpsertIssueEvents(ctx, []IssueEvent{
+		{IssueID: inaccessibleIssueID, EventType: "comment", Author: "visible-issue-event", CreatedAt: now, DedupeKey: "visible-issue-event"},
+		{IssueID: removedIssueID, EventType: "comment", Author: "removed-issue-event", CreatedAt: now, DedupeKey: "removed-issue-event"},
+	}))
+
+	users, err := d.ListCommentAutocompleteUsers(
+		ctx, "github", "github.com", "acme", "widget", "", 20,
+	)
+	require.NoError(err)
+	require.ElementsMatch([]string{
+		"visible-pull-author", "visible-pull-event",
+		"visible-issue-author", "visible-issue-event",
+	}, users)
+}
+
 func TestListCommentAutocompleteReferences(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -5325,6 +5325,63 @@ func TestWorkspaceSummaries(t *testing.T) {
 	assert.Nil(missSum)
 }
 
+func TestWorkspaceSummariesRetainWorkspaceWithoutRemovedPullMetadata(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	now := baseTime()
+	repoID := insertTestRepo(t, d, "acme", "widget")
+	mr := testMR(repoID, 7, withMRTitle("Removed pull"), withMRBranches("feature", "main"))
+	mr.CIStatus = "failure"
+	mr.ReviewDecision = "changes_requested"
+	mr.Additions = 12
+	mr.Deletions = 3
+	mr.CommentCount = 5
+	mr.MergeableState = "dirty"
+	insertTestMRWithOptions(t, d, mr)
+	require.NoError(d.InsertWorkspace(ctx, &Workspace{
+		ID: "ws-removed-pr", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget",
+		ItemType: WorkspaceItemTypePullRequest, ItemNumber: 7,
+		GitHeadRef: "feature", WorktreePath: "/tmp/ws-removed-pr",
+		TmuxSession: "ws-removed-pr", Status: "ready",
+	}))
+	_, err := d.WriteDB().ExecContext(ctx, `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES (?, 'merge_request', 7, 'pull-7', ?, ?, 'removed_upstream')`,
+		repoID, now, now,
+	)
+	require.NoError(err)
+
+	summary, err := d.GetWorkspaceSummary(ctx, "ws-removed-pr")
+	require.NoError(err)
+	require.NotNil(summary)
+	require.Equal("ws-removed-pr", summary.ID)
+	require.Equal(7, summary.ItemNumber)
+	require.Nil(summary.SourceTitle)
+	require.Nil(summary.SourceState)
+	require.Nil(summary.SourceURL)
+	require.Nil(summary.MRTitle)
+	require.Nil(summary.MRState)
+	require.Nil(summary.MRIsDraft)
+	require.Nil(summary.MRCIStatus)
+	require.Nil(summary.MRReviewDecision)
+	require.Nil(summary.MRAdditions)
+	require.Nil(summary.MRDeletions)
+	require.Nil(summary.MRCommentCount)
+	require.Nil(summary.MRMergeableState)
+	require.Nil(summary.MRHeadBranch)
+	require.Nil(summary.ItemLastActivityAt)
+
+	summaries, err := d.ListWorkspaceSummaries(ctx)
+	require.NoError(err)
+	require.Len(summaries, 1)
+	require.Equal("ws-removed-pr", summaries[0].ID)
+	require.Nil(summaries[0].MRTitle)
+}
+
 func TestSetWorkspaceAssociatedPRNumberIfNull(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -5275,7 +5275,7 @@ func TestWorkspaceSummaries(t *testing.T) {
 	assert.Nil(noMR.MRDeletions)
 	assert.Nil(noMR.AssociatedPRNumber)
 	assert.Nil(noMR.ItemLastActivityAt)
-	assert.True(noMR.SourceItemVisible)
+	assert.False(noMR.SourceItemVisible)
 	assert.False(noMR.AssociatedPRVisible)
 
 	// Issue workspace keeps issue-owned header metadata and the linked PR number.
@@ -5432,6 +5432,46 @@ func TestWorkspaceSummariesRetainWorkspaceWithoutRemovedPullMetadata(t *testing.
 	require.Len(summaries, 1)
 	require.Equal("ws-removed-pr", summaries[0].ID)
 	require.Nil(summaries[0].MRTitle)
+}
+
+func TestWorkspaceSummariesHideProviderMetadataForReusedRoute(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	observedAt := baseTime()
+	reconcileCatalogRepository(
+		t, d, "provider-original", "org-a", "project-a", observedAt,
+	)
+	associatedPR := 42
+	headRepo := "https://github.com/contributor/project-a.git"
+	require.NoError(d.InsertWorkspace(t.Context(), &Workspace{
+		ID: "ws-reused-route", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "org-a", RepoName: "project-a",
+		ItemType: WorkspaceItemTypePullRequest, ItemNumber: 7,
+		AssociatedPRNumber: &associatedPR,
+		GitHeadRef:         "feature/stale",
+		MRHeadRepo:         &headRepo,
+		WorktreePath:       "/tmp/ws-reused-route",
+		Status:             "ready",
+	}))
+	reconcileCatalogRepository(
+		t, d, "provider-original", "org-a", "renamed-project", observedAt.Add(time.Minute),
+	)
+	reconcileCatalogRepository(
+		t, d, "provider-replacement", "org-a", "project-a", observedAt.Add(2*time.Minute),
+	)
+
+	summary, err := d.GetWorkspaceSummary(t.Context(), "ws-reused-route")
+	require.NoError(err)
+	require.NotNil(summary)
+	require.Zero(summary.RepoID)
+	require.False(summary.SourceItemVisible)
+	require.False(summary.AssociatedPRVisible)
+
+	summaries, err := d.ListWorkspaceSummaries(t.Context())
+	require.NoError(err)
+	require.Len(summaries, 1)
+	require.False(summaries[0].SourceItemVisible)
+	require.False(summaries[0].AssociatedPRVisible)
 }
 
 func TestSetWorkspaceAssociatedPRNumberIfNull(t *testing.T) {

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -3717,6 +3717,40 @@ func TestListCommentAutocompleteReferences(t *testing.T) {
 	}, refs)
 }
 
+func TestListCommentAutocompleteReferencesHidesOnlyRemovedUpstreamItems(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	now := baseTime()
+	repoID := insertTestRepo(t, d, "acme", "widget")
+	insertTestMR(t, d, repoID, 1, "inaccessible pull", now)
+	insertTestMR(t, d, repoID, 2, "removed pull", now)
+	insertTestIssue(t, d, repoID, 3, "inaccessible issue", now)
+	insertTestIssue(t, d, repoID, 4, "removed issue", now)
+	_, err := d.WriteDB().ExecContext(ctx, `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES
+			(?, 'merge_request', 1, 'pr-1', ?, ?, 'inaccessible'),
+			(?, 'merge_request', 2, 'pr-2', ?, ?, 'removed_upstream'),
+			(?, 'issue', 3, 'issue-3', ?, ?, 'inaccessible'),
+			(?, 'issue', 4, 'issue-4', ?, ?, 'removed_upstream')`,
+		repoID, now, now, repoID, now, now,
+		repoID, now, now, repoID, now, now,
+	)
+	require.NoError(err)
+
+	refs, err := d.ListCommentAutocompleteReferences(
+		ctx, "github", "github.com", "acme", "widget", "", "", 10,
+	)
+	require.NoError(err)
+	require.ElementsMatch([]CommentAutocompleteReference{
+		{Kind: "pull", Number: 1, Title: "inaccessible pull", State: "open"},
+		{Kind: "issue", Number: 3, Title: "inaccessible issue", State: "open"},
+	}, refs)
+}
+
 func TestListCommentAutocompleteReferencesScopesByProvider(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -4416,6 +4416,7 @@ func TestUpdateWorkspaceMRHeadRepoForSnapshotRejectsStaleRevision(t *testing.T) 
 		repoID,
 		mr.Number,
 		stale.SnapshotRevision,
+		false,
 		nil,
 	)
 	require.NoError(err)
@@ -4433,6 +4434,7 @@ func TestUpdateWorkspaceMRHeadRepoForSnapshotRejectsStaleRevision(t *testing.T) 
 		repoID,
 		mr.Number,
 		updated.SnapshotRevision,
+		false,
 		nil,
 	)
 	require.Error(err)
@@ -5273,6 +5275,8 @@ func TestWorkspaceSummaries(t *testing.T) {
 	assert.Nil(noMR.MRDeletions)
 	assert.Nil(noMR.AssociatedPRNumber)
 	assert.Nil(noMR.ItemLastActivityAt)
+	assert.True(noMR.SourceItemVisible)
+	assert.False(noMR.AssociatedPRVisible)
 
 	// Issue workspace keeps issue-owned header metadata and the linked PR number.
 	require.NotNil(issueWithPR.MRTitle)
@@ -5288,6 +5292,8 @@ func TestWorkspaceSummaries(t *testing.T) {
 	assert.Equal(42, *issueWithPR.AssociatedPRNumber)
 	require.NotNil(issueWithPR.ItemLastActivityAt)
 	assert.Equal(issueActivity.UTC(), issueWithPR.ItemLastActivityAt.UTC())
+	assert.True(issueWithPR.SourceItemVisible)
+	assert.True(issueWithPR.AssociatedPRVisible)
 
 	// PR workspace exposes PR metadata in the owner slots.
 	require.NotNil(withMR.MRTitle)
@@ -5307,6 +5313,8 @@ func TestWorkspaceSummaries(t *testing.T) {
 	assert.Nil(withMR.AssociatedPRNumber)
 	require.NotNil(withMR.ItemLastActivityAt)
 	assert.Equal(prActivity.UTC(), withMR.ItemLastActivityAt.UTC())
+	assert.True(withMR.SourceItemVisible)
+	assert.False(withMR.AssociatedPRVisible)
 
 	// GetWorkspaceSummary by ID
 	single, err := d.GetWorkspaceSummary(ctx, "ws-issue-with-pr")
@@ -5319,6 +5327,47 @@ func TestWorkspaceSummaries(t *testing.T) {
 	assert.Equal(42, *single.AssociatedPRNumber)
 	require.NotNil(single.ItemLastActivityAt)
 	assert.Equal(issueActivity.UTC(), single.ItemLastActivityAt.UTC())
+	assert.True(single.SourceItemVisible)
+	assert.True(single.AssociatedPRVisible)
+
+	_, err = d.WriteDB().ExecContext(ctx, `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES (?, 'merge_request', 42, 'pull-42', ?, ?, 'removed_upstream')`,
+		repoID, base, base,
+	)
+	require.NoError(err)
+	single, err = d.GetWorkspaceSummary(ctx, "ws-issue-with-pr")
+	require.NoError(err)
+	require.NotNil(single)
+	assert.True(single.SourceItemVisible)
+	assert.False(single.AssociatedPRVisible)
+	_, err = d.WriteDB().ExecContext(ctx, `
+		UPDATE forge_archive_items
+		SET lifecycle_state = 'inaccessible'
+		WHERE repo_id = ? AND item_type = 'merge_request' AND item_number = 42`,
+		repoID,
+	)
+	require.NoError(err)
+	single, err = d.GetWorkspaceSummary(ctx, "ws-issue-with-pr")
+	require.NoError(err)
+	require.NotNil(single)
+	assert.True(single.SourceItemVisible)
+	assert.True(single.AssociatedPRVisible)
+	_, err = d.WriteDB().ExecContext(ctx, `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES (?, 'issue', 7, 'issue-7', ?, ?, 'removed_upstream')`,
+		repoID, base, base,
+	)
+	require.NoError(err)
+	single, err = d.GetWorkspaceSummary(ctx, "ws-issue-with-pr")
+	require.NoError(err)
+	require.NotNil(single)
+	assert.False(single.SourceItemVisible)
+	assert.True(single.AssociatedPRVisible)
 
 	// GetWorkspaceSummary miss
 	missSum, err := d.GetWorkspaceSummary(ctx, "nonexistent")
@@ -5375,6 +5424,8 @@ func TestWorkspaceSummariesRetainWorkspaceWithoutRemovedPullMetadata(t *testing.
 	require.Nil(summary.MRMergeableState)
 	require.Nil(summary.MRHeadBranch)
 	require.Nil(summary.ItemLastActivityAt)
+	require.False(summary.SourceItemVisible)
+	require.False(summary.AssociatedPRVisible)
 
 	summaries, err := d.ListWorkspaceSummaries(ctx)
 	require.NoError(err)

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -5845,6 +5846,64 @@ func TestUpsertIssue_NormalizesEmptyAssigneesJSON(t *testing.T) {
 	issues, err := d.ListIssues(ctx, ListIssuesOpts{Assignee: "anyone", State: "all"})
 	require.NoError(err)
 	assert.Empty(issues)
+}
+
+func TestPeriodicSyncCandidatesExcludeRemovedUpstream(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	repoID := insertTestRepo(t, d, "acme", "widget")
+	base := baseTime()
+
+	insertTestMR(t, d, repoID, 1, "visible pull", base)
+	insertTestMR(t, d, repoID, 2, "removed pull", base)
+	insertTestIssue(t, d, repoID, 3, "visible issue", base)
+	insertTestIssue(t, d, repoID, 4, "removed issue", base)
+	mergedAt := base.Add(time.Hour)
+	insertTestMRWithOptions(t, d, testMR(repoID, 5, func(mr *MergeRequest) {
+		mr.State = MergeRequestStateMerged
+		mr.MergedAt = &mergedAt
+	}))
+	insertTestMRWithOptions(t, d, testMR(repoID, 6, func(mr *MergeRequest) {
+		mr.State = MergeRequestStateMerged
+		mr.MergedAt = &mergedAt
+	}))
+
+	for _, item := range []struct {
+		itemType ArchiveItemType
+		number   int
+	}{
+		{itemType: ArchiveItemTypeMergeRequest, number: 2},
+		{itemType: ArchiveItemTypeIssue, number: 4},
+		{itemType: ArchiveItemTypeMergeRequest, number: 6},
+	} {
+		_, err := d.WriteDB().ExecContext(ctx, `
+			INSERT INTO forge_archive_items (
+				repo_id, item_type, item_number, provider_item_id,
+				provider_created_at, provider_updated_at, lifecycle_state
+			) VALUES (?, ?, ?, ?, ?, ?, 'removed_upstream')`,
+			repoID, item.itemType, item.number,
+			fmt.Sprintf("%s-%d", item.itemType, item.number), base, base,
+		)
+		require.NoError(err)
+	}
+
+	closedMRs, err := d.GetPreviouslyOpenMRNumbers(ctx, repoID, map[int]bool{})
+	require.NoError(err)
+	require.Equal([]int{1}, closedMRs)
+	closedIssues, err := d.GetPreviouslyOpenIssueNumbers(ctx, repoID, map[int]bool{})
+	require.NoError(err)
+	require.Equal([]int{3}, closedIssues)
+	missingActors, err := d.GetMergedMRNumbersMissingMergedActor(
+		ctx, repoID, base,
+		MergedMRMissingActorCursor{
+			MergedAt: mergedAt.Add(time.Hour), MergeRequestID: 1<<63 - 1,
+		},
+		10,
+	)
+	require.NoError(err)
+	require.Len(missingActors, 1)
+	require.Equal(5, missingActors[0].Number)
 }
 
 func TestGetMergedMRNumbersMissingMergedActor(t *testing.T) {

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -1305,20 +1305,25 @@ type Workspace struct {
 // WorkspaceSummary extends Workspace with joined source-item metadata.
 type WorkspaceSummary struct {
 	Workspace
-	RepoID           int64
-	RepoPlatformID   string
-	SourceTitle      *string
-	SourceState      *string
-	SourceURL        *string
-	MRTitle          *string
-	MRState          *string
-	MRIsDraft        *bool
-	MRCIStatus       *string
-	MRReviewDecision *string
-	MRAdditions      *int
-	MRDeletions      *int
-	MRCommentCount   *int
-	MRMergeableState *string
+	RepoID         int64
+	RepoPlatformID string
+	// SourceItemVisible and AssociatedPRVisible are false only at the public
+	// removed-upstream boundary. Inaccessible and not-yet-synced items remain
+	// visible by number, matching the rest of the public read contract.
+	SourceItemVisible   bool
+	AssociatedPRVisible bool
+	SourceTitle         *string
+	SourceState         *string
+	SourceURL           *string
+	MRTitle             *string
+	MRState             *string
+	MRIsDraft           *bool
+	MRCIStatus          *string
+	MRReviewDecision    *string
+	MRAdditions         *int
+	MRDeletions         *int
+	MRCommentCount      *int
+	MRMergeableState    *string
 	// MRHeadBranch is the currently synced PR head branch, which can move
 	// after workspace creation (branch rename); prefer it over the
 	// creation-time GitHeadRef snapshot for push-target context.

--- a/internal/db/workspace_subjects.go
+++ b/internal/db/workspace_subjects.go
@@ -46,6 +46,13 @@ func (d *DB) ListWorkspaceSubjectMetadata(
 		JOIN forge_repos r ON r.id = q.repo_id AND r.lifecycle_state = 'active'
 		JOIN forge_merge_requests p
 		  ON q.item_type = 'pull_request' AND p.repo_id = q.repo_id AND p.number = q.item_number
+		WHERE NOT EXISTS (
+			SELECT 1 FROM forge_archive_items ai
+			WHERE ai.repo_id = p.repo_id
+			  AND ai.item_type = 'merge_request'
+			  AND ai.item_number = p.number
+			  AND ai.lifecycle_state = 'removed_upstream'
+		)
 		UNION ALL
 		SELECT q.repo_id, q.item_type, q.item_number,
 		       r.platform, r.platform_host, r.owner, r.name, r.repo_path,
@@ -53,7 +60,14 @@ func (d *DB) ListWorkspaceSubjectMetadata(
 		FROM requested q
 		JOIN forge_repos r ON r.id = q.repo_id AND r.lifecycle_state = 'active'
 		JOIN forge_issues i
-		  ON q.item_type = 'issue' AND i.repo_id = q.repo_id AND i.number = q.item_number`
+		  ON q.item_type = 'issue' AND i.repo_id = q.repo_id AND i.number = q.item_number
+		WHERE NOT EXISTS (
+			SELECT 1 FROM forge_archive_items ai
+			WHERE ai.repo_id = i.repo_id
+			  AND ai.item_type = 'issue'
+			  AND ai.item_number = i.number
+			  AND ai.lifecycle_state = 'removed_upstream'
+		)`
 	rows, err := d.ro.QueryContext(ctx, query, string(requestedJSON))
 	if err != nil {
 		return nil, fmt.Errorf("list workspace subject metadata: %w", err)

--- a/internal/db/workspace_subjects_test.go
+++ b/internal/db/workspace_subjects_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,6 +29,46 @@ func TestListWorkspaceSubjectMetadataReturnsPullRequestAndIssue(t *testing.T) {
 	assert.Equal("live issue", got[WorkspaceSubjectKey{
 		RepoID: repoID, ItemType: WorkspaceItemTypeIssue, ItemNumber: 5,
 	}].Title)
+}
+
+func TestListWorkspaceSubjectMetadataHidesOnlyRemovedUpstreamItems(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	repoID := insertTestRepo(t, d, "acme", "widget")
+	now := time.Now().UTC().Truncate(time.Second)
+	insertTestMR(t, d, repoID, 1, "inaccessible pull", now)
+	insertTestMR(t, d, repoID, 2, "removed pull", now)
+	insertTestIssue(t, d, repoID, 3, "inaccessible issue", now)
+	insertTestIssue(t, d, repoID, 4, "removed issue", now)
+	_, err := d.WriteDB().ExecContext(ctx, `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES
+			(?, 'merge_request', 1, 'pr-1', ?, ?, 'inaccessible'),
+			(?, 'merge_request', 2, 'pr-2', ?, ?, 'removed_upstream'),
+			(?, 'issue', 3, 'issue-3', ?, ?, 'inaccessible'),
+			(?, 'issue', 4, 'issue-4', ?, ?, 'removed_upstream')`,
+		repoID, now, now, repoID, now, now,
+		repoID, now, now, repoID, now, now,
+	)
+	require.NoError(err)
+
+	got, err := d.ListWorkspaceSubjectMetadata(ctx, []WorkspaceSubjectKey{
+		{RepoID: repoID, ItemType: WorkspaceItemTypePullRequest, ItemNumber: 1},
+		{RepoID: repoID, ItemType: WorkspaceItemTypePullRequest, ItemNumber: 2},
+		{RepoID: repoID, ItemType: WorkspaceItemTypeIssue, ItemNumber: 3},
+		{RepoID: repoID, ItemType: WorkspaceItemTypeIssue, ItemNumber: 4},
+	})
+	require.NoError(err)
+	require.Len(got, 2)
+	require.Contains(got, WorkspaceSubjectKey{
+		RepoID: repoID, ItemType: WorkspaceItemTypePullRequest, ItemNumber: 1,
+	})
+	require.Contains(got, WorkspaceSubjectKey{
+		RepoID: repoID, ItemType: WorkspaceItemTypeIssue, ItemNumber: 3,
+	})
 }
 
 func TestListWorkspaceSubjectMetadataSupportsLargeSubjectSets(t *testing.T) {

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -8507,10 +8507,22 @@ func (s *Syncer) reclassifyWorkspaceHeadRepoTrustUnderRepositoryReconciliationRe
 		}
 		cloneURL := ""
 		var snapshotRevision int64
+		removed, visibilityErr := s.db.IsArchiveItemRemovedUpstream(
+			ctx, repoID, db.ArchiveItemTypeMergeRequest, mrNumber,
+		)
+		if visibilityErr != nil {
+			slog.Error("check workspace merge request visibility for head-repo trust reclassification failed",
+				"repo", repo.Owner+"/"+repo.Name,
+				"number", mrNumber, "err", visibilityErr,
+			)
+			return
+		}
 		if stored != nil {
-			cloneURL = stored.HeadRepoCloneURL
 			snapshotRevision = stored.SnapshotRevision
-			if stored.HeadRepoIdentityStale {
+			if !removed {
+				cloneURL = stored.HeadRepoCloneURL
+			}
+			if !removed && stored.HeadRepoIdentityStale {
 				return
 			}
 		}
@@ -8527,6 +8539,7 @@ func (s *Syncer) reclassifyWorkspaceHeadRepoTrustUnderRepositoryReconciliationRe
 			repoID,
 			mrNumber,
 			snapshotRevision,
+			removed,
 			refreshed,
 		)
 		if updateErr != nil {

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -13296,6 +13296,36 @@ func (s *Syncer) SyncArchiveItem(
 	}
 }
 
+// FinalizeArchiveItemSync applies persistence that depends on the archive
+// lifecycle commit. A concurrent terminal observation can land after the item
+// is claimed, so parent-snapshot reclassification may still see the item as
+// removed. The successful archive commit reactivates it before this callback.
+func (s *Syncer) FinalizeArchiveItemSync(
+	ctx context.Context,
+	repoID int64,
+	itemType db.ArchiveItemType,
+	number int,
+) {
+	if itemType != db.ArchiveItemTypeMergeRequest {
+		return
+	}
+	stored, err := s.db.GetRepoByID(ctx, repoID)
+	if err != nil {
+		slog.Error("look up repository for archive item finalization failed",
+			"repo_id", repoID, "number", number, "err", err,
+		)
+		return
+	}
+	if stored == nil {
+		return
+	}
+	s.reclassifyWorkspaceHeadRepoTrust(ctx, RepoRef{
+		Platform: platform.Kind(stored.Platform), PlatformHost: stored.PlatformHost,
+		Owner: stored.Owner, Name: stored.Name, RepoPath: stored.RepoPath,
+		PlatformExternalID: stored.PlatformRepoID,
+	}, repoID, number)
+}
+
 func (s *Syncer) requireGitHubArchiveMergedMRMetrics(
 	ctx context.Context,
 	repoID int64,

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -9538,6 +9538,15 @@ func (s *Syncer) fetchMRDetail(
 	number int,
 	cloneFetchOK bool,
 ) (int, error) {
+	removed, err := s.removedUpstreamForLiveSync(
+		ctx, repoID, db.ArchiveItemTypeMergeRequest, number,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("check PR #%d visibility: %w", number, err)
+	}
+	if removed {
+		return 0, nil
+	}
 	calls, err := s.fetchMRDetailWithRouteFence(
 		ctx, repo, repoID, number, cloneFetchOK,
 	)
@@ -10169,6 +10178,15 @@ func (s *Syncer) fetchIssueDetail(
 	repoID int64,
 	number int,
 ) (int, error) {
+	removed, err := s.removedUpstreamForLiveSync(
+		ctx, repoID, db.ArchiveItemTypeIssue, number,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("check issue #%d visibility: %w", number, err)
+	}
+	if removed {
+		return 0, nil
+	}
 	calls := 0
 	issueReader, err := s.issueReaderFor(repo)
 	if err != nil {
@@ -12396,6 +12414,22 @@ func (s *Syncer) syncMRForRepo(
 	)
 }
 
+// removedUpstreamForLiveSync fences delayed live work against an archive
+// tombstone created after the work was queued. Archive hydration deliberately
+// bypasses this check because it must fetch terminal items to repair them when
+// they reappear upstream.
+func (s *Syncer) removedUpstreamForLiveSync(
+	ctx context.Context,
+	repoID int64,
+	itemType db.ArchiveItemType,
+	number int,
+) (bool, error) {
+	if IsArchiveSyncBudgetContext(ctx) {
+		return false, nil
+	}
+	return s.db.IsArchiveItemRemovedUpstream(ctx, repoID, itemType, number)
+}
+
 type mergeRequestFetchEvidence struct {
 	merged         bool
 	headSHA        string
@@ -12458,6 +12492,15 @@ func (s *Syncer) syncMRForRepoResolved(
 		slog.Debug("skipping MR detail sync for archived repo",
 			"repo", owner+"/"+name, "number", number,
 		)
+		return nil
+	}
+	removed, err := s.removedUpstreamForLiveSync(
+		ctx, repoID, db.ArchiveItemTypeMergeRequest, number,
+	)
+	if err != nil {
+		return fmt.Errorf("check MR #%d visibility: %w", number, err)
+	}
+	if removed {
 		return nil
 	}
 	ctx = withCloneRepositoryIdentity(ctx, repo)

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -8825,7 +8825,7 @@ func (s *Syncer) drainPendingCommentSyncs(
 			)
 			continue
 		}
-		pr, err := s.db.GetMergeRequestByRepoIDAndNumber(
+		pr, err := s.db.GetVisibleMergeRequestByRepoIDAndNumber(
 			refreshCtx, item.repoID, item.number,
 		)
 		if err != nil {
@@ -8834,6 +8834,9 @@ func (s *Syncer) drainPendingCommentSyncs(
 				"number", item.number,
 				"err", err,
 			)
+			continue
+		}
+		if pr == nil {
 			continue
 		}
 		probe, due := s.beginRepositoryFeatureProbe(
@@ -8890,7 +8893,7 @@ func (s *Syncer) drainPendingCommentSyncs(
 			)
 			continue
 		}
-		issue, err := s.db.GetIssueByRepoIDAndNumber(
+		issue, err := s.db.GetVisibleIssueByRepoIDAndNumber(
 			refreshCtx, item.repoID, item.number,
 		)
 		if err != nil {
@@ -8899,6 +8902,9 @@ func (s *Syncer) drainPendingCommentSyncs(
 				"number", item.number,
 				"err", err,
 			)
+			continue
+		}
+		if issue == nil {
 			continue
 		}
 		probe, due := s.beginRepositoryFeatureProbe(

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -8186,6 +8186,17 @@ func (s *Syncer) backfillMergedActorEvent(
 	repoID int64,
 	number int,
 ) (bool, error) {
+	removed, err := s.db.IsArchiveItemRemovedUpstream(
+		ctx, repoID, db.ArchiveItemTypeMergeRequest, number,
+	)
+	if err != nil {
+		return false, fmt.Errorf(
+			"check MR #%d for merged-actor backfill: %w", number, err,
+		)
+	}
+	if removed {
+		return false, nil
+	}
 	stored, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repoID, number)
 	if err != nil {
 		return false, fmt.Errorf("get MR #%d for merged-actor backfill: %w", number, err)
@@ -11700,6 +11711,15 @@ func (s *Syncer) persistIssueComments(
 func (s *Syncer) fetchAndUpdateClosedIssue(
 	ctx context.Context, repo RepoRef, repoID int64, number int,
 ) error {
+	removed, err := s.db.IsArchiveItemRemovedUpstream(
+		ctx, repoID, db.ArchiveItemTypeIssue, number,
+	)
+	if err != nil {
+		return fmt.Errorf("check closed issue #%d visibility: %w", number, err)
+	}
+	if removed {
+		return nil
+	}
 	client, err := s.clientFor(repo)
 	if err != nil {
 		return fmt.Errorf("resolve client for %s/%s: %w", repo.Owner, repo.Name, err)
@@ -11800,6 +11820,15 @@ func (s *Syncer) fetchAndUpdateClosedPlatformIssue(
 	repoID int64,
 	number int,
 ) error {
+	removed, err := s.db.IsArchiveItemRemovedUpstream(
+		ctx, repoID, db.ArchiveItemTypeIssue, number,
+	)
+	if err != nil {
+		return fmt.Errorf("check closed issue #%d visibility: %w", number, err)
+	}
+	if removed {
+		return nil
+	}
 	issueReader, err := s.issueReaderFor(repo)
 	if err != nil {
 		return fmt.Errorf("resolve issue reader for %s/%s: %w", repo.Owner, repo.Name, err)
@@ -13385,6 +13414,15 @@ func CarryMergeRequestDerivedFields(normalized, existing *db.MergeRequest) {
 
 // fetchAndUpdateClosed retrieves the final state of a now-closed PR from GitHub.
 func (s *Syncer) fetchAndUpdateClosed(ctx context.Context, repo RepoRef, repoID int64, number int, cloneFetchOK bool) error {
+	removed, err := s.db.IsArchiveItemRemovedUpstream(
+		ctx, repoID, db.ArchiveItemTypeMergeRequest, number,
+	)
+	if err != nil {
+		return fmt.Errorf("check closed PR #%d visibility: %w", number, err)
+	}
+	if removed {
+		return nil
+	}
 	client, err := s.clientFor(repo)
 	if err != nil {
 		return fmt.Errorf("resolve client for %s/%s: %w", repo.Owner, repo.Name, err)
@@ -13566,6 +13604,15 @@ func (s *Syncer) fetchAndUpdateClosedMergeRequest(
 	number int,
 	cloneFetchOK bool,
 ) error {
+	removed, err := s.db.IsArchiveItemRemovedUpstream(
+		ctx, repoID, db.ArchiveItemTypeMergeRequest, number,
+	)
+	if err != nil {
+		return fmt.Errorf("check closed MR #%d visibility: %w", number, err)
+	}
+	if removed {
+		return nil
+	}
 	if _, ok := reader.(interface {
 		GetGitHubPullRequest(context.Context, platform.RepoRef, int) (*gh.PullRequest, platform.MergeRequest, error)
 	}); ok {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -11862,6 +11862,91 @@ func TestDetailDrainSkipsRepoArchivedMidPass(t *testing.T) {
 	assert.True(tracked[0].Archived)
 }
 
+func TestDetailDrainRechecksRemovedUpstreamAfterQueueConstruction(t *testing.T) {
+	for _, itemType := range []db.ArchiveItemType{
+		db.ArchiveItemTypeMergeRequest,
+		db.ArchiveItemTypeIssue,
+	} {
+		t.Run(string(itemType), func(t *testing.T) {
+			require := require.New(t)
+			ctx := t.Context()
+			d := openTestDB(t)
+			now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+			repoID, err := d.UpsertRepo(ctx, verifiedGitHubRepoIdentity(
+				"github.com", "owner", "repo",
+			))
+			require.NoError(err)
+			pr := buildOpenPR(7, now)
+			issue := buildOpenIssue(7, now)
+			if itemType == db.ArchiveItemTypeMergeRequest {
+				normalized, normalizeErr := NormalizePR(repoID, pr)
+				require.NoError(normalizeErr)
+				_, err = d.UpsertMergeRequest(ctx, normalized)
+			} else {
+				normalized, normalizeErr := NormalizeIssue(repoID, issue)
+				require.NoError(normalizeErr)
+				_, err = d.UpsertIssue(ctx, normalized)
+			}
+			require.NoError(err)
+
+			var detailCalls atomic.Int32
+			client := &mockClient{
+				getPullRequestFn: func(
+					context.Context, string, string, int,
+				) (*gh.PullRequest, error) {
+					detailCalls.Add(1)
+					return pr, nil
+				},
+				getIssueFn: func(
+					context.Context, string, string, int,
+				) (*gh.Issue, error) {
+					detailCalls.Add(1)
+					return issue, nil
+				},
+			}
+			client.getRepositoryFn = func(
+				_ context.Context, owner, name string,
+			) (*gh.Repository, error) {
+				_, insertErr := d.WriteDB().ExecContext(ctx, `
+					INSERT OR IGNORE INTO forge_archive_items (
+						repo_id, item_type, item_number, provider_item_id,
+						provider_created_at, provider_updated_at, lifecycle_state
+					) VALUES (?, ?, ?, ?, ?, ?, 'removed_upstream')`,
+					repoID, itemType, 7, string(itemType)+"-7", now, now,
+				)
+				require.NoError(insertErr)
+				id := int64(1)
+				nodeID := "repo-" + owner + "-" + name
+				return &gh.Repository{
+					ID: &id, NodeID: &nodeID, Name: &name,
+					Owner: &gh.User{Login: &owner},
+				}, nil
+			}
+			syncer := NewSyncer(
+				map[string]Client{"github.com": client}, d, nil,
+				[]RepoRef{{
+					Platform: platform.KindGitHub, PlatformHost: "github.com",
+					Owner: "owner", Name: "repo",
+				}},
+				time.Minute, nil, testBudget(500),
+			)
+			bucket, err := syncer.bucketKeyForRepo(RepoRef{
+				Platform: platform.KindGitHub, PlatformHost: "github.com",
+				Owner: "owner", Name: "repo",
+			}, false)
+			require.NoError(err)
+
+			syncer.drainDetailQueue(ctx, map[string]bool{bucket: true}, []RepoRef{{
+				Platform: platform.KindGitHub, PlatformHost: "github.com",
+				Owner: "owner", Name: "repo",
+			}})
+
+			require.Zero(detailCalls.Load(),
+				"detail drain must recheck a queued item after repository resolution")
+		})
+	}
+}
+
 func TestSyncWatchedMRsSkipsRepoArchivedMidPass(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -11912,6 +11997,50 @@ func TestSyncWatchedMRsSkipsRepoArchivedMidPass(t *testing.T) {
 	tracked := syncer.TrackedRepos()
 	require.Len(tracked, 1)
 	assert.True(tracked[0].Archived)
+}
+
+func TestSyncWatchedMRsSkipsRemovedUpstreamPR(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	repoID, err := d.UpsertRepo(ctx, verifiedGitHubRepoIdentity(
+		"github.com", "acme", "app",
+	))
+	require.NoError(err)
+	pr := buildOpenPR(7, now)
+	normalized, err := NormalizePR(repoID, pr)
+	require.NoError(err)
+	_, err = d.UpsertMergeRequest(ctx, normalized)
+	require.NoError(err)
+	_, err = d.WriteDB().ExecContext(ctx, `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES (?, 'merge_request', ?, ?, ?, ?, 'removed_upstream')`,
+		repoID, 7, "pr-7", now, now,
+	)
+	require.NoError(err)
+
+	client := &detailTrackingClient{}
+	client.singlePR = pr
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, d, nil,
+		[]RepoRef{{
+			Platform: platform.KindGitHub, PlatformHost: "github.com",
+			Owner: "acme", Name: "app",
+		}},
+		time.Hour, nil, nil,
+	)
+	syncer.SetWatchedMRs([]WatchedMR{{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "app", Number: 7,
+	}})
+
+	syncer.syncWatchedMRs(ctx)
+
+	require.Zero(client.getPRCalls.Load(),
+		"a stale watch entry must not fetch a removed PR")
 }
 
 func TestSyncMRForRepoHydratesArchivedRepoUnderArchiveBudget(t *testing.T) {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -15428,6 +15428,89 @@ func TestSyncerSyncsIssuesOnPRList304(t *testing.T) {
 	assert.Equal(issueTitle, issue.Title)
 }
 
+func TestSyncRepoSkipsRemovedUpstreamPeriodicCandidates(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	repo := RepoRef{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "owner", Name: "repo", RepoPath: "owner/repo",
+		PlatformExternalID: "repo-owner-repo",
+	}
+	repoID, err := d.UpsertRepo(ctx, verifiedGitHubRepoIdentity(
+		"github.com", "owner", "repo",
+	))
+	require.NoError(err)
+
+	openPR := buildOpenPR(7, now)
+	normalizedPR, err := NormalizePR(repoID, openPR)
+	require.NoError(err)
+	_, err = d.UpsertMergeRequest(ctx, normalizedPR)
+	require.NoError(err)
+	openIssue := buildOpenIssue(8, now)
+	normalizedIssue, err := NormalizeIssue(repoID, openIssue)
+	require.NoError(err)
+	_, err = d.UpsertIssue(ctx, normalizedIssue)
+	require.NoError(err)
+	mergedPR := buildOpenPR(9, now)
+	normalizedMerged, err := NormalizePR(repoID, mergedPR)
+	require.NoError(err)
+	_, err = d.UpsertMergeRequest(ctx, normalizedMerged)
+	require.NoError(err)
+	mergedAt := now.Add(time.Minute)
+	require.NoError(d.UpdateMRState(
+		ctx, repoID, 9, "merged", &mergedAt, &mergedAt,
+	))
+
+	for _, item := range []struct {
+		itemType db.ArchiveItemType
+		number   int
+	}{
+		{itemType: db.ArchiveItemTypeMergeRequest, number: 7},
+		{itemType: db.ArchiveItemTypeIssue, number: 8},
+		{itemType: db.ArchiveItemTypeMergeRequest, number: 9},
+	} {
+		_, err = d.WriteDB().ExecContext(ctx, `
+			INSERT INTO forge_archive_items (
+				repo_id, item_type, item_number, provider_item_id,
+				provider_created_at, provider_updated_at, lifecycle_state
+			) VALUES (?, ?, ?, ?, ?, ?, 'removed_upstream')`,
+			repoID, item.itemType, item.number,
+			fmt.Sprintf("%s-%d", item.itemType, item.number), now, now,
+		)
+		require.NoError(err)
+	}
+
+	var pullCalls atomic.Int32
+	var issueCalls atomic.Int32
+	client := &mockClient{
+		getPullRequestFn: func(context.Context, string, string, int) (*gh.PullRequest, error) {
+			pullCalls.Add(1)
+			return nil, errors.New("removed pull must not be fetched")
+		},
+		getIssueFn: func(context.Context, string, string, int) (*gh.Issue, error) {
+			issueCalls.Add(1)
+			return nil, errors.New("removed issue must not be fetched")
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, d, nil,
+		[]RepoRef{repo}, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	syncer.SetClock(func() time.Time { return now.Add(time.Hour) })
+
+	require.NoError(syncer.fetchAndUpdateClosed(ctx, repo, repoID, 7, false))
+	require.NoError(syncer.fetchAndUpdateClosedIssue(ctx, repo, repoID, 8))
+	changed, err := syncer.backfillMergedActorEvent(ctx, repo, repoID, 9)
+	require.NoError(err)
+	require.False(changed)
+	require.NoError(syncer.syncRepo(ctx, repo))
+	require.Zero(pullCalls.Load())
+	require.Zero(issueCalls.Load())
+}
+
 func TestSyncStoresIssueLabels(t *testing.T) {
 	require := require.New(t)
 	ctx := t.Context()

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -7652,6 +7652,9 @@ type dedupGetUserClient struct {
 	mockClient
 	getUserCount atomic.Int32
 	block        chan struct{}
+	listEntered  chan struct{}
+	listRelease  chan struct{}
+	userEntered  chan struct{}
 	author       string
 	now          time.Time
 }
@@ -7659,6 +7662,8 @@ type dedupGetUserClient struct {
 func (c *dedupGetUserClient) ListOpenPullRequests(
 	_ context.Context, _, repo string,
 ) ([]*gh.PullRequest, error) {
+	c.listEntered <- struct{}{}
+	<-c.listRelease
 	number := 1
 	if repo == "r2" {
 		number = 2
@@ -7672,6 +7677,7 @@ func (c *dedupGetUserClient) GetUser(
 	_ context.Context, login string,
 ) (*gh.User, error) {
 	c.getUserCount.Add(1)
+	c.userEntered <- struct{}{}
 	<-c.block
 	name := "Display " + login
 	return &gh.User{Login: &login, Name: &name}, nil
@@ -7686,9 +7692,12 @@ func TestResolveDisplayNameDedupsConcurrentLookups(t *testing.T) {
 	now := time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC)
 
 	mc := &dedupGetUserClient{
-		block:  make(chan struct{}),
-		author: author,
-		now:    now,
+		block:       make(chan struct{}),
+		listEntered: make(chan struct{}, 2),
+		listRelease: make(chan struct{}),
+		userEntered: make(chan struct{}, 1),
+		author:      author,
+		now:         now,
 	}
 
 	syncer := NewSyncer(
@@ -7707,14 +7716,26 @@ func TestResolveDisplayNameDedupsConcurrentLookups(t *testing.T) {
 		close(done)
 	}()
 
-	// Wait until at least one worker has entered GetUser. Sleeping
-	// does not prove the second worker has arrived yet, but the
-	// blocked fn holds the singleflight slot open until we release
-	// it, so any arriving worker will be coalesced.
-	require.Eventually(func() bool {
-		return mc.getUserCount.Load() >= 1
-	}, 2*time.Second, 5*time.Millisecond,
-		"no worker reached GetUser")
+	// Hold both repository workers at the PR-list boundary. This keeps the
+	// assertion focused on display-name coalescing instead of imposing a short
+	// wall-clock deadline on the complete repository-sync startup path.
+	startupDeadline := time.NewTimer(30 * time.Second)
+	defer startupDeadline.Stop()
+	for range 2 {
+		select {
+		case <-mc.listEntered:
+		case <-startupDeadline.C:
+			require.Fail("both workers did not reach pull request listing")
+			return
+		}
+	}
+	close(mc.listRelease)
+
+	select {
+	case <-mc.userEntered:
+	case <-time.After(30 * time.Second):
+		require.Fail("no worker reached GetUser")
+	}
 
 	// Give the second worker plenty of time to enter singleflight.
 	time.Sleep(100 * time.Millisecond)
@@ -7723,7 +7744,7 @@ func TestResolveDisplayNameDedupsConcurrentLookups(t *testing.T) {
 
 	select {
 	case <-done:
-	case <-time.After(5 * time.Second):
+	case <-time.After(30 * time.Second):
 		require.Fail("RunOnce did not complete")
 	}
 

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -17737,6 +17737,93 @@ func TestDeferredCommentRefreshRejectsABARoutePayload(t *testing.T) {
 	})
 }
 
+func TestDeferredCommentRefreshSkipsRemovedUpstreamItems(t *testing.T) {
+	for _, itemType := range []db.ArchiveItemType{
+		db.ArchiveItemTypeMergeRequest,
+		db.ArchiveItemTypeIssue,
+	} {
+		t.Run(string(itemType), func(t *testing.T) {
+			require := require.New(t)
+			ctx := t.Context()
+			database := openTestDB(t)
+			now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+			repo := RepoRef{
+				Platform: platform.KindGitHub, PlatformHost: "github.com",
+				Owner: "acme", Name: "widget",
+			}
+			repoID, err := database.UpsertRepo(
+				ctx, verifiedGitHubRepoIdentity("github.com", repo.Owner, repo.Name),
+			)
+			require.NoError(err)
+			detailFetchedAt := now
+			var parentID int64
+			if itemType == db.ArchiveItemTypeMergeRequest {
+				parentID, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+					RepoID: repoID, PlatformID: 7007, Number: 7,
+					URL: "https://github.com/acme/widget/pull/7", Title: "queued PR",
+					Author: "ada", State: db.MergeRequestStateOpen,
+					CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+					DetailFetchedAt: &detailFetchedAt,
+				})
+			} else {
+				parentID, err = database.UpsertIssue(ctx, &db.Issue{
+					RepoID: repoID, PlatformID: 8007, Number: 7,
+					URL: "https://github.com/acme/widget/issues/7", Title: "queued issue",
+					Author: "ada", State: "open",
+					CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+					DetailFetchedAt: &detailFetchedAt,
+				})
+			}
+			require.NoError(err)
+
+			var providerCalls atomic.Int32
+			commentID, body := int64(91), "must not persist"
+			client := &mockClient{listIssueCommentsIfChangedFn: func(
+				context.Context, string, string, int,
+			) ([]*gh.IssueComment, error) {
+				providerCalls.Add(1)
+				return []*gh.IssueComment{{
+					ID: &commentID, Body: &body,
+					CreatedAt: makeTimestamp(now), UpdatedAt: makeTimestamp(now),
+				}}, nil
+			}}
+			syncer := NewSyncer(
+				map[string]Client{"github.com": client}, database, nil,
+				[]RepoRef{repo}, time.Minute, nil, nil,
+			)
+			if itemType == db.ArchiveItemTypeMergeRequest {
+				syncer.queuePRCommentSync(repo, repoID, 7)
+			} else {
+				syncer.queueIssueCommentSync(repo, repoID, 7)
+			}
+			_, err = database.WriteDB().ExecContext(ctx, `
+				INSERT INTO forge_archive_items (
+					repo_id, item_type, item_number, provider_item_id,
+					provider_created_at, provider_updated_at, lifecycle_state
+				) VALUES (?, ?, ?, ?, ?, ?, 'removed_upstream')`,
+				repoID, itemType, 7, string(itemType)+"-7", now, now,
+			)
+			require.NoError(err)
+
+			syncer.drainPendingCommentSyncs(
+				ctx, map[string]bool{"github.com": true},
+			)
+
+			require.Zero(providerCalls.Load(),
+				"a queued comment refresh must recheck parent visibility")
+			if itemType == db.ArchiveItemTypeMergeRequest {
+				events, listErr := database.ListMREvents(ctx, parentID)
+				require.NoError(listErr)
+				require.Empty(events)
+			} else {
+				events, listErr := database.ListIssueEvents(ctx, parentID)
+				require.NoError(listErr)
+				require.Empty(events)
+			}
+		})
+	}
+}
+
 func TestFetchMRDetailRejectsABAOnNotModified(t *testing.T) {
 	require := require.New(t)
 	ctx := t.Context()

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1114,6 +1114,25 @@ func verifiedGitHubRepoIdentity(host, owner, name string) db.RepoIdentity {
 	return identity
 }
 
+func markArchiveItemRemovedUpstreamForServerTest(
+	t *testing.T,
+	database *db.DB,
+	repoID int64,
+	itemType db.ArchiveItemType,
+	number int,
+) {
+	t.Helper()
+	now := time.Now().UTC().Truncate(time.Second)
+	_, err := database.WriteDB().ExecContext(t.Context(), `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES (?, ?, ?, ?, ?, ?, 'removed_upstream')`,
+		repoID, itemType, number, fmt.Sprintf("%s-%d", itemType, number), now, now,
+	)
+	require.NoError(t, err)
+}
+
 func setupTestServerWithRepos(
 	t *testing.T, mock *mockGH, repos []ghclient.RepoRef,
 ) (*Server, *db.DB) {
@@ -3150,6 +3169,121 @@ func TestAPIEnqueuePRSyncQueuesOneRerun(t *testing.T) {
 		time.Millisecond,
 		"duplicate async sync requests must collapse to one pending rerun",
 	)
+}
+
+func TestAPIEnqueueItemSyncRejectsRemovedUpstreamWithoutProviderCalls(t *testing.T) {
+	require := require.New(t)
+	var pullCalls atomic.Int64
+	var issueCalls atomic.Int64
+	mock := &mockGH{
+		getPullRequestFn: func(context.Context, string, string, int) (*gh.PullRequest, error) {
+			pullCalls.Add(1)
+			return nil, errors.New("removed pull must not be fetched")
+		},
+		getIssueFn: func(context.Context, string, string, int) (*gh.Issue, error) {
+			issueCalls.Add(1)
+			return nil, errors.New("removed issue must not be fetched")
+		},
+	}
+
+	srv, database := setupTestServerWithMock(t, mock)
+	ctx := t.Context()
+	seedPR(t, database, "acme", "widget", 1)
+	seedIssue(t, database, "acme", "widget", 2, "open")
+	repo, err := database.GetRepoByIdentity(
+		ctx, verifiedGitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+	require.NotNil(repo)
+	markArchiveItemRemovedUpstreamForServerTest(
+		t, database, repo.ID, db.ArchiveItemTypeMergeRequest, 1,
+	)
+	markArchiveItemRemovedUpstreamForServerTest(
+		t, database, repo.ID, db.ArchiveItemTypeIssue, 2,
+	)
+	client := setupTestClient(t, srv)
+
+	pullResp, err := client.HTTP.EnqueuePrSyncWithResponse(
+		ctx, "gh", "acme", "widget", 1,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusNotFound, pullResp.StatusCode(), string(pullResp.Body))
+	require.NotNil(pullResp.ApplicationproblemJSONDefault)
+	require.Equal(
+		generated.ProblemErrorCode("pullNotFound"),
+		pullResp.ApplicationproblemJSONDefault.Code,
+	)
+
+	issueResp, err := client.HTTP.EnqueueIssueSyncWithResponse(
+		ctx, "gh", "acme", "widget", 2,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusNotFound, issueResp.StatusCode(), string(issueResp.Body))
+	require.NotNil(issueResp.ApplicationproblemJSONDefault)
+	require.Equal(
+		generated.ProblemErrorCode("issueNotFound"),
+		issueResp.ApplicationproblemJSONDefault.Code,
+	)
+	require.Zero(pullCalls.Load())
+	require.Zero(issueCalls.Load())
+}
+
+func TestAPIQueuedPRSyncRechecksRemovedUpstreamBeforeProviderCall(t *testing.T) {
+	require := require.New(t)
+	var providerCalls atomic.Int64
+	mock := &mockGH{
+		getPullRequestFn: func(context.Context, string, string, int) (*gh.PullRequest, error) {
+			providerCalls.Add(1)
+			return nil, errors.New("removed pull must not be fetched")
+		},
+	}
+
+	srv, database := setupTestServerWithMock(t, mock)
+	ctx := t.Context()
+	seedPR(t, database, "acme", "widget", 1)
+	repo, err := database.GetRepoByIdentity(
+		ctx, verifiedGitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+	require.NotNil(repo)
+	client := setupTestClient(t, srv)
+
+	key := "pr:github:github.com:acme/widget#1"
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	require.True(srv.enqueueDetailSyncOrRerun(
+		key, nil, func(context.Context) error {
+			close(firstStarted)
+			<-releaseFirst
+			return nil
+		},
+	))
+	require.Eventually(func() bool {
+		select {
+		case <-firstStarted:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+
+	resp, err := client.HTTP.EnqueuePrSyncWithResponse(
+		ctx, "gh", "acme", "widget", 1,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, resp.StatusCode(), string(resp.Body))
+	markArchiveItemRemovedUpstreamForServerTest(
+		t, database, repo.ID, db.ArchiveItemTypeMergeRequest, 1,
+	)
+	close(releaseFirst)
+
+	require.Eventually(func() bool {
+		srv.detailSyncMu.Lock()
+		defer srv.detailSyncMu.Unlock()
+		_, inFlight := srv.detailSyncInFlight[key]
+		return !inFlight
+	}, 10*time.Second, time.Millisecond)
+	require.Zero(providerCalls.Load())
 }
 
 // TestAPIEnqueuePRSyncPersistsWorkflowApproval verifies that the
@@ -31157,6 +31291,88 @@ func TestKataWorkspaceManualRefreshDiscoversAndSyncsAssociatedPR(t *testing.T) {
 	require.NotNil(pr)
 	assert.Equal(prTitleFromDetail, pr.Title)
 	assert.Equal(headSHA, pr.PlatformHeadSHA)
+}
+
+func TestWorkspaceManualRefreshSkipsRemovedIssueProviderDetail(t *testing.T) {
+	t.Parallel()
+	acquireRootWorkspaceGitSlot(t)
+
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+	issueNumber := 7
+	issueID := int64(7001)
+	issueTitle := "Removed issue"
+	issueState := "open"
+	issueURL := "https://github.com/acme/widget/issues/7"
+	prNumber := 1
+	prID := int64(1001)
+	prTitle := "Seeded pull"
+	prState := "open"
+	prURL := "https://github.com/acme/widget/pull/1"
+	author := "alice"
+	headRef := "feature"
+	baseRef := "main"
+	var issueDetailCalls atomic.Int64
+	mock := &mockGH{
+		listOpenIssuesFn: func(context.Context, string, string) ([]*gh.Issue, error) {
+			return []*gh.Issue{{
+				ID: &issueID, Number: &issueNumber, Title: &issueTitle,
+				State: &issueState, HTMLURL: &issueURL,
+				User:      &gh.User{Login: &author},
+				CreatedAt: &gh.Timestamp{Time: now}, UpdatedAt: &gh.Timestamp{Time: now},
+			}}, nil
+		},
+		getIssueFn: func(context.Context, string, string, int) (*gh.Issue, error) {
+			issueDetailCalls.Add(1)
+			return nil, errors.New("removed issue must not be fetched")
+		},
+		listOpenPullRequestsFn: func(context.Context, string, string) ([]*gh.PullRequest, error) {
+			return []*gh.PullRequest{{
+				ID: &prID, Number: &prNumber, Title: &prTitle,
+				State: &prState, HTMLURL: &prURL,
+				User:      &gh.User{Login: &author},
+				CreatedAt: &gh.Timestamp{Time: now}, UpdatedAt: &gh.Timestamp{Time: now},
+				Head: &gh.PullRequestBranch{Ref: &headRef},
+				Base: &gh.PullRequestBranch{Ref: &baseRef},
+			}}, nil
+		},
+	}
+	fixture := setupWorkspaceServerFixtureWithMockHostAndOptions(
+		t, nil, mock, "github.com",
+		ServerOptions{
+			PtyOwnerInProcess:                  true,
+			DisableWorkspaceBackgroundMonitors: true,
+		},
+	)
+	seedIssue(t, fixture.database, "acme", "widget", issueNumber, "open")
+
+	createRR := doJSON(
+		t, fixture.server, http.MethodPost,
+		"/api/v1/issues/gh/acme/widget/7/workspace", map[string]string{},
+	)
+	require.Equal(http.StatusAccepted, createRR.Code, createRR.Body.String())
+	var created rawWorkspaceStatusResponse
+	require.NoError(json.NewDecoder(createRR.Body).Decode(&created))
+	waitForWorkspaceReady(t, ctx, fixture.client, created.ID)
+
+	repo, err := fixture.database.GetRepoByIdentity(
+		ctx, verifiedGitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+	require.NotNil(repo)
+	markArchiveItemRemovedUpstreamForServerTest(
+		t, fixture.database, repo.ID, db.ArchiveItemTypeIssue, issueNumber,
+	)
+	before := issueDetailCalls.Load()
+
+	refreshRR := doJSON(
+		t, fixture.server, http.MethodPost,
+		"/api/v1/workspaces/"+created.ID+"/refresh", nil,
+	)
+	require.Equal(http.StatusOK, refreshRR.Code, refreshRR.Body.String())
+	require.Equal(before, issueDetailCalls.Load(),
+		"manual refresh must not fetch a tombstoned issue")
 }
 
 // TestWorkspaceRefreshProceedsThroughIssueScopePartialSyncFailure drives

--- a/internal/server/apitest/api_test.go
+++ b/internal/server/apitest/api_test.go
@@ -1,6 +1,7 @@
 package apitest
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
@@ -166,8 +167,20 @@ func TestAPIActivityAndRepoSummariesHideRemovedUpstreamArchiveRows(t *testing.T)
 		ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"),
 	)
 	require.NoError(err)
-	require.NotNil(repo)
 	now := time.Now().UTC().Truncate(time.Second)
+	require.NoError(database.InsertWorkspace(ctx, &db.Workspace{
+		ID:           "removed-pull-workspace",
+		Platform:     "github",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   2,
+		WorktreePath: t.TempDir(),
+		Status:       "ready",
+		CreatedAt:    now,
+	}))
+	require.NotNil(repo)
 	_, err = database.WriteDB().ExecContext(ctx, `
 		UPDATE forge_merge_requests
 		SET author = CASE number WHEN 1 THEN 'visible-pr-author' ELSE 'removed-pr-author' END,
@@ -261,6 +274,141 @@ func TestAPIActivityAndRepoSummariesHideRemovedUpstreamArchiveRows(t *testing.T)
 	require.Len(*summary.RecentIssues, 1)
 	require.EqualValues(3, (*summary.RecentIssues)[0].Number)
 	require.Equal("Visible issue", (*summary.RecentIssues)[0].Title)
+}
+
+func TestAPIResolveAndAutocompleteHideOnlyRemovedUpstreamItems(t *testing.T) {
+	require := require.New(t)
+	srv, database, providerClient, _ := setupTestServerWithFixtureClient(t)
+	ctx := t.Context()
+	seedPR(t, database, "acme", "widget", 1)
+	seedPR(t, database, "acme", "widget", 2)
+	seedIssue(t, database, "acme", "widget", 3, "open")
+	seedIssue(t, database, "acme", "widget", 4, "open")
+	repo, err := database.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
+	require.NoError(err)
+	require.NotNil(repo)
+	markArchiveItemLifecycle(t, database, repo.ID, db.ArchiveItemTypeMergeRequest, 1, db.ArchiveLifecycleStateInaccessible)
+	markArchiveItemLifecycle(t, database, repo.ID, db.ArchiveItemTypeMergeRequest, 2, db.ArchiveLifecycleStateRemovedUpstream)
+	markArchiveItemLifecycle(t, database, repo.ID, db.ArchiveItemTypeIssue, 3, db.ArchiveLifecycleStateInaccessible)
+	markArchiveItemLifecycle(t, database, repo.ID, db.ArchiveItemTypeIssue, 4, db.ArchiveLifecycleStateRemovedUpstream)
+
+	now := gh.Timestamp{Time: time.Now().UTC().Truncate(time.Second)}
+	providerClient.PRs["acme/widget"] = []*gh.PullRequest{{
+		ID: new(int64(2002)), Number: new(2), Title: new("removed pull"), State: new("open"),
+		CreatedAt: &now, UpdatedAt: &now,
+	}}
+	providerClient.Issues["acme/widget"] = []*gh.Issue{{
+		ID: new(int64(4004)), Number: new(4), Title: new("removed issue"), State: new("open"),
+		CreatedAt: &now, UpdatedAt: &now,
+	}}
+
+	client := setupTestClient(t, srv)
+	for _, tc := range []struct {
+		number int64
+		status int
+	}{
+		{number: 1, status: http.StatusOK},
+		{number: 2, status: http.StatusNotFound},
+		{number: 3, status: http.StatusOK},
+		{number: 4, status: http.StatusNotFound},
+	} {
+		resp, resolveErr := client.HTTP.ResolveRepoItemWithResponse(
+			ctx, "github", "acme", "widget", tc.number, nil,
+		)
+		require.NoError(resolveErr)
+		require.Equal(tc.status, resp.StatusCode(), string(resp.Body))
+	}
+
+	trigger, query := "#", ""
+	autocomplete, err := client.HTTP.GetCommentAutocompleteWithResponse(
+		ctx, "github", "acme", "widget",
+		&generated.GetCommentAutocompleteParams{Trigger: &trigger, Q: &query},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, autocomplete.StatusCode(), string(autocomplete.Body))
+	require.NotNil(autocomplete.JSON200)
+	require.NotNil(autocomplete.JSON200.References)
+	require.ElementsMatch([]generated.CommentAutocompleteReference{
+		{Kind: "pull", Number: 1, Title: "Test PR #1", State: "open"},
+		{Kind: "issue", Number: 3, Title: "Test Issue", State: "open"},
+	}, *autocomplete.JSON200.References)
+}
+
+func TestAPIRemovedIssueMutationsReturnNotFoundWithoutProviderWrites(t *testing.T) {
+	req := require.New(t)
+	srv, database, providerClient, _ := setupTestServerWithFixtureClient(t)
+	ctx := t.Context()
+	issueID := seedIssue(t, database, "acme", "widget", 7, "open")
+	repo, err := database.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
+	req.NoError(err)
+	req.NotNil(repo)
+	markArchiveItemLifecycle(t, database, repo.ID, db.ArchiveItemTypeIssue, 7, db.ArchiveLifecycleStateRemovedUpstream)
+	req.NoError(database.UpsertIssueEvents(ctx, []db.IssueEvent{{
+		IssueID: issueID, PlatformExternalID: "99", EventType: "issue_comment",
+		CreatedAt: time.Now().UTC(), DedupeKey: "removed-comment-99",
+	}}))
+	now := gh.Timestamp{Time: time.Now().UTC().Truncate(time.Second)}
+	providerIssue := &gh.Issue{
+		ID: new(int64(7007)), Number: new(7), Title: new("original title"), Body: new("original body"),
+		State: new("open"), CreatedAt: &now, UpdatedAt: &now,
+	}
+	providerClient.Issues["acme/widget"] = []*gh.Issue{providerIssue}
+	providerClient.OpenIssues["acme/widget"] = []*gh.Issue{providerIssue}
+
+	for _, tc := range []struct {
+		name   string
+		method string
+		path   string
+		body   any
+	}{
+		{name: "post comment", method: http.MethodPost, path: "/api/v1/issues/github/acme/widget/7/comments", body: map[string]any{"body": "new comment"}},
+		{name: "edit comment", method: http.MethodPatch, path: "/api/v1/issues/github/acme/widget/7/comments/99", body: map[string]any{"body": "edited comment"}},
+		{name: "delete comment", method: http.MethodDelete, path: "/api/v1/issues/github/acme/widget/7/comments/99", body: map[string]any{}},
+		{name: "edit content", method: http.MethodPatch, path: "/api/v1/issues/github/acme/widget/7", body: map[string]any{"title": "changed title"}},
+		{name: "set labels", method: http.MethodPut, path: "/api/v1/issues/github/acme/widget/7/labels", body: map[string]any{"labels": []string{}}},
+		{name: "set assignees", method: http.MethodPut, path: "/api/v1/issues/github/acme/widget/7/assignees", body: map[string]any{"assignees": []string{}}},
+		{name: "set state", method: http.MethodPost, path: "/api/v1/issues/github/acme/widget/7/github-state", body: map[string]any{"state": "closed"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			rr := doLabelAPIRequest(t, srv, tc.method, tc.path, tc.body)
+			require.Equal(http.StatusNotFound, rr.Code, rr.Body.String())
+			var problem generated.ProblemError
+			require.NoError(json.Unmarshal(rr.Body.Bytes(), &problem))
+			require.Equal(generated.ProblemErrorCode("issueNotFound"), problem.Code)
+		})
+	}
+	req.Empty(providerClient.Comments["acme/widget#7"])
+	req.Equal("original title", providerIssue.GetTitle())
+	req.Equal("original body", providerIssue.GetBody())
+	req.Equal("open", providerIssue.GetState())
+}
+
+func TestAPIRefreshPullCIHidesOnlyRemovedUpstreamItems(t *testing.T) {
+	require := require.New(t)
+	srv, database, providerClient, _ := setupTestServerWithFixtureClient(t)
+	ctx := t.Context()
+	seedPRWithHeadSHA(t, database, "acme", "widget", 1, "visible-head")
+	seedPRWithHeadSHA(t, database, "acme", "widget", 2, "removed-head")
+	repo, err := database.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
+	require.NoError(err)
+	require.NotNil(repo)
+	markArchiveItemLifecycle(t, database, repo.ID, db.ArchiveItemTypeMergeRequest, 1, db.ArchiveLifecycleStateInaccessible)
+	markArchiveItemLifecycle(t, database, repo.ID, db.ArchiveItemTypeMergeRequest, 2, db.ArchiveLifecycleStateRemovedUpstream)
+	providerClient.CheckRuns["acme/widget@visible-head"] = []*gh.CheckRun{}
+
+	client := setupTestClient(t, srv)
+	visible, err := client.HTTP.RefreshPullCiWithResponse(ctx, "github", "acme", "widget", 1)
+	require.NoError(err)
+	require.Equal(http.StatusOK, visible.StatusCode(), string(visible.Body))
+	removed, err := client.HTTP.RefreshPullCiWithResponse(ctx, "github", "acme", "widget", 2)
+	require.NoError(err)
+	require.Equal(http.StatusNotFound, removed.StatusCode(), string(removed.Body))
+	require.NotNil(removed.ApplicationproblemJSONDefault)
+	require.Equal(
+		generated.ProblemErrorCode("pullNotFound"),
+		removed.ApplicationproblemJSONDefault.Code,
+	)
 }
 
 func TestAPIIssuesHideRemovedUpstreamArchiveRows(t *testing.T) {

--- a/internal/server/apitest/api_test.go
+++ b/internal/server/apitest/api_test.go
@@ -291,6 +291,12 @@ func TestAPIResolveAndAutocompleteHideOnlyRemovedUpstreamItems(t *testing.T) {
 	markArchiveItemLifecycle(t, database, repo.ID, db.ArchiveItemTypeMergeRequest, 2, db.ArchiveLifecycleStateRemovedUpstream)
 	markArchiveItemLifecycle(t, database, repo.ID, db.ArchiveItemTypeIssue, 3, db.ArchiveLifecycleStateInaccessible)
 	markArchiveItemLifecycle(t, database, repo.ID, db.ArchiveItemTypeIssue, 4, db.ArchiveLifecycleStateRemovedUpstream)
+	_, err = database.WriteDB().ExecContext(ctx, `
+		UPDATE forge_merge_requests SET author = CASE number
+			WHEN 1 THEN 'visible-pull-author' ELSE 'removed-pull-author' END;
+		UPDATE forge_issues SET author = CASE number
+			WHEN 3 THEN 'visible-issue-author' ELSE 'removed-issue-author' END`)
+	require.NoError(err)
 
 	now := gh.Timestamp{Time: time.Now().UTC().Truncate(time.Second)}
 	providerClient.PRs["acme/widget"] = []*gh.PullRequest{{
@@ -332,6 +338,20 @@ func TestAPIResolveAndAutocompleteHideOnlyRemovedUpstreamItems(t *testing.T) {
 		{Kind: "pull", Number: 1, Title: "Test PR #1", State: "open"},
 		{Kind: "issue", Number: 3, Title: "Test Issue", State: "open"},
 	}, *autocomplete.JSON200.References)
+
+	trigger = "@"
+	autocomplete, err = client.HTTP.GetCommentAutocompleteWithResponse(
+		ctx, "github", "acme", "widget",
+		&generated.GetCommentAutocompleteParams{Trigger: &trigger, Q: &query},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, autocomplete.StatusCode(), string(autocomplete.Body))
+	require.NotNil(autocomplete.JSON200)
+	require.NotNil(autocomplete.JSON200.Users)
+	require.ElementsMatch(
+		[]string{"visible-pull-author", "visible-issue-author"},
+		*autocomplete.JSON200.Users,
+	)
 }
 
 func TestAPIRemovedIssueMutationsReturnNotFoundWithoutProviderWrites(t *testing.T) {

--- a/internal/server/apitest/api_test.go
+++ b/internal/server/apitest/api_test.go
@@ -38,6 +38,90 @@ func TestAPIListPullsIncludesLabels(t *testing.T) {
 	}}, *(*resp.JSON200)[0].Labels)
 }
 
+func TestAPIPullsHideRemovedUpstreamArchiveRows(t *testing.T) {
+	require := require.New(t)
+	srv, database := setupTestServer(t)
+	ctx := t.Context()
+
+	seedPR(t, database, "acme", "widget", 1)
+	seedPR(t, database, "acme", "widget", 2)
+	repo, err := database.GetRepoByIdentity(
+		ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+	require.NotNil(repo)
+	now := time.Now().UTC().Truncate(time.Second)
+	_, err = database.WriteDB().ExecContext(ctx, `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES
+			(?, 'merge_request', 1, 'inaccessible-pr-1', ?, ?, 'inaccessible'),
+			(?, 'merge_request', 2, 'removed-pr-2', ?, ?, 'removed_upstream')`,
+		repo.ID, now, now, repo.ID, now, now,
+	)
+	require.NoError(err)
+
+	client := setupTestClient(t, srv)
+	state := "all"
+	listed, err := client.HTTP.ListPullsWithResponse(
+		ctx, &generated.ListPullsParams{State: &state},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, listed.StatusCode())
+	require.NotNil(listed.JSON200)
+	require.Len(*listed.JSON200, 1)
+	require.EqualValues(1, (*listed.JSON200)[0].Number)
+
+	detail, err := client.HTTP.GetPullWithResponse(
+		ctx, "gh", "acme", "widget", 2,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusNotFound, detail.StatusCode())
+}
+
+func TestAPIIssuesHideRemovedUpstreamArchiveRows(t *testing.T) {
+	require := require.New(t)
+	srv, database := setupTestServer(t)
+	ctx := t.Context()
+
+	seedIssue(t, database, "acme", "widget", 1, "open")
+	seedIssue(t, database, "acme", "widget", 2, "closed")
+	repo, err := database.GetRepoByIdentity(
+		ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+	require.NotNil(repo)
+	now := time.Now().UTC().Truncate(time.Second)
+	_, err = database.WriteDB().ExecContext(ctx, `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES
+			(?, 'issue', 1, 'inaccessible-issue-1', ?, ?, 'inaccessible'),
+			(?, 'issue', 2, 'removed-issue-2', ?, ?, 'removed_upstream')`,
+		repo.ID, now, now, repo.ID, now, now,
+	)
+	require.NoError(err)
+
+	client := setupTestClient(t, srv)
+	state := "all"
+	listed, err := client.HTTP.ListIssuesWithResponse(
+		ctx, &generated.ListIssuesParams{State: &state},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, listed.StatusCode())
+	require.NotNil(listed.JSON200)
+	require.Len(*listed.JSON200, 1)
+	require.EqualValues(1, (*listed.JSON200)[0].Number)
+
+	detail, err := client.HTTP.GetIssueWithResponse(
+		ctx, "gh", "acme", "widget", 2,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusNotFound, detail.StatusCode())
+}
+
 func TestAPIGetPull(t *testing.T) {
 	require := require.New(t)
 	srv, database := setupTestServer(t)

--- a/internal/server/apitest/api_test.go
+++ b/internal/server/apitest/api_test.go
@@ -39,17 +39,17 @@ func TestAPIListPullsIncludesLabels(t *testing.T) {
 }
 
 func TestAPIPullsHideRemovedUpstreamArchiveRows(t *testing.T) {
-	require := require.New(t)
+	req := require.New(t)
 	srv, database := setupTestServer(t)
 	ctx := t.Context()
 
-	seedPR(t, database, "acme", "widget", 1)
-	seedPR(t, database, "acme", "widget", 2)
+	inaccessiblePRID := seedPR(t, database, "acme", "widget", 1)
+	removedPRID := seedPR(t, database, "acme", "widget", 2)
 	repo, err := database.GetRepoByIdentity(
 		ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"),
 	)
-	require.NoError(err)
-	require.NotNil(repo)
+	req.NoError(err)
+	req.NotNil(repo)
 	now := time.Now().UTC().Truncate(time.Second)
 	_, err = database.WriteDB().ExecContext(ctx, `
 		INSERT INTO forge_archive_items (
@@ -60,24 +60,207 @@ func TestAPIPullsHideRemovedUpstreamArchiveRows(t *testing.T) {
 			(?, 'merge_request', 2, 'removed-pr-2', ?, ?, 'removed_upstream')`,
 		repo.ID, now, now, repo.ID, now, now,
 	)
-	require.NoError(err)
+	req.NoError(err)
 
 	client := setupTestClient(t, srv)
 	state := "all"
 	listed, err := client.HTTP.ListPullsWithResponse(
 		ctx, &generated.ListPullsParams{State: &state},
 	)
-	require.NoError(err)
-	require.Equal(http.StatusOK, listed.StatusCode())
-	require.NotNil(listed.JSON200)
-	require.Len(*listed.JSON200, 1)
-	require.EqualValues(1, (*listed.JSON200)[0].Number)
+	req.NoError(err)
+	req.Equal(http.StatusOK, listed.StatusCode())
+	req.NotNil(listed.JSON200)
+	req.Len(*listed.JSON200, 1)
+	req.EqualValues(1, (*listed.JSON200)[0].Number)
 
 	detail, err := client.HTTP.GetPullWithResponse(
 		ctx, "gh", "acme", "widget", 2,
 	)
+	req.NoError(err)
+	req.Equal(http.StatusNotFound, detail.StatusCode())
+
+	stackID, err := database.UpsertStack(ctx, repo.ID, 1, "Synthetic stack")
+	req.NoError(err)
+	req.NoError(database.ReplaceStackMembers(ctx, stackID, []db.StackMember{
+		{MergeRequestID: inaccessiblePRID, Position: 1},
+		{MergeRequestID: removedPRID, Position: 2},
+	}))
+
+	previewPath := "README.md"
+	readPaths := map[string]func() (int, error){
+		"commits": func() (int, error) {
+			resp, requestErr := client.HTTP.GetPullCommitsWithResponse(
+				ctx, "gh", "acme", "widget", 2,
+			)
+			return resp.StatusCode(), requestErr
+		},
+		"diff": func() (int, error) {
+			resp, requestErr := client.HTTP.GetPullDiffWithResponse(
+				ctx, "gh", "acme", "widget", 2, &generated.GetPullDiffParams{},
+			)
+			return resp.StatusCode(), requestErr
+		},
+		"file preview": func() (int, error) {
+			resp, requestErr := client.HTTP.GetPullFilePreviewWithResponse(
+				ctx, "gh", "acme", "widget", 2,
+				&generated.GetPullFilePreviewParams{Path: &previewPath},
+			)
+			return resp.StatusCode(), requestErr
+		},
+		"files": func() (int, error) {
+			resp, requestErr := client.HTTP.GetPullFilesWithResponse(
+				ctx, "gh", "acme", "widget", 2,
+			)
+			return resp.StatusCode(), requestErr
+		},
+		"import metadata": func() (int, error) {
+			resp, requestErr := client.HTTP.GetPullImportMetadataWithResponse(
+				ctx, "gh", "acme", "widget", 2,
+			)
+			return resp.StatusCode(), requestErr
+		},
+		"review draft": func() (int, error) {
+			resp, requestErr := client.HTTP.GetPrReviewDraftWithResponse(
+				ctx, "gh", "acme", "widget", 2,
+			)
+			return resp.StatusCode(), requestErr
+		},
+		"stack": func() (int, error) {
+			resp, requestErr := client.HTTP.GetPullStackWithResponse(
+				ctx, "gh", "acme", "widget", 2,
+			)
+			return resp.StatusCode(), requestErr
+		},
+	}
+	for name, readPath := range readPaths {
+		t.Run(name, func(t *testing.T) {
+			status, requestErr := readPath()
+			require.NoError(t, requestErr)
+			assert.Equal(t, http.StatusNotFound, status)
+		})
+	}
+
+	repoFilter := "acme/widget"
+	stacks, err := client.HTTP.ListStacksWithResponse(
+		ctx, &generated.ListStacksParams{Repo: &repoFilter},
+	)
+	req.NoError(err)
+	req.Equal(http.StatusOK, stacks.StatusCode())
+	req.NotNil(stacks.JSON200)
+	req.Len(*stacks.JSON200, 1)
+	req.NotNil((*stacks.JSON200)[0].Members)
+	req.Len(*(*stacks.JSON200)[0].Members, 1)
+	req.EqualValues(1, (*(*stacks.JSON200)[0].Members)[0].Number)
+}
+
+func TestAPIActivityAndRepoSummariesHideRemovedUpstreamArchiveRows(t *testing.T) {
+	require := require.New(t)
+	srv, database := setupTestServer(t)
+	ctx := t.Context()
+
+	inaccessiblePRID := seedPR(t, database, "acme", "widget", 1)
+	removedPRID := seedPR(t, database, "acme", "widget", 2)
+	inaccessibleIssueID := seedIssue(t, database, "acme", "widget", 3, "open")
+	removedIssueID := seedIssue(t, database, "acme", "widget", 4, "open")
+	repo, err := database.GetRepoByIdentity(
+		ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"),
+	)
 	require.NoError(err)
-	require.Equal(http.StatusNotFound, detail.StatusCode())
+	require.NotNil(repo)
+	now := time.Now().UTC().Truncate(time.Second)
+	_, err = database.WriteDB().ExecContext(ctx, `
+		UPDATE forge_merge_requests
+		SET author = CASE number WHEN 1 THEN 'visible-pr-author' ELSE 'removed-pr-author' END,
+		    is_draft = 1,
+		    created_at = CASE number WHEN 1 THEN ? ELSE ? END,
+		    updated_at = CASE number WHEN 1 THEN ? ELSE ? END,
+		    last_activity_at = CASE number WHEN 1 THEN ? ELSE ? END
+		WHERE repo_id = ? AND number IN (1, 2)`,
+		now.Add(-4*time.Minute), now.Add(-time.Minute),
+		now.Add(-4*time.Minute), now.Add(-time.Minute),
+		now.Add(-4*time.Minute), now.Add(-time.Minute), repo.ID,
+	)
+	require.NoError(err)
+	_, err = database.WriteDB().ExecContext(ctx, `
+		UPDATE forge_issues
+		SET author = CASE number WHEN 3 THEN 'visible-issue-author' ELSE 'removed-issue-author' END,
+		    title = CASE number WHEN 3 THEN 'Visible issue' ELSE 'Removed issue' END,
+		    created_at = CASE number WHEN 3 THEN ? ELSE ? END,
+		    updated_at = CASE number WHEN 3 THEN ? ELSE ? END,
+		    last_activity_at = CASE number WHEN 3 THEN ? ELSE ? END
+		WHERE repo_id = ? AND number IN (3, 4)`,
+		now.Add(-3*time.Minute), now,
+		now.Add(-3*time.Minute), now,
+		now.Add(-3*time.Minute), now, repo.ID,
+	)
+	require.NoError(err)
+	require.NoError(database.UpsertMREvents(ctx, []db.MREvent{
+		{MergeRequestID: inaccessiblePRID, PlatformExternalID: "visible-pr-comment", EventType: "issue_comment", Author: "visible-commenter", CreatedAt: now.Add(-2 * time.Minute), DedupeKey: "visible-pr-comment"},
+		{MergeRequestID: removedPRID, PlatformExternalID: "removed-pr-comment", EventType: "issue_comment", Author: "removed-commenter", CreatedAt: now, DedupeKey: "removed-pr-comment"},
+	}))
+	require.NoError(database.UpsertIssueEvents(ctx, []db.IssueEvent{
+		{IssueID: inaccessibleIssueID, PlatformExternalID: "visible-issue-comment", EventType: "issue_comment", Author: "visible-commenter", CreatedAt: now.Add(-2 * time.Minute), DedupeKey: "visible-issue-comment"},
+		{IssueID: removedIssueID, PlatformExternalID: "removed-issue-comment", EventType: "issue_comment", Author: "removed-commenter", CreatedAt: now, DedupeKey: "removed-issue-comment"},
+	}))
+	_, err = database.WriteDB().ExecContext(ctx, `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES
+			(?, 'merge_request', 1, 'inaccessible-pr-1', ?, ?, 'inaccessible'),
+			(?, 'merge_request', 2, 'removed-pr-2', ?, ?, 'removed_upstream'),
+			(?, 'issue', 3, 'inaccessible-issue-3', ?, ?, 'inaccessible'),
+			(?, 'issue', 4, 'removed-issue-4', ?, ?, 'removed_upstream')`,
+		repo.ID, now, now, repo.ID, now, now,
+		repo.ID, now, now, repo.ID, now, now,
+	)
+	require.NoError(err)
+
+	client := setupTestClient(t, srv)
+	since := now.Add(-time.Hour).Format(time.RFC3339)
+	activity, err := client.HTTP.ListActivityWithResponse(
+		ctx, &generated.ListActivityParams{Since: &since},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, activity.StatusCode())
+	require.NotNil(activity.JSON200)
+	require.NotNil(activity.JSON200.Items)
+	require.Len(*activity.JSON200.Items, 4)
+	for _, item := range *activity.JSON200.Items {
+		require.NotEqualValues(2, item.ItemNumber)
+		require.NotEqualValues(4, item.ItemNumber)
+	}
+	authors, err := client.HTTP.ListActivityAuthorsWithResponse(
+		ctx, &generated.ListActivityAuthorsParams{Since: &since},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, authors.StatusCode())
+	require.NotNil(authors.JSON200)
+	require.NotNil(authors.JSON200.Authors)
+	require.NotContains(*authors.JSON200.Authors, "removed-pr-author")
+	require.NotContains(*authors.JSON200.Authors, "removed-issue-author")
+
+	summaries, err := client.HTTP.ListRepoSummariesWithResponse(ctx)
+	require.NoError(err)
+	require.Equal(http.StatusOK, summaries.StatusCode())
+	require.NotNil(summaries.JSON200)
+	require.Len(*summaries.JSON200, 1)
+	summary := (*summaries.JSON200)[0]
+	require.EqualValues(1, summary.CachedPrCount)
+	require.EqualValues(1, summary.OpenPrCount)
+	require.EqualValues(1, summary.DraftPrCount)
+	require.EqualValues(1, summary.CachedIssueCount)
+	require.EqualValues(1, summary.OpenIssueCount)
+	require.NotNil(summary.ActiveAuthors)
+	require.Len(*summary.ActiveAuthors, 2)
+	require.ElementsMatch(
+		[]string{"visible-pr-author", "visible-issue-author"},
+		[]string{(*summary.ActiveAuthors)[0].Login, (*summary.ActiveAuthors)[1].Login},
+	)
+	require.NotNil(summary.RecentIssues)
+	require.Len(*summary.RecentIssues, 1)
+	require.EqualValues(3, (*summary.RecentIssues)[0].Number)
+	require.Equal("Visible issue", (*summary.RecentIssues)[0].Title)
 }
 
 func TestAPIIssuesHideRemovedUpstreamArchiveRows(t *testing.T) {

--- a/internal/server/apitest/api_test.go
+++ b/internal/server/apitest/api_test.go
@@ -411,6 +411,124 @@ func TestAPIRefreshPullCIHidesOnlyRemovedUpstreamItems(t *testing.T) {
 	)
 }
 
+func TestAPIRemovedPullMutationsReturnNotFoundWithoutProviderWrites(t *testing.T) {
+	req := require.New(t)
+	srv, database, providerClient, _ := setupTestServerWithFixtureClient(t)
+	ctx := t.Context()
+	seedPR(t, database, "acme", "widget", 7)
+	repo, err := database.GetRepoByIdentity(
+		ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	req.NoError(err)
+	req.NotNil(repo)
+	markArchiveItemLifecycle(
+		t, database, repo.ID, db.ArchiveItemTypeMergeRequest, 7,
+		db.ArchiveLifecycleStateRemovedUpstream,
+	)
+
+	now := gh.Timestamp{Time: time.Now().UTC().Truncate(time.Second)}
+	providerPR := &gh.PullRequest{
+		ID: new(int64(7007)), Number: new(7), Title: new("removed pull"),
+		State: new("open"), Draft: new(true), CreatedAt: &now, UpdatedAt: &now,
+	}
+	providerClient.PRs["acme/widget"] = []*gh.PullRequest{providerPR}
+	providerClient.OpenPRs["acme/widget"] = []*gh.PullRequest{providerPR}
+	client := setupTestClient(t, srv)
+
+	t.Run("post comment", func(t *testing.T) {
+		require := require.New(t)
+		resp, requestErr := client.HTTP.PostPrCommentWithResponse(
+			ctx, "github", "acme", "widget", 7,
+			generated.PostPrCommentJSONRequestBody{Body: "must not post"},
+		)
+		require.NoError(requestErr)
+		require.Equal(http.StatusNotFound, resp.StatusCode(), string(resp.Body))
+		require.NotNil(resp.ApplicationproblemJSONDefault)
+		require.Equal(
+			generated.ProblemErrorCode("pullNotFound"),
+			resp.ApplicationproblemJSONDefault.Code,
+		)
+	})
+
+	t.Run("ready for review", func(t *testing.T) {
+		require := require.New(t)
+		resp, requestErr := client.HTTP.MarkPullReadyForReviewWithResponse(
+			ctx, "github", "acme", "widget", 7,
+		)
+		require.NoError(requestErr)
+		require.Equal(http.StatusNotFound, resp.StatusCode(), string(resp.Body))
+		require.NotNil(resp.ApplicationproblemJSONDefault)
+		require.Equal(
+			generated.ProblemErrorCode("pullNotFound"),
+			resp.ApplicationproblemJSONDefault.Code,
+		)
+	})
+
+	req.Empty(providerClient.Comments["acme/widget#7"])
+	req.True(providerPR.GetDraft())
+}
+
+func TestAPISynchronousSyncRejectsRemovedUpstreamTombstones(t *testing.T) {
+	require := require.New(t)
+	srv, database, providerClient, _ := setupTestServerWithFixtureClient(t)
+	ctx := t.Context()
+	seedPR(t, database, "acme", "widget", 9)
+	seedIssue(t, database, "acme", "widget", 10, "open")
+	repo, err := database.GetRepoByIdentity(
+		ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+	require.NotNil(repo)
+	markArchiveItemLifecycle(
+		t, database, repo.ID, db.ArchiveItemTypeMergeRequest, 9,
+		db.ArchiveLifecycleStateRemovedUpstream,
+	)
+	markArchiveItemLifecycle(
+		t, database, repo.ID, db.ArchiveItemTypeIssue, 10,
+		db.ArchiveLifecycleStateRemovedUpstream,
+	)
+
+	now := gh.Timestamp{Time: time.Now().UTC().Truncate(time.Second)}
+	providerClient.PRs["acme/widget"] = []*gh.PullRequest{{
+		ID: new(int64(9009)), Number: new(9), Title: new("reappeared pull"),
+		State: new("open"), CreatedAt: &now, UpdatedAt: &now,
+		User: &gh.User{Login: new("provider-user")},
+		Head: &gh.PullRequestBranch{
+			Ref: new("feature"), SHA: new("head-sha"),
+			Repo: &gh.Repository{FullName: new("acme/widget")},
+		},
+		Base: &gh.PullRequestBranch{Ref: new("main"), SHA: new("base-sha")},
+	}}
+	providerClient.Issues["acme/widget"] = []*gh.Issue{{
+		ID: new(int64(1010)), Number: new(10), Title: new("reappeared issue"),
+		State: new("open"), CreatedAt: &now, UpdatedAt: &now,
+		User: &gh.User{Login: new("provider-user")},
+	}}
+	client := setupTestClient(t, srv)
+
+	pull, err := client.HTTP.SyncPullWithResponse(
+		ctx, "github", "acme", "widget", 9,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusNotFound, pull.StatusCode(), string(pull.Body))
+	require.NotNil(pull.ApplicationproblemJSONDefault)
+	require.Equal(
+		generated.ProblemErrorCode("pullNotFound"),
+		pull.ApplicationproblemJSONDefault.Code,
+	)
+
+	issue, err := client.HTTP.SyncIssueWithResponse(
+		ctx, "github", "acme", "widget", 10,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusNotFound, issue.StatusCode(), string(issue.Body))
+	require.NotNil(issue.ApplicationproblemJSONDefault)
+	require.Equal(
+		generated.ProblemErrorCode("issueNotFound"),
+		issue.ApplicationproblemJSONDefault.Code,
+	)
+}
+
 func TestAPIIssuesHideRemovedUpstreamArchiveRows(t *testing.T) {
 	require := require.New(t)
 	srv, database := setupTestServer(t)

--- a/internal/server/apitest/archive_test.go
+++ b/internal/server/apitest/archive_test.go
@@ -3,6 +3,7 @@ package apitest
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -190,6 +191,107 @@ func TestAPIArchiveStartPauseStatusAndReport(t *testing.T) {
 	require.Len(*startedAll.JSON200, 1)
 	assert.Equal(generated.ArchiveStatusResponseStatusWaitingForBudget, (*startedAll.JSON200)[0].Status,
 		"idempotent start preserves an active provider budget wait")
+}
+
+func TestAPIArchiveReportExcludesOnlyRemovedUpstreamParents(t *testing.T) {
+	require := require.New(t)
+	srv, database, provider, _, ref := setupArchiveTestServer(t, nil)
+	client := setupTestClient(t, srv)
+	ctx := t.Context()
+
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	repo, err := database.GetRepoByIdentity(ctx, platform.DBRepoIdentity(ref))
+	require.NoError(err)
+	require.NotNil(repo)
+
+	insertIssue := func(number int, externalID, lifecycle string) int64 {
+		result, insertErr := database.WriteDB().ExecContext(ctx, `
+			INSERT INTO forge_issues (
+				repo_id, platform_id, platform_external_id, number, url, title, author,
+				state, body, created_at, updated_at, last_activity_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, 'open', 'body', ?, ?, ?)`,
+			repo.ID, number, externalID, number,
+			"https://github.test/owner/repo/issues/"+fmt.Sprint(number),
+			"Synthetic issue "+fmt.Sprint(number), "issue-author", now, now, now,
+		)
+		require.NoError(insertErr)
+		id, insertErr := result.LastInsertId()
+		require.NoError(insertErr)
+		_, insertErr = database.WriteDB().ExecContext(ctx, `
+			INSERT INTO forge_archive_items (
+				repo_id, item_type, item_number, provider_item_id,
+				provider_created_at, provider_updated_at, lifecycle_state
+			) VALUES (?, 'issue', ?, ?, ?, ?, ?)`,
+			repo.ID, number, externalID, now, now, lifecycle,
+		)
+		require.NoError(insertErr)
+		return id
+	}
+	insertMR := func(number int, externalID, lifecycle string) int64 {
+		id, insertErr := database.UpsertMergeRequest(ctx, &db.MergeRequest{
+			RepoID: repo.ID, PlatformID: int64(number), PlatformExternalID: externalID,
+			Number: number, URL: "https://github.test/owner/repo/pull/" + fmt.Sprint(number),
+			Title: "Synthetic merge request " + fmt.Sprint(number), Author: "pr-author",
+			State: db.MergeRequestStateOpen, Body: "body",
+			CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+		})
+		require.NoError(insertErr)
+		_, insertErr = database.WriteDB().ExecContext(ctx, `
+			INSERT INTO forge_archive_items (
+				repo_id, item_type, item_number, provider_item_id,
+				provider_created_at, provider_updated_at, lifecycle_state
+			) VALUES (?, 'merge_request', ?, ?, ?, ?, ?)`,
+			repo.ID, number, externalID, now, now, lifecycle,
+		)
+		require.NoError(insertErr)
+		return id
+	}
+
+	inaccessibleIssueID := insertIssue(1, "inaccessible-issue-1", "inaccessible")
+	removedIssueID := insertIssue(2, "removed-issue-2", "removed_upstream")
+	inaccessibleMRID := insertMR(3, "inaccessible-pr-3", "inaccessible")
+	removedMRID := insertMR(4, "removed-pr-4", "removed_upstream")
+	require.NoError(database.UpsertIssueEvents(ctx, []db.IssueEvent{
+		{IssueID: inaccessibleIssueID, PlatformExternalID: "inaccessible-issue-comment", EventType: "issue_comment", Author: "commenter", CreatedAt: now.Add(time.Minute), DedupeKey: "inaccessible-issue-comment"},
+		{IssueID: removedIssueID, PlatformExternalID: "removed-issue-comment", EventType: "issue_comment", Author: "commenter", CreatedAt: now.Add(time.Minute), DedupeKey: "removed-issue-comment"},
+	}))
+	require.NoError(database.UpsertMREvents(ctx, []db.MREvent{
+		{MergeRequestID: inaccessibleMRID, PlatformExternalID: "inaccessible-pr-review", EventType: "review", Author: "reviewer", CreatedAt: now.Add(2 * time.Minute), DedupeKey: "inaccessible-pr-review"},
+		{MergeRequestID: removedMRID, PlatformExternalID: "removed-pr-review", EventType: "review", Author: "reviewer", CreatedAt: now.Add(2 * time.Minute), DedupeKey: "removed-pr-review"},
+	}))
+	_, err = database.WriteDB().ExecContext(ctx, `
+		UPDATE forge_archive_repos
+		SET issues_coverage = 'supported', merge_requests_coverage = 'supported'
+		WHERE repo_id = ?`, repo.ID)
+	require.NoError(err)
+
+	var removedCount int
+	require.NoError(database.ReadDB().QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM forge_archive_items
+		WHERE repo_id = ? AND lifecycle_state = 'removed_upstream'`, repo.ID,
+	).Scan(&removedCount))
+	require.Equal(2, removedCount)
+
+	verbose := true
+	response, err := client.HTTP.GetArchiveReportWithResponse(ctx, &generated.GetArchiveReportParams{
+		Start:   now.Add(-time.Hour).Format(time.RFC3339),
+		End:     now.Add(time.Hour).Format(time.RFC3339),
+		Verbose: &verbose,
+	})
+	require.NoError(err)
+	require.Equal(http.StatusOK, response.StatusCode())
+	require.NotNil(response.JSON200)
+	require.EqualValues(1, response.JSON200.Totals.IssuesOpened)
+	require.EqualValues(1, response.JSON200.Totals.MergeRequestsOpened)
+	require.EqualValues(1, response.JSON200.Totals.OrdinaryComments)
+	require.EqualValues(1, response.JSON200.Totals.ReviewsSubmitted)
+	require.NotNil(response.JSON200.Activity)
+	require.Len(*response.JSON200.Activity, 4)
+	for _, activity := range *response.JSON200.Activity {
+		require.NotEqualValues(2, activity.ItemNumber)
+		require.NotEqualValues(4, activity.ItemNumber)
+	}
+	require.Zero(provider.calls.Load(), "reports must read SQLite only")
 }
 
 func TestAPIArchiveValidationAndLimitProblemDetails(t *testing.T) {

--- a/internal/server/apitest/fixtures_test.go
+++ b/internal/server/apitest/fixtures_test.go
@@ -279,6 +279,27 @@ func seedIssueWithAssignees(t *testing.T, database *db.DB, owner, name string, n
 	return issueID
 }
 
+func markArchiveItemLifecycle(
+	t *testing.T,
+	database *db.DB,
+	repoID int64,
+	itemType db.ArchiveItemType,
+	number int,
+	lifecycle db.ArchiveLifecycleState,
+) {
+	t.Helper()
+	now := time.Now().UTC().Truncate(time.Second)
+	_, err := database.WriteDB().ExecContext(t.Context(), `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		repoID, itemType, number, fmt.Sprintf("%s-%d", itemType, number),
+		now, now, lifecycle,
+	)
+	require.NoError(t, err)
+}
+
 func verifiedGitHubRepoIdentity(host, owner, name string) db.RepoIdentity {
 	identity := db.GitHubRepoIdentity(host, owner, name)
 	identity.PlatformRepoID = "repo-" + owner + "-" + name

--- a/internal/server/apitest/labels_test.go
+++ b/internal/server/apitest/labels_test.go
@@ -243,6 +243,32 @@ func TestAPISetPullLabelsReplacesAssignedLabelsFromCatalog(t *testing.T) {
 	require.Equal("triage", resynced.Labels[0].Name)
 }
 
+func TestAPISetPullLabelsChecksVisibilityBeforeCatalogRefresh(t *testing.T) {
+	require := require.New(t)
+	srv, database, _, _ := setupLabelTestServer(t)
+	seedPR(t, database, "acme", "widget", 1)
+	repo, err := database.GetRepoByIdentity(
+		t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+	require.NotNil(repo)
+	markArchiveItemLifecycle(
+		t, database, repo.ID, db.ArchiveItemTypeMergeRequest, 1,
+		db.ArchiveLifecycleStateRemovedUpstream,
+	)
+
+	rr := doLabelAPIRequest(
+		t, srv, http.MethodPut, "/api/v1/pulls/github/acme/widget/1/labels",
+		map[string][]string{"labels": {"bug"}},
+	)
+	require.Equal(http.StatusNotFound, rr.Code, rr.Body.String())
+
+	catalog, freshness, err := database.ListRepoLabelCatalog(t.Context(), repo.ID)
+	require.NoError(err)
+	require.Empty(catalog)
+	require.Nil(freshness.CheckedAt)
+}
+
 func TestAPISetIssueLabelsReplacesAssignedLabelsViaProvider(t *testing.T) {
 	require := require.New(t)
 	srv, database, providerClient, _ := setupLabelTestServer(t)

--- a/internal/server/e2etest/archive_merge_metrics_test.go
+++ b/internal/server/e2etest/archive_merge_metrics_test.go
@@ -2,9 +2,12 @@ package e2etest
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -214,6 +217,220 @@ func TestArchiveHydrationRejectsInterveningMergeRequestSnapshotE2E(t *testing.T)
 	assert.Equal("intervening-merge-sha", stored.MergeCommitSHA)
 	require.NotNil(stored.FilesChanged)
 	assert.Equal(9, *stored.FilesChanged)
+}
+
+func TestArchiveReactivationReclassifiesWorkspaceHeadRepoE2E(t *testing.T) {
+	tests := []struct {
+		name       string
+		headOwner  string
+		headRepoID int64
+		headClone  string
+		expectKind generated.WorkspaceResponseMrHeadRepoKind
+	}{
+		{
+			name: "same repository", headOwner: "acme", headRepoID: 1,
+			headClone:  "https://github.com/acme/widget.git",
+			expectKind: generated.WorkspaceResponseMrHeadRepoKindSameRepo,
+		},
+		{
+			name: "fork", headOwner: "contributor", headRepoID: 2,
+			headClone:  "https://github.com/contributor/widget.git",
+			expectKind: generated.WorkspaceResponseMrHeadRepoKindFork,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testArchiveReactivationReclassifiesWorkspaceHeadRepo(t, tt.headOwner, tt.headRepoID, tt.headClone, tt.expectKind)
+		})
+	}
+}
+
+func testArchiveReactivationReclassifiesWorkspaceHeadRepo(
+	t *testing.T,
+	headOwner string,
+	headRepoID int64,
+	headClone string,
+	expectKind generated.WorkspaceResponseMrHeadRepoKind,
+) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	pullStarted := make(chan struct{})
+	releasePull := make(chan struct{})
+	var startOnce sync.Once
+
+	providerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		baseRepo := map[string]any{
+			"id": int64(1), "node_id": "R_widget", "name": "widget",
+			"full_name": "acme/widget", "clone_url": "https://github.com/acme/widget.git",
+			"owner": map[string]any{"login": "acme"},
+		}
+		switch r.URL.Path {
+		case "/api/graphql":
+			var request struct {
+				Query string `json:"query"`
+			}
+			assert.NoError(json.NewDecoder(r.Body).Decode(&request))
+			switch {
+			case strings.Contains(request.Query, "reviewThreads"):
+				_, _ = w.Write([]byte(`{"data":{"repository":{"pullRequest":{"reviewThreads":{"edges":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`))
+			case strings.Contains(request.Query, "timelineItems"):
+				_, _ = w.Write([]byte(`{"data":{"repository":{"pullRequest":{"timelineItems":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`))
+			default:
+				http.Error(w, `{"message":"unexpected GraphQL query"}`, http.StatusBadRequest)
+			}
+		case "/api/v3/repos/acme/widget":
+			assert.NoError(json.NewEncoder(w).Encode(baseRepo))
+		case "/api/v3/repos/acme/widget/pulls/7":
+			startOnce.Do(func() { close(pullStarted) })
+			<-releasePull
+			headRepo := map[string]any{
+				"id": headRepoID, "node_id": fmt.Sprintf("R_%d", headRepoID),
+				"name": "widget", "full_name": headOwner + "/widget",
+				"clone_url": headClone, "owner": map[string]any{"login": headOwner},
+			}
+			assert.NoError(json.NewEncoder(w).Encode(map[string]any{
+				"id": int64(7), "node_id": "PR_7", "number": 7,
+				"html_url": "https://github.com/acme/widget/pull/7",
+				"title":    "Reappeared pull", "state": "open", "merged": false,
+				"created_at": now.Add(-2 * time.Hour).Format(time.RFC3339),
+				"updated_at": now.Format(time.RFC3339),
+				"head":       map[string]any{"ref": "feature", "sha": "head-sha", "repo": headRepo},
+				"base":       map[string]any{"ref": "main", "sha": "base-sha", "repo": baseRepo},
+			}))
+		case "/api/v3/repos/acme/widget/commits/head-sha/check-runs":
+			assert.NoError(json.NewEncoder(w).Encode(map[string]any{
+				"total_count": 0, "check_runs": []any{},
+			}))
+		case "/api/v3/repos/acme/widget/commits/head-sha/status":
+			assert.NoError(json.NewEncoder(w).Encode(map[string]any{
+				"state": "success", "sha": "head-sha", "statuses": []any{},
+			}))
+		case "/api/v3/repos/acme/widget/actions/runs":
+			assert.NoError(json.NewEncoder(w).Encode(map[string]any{
+				"total_count": 0, "workflow_runs": []any{},
+			}))
+		default:
+			assert.NoError(json.NewEncoder(w).Encode([]any{}))
+		}
+	}))
+	t.Cleanup(providerServer.Close)
+
+	providerClient, err := ghclient.NewClient(
+		staticTokenSource("archive-token"), "github.com", nil, nil,
+		ghclient.WithBaseURLForTesting(providerServer.URL),
+	)
+	require.NoError(err)
+	registry, err := ghclient.NewProviderRegistry(map[string]ghclient.Client{
+		"github.com": providerClient,
+	})
+	require.NoError(err)
+	database := dbtest.Open(t)
+	ref := platform.RepoRef{
+		Platform: platform.KindGitHub, Host: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	}
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry, database, nil,
+		[]ghclient.RepoRef{{
+			Platform: ref.Platform, PlatformHost: ref.Host,
+			Owner: ref.Owner, Name: ref.Name, RepoPath: ref.RepoPath,
+		}},
+		time.Hour, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	archiveService, err := archive.NewService(
+		database, registry, nil, syncer, nil,
+		archiveMergeMetricsClock{now: now.Add(2 * time.Minute)},
+	)
+	require.NoError(err)
+	requireEnsureConfigured(t, archiveService, []platform.RepoRef{ref})
+
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{
+		Archive: archiveService, HostCheckAllowLoopbackAnyPort: true,
+		WorktreeDir: t.TempDir(), DisableWorkspaceBackgroundMonitors: true,
+	})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	forgeServer := httptest.NewServer(srv)
+	t.Cleanup(forgeServer.Close)
+	api, err := apiclient.NewWithHTTPClient(forgeServer.URL, forgeServer.Client())
+	require.NoError(err)
+	repositories := []generated.ArchiveRepositoryRef{{
+		Provider: "github", PlatformHost: "github.com",
+		Owner: ref.Owner, Name: ref.Name, RepoPath: ref.RepoPath,
+	}}
+	started, err := api.HTTP.StartArchivesWithResponse(
+		ctx, generated.ArchiveMutationBody{Repositories: &repositories},
+	)
+	require.NoError(err)
+	require.NotNil(started.JSON200)
+
+	repo, err := database.GetRepoByIdentity(ctx, platform.DBRepoIdentity(ref))
+	require.NoError(err)
+	require.NotNil(repo)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID: repo.ID, PlatformID: 7, PlatformExternalID: "PR_7", Number: 7,
+		URL: "https://github.com/acme/widget/pull/7", Title: "Stored pull",
+		State: db.MergeRequestStateOpen, PlatformHeadSHA: "old-head",
+		CreatedAt: now.Add(-3 * time.Hour), UpdatedAt: now.Add(-time.Hour),
+		LastActivityAt: now.Add(-time.Hour),
+	})
+	require.NoError(err)
+	unknownHead := ""
+	require.NoError(database.InsertWorkspace(ctx, &db.Workspace{
+		ID: "ws-reappeared", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget",
+		ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: 7,
+		GitHeadRef: "feature", MRHeadRepo: &unknownHead,
+		WorktreePath: t.TempDir(), Status: "creating",
+	}))
+	require.NoError(database.CommitArchiveInventoryPage(ctx, db.ArchiveInventoryCommit{
+		RepoID: repo.ID, ItemType: db.ArchiveItemTypeIssue,
+		ScanGeneration: 1, Exhausted: true, Coverage: db.ArchiveCoverageSupported,
+		Now: now,
+	}))
+	require.NoError(database.CommitArchiveInventoryPage(ctx, db.ArchiveInventoryCommit{
+		RepoID: repo.ID, ItemType: db.ArchiveItemTypeMergeRequest,
+		Items: []db.ArchiveInventoryItem{{
+			Number: 7, ProviderItemID: "PR_7",
+			ProviderCreatedAt: now.Add(-3 * time.Hour), ProviderUpdatedAt: now,
+		}},
+		ScanGeneration: 1, Exhausted: true, Coverage: db.ArchiveCoverageSupported,
+		Now: now,
+	}))
+	progress, err := database.GetDatasetProgress(
+		ctx, repo.ID, db.ArchiveItemTypeMergeRequest, 7, db.ArchiveDatasetLookup,
+	)
+	require.NoError(err)
+
+	runDone := make(chan error, 1)
+	go func() { runDone <- archiveService.RunEligible(ctx) }()
+	select {
+	case <-pullStarted:
+	case <-time.After(2 * time.Second):
+		require.Fail("archive hydration did not reach the provider pull request")
+	}
+	require.NoError(database.CommitArchiveItemSync(ctx, db.ArchiveItemSyncCommit{
+		RepoID: repo.ID, ItemType: db.ArchiveItemTypeMergeRequest, ItemNumber: 7,
+		ScanGeneration: progress.ScanGeneration, Outcome: db.ArchiveLookupRemoved,
+		Now: now.Add(time.Minute),
+	}))
+	close(releasePull)
+	require.NoError(<-runDone)
+
+	removed, err := database.IsArchiveItemRemovedUpstream(
+		ctx, repo.ID, db.ArchiveItemTypeMergeRequest, 7,
+	)
+	require.NoError(err)
+	require.False(removed)
+	detail, err := api.HTTP.GetWorkspaceWithResponse(ctx, "ws-reappeared")
+	require.NoError(err)
+	require.Equal(http.StatusOK, detail.StatusCode(), string(detail.Body))
+	require.NotNil(detail.JSON200)
+	require.NotNil(detail.JSON200.MrHeadRepoKind)
+	require.Equal(expectKind, *detail.JSON200.MrHeadRepoKind)
 }
 
 func testArchiveReportRepairsMergedMetricsAcrossRepositoryRename(

--- a/internal/server/e2etest/fleet_snapshot_test.go
+++ b/internal/server/e2etest/fleet_snapshot_test.go
@@ -130,6 +130,10 @@ func TestFleetSnapshotLocalE2E(t *testing.T) {
 		DisplayName: "widget", LocalPath: t.TempDir() + "/widget", DefaultBranch: "main",
 	})
 	require.NoError(err)
+	repoIdentity := dbpkg.GitHubRepoIdentity("github.com", "acme", "widget")
+	repoIdentity.PlatformRepoID = "repo-acme-widget"
+	_, err = database.UpsertRepo(ctx, repoIdentity)
+	require.NoError(err)
 	require.NoError(database.InsertWorkspace(ctx, &dbpkg.Workspace{
 		ID: "ws-1", Platform: "github", PlatformHost: "github.com",
 		RepoOwner: "acme", RepoName: "widget",
@@ -238,10 +242,9 @@ func TestFleetSnapshotIssueWorkspaceLinksIssueOnlyE2E(t *testing.T) {
 	ts, database := bootFleetServer(t, nil)
 	ctx := context.Background()
 
-	repoID, err := database.UpsertRepo(
-		ctx,
-		dbpkg.GitHubRepoIdentity("github.com", "acme", "widget"),
-	)
+	repoIdentity := dbpkg.GitHubRepoIdentity("github.com", "acme", "widget")
+	repoIdentity.PlatformRepoID = "repo-acme-widget"
+	repoID, err := database.UpsertRepo(ctx, repoIdentity)
 	require.NoError(err)
 	now := time.Now().UTC().Truncate(time.Second)
 	_, err = database.UpsertIssue(ctx, &dbpkg.Issue{

--- a/internal/server/e2etest/fleet_snapshot_test.go
+++ b/internal/server/e2etest/fleet_snapshot_test.go
@@ -3,6 +3,7 @@ package e2etest
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -171,6 +172,65 @@ func TestFleetSnapshotLocalE2E(t *testing.T) {
 	}
 	require.Len(prWorktrees, 1, "exactly one seeded PR workspace worktree")
 	require.Equal(7, *prWorktrees[0].LinkedPRNumber, "PR workspace must surface linkedPRNumber=7")
+}
+
+func TestFleetSnapshotRetainsWorktreeWithoutRemovedPullMetadataE2E(t *testing.T) {
+	require := require.New(t)
+	ts, database := bootFleetServer(t, nil)
+	ctx := t.Context()
+	repoID, err := database.UpsertRepo(
+		ctx, dbpkg.GitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+	now := time.Now().UTC().Truncate(time.Second)
+	mrID, err := database.UpsertMergeRequest(ctx, &dbpkg.MergeRequest{
+		RepoID: repoID, PlatformID: 7001, Number: 7,
+		URL: "https://github.com/acme/widget/pull/7", Title: "Removed pull",
+		Author: "dev", State: "open", IsDraft: true,
+		HeadBranch: "feature", BaseBranch: "main", CIStatus: "failure",
+		ReviewDecision: "changes_requested", MergeableState: "dirty",
+		Additions: 12, Deletions: 3, CommentCount: 5,
+		CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+	project, err := database.CreateProject(ctx, dbpkg.CreateProjectInput{
+		DisplayName: "widget", LocalPath: filepath.Join(t.TempDir(), "widget"),
+		DefaultBranch: "main", RepoID: sql.NullInt64{Int64: repoID, Valid: true},
+	})
+	require.NoError(err)
+	worktreePath := filepath.Join(t.TempDir(), "feature")
+	_, err = database.CreateProjectWorktree(ctx, dbpkg.CreateProjectWorktreeInput{
+		ProjectID: project.ID, Branch: "feature", Path: worktreePath,
+	})
+	require.NoError(err)
+	worktreeKey := "worktree:" + filepath.Clean(worktreePath)
+	require.NoError(database.SetWorktreeLinks(ctx, []dbpkg.WorktreeLink{{
+		MergeRequestID: mrID, WorktreeKey: worktreeKey,
+		WorktreePath: worktreePath, WorktreeBranch: "feature", LinkedAt: now,
+	}}))
+	_, err = database.WriteDB().ExecContext(ctx, `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES (?, 'merge_request', 7, 'pull-7', ?, ?, 'removed_upstream')`,
+		repoID, now, now,
+	)
+	require.NoError(err)
+
+	var snap fleet.Snapshot
+	getJSON(t, ts, "/api/v1/snapshot", &snap)
+	worktree := worktreeByScopedKey(snap.Worktrees, worktreeKey)
+	require.NotNil(worktree, "local project worktree remains in the fleet snapshot")
+	require.Equal("feature", worktree.Branch)
+	require.Nil(worktree.LinkedPRNumber)
+	require.Nil(worktree.PRTitle)
+	require.Nil(worktree.PRState)
+	require.Nil(worktree.ChecksStatus)
+	require.Nil(worktree.PRReviewDecision)
+	require.Nil(worktree.PRMergeable)
+	require.Nil(worktree.PRAdditions)
+	require.Nil(worktree.PRDeletions)
+	require.Nil(worktree.PRCommentCount)
 }
 
 func TestFleetSnapshotIssueWorkspaceLinksIssueOnlyE2E(t *testing.T) {

--- a/internal/server/e2etest/workspace_visibility_test.go
+++ b/internal/server/e2etest/workspace_visibility_test.go
@@ -1,0 +1,73 @@
+package e2etest
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/apiclient"
+	"go.kenn.io/forge/internal/db"
+)
+
+func TestWorkspaceAPIHidesRemovedAssociatedPullRequestE2E(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	ts, database := bootFleetServer(t, nil)
+
+	repoIdentity := db.GitHubRepoIdentity("github.com", "acme", "widget")
+	repoIdentity.PlatformRepoID = "repo-acme-widget"
+	repoID, err := database.UpsertRepo(ctx, repoIdentity)
+	require.NoError(err)
+	now := time.Now().UTC().Truncate(time.Second)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID: repoID, PlatformID: 4200, Number: 42,
+		URL: "https://github.com/acme/widget/pull/42", Title: "Removed pull",
+		Author: "dev", State: "open", HeadBranch: "feature", BaseBranch: "main",
+		CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+	associatedPR := 42
+	require.NoError(database.InsertWorkspace(ctx, &db.Workspace{
+		ID: "ws-adhoc", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget",
+		ItemType: db.WorkspaceItemTypeAdHoc, ItemKey: db.AdHocWorkspaceItemKey("feature"),
+		AssociatedPRNumber: &associatedPR,
+		GitHeadRef:         "feature", WorktreePath: t.TempDir(), Status: "creating",
+	}))
+	_, err = database.WriteDB().ExecContext(ctx, `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES (?, 'merge_request', 42, 'pull-42', ?, ?, 'removed_upstream')`,
+		repoID, now, now,
+	)
+	require.NoError(err)
+	summary, err := database.GetWorkspaceSummary(ctx, "ws-adhoc")
+	require.NoError(err)
+	require.NotNil(summary)
+	require.False(summary.AssociatedPRVisible)
+
+	client, err := apiclient.NewWithHTTPClient(ts.URL, ts.Client())
+	require.NoError(err)
+	list, err := client.HTTP.ListWorkspacesWithResponse(ctx)
+	require.NoError(err)
+	require.Equal(http.StatusOK, list.StatusCode(), string(list.Body))
+	require.NotNil(list.JSON200)
+	require.NotNil(list.JSON200.Workspaces)
+	require.Len(*list.JSON200.Workspaces, 1)
+	require.Equal("ws-adhoc", (*list.JSON200.Workspaces)[0].Id)
+	require.Nil((*list.JSON200.Workspaces)[0].AssociatedPrNumber)
+
+	detail, err := client.HTTP.GetWorkspaceWithResponse(ctx, "ws-adhoc")
+	require.NoError(err)
+	require.Equal(http.StatusOK, detail.StatusCode(), string(detail.Body))
+	require.NotNil(detail.JSON200)
+	require.Nil(detail.JSON200.AssociatedPrNumber)
+
+	stored, err := database.GetWorkspace(ctx, "ws-adhoc")
+	require.NoError(err)
+	require.NotNil(stored)
+	require.NotNil(stored.AssociatedPRNumber)
+	require.Equal(42, *stored.AssociatedPRNumber)
+}

--- a/internal/server/e2etest/workspace_visibility_test.go
+++ b/internal/server/e2etest/workspace_visibility_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/apiclient"
+	"go.kenn.io/forge/internal/apiclient/generated"
 	"go.kenn.io/forge/internal/db"
 )
 
@@ -70,4 +71,83 @@ func TestWorkspaceAPIHidesRemovedAssociatedPullRequestE2E(t *testing.T) {
 	require.NotNil(stored)
 	require.NotNil(stored.AssociatedPRNumber)
 	require.Equal(42, *stored.AssociatedPRNumber)
+}
+
+func TestWorkspaceAPIHidesProviderMetadataForReusedRouteE2E(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	ts, database := bootFleetServer(t, nil)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	original, accepted, err := database.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repo-original", Owner: "acme", Name: "widget",
+		RepoPath: "acme/widget",
+	}, now)
+	require.NoError(err)
+	require.True(accepted)
+	require.NotNil(original)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID: original.Repository.ID, PlatformID: 4200, Number: 42,
+		URL: "https://github.com/acme/widget/pull/42", Title: "Original pull",
+		Author: "dev", State: "open", HeadBranch: "feature", BaseBranch: "main",
+		CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+	associatedPR := 42
+	require.NoError(database.InsertWorkspace(ctx, &db.Workspace{
+		ID: "ws-associated", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget",
+		ItemType: db.WorkspaceItemTypeAdHoc, ItemKey: db.AdHocWorkspaceItemKey("feature"),
+		AssociatedPRNumber: &associatedPR,
+		GitHeadRef:         "feature", WorktreePath: t.TempDir(), Status: "ready",
+	}))
+	forkHead := "https://github.com/contributor/widget.git"
+	require.NoError(database.InsertWorkspace(ctx, &db.Workspace{
+		ID: "ws-pull", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget",
+		ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: 42,
+		GitHeadRef: "feature", MRHeadRepo: &forkHead,
+		WorktreePath: t.TempDir(), Status: "ready",
+	}))
+
+	_, accepted, err = database.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repo-original", Owner: "acme", Name: "renamed-widget",
+		RepoPath: "acme/renamed-widget",
+	}, now.Add(time.Minute))
+	require.NoError(err)
+	require.True(accepted)
+	_, accepted, err = database.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repo-replacement", Owner: "acme", Name: "widget",
+		RepoPath: "acme/widget",
+	}, now.Add(2*time.Minute))
+	require.NoError(err)
+	require.True(accepted)
+
+	pullSummary, err := database.GetWorkspaceSummary(ctx, "ws-pull")
+	require.NoError(err)
+	require.NotNil(pullSummary)
+	require.False(pullSummary.SourceItemVisible)
+	associatedSummary, err := database.GetWorkspaceSummary(ctx, "ws-associated")
+	require.NoError(err)
+	require.NotNil(associatedSummary)
+	require.False(associatedSummary.AssociatedPRVisible)
+
+	client, err := apiclient.NewWithHTTPClient(ts.URL, ts.Client())
+	require.NoError(err)
+	list, err := client.HTTP.ListWorkspacesWithResponse(ctx)
+	require.NoError(err)
+	require.Equal(http.StatusOK, list.StatusCode(), string(list.Body))
+	require.NotNil(list.JSON200)
+	require.NotNil(list.JSON200.Workspaces)
+	require.Len(*list.JSON200.Workspaces, 2)
+	byID := make(map[string]generated.WorkspaceResponse, 2)
+	for _, workspace := range *list.JSON200.Workspaces {
+		byID[workspace.Id] = workspace
+	}
+	require.Nil(byID["ws-associated"].AssociatedPrNumber)
+	require.Nil(byID["ws-pull"].MrHeadRepoKind)
+	require.Nil(byID["ws-pull"].MrTitle)
 }

--- a/internal/server/fleetapi/fleet_adapter.go
+++ b/internal/server/fleetapi/fleet_adapter.go
@@ -291,11 +291,15 @@ func worktreeFromWorkspace(sum db.WorkspaceSummary, wtKey, projKey string) fleet
 		SessionBackend: sessionBackendForWorkspace(sum),
 	}
 	if sum.ItemType == db.WorkspaceItemTypeIssue {
-		wt.LinkedIssueNumbers = []int{sum.ItemNumber}
+		if sum.SourceItemVisible {
+			wt.LinkedIssueNumbers = []int{sum.ItemNumber}
+		}
 		// AssociatedPRNumber is the PR linked to the issue, if any. The
 		// summary does not carry that PR's title/state/checks, so only the
 		// number is surfaced, never PR display fields built from issue data.
-		wt.LinkedPRNumber = sum.AssociatedPRNumber
+		if sum.AssociatedPRVisible {
+			wt.LinkedPRNumber = sum.AssociatedPRNumber
+		}
 		return wt
 	}
 	if sum.ItemType == db.WorkspaceItemTypeKataTask {
@@ -304,7 +308,12 @@ func worktreeFromWorkspace(sum db.WorkspaceSummary, wtKey, projKey string) fleet
 	if sum.ItemType == db.WorkspaceItemTypeAdHoc {
 		// Ad-hoc workspaces have no provider item; only a PR later detected
 		// for the pushed branch can be linked.
-		wt.LinkedPRNumber = sum.AssociatedPRNumber
+		if sum.AssociatedPRVisible {
+			wt.LinkedPRNumber = sum.AssociatedPRNumber
+		}
+		return wt
+	}
+	if sum.ItemType == db.WorkspaceItemTypePullRequest && !sum.SourceItemVisible {
 		return wt
 	}
 	// Pull-request workspaces: the PR number is the item itself, and the

--- a/internal/server/fleetapi/fleet_adapter_test.go
+++ b/internal/server/fleetapi/fleet_adapter_test.go
@@ -585,8 +585,10 @@ func TestWorktreeFromWorkspaceIssueExposesIssueLink(t *testing.T) {
 			ItemNumber:         42,
 			AssociatedPRNumber: &associatedPR,
 		},
-		MRTitle: &issueTitle,
-		MRState: &issueState,
+		MRTitle:             &issueTitle,
+		MRState:             &issueState,
+		SourceItemVisible:   true,
+		AssociatedPRVisible: true,
 	}
 	wt := worktreeFromWorkspace(sum, "worktree:/tmp/wt-issue", "repo:/tmp")
 	require.Equal([]int{42}, wt.LinkedIssueNumbers, "issue number must surface as the issue link")
@@ -613,13 +615,14 @@ func TestWorktreeFromWorkspacePRPopulatesPRFields(t *testing.T) {
 			ItemType:     db.WorkspaceItemTypePullRequest,
 			ItemNumber:   7,
 		},
-		MRTitle:          &title,
-		MRState:          &state,
-		MRReviewDecision: &reviewDecision,
-		MRMergeableState: &mergeable,
-		MRAdditions:      &additions,
-		MRDeletions:      &deletions,
-		MRCommentCount:   &comments,
+		MRTitle:           &title,
+		MRState:           &state,
+		MRReviewDecision:  &reviewDecision,
+		MRMergeableState:  &mergeable,
+		MRAdditions:       &additions,
+		MRDeletions:       &deletions,
+		MRCommentCount:    &comments,
+		SourceItemVisible: true,
 	}
 	wt := worktreeFromWorkspace(sum, "worktree:/tmp/wt-pr", "repo:/tmp")
 	require.Empty(wt.LinkedIssueNumbers, "PR workspaces carry no issue link")
@@ -639,6 +642,64 @@ func TestWorktreeFromWorkspacePRPopulatesPRFields(t *testing.T) {
 	require.Equal(9, *wt.PRDeletions)
 	require.NotNil(wt.PRCommentCount)
 	require.Equal(4, *wt.PRCommentCount)
+}
+
+func TestWorktreeFromWorkspaceHidesRemovedSourceAndAssociatedItems(t *testing.T) {
+	require := require.New(t)
+	associatedPR := 99
+	title := "Retained title"
+	state := "open"
+
+	tests := []struct {
+		name    string
+		summary db.WorkspaceSummary
+	}{
+		{
+			name: "pull request source",
+			summary: db.WorkspaceSummary{
+				Workspace: db.Workspace{
+					WorktreePath: "/tmp/wt-removed-pr",
+					ItemType:     db.WorkspaceItemTypePullRequest,
+					ItemNumber:   7,
+				},
+				MRTitle: &title,
+				MRState: &state,
+			},
+		},
+		{
+			name: "issue source and associated pull request",
+			summary: db.WorkspaceSummary{
+				Workspace: db.Workspace{
+					WorktreePath:       "/tmp/wt-removed-issue",
+					ItemType:           db.WorkspaceItemTypeIssue,
+					ItemNumber:         42,
+					AssociatedPRNumber: &associatedPR,
+				},
+			},
+		},
+		{
+			name: "ad hoc associated pull request",
+			summary: db.WorkspaceSummary{
+				Workspace: db.Workspace{
+					WorktreePath:       "/tmp/wt-removed-associated-pr",
+					ItemType:           db.WorkspaceItemTypeAdHoc,
+					AssociatedPRNumber: &associatedPR,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wt := worktreeFromWorkspace(
+				tt.summary, "worktree:"+tt.summary.WorktreePath, "repo:/tmp",
+			)
+			require.Empty(wt.LinkedIssueNumbers)
+			require.Nil(wt.LinkedPRNumber)
+			require.Nil(wt.PRTitle)
+			require.Nil(wt.PRState)
+		})
+	}
 }
 
 // TestWorktreeFromWorkspacePREnrichmentOmitsZeroAndEmpty guards the

--- a/internal/server/fleetapi/fleet_adapter_test.go
+++ b/internal/server/fleetapi/fleet_adapter_test.go
@@ -106,6 +106,11 @@ func TestBuildLocalRawOverlaysWorkspaceOntoProjectWorktree(t *testing.T) {
 		DisplayName: "app", LocalPath: filepath.Join(t.TempDir(), "app"), DefaultBranch: "main",
 	})
 	require.NoError(err)
+	_, err = database.UpsertRepo(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: "repo-o-app",
+		Owner: "o", Name: "app", RepoPath: "o/app",
+	})
+	require.NoError(err)
 
 	shared := filepath.Join(t.TempDir(), "shared-wt")
 	_, err = database.CreateProjectWorktree(ctx, db.CreateProjectWorktreeInput{

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1099,6 +1099,17 @@ func (s *Server) syncPR(ctx context.Context, input *repoNumberInput) (*syncPROut
 	if err != nil {
 		return nil, httpapi.ProviderRouteLookupError(err)
 	}
+	removed, err := s.db.IsArchiveItemRemovedUpstream(
+		ctx, repo.ID, db.ArchiveItemTypeMergeRequest, input.Number,
+	)
+	if err != nil {
+		return nil, httpapi.Internal("check pull request visibility: " + err.Error())
+	}
+	if removed {
+		return nil, httpapi.NotFound(
+			httpapi.CodePullNotFound, "pull request not found", nil,
+		)
+	}
 	// SyncMR distinguishes a non-fatal diff failure from a hard sync failure
 	// via DiffSyncError. The PR row, timeline, and CI status are all current
 	// in either case, so degrade gracefully: keep the response, but report
@@ -1120,7 +1131,7 @@ func (s *Server) syncPR(ctx context.Context, input *repoNumberInput) (*syncPROut
 		)
 	}
 
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	mr, err := s.db.GetVisibleMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("get pull request: " + err.Error())
 	}
@@ -1187,6 +1198,17 @@ func (s *Server) syncIssue(ctx context.Context, input *issueRepoNumberInput) (*s
 	if err != nil {
 		return nil, httpapi.ProviderRouteLookupError(err)
 	}
+	removed, err := s.db.IsArchiveItemRemovedUpstream(
+		ctx, repo.ID, db.ArchiveItemTypeIssue, input.Number,
+	)
+	if err != nil {
+		return nil, httpapi.Internal("check issue visibility: " + err.Error())
+	}
+	if removed {
+		return nil, httpapi.NotFound(
+			httpapi.CodeIssueNotFound, "issue not found", nil,
+		)
+	}
 	err = s.syncer.SyncIssueOnProvider(
 		ctx, httpapi.ProviderKind(*repo), httpapi.ProviderHost(*repo),
 		repo.Owner, repo.Name, input.Number,
@@ -1202,7 +1224,7 @@ func (s *Server) syncIssue(ctx context.Context, input *issueRepoNumberInput) (*s
 		)
 	}
 
-	issue, err := s.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	issue, err := s.db.GetVisibleIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("get issue: " + err.Error())
 	}

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1167,6 +1167,17 @@ func (s *Server) enqueuePRSync(ctx context.Context, input *repoNumberInput) (*ac
 	if err != nil {
 		return nil, httpapi.ProviderRouteLookupError(err)
 	}
+	removed, err := s.db.IsArchiveItemRemovedUpstream(
+		ctx, repo.ID, db.ArchiveItemTypeMergeRequest, input.Number,
+	)
+	if err != nil {
+		return nil, httpapi.Internal("check pull request visibility: " + err.Error())
+	}
+	if removed {
+		return nil, httpapi.NotFound(
+			httpapi.CodePullNotFound, "pull request not found", nil,
+		)
+	}
 	kind := httpapi.ProviderKind(*repo)
 	host := httpapi.ProviderHost(*repo)
 	key := "pr:" + string(kind) + ":" + host + ":" + repo.RepoPath +
@@ -1183,6 +1194,15 @@ func (s *Server) enqueuePRSync(ctx context.Context, input *repoNumberInput) (*ac
 			"number", input.Number,
 		},
 		func(ctx context.Context) error {
+			removed, err := s.db.IsArchiveItemRemovedUpstream(
+				ctx, repo.ID, db.ArchiveItemTypeMergeRequest, input.Number,
+			)
+			if err != nil {
+				return fmt.Errorf("check pull request visibility: %w", err)
+			}
+			if removed {
+				return nil
+			}
 			return s.syncer.SyncMROnProvider(
 				ctx, kind, host, repo.Owner, repo.Name, input.Number,
 			)
@@ -1246,6 +1266,17 @@ func (s *Server) enqueueIssueSync(ctx context.Context, input *issueRepoNumberInp
 	if err != nil {
 		return nil, httpapi.ProviderRouteLookupError(err)
 	}
+	removed, err := s.db.IsArchiveItemRemovedUpstream(
+		ctx, repo.ID, db.ArchiveItemTypeIssue, input.Number,
+	)
+	if err != nil {
+		return nil, httpapi.Internal("check issue visibility: " + err.Error())
+	}
+	if removed {
+		return nil, httpapi.NotFound(
+			httpapi.CodeIssueNotFound, "issue not found", nil,
+		)
+	}
 	kind := httpapi.ProviderKind(*repo)
 	host := httpapi.ProviderHost(*repo)
 	key := "issue:" + string(kind) + ":" + host + ":" + repo.RepoPath +
@@ -1262,6 +1293,15 @@ func (s *Server) enqueueIssueSync(ctx context.Context, input *issueRepoNumberInp
 			"number", input.Number,
 		},
 		func(ctx context.Context) error {
+			removed, err := s.db.IsArchiveItemRemovedUpstream(
+				ctx, repo.ID, db.ArchiveItemTypeIssue, input.Number,
+			)
+			if err != nil {
+				return fmt.Errorf("check issue visibility: %w", err)
+			}
+			if removed {
+				return nil
+			}
 			return s.syncer.SyncIssueOnProvider(
 				ctx, kind, host, repo.Owner, repo.Name, input.Number,
 			)

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1045,7 +1045,7 @@ func (s *Server) syncPRCI(ctx context.Context, input *repoNumberInput) (*syncPRC
 		return nil, httpapi.ProviderRouteLookupError(err)
 	}
 
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	mr, err := s.db.GetVisibleMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("get pull request: " + err.Error())
 	}
@@ -1077,7 +1077,7 @@ func (s *Server) syncPRCI(ctx context.Context, input *repoNumberInput) (*syncPRC
 		)
 	}
 
-	mr, err = s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	mr, err = s.db.GetVisibleMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("get pull request: " + err.Error())
 	}
@@ -1809,6 +1809,27 @@ func (s *Server) resolveItem(
 			},
 		}, nil
 	}
+	archiveTypes := []db.ArchiveItemType{
+		db.ArchiveItemTypeMergeRequest,
+		db.ArchiveItemTypeIssue,
+	}
+	switch itemTypeHint {
+	case "pr":
+		archiveTypes = []db.ArchiveItemType{db.ArchiveItemTypeMergeRequest}
+	case "issue":
+		archiveTypes = []db.ArchiveItemType{db.ArchiveItemTypeIssue}
+	}
+	for _, archiveType := range archiveTypes {
+		removed, removedErr := s.db.IsArchiveItemRemovedUpstream(
+			ctx, repo.ID, archiveType, number,
+		)
+		if removedErr != nil {
+			return nil, httpapi.Internal("resolve item: " + removedErr.Error())
+		}
+		if removed {
+			return nil, httpapi.NotFound(httpapi.CodeNotFound, "item not found", nil)
+		}
+	}
 
 	if providerKind == platform.KindGitLab && itemTypeHint != "" {
 		var syncErr error
@@ -1905,6 +1926,14 @@ func (s *Server) resolveItem(
 			"err", err,
 		)
 	}
+	resolvedType, visible, resolveErr := s.db.ResolveItemNumber(ctx, repo.ID, number)
+	if resolveErr != nil {
+		return nil, httpapi.Internal("resolve item: " + resolveErr.Error())
+	}
+	if !visible {
+		return nil, httpapi.NotFound(httpapi.CodeNotFound, "item not found", nil)
+	}
+	itemType = resolvedType
 
 	return &resolveItemOutput{
 		Body: resolveItemResponse{

--- a/internal/server/issueapi/mutation_handlers.go
+++ b/internal/server/issueapi/mutation_handlers.go
@@ -28,6 +28,10 @@ func (s *Handler) postIssueComment(ctx context.Context, input *postIssueCommentI
 	if err := s.requireSyncerCapability(*repo, capabilityCommentMutation); err != nil {
 		return nil, err
 	}
+	issueID, err := s.lookupIssueID(ctx, repo, input.Number)
+	if err != nil {
+		return nil, err
+	}
 	mutator, err := s.syncer.CommentMutator(httpapi.ProviderKind(*repo), httpapi.ProviderHost(*repo))
 	if err != nil {
 		return nil, httpapi.UnsupportedCapability(*repo, capabilityCommentMutation)
@@ -38,10 +42,6 @@ func (s *Handler) postIssueComment(ctx context.Context, input *postIssueCommentI
 			err, string(httpapi.ProviderKind(*repo)), httpapi.ProviderHost(*repo),
 			"create comment on provider failed",
 		)
-	}
-	issueID, err := s.lookupIssueID(ctx, repo, input.Number)
-	if err != nil {
-		return nil, httpapi.NotFound(httpapi.CodeIssueNotFound, err.Error(), nil)
 	}
 	event := platform.DBIssueEvent(issueID, providerEvent)
 	// Preserve the established best-effort local write: provider success is
@@ -63,13 +63,13 @@ func (s *Handler) editIssueComment(ctx context.Context, input *editIssueCommentI
 	if err := s.requireSyncerCapability(*repo, capabilityCommentMutation); err != nil {
 		return nil, err
 	}
+	issueID, err := s.lookupIssueID(ctx, repo, input.Number)
+	if err != nil {
+		return nil, err
+	}
 	mutator, err := s.syncer.CommentMutator(httpapi.ProviderKind(*repo), httpapi.ProviderHost(*repo))
 	if err != nil {
 		return nil, httpapi.UnsupportedCapability(*repo, capabilityCommentMutation)
-	}
-	issueID, err := s.lookupIssueID(ctx, repo, input.Number)
-	if err != nil {
-		return nil, httpapi.NotFound(httpapi.CodeIssueNotFound, err.Error(), nil)
 	}
 	exists, err := s.db.IssueCommentEventExists(ctx, issueID, input.CommentID)
 	if err != nil {
@@ -118,13 +118,13 @@ func (s *Handler) deleteIssueComment(ctx context.Context, input *deleteIssueComm
 	if err := s.requireSyncerCapability(*repo, capabilityCommentMutation); err != nil {
 		return nil, err
 	}
+	issueID, err := s.lookupIssueID(ctx, repo, input.Number)
+	if err != nil {
+		return nil, err
+	}
 	mutator, err := s.syncer.CommentMutator(httpapi.ProviderKind(*repo), httpapi.ProviderHost(*repo))
 	if err != nil {
 		return nil, httpapi.UnsupportedCapability(*repo, capabilityCommentMutation)
-	}
-	issueID, err := s.lookupIssueID(ctx, repo, input.Number)
-	if err != nil {
-		return nil, httpapi.NotFound(httpapi.CodeIssueNotFound, err.Error(), nil)
 	}
 	exists, err := s.db.IssueCommentEventExists(ctx, issueID, input.CommentID)
 	if err != nil {
@@ -143,29 +143,39 @@ func (s *Handler) deleteIssueComment(ctx context.Context, input *deleteIssueComm
 }
 
 func (s *Handler) lookupIssueID(ctx context.Context, repo *db.Repo, number int) (int64, error) {
-	issue, err := s.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, number)
+	issue, err := s.requireVisibleIssue(ctx, repo, number)
 	if err != nil {
 		return 0, err
-	}
-	if issue == nil {
-		return 0, fmt.Errorf("issue %s/%s#%d on %s not found", repo.Owner, repo.Name, number, repo.PlatformHost)
 	}
 	return issue.ID, nil
 }
 
+func (s *Handler) requireVisibleIssue(
+	ctx context.Context,
+	repo *db.Repo,
+	number int,
+) (*db.Issue, error) {
+	issue, err := s.db.GetVisibleIssueByRepoIDAndNumber(ctx, repo.ID, number)
+	if err != nil {
+		return nil, httpapi.Internal("get issue failed: " + err.Error())
+	}
+	if issue == nil {
+		return nil, httpapi.NotFound(
+			httpapi.CodeIssueNotFound,
+			fmt.Sprintf("issue %s/%s#%d on %s not found", repo.Owner, repo.Name, number, repo.PlatformHost),
+			nil,
+		)
+	}
+	return issue, nil
+}
+
 func (s *Handler) setIssueLabels(ctx context.Context, input *setIssueLabelsInput) (*setLabelsOutput, error) {
-	repo, names, err := s.resolveRequestedLabelNames(
-		ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, input.Body.LabelNames(),
+	repo, issue, names, err := s.resolveRequestedLabelNames(
+		ctx, input.Provider, input.PlatformHost, input.Owner, input.Name,
+		input.Number, input.Body.LabelNames(),
 	)
 	if err != nil {
 		return nil, err
-	}
-	issue, err := s.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)
-	if err != nil {
-		return nil, httpapi.Internal("get issue failed")
-	}
-	if issue == nil {
-		return nil, httpapi.NotFound(httpapi.CodeIssueNotFound, "issue not found", nil)
 	}
 	if s.syncer == nil {
 		return nil, httpapi.UnsupportedCapability(*repo, capabilityLabelMutation)
@@ -184,7 +194,7 @@ func (s *Handler) setIssueLabels(ctx context.Context, input *setIssueLabelsInput
 	if err := s.db.ReplaceIssueLabels(ctx, repo.ID, issue.ID, labels); err != nil {
 		return nil, httpapi.Internal("save issue labels failed")
 	}
-	stored, err := s.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	stored, err := s.db.GetVisibleIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil || stored == nil {
 		return nil, httpapi.Internal("get issue failed")
 	}
@@ -194,31 +204,36 @@ func (s *Handler) setIssueLabels(ctx context.Context, input *setIssueLabelsInput
 func (s *Handler) resolveRequestedLabelNames(
 	ctx context.Context,
 	provider, platformHost, owner, name string,
+	number int,
 	names []string,
-) (*db.Repo, []string, error) {
+) (*db.Repo, *db.Issue, []string, error) {
 	repo, err := s.resolver.LookupRoute(ctx, provider, platformHost, owner, name)
 	if err != nil {
-		return nil, nil, httpapi.ProviderRouteLookupError(err)
+		return nil, nil, nil, httpapi.ProviderRouteLookupError(err)
 	}
 	caps := s.resolver.CapabilitiesForRepo(*repo)
 	if !httpapi.CapabilityEnabled(caps, capabilityReadLabels) {
-		return nil, nil, httpapi.UnsupportedCapability(*repo, capabilityReadLabels)
+		return nil, nil, nil, httpapi.UnsupportedCapability(*repo, capabilityReadLabels)
 	}
 	if !httpapi.CapabilityEnabled(caps, capabilityLabelMutation) {
-		return nil, nil, httpapi.UnsupportedCapability(*repo, capabilityLabelMutation)
+		return nil, nil, nil, httpapi.UnsupportedCapability(*repo, capabilityLabelMutation)
+	}
+	issue, err := s.requireVisibleIssue(ctx, repo, number)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 	if names == nil {
-		return nil, nil, httpapi.Validation("body.labels", "labels must be an array")
+		return nil, nil, nil, httpapi.Validation("body.labels", "labels must be an array")
 	}
 	catalog, freshness, err := s.db.ListRepoLabelCatalog(ctx, repo.ID)
 	if err != nil {
-		return nil, nil, httpapi.Internal("list repo labels failed")
+		return nil, nil, nil, httpapi.Internal("list repo labels failed")
 	}
 	if labelCatalogStale(freshness, time.Now().UTC()) && s.syncer != nil {
 		_ = s.syncer.RefreshRepoLabelCatalog(ctx, *repo)
 		catalog, _, err = s.db.ListRepoLabelCatalog(ctx, repo.ID)
 		if err != nil {
-			return nil, nil, httpapi.Internal("list repo labels failed")
+			return nil, nil, nil, httpapi.Internal("list repo labels failed")
 		}
 	}
 	catalogByName := make(map[string]struct{}, len(catalog))
@@ -230,13 +245,13 @@ func (s *Handler) resolveRequestedLabelNames(
 	for _, raw := range names {
 		label := strings.TrimSpace(raw)
 		if label == "" {
-			return nil, nil, httpapi.Validation("body.labels", "label names must not be empty")
+			return nil, nil, nil, httpapi.Validation("body.labels", "label names must not be empty")
 		}
 		if _, ok := seen[label]; ok {
-			return nil, nil, httpapi.Validation("body.labels", fmt.Sprintf("duplicate label %q", label))
+			return nil, nil, nil, httpapi.Validation("body.labels", fmt.Sprintf("duplicate label %q", label))
 		}
 		if _, ok := catalogByName[label]; !ok {
-			return nil, nil, httpapi.NewProblem(
+			return nil, nil, nil, httpapi.NewProblem(
 				http.StatusBadRequest, httpapi.CodeValidationError,
 				fmt.Sprintf("label %q is not in the repository label catalog", label),
 				map[string]any{"field": "body.labels", "label": label},
@@ -245,7 +260,7 @@ func (s *Handler) resolveRequestedLabelNames(
 		seen[label] = struct{}{}
 		resolved = append(resolved, label)
 	}
-	return repo, resolved, nil
+	return repo, issue, resolved, nil
 }
 
 func (s *Handler) setIssueAssignees(ctx context.Context, input *setIssueAssigneesInput) (*setAssigneesOutput, error) {
@@ -255,12 +270,9 @@ func (s *Handler) setIssueAssignees(ctx context.Context, input *setIssueAssignee
 	if err != nil {
 		return nil, err
 	}
-	issue, err := s.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	issue, err := s.requireVisibleIssue(ctx, repo, input.Number)
 	if err != nil {
-		return nil, httpapi.Internal("get issue failed")
-	}
-	if issue == nil {
-		return nil, httpapi.NotFound(httpapi.CodeIssueNotFound, "issue not found", nil)
+		return nil, err
 	}
 	mutator, err := s.syncer.AssigneeMutator(httpapi.ProviderKind(*repo), httpapi.ProviderHost(*repo))
 	if err != nil {
@@ -322,12 +334,9 @@ func (s *Handler) setIssueGitHubState(ctx context.Context, input *githubStateInp
 	if err != nil {
 		return nil, err
 	}
-	issue, err := s.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	issue, err := s.requireVisibleIssue(ctx, repo, input.Number)
 	if err != nil {
-		return nil, httpapi.Internal("get issue: " + err.Error())
-	}
-	if issue == nil {
-		return nil, httpapi.NotFound(httpapi.CodeIssueNotFound, "issue not found", nil)
+		return nil, err
 	}
 	if err := s.requireSyncerCapability(*repo, capabilityStateMutation); err != nil {
 		return nil, err

--- a/internal/server/issueapi/routes.go
+++ b/internal/server/issueapi/routes.go
@@ -149,7 +149,7 @@ func (s *Handler) getIssue(ctx context.Context, input *issueRepoNumberInput) (*g
 	if err != nil {
 		return nil, httpapi.ProviderRouteLookupError(err)
 	}
-	issue, err := s.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	issue, err := s.db.GetVisibleIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("get issue failed")
 	}

--- a/internal/server/issueapi/routes.go
+++ b/internal/server/issueapi/routes.go
@@ -234,19 +234,16 @@ func (s *Handler) editIssueContent(ctx context.Context, input *editIssueContentI
 	if err != nil {
 		return nil, err
 	}
+	issue, err := s.requireVisibleIssue(ctx, repo, input.Number)
+	if err != nil {
+		return nil, err
+	}
 	if err := s.requireSyncerCapability(*repo, capabilityStateMutation); err != nil {
 		return nil, err
 	}
 	mutator, err := s.syncer.IssueContentMutator(httpapi.ProviderKind(*repo), httpapi.ProviderHost(*repo))
 	if err != nil {
 		return nil, httpapi.UnsupportedCapability(*repo, capabilityStateMutation)
-	}
-	issue, err := s.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)
-	if err != nil {
-		return nil, httpapi.Internal("get issue failed")
-	}
-	if issue == nil {
-		return nil, httpapi.NotFound(httpapi.CodeIssueNotFound, "issue not found", nil)
 	}
 	updated, err := mutator.EditIssueContent(ctx, httpapi.PlatformRepoRef(*repo), input.Number, input.Body.Title, input.Body.Body)
 	if err != nil {
@@ -271,7 +268,7 @@ func (s *Handler) editIssueContent(ctx context.Context, input *editIssueContentI
 	if err := s.db.UpdateIssueTitleBody(ctx, issue.ID, newTitle, newBody, updatedAt); err != nil {
 		return nil, httpapi.Internal("update title/body failed")
 	}
-	issue, err = s.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	issue, err = s.db.GetVisibleIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil || issue == nil {
 		return nil, httpapi.Internal("re-read issue failed")
 	}

--- a/internal/server/kata/links.go
+++ b/internal/server/kata/links.go
@@ -420,7 +420,7 @@ func (h *Handler) resolveProviderKataLinkSubject(
 	var externalID string
 	switch kind {
 	case db.KataLinkSubjectIssue:
-		issue, err := h.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, number)
+		issue, err := h.db.GetVisibleIssueByRepoIDAndNumber(ctx, repo.ID, number)
 		if err != nil {
 			return db.KataLinkSubject{}, httpapi.Internal("get issue failed")
 		}
@@ -429,7 +429,7 @@ func (h *Handler) resolveProviderKataLinkSubject(
 		}
 		externalID = strings.TrimSpace(issue.PlatformExternalID)
 	case db.KataLinkSubjectPullRequest:
-		pull, err := h.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, number)
+		pull, err := h.db.GetVisibleMergeRequestByRepoIDAndNumber(ctx, repo.ID, number)
 		if err != nil {
 			return db.KataLinkSubject{}, httpapi.Internal("get pull request failed")
 		}

--- a/internal/server/kata/links_test.go
+++ b/internal/server/kata/links_test.go
@@ -208,6 +208,70 @@ func TestKataLinkRouteRequiresProviderExternalID(t *testing.T) {
 	assert.Zero(count)
 }
 
+func TestKataLinkRoutesHideRemovedProviderSubjects(t *testing.T) {
+	kataDaemon := newKataLinkTestDaemon(t)
+	configureKataLinkTestDaemon(t, kataDaemon.URL)
+	srv, database := setupTestServer(t)
+
+	for _, kind := range []db.KataLinkSubjectKind{
+		db.KataLinkSubjectIssue,
+		db.KataLinkSubjectPullRequest,
+	} {
+		t.Run(string(kind), func(t *testing.T) {
+			require := require.New(t)
+			number := 42
+			externalID := "removed-item"
+			repoID := insertKataProviderSubject(
+				t, database, platform.KindGitHub, platform.DefaultGitHubHost,
+				"widget-"+string(kind), number, kind, externalID,
+			)
+			created, err := database.CreateKataIssueLink(t.Context(), db.KataIssueLink{
+				Subject: db.KataLinkSubject{
+					Kind: kind, RepoID: repoID, ProviderItemExternalID: externalID,
+				},
+				DaemonID: "primary", ProjectUID: "project-a", IssueUID: "issue-a",
+			})
+			require.NoError(err)
+			now := time.Now().UTC().Truncate(time.Second)
+			itemType := db.ArchiveItemTypeIssue
+			if kind == db.KataLinkSubjectPullRequest {
+				itemType = db.ArchiveItemTypeMergeRequest
+			}
+			_, err = database.WriteDB().ExecContext(t.Context(), `
+				INSERT INTO forge_archive_items (
+					repo_id, item_type, item_number, provider_item_id,
+					provider_created_at, provider_updated_at, lifecycle_state
+				) VALUES (?, ?, ?, ?, ?, ?, 'removed_upstream')`,
+				repoID, itemType, number, externalID, now, now,
+			)
+			require.NoError(err)
+
+			base := kataProviderLinkRoute(
+				platform.KindGitHub, platform.DefaultGitHubHost,
+				"widget-"+string(kind), number, kind, false,
+			)
+			for _, request := range []struct {
+				method string
+				path   string
+				body   any
+			}{
+				{method: http.MethodGet, path: base},
+				{method: http.MethodPost, path: base, body: map[string]any{
+					"daemon_id": "primary", "project_uid": "project-a", "issue_uid": "issue-a",
+				}},
+				{method: http.MethodDelete, path: fmt.Sprintf("%s/%d", base, created.ID)},
+			} {
+				rr := doJSON(t, srv, request.method, request.path, request.body)
+				require.Equal(http.StatusNotFound, rr.Code, rr.Body.String())
+			}
+			links, err := database.ListKataIssueLinks(t.Context(), created.Subject)
+			require.NoError(err)
+			require.Len(links, 1)
+			require.Equal(created.ID, links[0].ID)
+		})
+	}
+}
+
 func newKataLinkTestDaemon(t *testing.T) *httptest.Server {
 	t.Helper()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/pullapi/assignee_reviewer_handlers.go
+++ b/internal/server/pullapi/assignee_reviewer_handlers.go
@@ -52,7 +52,7 @@ func (s *Handler) setPullAssignees(
 		return nil, err
 	}
 
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	mr, err := s.visibleMergeRequest(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("get pull failed")
 	}
@@ -94,7 +94,7 @@ func (s *Handler) setPullReviewers(
 		return nil, err
 	}
 
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	mr, err := s.visibleMergeRequest(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("get pull failed")
 	}

--- a/internal/server/pullapi/deferred_merge.go
+++ b/internal/server/pullapi/deferred_merge.go
@@ -116,7 +116,7 @@ func (s *Handler) enqueueDeferredMerge(
 	if err := s.requireSyncerCapability(*repo, capabilityMergeMutation); err != nil {
 		return deferMergePRBody{}, err
 	}
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, number)
+	mr, err := s.visibleMergeRequest(ctx, repo.ID, number)
 	if err != nil {
 		return deferMergePRBody{}, httpapi.Internal("get pull request failed")
 	}
@@ -266,7 +266,7 @@ func (s *Handler) refreshDeferredMergeCI(
 	pendingKeys []deferredMergeCheckKey,
 	queuedTarget deferredMergeTargetSnapshot,
 ) (string, error) {
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, number)
+	mr, err := s.visibleMergeRequest(ctx, repo.ID, number)
 	if err != nil {
 		return "", err
 	}
@@ -292,7 +292,7 @@ func (s *Handler) refreshDeferredMergeCI(
 	if len(warnings) > 0 {
 		return "", errors.New("could not refresh CI checks; deferred merge was not performed: " + strings.Join(warnings, "; "))
 	}
-	refreshed, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, number)
+	refreshed, err := s.visibleMergeRequest(ctx, repo.ID, number)
 	if err != nil {
 		return "", err
 	}
@@ -349,7 +349,7 @@ func (s *Handler) refreshPendingDeferredMergeCheckKeys(
 			map[string]any{"reason": "ci_refresh_unavailable", "warnings": warnings},
 		)
 	}
-	refreshed, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, number)
+	refreshed, err := s.visibleMergeRequest(ctx, repo.ID, number)
 	if err != nil {
 		return nil, nil, httpapi.Internal("get pull request after CI refresh failed")
 	}
@@ -439,7 +439,7 @@ func (s *Handler) completeDeferredMerge(
 }
 
 func (s *Handler) ensureDeferredMergeTargetUnchanged(ctx context.Context, repo db.Repo, number int, queuedTarget deferredMergeTargetSnapshot) error {
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, number)
+	mr, err := s.visibleMergeRequest(ctx, repo.ID, number)
 	if err != nil {
 		return err
 	}

--- a/internal/server/pullapi/diff_review_handlers.go
+++ b/internal/server/pullapi/diff_review_handlers.go
@@ -200,7 +200,7 @@ func (s *Handler) applyReviewSuggestions(
 		availability.Code == "rate_limited" {
 		return nil, operationRateLimitedProblem(*repo, availability)
 	}
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	mr, err := s.visibleMergeRequest(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("get pull request failed")
 	}
@@ -491,7 +491,7 @@ func (s *Handler) publishDiffReviewDraft(
 	if err != nil {
 		return nil, err
 	}
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	mr, err := s.visibleMergeRequest(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("get pull request failed")
 	}
@@ -713,7 +713,7 @@ func (s *Handler) setDiffReviewThreadResolved(
 	if err != nil {
 		return nil, err
 	}
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	mr, err := s.visibleMergeRequest(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("get pull request failed")
 	}
@@ -768,7 +768,7 @@ func (s *Handler) lookupReviewDraftTarget(
 	if err != nil {
 		return nil, nil, providerRouteLookupError(err)
 	}
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, number)
+	mr, err := s.visibleMergeRequest(ctx, repo.ID, number)
 	if err != nil {
 		return nil, nil, huma.Error500InternalServerError("get pull request failed")
 	}
@@ -791,7 +791,7 @@ func (s *Handler) lookupReviewDraftMutationTarget(
 	if err != nil {
 		return nil, nil, err
 	}
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, number)
+	mr, err := s.visibleMergeRequest(ctx, repo.ID, number)
 	if err != nil {
 		return nil, nil, huma.Error500InternalServerError("get pull request failed")
 	}

--- a/internal/server/pullapi/diff_review_handlers.go
+++ b/internal/server/pullapi/diff_review_handlers.go
@@ -472,10 +472,29 @@ func (s *Handler) syncAfterReviewSuggestionApply(repo db.Repo, number int) {
 			"source", "review_suggestion_apply",
 		},
 		func(ctx context.Context) error {
-			return s.syncer.SyncMROnProvider(
-				ctx, kind, host, repo.Owner, repo.Name, number,
-			)
+			return s.syncMergeRequestIfVisible(ctx, repo, number)
 		},
+	)
+}
+
+func (s *Handler) syncMergeRequestIfVisible(
+	ctx context.Context,
+	repo db.Repo,
+	number int,
+) error {
+	removed, err := s.db.IsArchiveItemRemovedUpstream(
+		ctx, repo.ID, db.ArchiveItemTypeMergeRequest, number,
+	)
+	if err != nil {
+		return fmt.Errorf("check pull request visibility: %w", err)
+	}
+	if removed {
+		return nil
+	}
+	return s.syncer.SyncMROnProvider(
+		ctx,
+		repoProviderKind(repo), repoProviderHost(repo),
+		repo.Owner, repo.Name, number,
 	)
 }
 
@@ -626,10 +645,8 @@ func (s *Handler) tryIngestPublishedReviewThreads(
 
 func (s *Handler) syncAfterReviewDraftPublish(repo db.Repo, number int) {
 	s.runBackground(func(bgCtx context.Context) {
-		if syncErr := s.syncer.SyncMROnProvider(
-			bgCtx,
-			repoProviderKind(repo), repoProviderHost(repo),
-			repo.Owner, repo.Name, number,
+		if syncErr := s.syncMergeRequestIfVisible(
+			bgCtx, repo, number,
 		); syncErr != nil {
 			slog.Warn("background sync after review draft publish", "err", syncErr)
 		}

--- a/internal/server/pullapi/diff_review_handlers_test.go
+++ b/internal/server/pullapi/diff_review_handlers_test.go
@@ -1,12 +1,94 @@
 package pullapi
 
 import (
+	"context"
+	"errors"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	gh "github.com/google/go-github/v89/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/db"
+	ghclient "go.kenn.io/forge/internal/github"
+	"go.kenn.io/forge/internal/testutil"
+	"go.kenn.io/forge/internal/testutil/dbtest"
 )
+
+type countingReviewSyncClient struct {
+	ghclient.Client
+	pullCalls atomic.Int32
+}
+
+func (c *countingReviewSyncClient) GetPullRequest(
+	context.Context, string, string, int,
+) (*gh.PullRequest, error) {
+	c.pullCalls.Add(1)
+	return nil, errors.New("removed pull must not be fetched")
+}
+
+func TestReviewBackgroundSyncsRecheckRemovedUpstream(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := dbtest.Open(t)
+	identity := db.GitHubRepoIdentity("github.com", "acme", "widget")
+	identity.PlatformRepoID = "repo-acme-widget"
+	repoID, err := database.UpsertRepo(ctx, identity)
+	require.NoError(err)
+	now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID: repoID, PlatformID: 7, PlatformExternalID: "pull-7", Number: 7,
+		Title: "Removed pull", State: db.MergeRequestStateOpen,
+		CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+	_, err = database.WriteDB().ExecContext(ctx, `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES (?, 'merge_request', 7, 'pull-7', ?, ?, 'removed_upstream')`,
+		repoID, now, now,
+	)
+	require.NoError(err)
+	repo, err := database.GetRepoByID(ctx, repoID)
+	require.NoError(err)
+	require.NotNil(repo)
+
+	client := &countingReviewSyncClient{Client: testutil.NewFixtureClient()}
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": client}, database, nil,
+		[]ghclient.RepoRef{{
+			Platform: "github", PlatformHost: "github.com",
+			Owner: "acme", Name: "widget", PlatformExternalID: "repo-acme-widget",
+		}},
+		time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	var queued func(context.Context) error
+	handler := New(Deps{
+		DB: database, Syncer: syncer,
+		EnqueueDetailSyncOrRerun: func(
+			_ string, _ []any, fn func(context.Context) error,
+		) bool {
+			queued = fn
+			return true
+		},
+	})
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(handler.Shutdown(shutdownCtx))
+	})
+
+	handler.syncAfterReviewSuggestionApply(*repo, 7)
+	require.NotNil(queued)
+	require.NoError(queued(ctx))
+	handler.syncAfterReviewDraftPublish(*repo, 7)
+	handler.bgWG.Wait()
+	require.Zero(client.pullCalls.Load())
+}
 
 func TestDBReviewLineRangeRejectsMalformedMultilineRanges(t *testing.T) {
 	validLine := 10

--- a/internal/server/pullapi/helpers.go
+++ b/internal/server/pullapi/helpers.go
@@ -8,6 +8,7 @@ import (
 
 	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/platform"
+	"go.kenn.io/forge/internal/server/httpapi"
 )
 
 type repoNumberPathRef struct {
@@ -44,6 +45,29 @@ func (s *Handler) visibleMergeRequest(
 	ctx context.Context, repoID int64, number int,
 ) (*db.MergeRequest, error) {
 	return s.db.GetVisibleMergeRequestByRepoIDAndNumber(ctx, repoID, number)
+}
+
+// requireVisibleMergeRequest is the public pull mutation boundary. It must run
+// before provider access so a retained removed-upstream row cannot cause an
+// external side effect.
+func (s *Handler) requireVisibleMergeRequest(
+	ctx context.Context, repo *db.Repo, number int,
+) (*db.MergeRequest, error) {
+	mr, err := s.visibleMergeRequest(ctx, repo.ID, number)
+	if err != nil {
+		return nil, httpapi.Internal("get pull request failed: " + err.Error())
+	}
+	if mr == nil {
+		return nil, httpapi.NotFound(
+			httpapi.CodePullNotFound,
+			fmt.Sprintf(
+				"pull request %s/%s#%d on %s not found",
+				repo.Owner, repo.Name, number, repo.PlatformHost,
+			),
+			nil,
+		)
+	}
+	return mr, nil
 }
 
 func (s *Handler) visibleDiffSHAs(

--- a/internal/server/pullapi/helpers.go
+++ b/internal/server/pullapi/helpers.go
@@ -37,9 +37,35 @@ func (s *Handler) lookupRepoMap(ctx context.Context) (map[int64]db.Repo, error) 
 	return buildRepoLookup(repos), nil
 }
 
+// visibleMergeRequest is the public pull API's read boundary. Provider sync
+// paths deliberately use the unfiltered getter so retained archive evidence
+// can still be repaired.
+func (s *Handler) visibleMergeRequest(
+	ctx context.Context, repoID int64, number int,
+) (*db.MergeRequest, error) {
+	return s.db.GetVisibleMergeRequestByRepoIDAndNumber(ctx, repoID, number)
+}
+
+func (s *Handler) visibleDiffSHAs(
+	ctx context.Context, repoID int64, number int,
+) (*db.DiffSHAs, error) {
+	mr, err := s.visibleMergeRequest(ctx, repoID, number)
+	if err != nil || mr == nil {
+		return nil, err
+	}
+	return &db.DiffSHAs{
+		PlatformHeadSHA: mr.PlatformHeadSHA,
+		PlatformBaseSHA: mr.PlatformBaseSHA,
+		DiffHeadSHA:     mr.DiffHeadSHA,
+		DiffBaseSHA:     mr.DiffBaseSHA,
+		MergeBaseSHA:    mr.MergeBaseSHA,
+		State:           string(mr.State),
+	}, nil
+}
+
 // filterConfiguredRepos returns only repos that are currently tracked.
 func (s *Handler) lookupMRID(ctx context.Context, ref repoNumberPathRef) (int64, error) {
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(
+	mr, err := s.visibleMergeRequest(
 		ctx, ref.repoID, ref.number,
 	)
 	if err != nil {

--- a/internal/server/pullapi/label_handlers.go
+++ b/internal/server/pullapi/label_handlers.go
@@ -27,24 +27,17 @@ func (s *Handler) setPullLabels(
 	ctx context.Context,
 	input *setPullLabelsInput,
 ) (*setLabelsOutput, error) {
-	repo, names, err := s.resolveRequestedLabelNames(
+	repo, mr, names, err := s.resolveRequestedLabelNames(
 		ctx,
 		input.Provider,
 		input.PlatformHost,
 		input.Owner,
 		input.Name,
+		input.Number,
 		input.Body.LabelNames(),
 	)
 	if err != nil {
 		return nil, err
-	}
-
-	mr, err := s.visibleMergeRequest(ctx, repo.ID, input.Number)
-	if err != nil {
-		return nil, httpapi.Internal("get pull failed")
-	}
-	if mr == nil {
-		return nil, httpapi.NotFound(httpapi.CodePullNotFound, "pull not found", nil)
 	}
 
 	if s.syncer == nil {
@@ -84,32 +77,37 @@ func (s *Handler) resolveRequestedLabelNames(
 	platformHost string,
 	owner string,
 	name string,
+	number int,
 	names []string,
-) (*db.Repo, []string, error) {
+) (*db.Repo, *db.MergeRequest, []string, error) {
 	repo, err := s.lookupRepoByProviderRoute(ctx, provider, platformHost, owner, name)
 	if err != nil {
-		return nil, nil, providerRouteLookupError(err)
+		return nil, nil, nil, providerRouteLookupError(err)
 	}
 	caps := s.capabilitiesForRepo(*repo)
 	if !capabilityEnabled(caps, capabilityReadLabels) {
-		return nil, nil, unsupportedCapabilityProblem(*repo, capabilityReadLabels)
+		return nil, nil, nil, unsupportedCapabilityProblem(*repo, capabilityReadLabels)
 	}
 	if !capabilityEnabled(caps, capabilityLabelMutation) {
-		return nil, nil, unsupportedCapabilityProblem(*repo, capabilityLabelMutation)
+		return nil, nil, nil, unsupportedCapabilityProblem(*repo, capabilityLabelMutation)
+	}
+	mr, err := s.requireVisibleMergeRequest(ctx, repo, number)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 	if names == nil {
-		return nil, nil, httpapi.Validation("body.labels", "labels must be an array")
+		return nil, nil, nil, httpapi.Validation("body.labels", "labels must be an array")
 	}
 
 	catalog, freshness, err := s.db.ListRepoLabelCatalog(ctx, repo.ID)
 	if err != nil {
-		return nil, nil, httpapi.Internal("list repo labels failed")
+		return nil, nil, nil, httpapi.Internal("list repo labels failed")
 	}
 	if labelCatalogStale(freshness, time.Now().UTC()) && s.syncer != nil {
 		_ = s.syncer.RefreshRepoLabelCatalog(ctx, *repo)
 		catalog, _, err = s.db.ListRepoLabelCatalog(ctx, repo.ID)
 		if err != nil {
-			return nil, nil, httpapi.Internal("list repo labels failed")
+			return nil, nil, nil, httpapi.Internal("list repo labels failed")
 		}
 	}
 	catalogByName := make(map[string]struct{}, len(catalog))
@@ -122,15 +120,15 @@ func (s *Handler) resolveRequestedLabelNames(
 	for _, raw := range names {
 		labelName := strings.TrimSpace(raw)
 		if labelName == "" {
-			return nil, nil, httpapi.Validation("body.labels", "label names must not be empty")
+			return nil, nil, nil, httpapi.Validation("body.labels", "label names must not be empty")
 		}
 		if _, ok := seen[labelName]; ok {
-			return nil, nil, httpapi.Validation(
+			return nil, nil, nil, httpapi.Validation(
 				"body.labels", fmt.Sprintf("duplicate label %q", labelName),
 			)
 		}
 		if _, ok := catalogByName[labelName]; !ok {
-			return nil, nil, httpapi.NewProblem(
+			return nil, nil, nil, httpapi.NewProblem(
 				http.StatusBadRequest,
 				httpapi.CodeValidationError,
 				fmt.Sprintf("label %q is not in the repository label catalog", labelName),
@@ -140,7 +138,7 @@ func (s *Handler) resolveRequestedLabelNames(
 		seen[labelName] = struct{}{}
 		resolved = append(resolved, labelName)
 	}
-	return repo, resolved, nil
+	return repo, mr, resolved, nil
 }
 
 func labelCatalogStale(freshness db.LabelCatalogFreshness, now time.Time) bool {

--- a/internal/server/pullapi/label_handlers.go
+++ b/internal/server/pullapi/label_handlers.go
@@ -39,7 +39,7 @@ func (s *Handler) setPullLabels(
 		return nil, err
 	}
 
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	mr, err := s.visibleMergeRequest(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("get pull failed")
 	}
@@ -71,7 +71,7 @@ func (s *Handler) setPullLabels(
 	// Re-read the stored rows: the label store merges provider responses
 	// with the repo label catalog, so providers that return bare names
 	// (GitLab) still yield color and description here.
-	stored, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	stored, err := s.visibleMergeRequest(ctx, repo.ID, input.Number)
 	if err != nil || stored == nil {
 		return nil, httpapi.Internal("get pull failed")
 	}

--- a/internal/server/pullapi/routes.go
+++ b/internal/server/pullapi/routes.go
@@ -952,6 +952,10 @@ func (s *Handler) postComment(ctx context.Context, input *postCommentInput) (*po
 	if err := s.requireSyncerCapability(*repo, capabilityCommentMutation); err != nil {
 		return nil, err
 	}
+	mr, err := s.requireVisibleMergeRequest(ctx, repo, input.Number)
+	if err != nil {
+		return nil, err
+	}
 
 	mutator, err := s.syncer.CommentMutator(
 		repoProviderKind(*repo), repoProviderHost(*repo),
@@ -971,19 +975,7 @@ func (s *Handler) postComment(ctx context.Context, input *postCommentInput) (*po
 		)
 	}
 
-	ref := repoNumberPathRef{
-		repoID:       repo.ID,
-		owner:        repo.Owner,
-		name:         repo.Name,
-		number:       input.Number,
-		platformHost: repo.PlatformHost,
-	}
-	mrID, err := s.lookupMRID(ctx, ref)
-	if err != nil {
-		return nil, httpapi.NotFound(httpapi.CodePullNotFound, err.Error(), nil)
-	}
-
-	event := platform.DBMREvent(mrID, platformEvent)
+	event := platform.DBMREvent(mr.ID, platformEvent)
 	if err := s.db.UpsertMREvents(ctx, []db.MREvent{event}); err != nil {
 		_ = err
 	}
@@ -1575,6 +1567,9 @@ func (s *Handler) readyForReview(ctx context.Context, input *repoNumberInput) (*
 		return nil, err
 	}
 	if err := s.requireSyncerCapability(*repo, capabilityReadyForReview); err != nil {
+		return nil, err
+	}
+	if _, err := s.requireVisibleMergeRequest(ctx, repo, input.Number); err != nil {
 		return nil, err
 	}
 	mutator, err := s.syncer.ReadyForReviewMutator(

--- a/internal/server/pullapi/routes.go
+++ b/internal/server/pullapi/routes.go
@@ -481,7 +481,7 @@ func (s *Handler) getPull(ctx context.Context, input *repoNumberInput) (*getPull
 	if err != nil {
 		return nil, providerRouteLookupError(err)
 	}
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	mr, err := s.db.GetVisibleMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("get pull request failed")
 	}

--- a/internal/server/pullapi/routes.go
+++ b/internal/server/pullapi/routes.go
@@ -481,7 +481,7 @@ func (s *Handler) getPull(ctx context.Context, input *repoNumberInput) (*getPull
 	if err != nil {
 		return nil, providerRouteLookupError(err)
 	}
-	mr, err := s.db.GetVisibleMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	mr, err := s.visibleMergeRequest(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("get pull request failed")
 	}
@@ -791,7 +791,7 @@ func (s *Handler) getMRImportMetadata(
 	if err != nil {
 		return nil, providerRouteLookupError(err)
 	}
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	mr, err := s.visibleMergeRequest(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("failed to query merge request")
 	}
@@ -875,7 +875,7 @@ func (s *Handler) editPRContent(
 		return nil, unsupportedCapabilityProblem(*repo, capabilityStateMutation)
 	}
 
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	mr, err := s.visibleMergeRequest(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("get pull request failed")
 	}
@@ -923,7 +923,7 @@ func (s *Handler) editPRContent(
 		return nil, httpapi.Internal("update title/body failed")
 	}
 
-	mr, err = s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	mr, err = s.visibleMergeRequest(ctx, repo.ID, input.Number)
 	if err != nil || mr == nil {
 		return nil, httpapi.Internal("re-read pull request failed")
 	}
@@ -1129,7 +1129,7 @@ func (s *Handler) replyToDiscussion(ctx context.Context, input *replyToDiscussio
 
 	// Verify the MR exists locally before calling the provider to avoid
 	// creating upstream replies for untracked or non-existent PRs.
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	mr, err := s.visibleMergeRequest(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("get pull request failed")
 	}
@@ -1254,7 +1254,7 @@ func (s *Handler) resolveDiscussion(ctx context.Context, input *resolveDiscussio
 
 	// Verify the MR exists locally before calling the provider to avoid
 	// resolving discussions on untracked or non-existent PRs.
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	mr, err := s.visibleMergeRequest(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("get pull request failed")
 	}
@@ -1316,7 +1316,7 @@ func (s *Handler) approvePR(ctx context.Context, input *approvePRInput) (*action
 		return nil, unsupportedCapabilityProblem(*repo, capabilityReviewMutation)
 	}
 
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	mr, err := s.visibleMergeRequest(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("get pull request failed")
 	}
@@ -1389,7 +1389,7 @@ func (s *Handler) requestChangesPR(ctx context.Context, input *requestChangesPRI
 		return nil, huma.Error400BadRequest("request changes review body is required")
 	}
 
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	mr, err := s.visibleMergeRequest(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("get pull request failed")
 	}
@@ -1468,7 +1468,7 @@ func (s *Handler) approveWorkflows(ctx context.Context, input *repoNumberInput) 
 	if err := s.requireSyncerCapability(*repo, capabilityWorkflowApproval); err != nil {
 		return nil, err
 	}
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	mr, err := s.visibleMergeRequest(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("get pull request failed")
 	}
@@ -1678,7 +1678,7 @@ func (s *Handler) mergePRWithBody(
 		return mergePRBody{}, unsupportedCapabilityProblem(*repo, capabilityMergeMutation)
 	}
 
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, number)
+	mr, err := s.visibleMergeRequest(ctx, repo.ID, number)
 	if err != nil {
 		return mergePRBody{}, httpapi.Internal("get pull request failed")
 	}
@@ -2049,7 +2049,7 @@ func (s *Handler) setPRGitHubState(
 		return nil, err
 	}
 
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	mr, err := s.visibleMergeRequest(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("get pull request: " + err.Error())
 	}
@@ -2202,22 +2202,21 @@ func (s *Handler) setPRGitHubState(
 type getCommitsOutput = httpapi.BodyOutput[commitsResponse]
 
 func (s *Handler) getCommits(ctx context.Context, input *repoNumberInput) (*getCommitsOutput, error) {
-	if s.clones == nil {
-		return nil, httpapi.ServiceUnavailable("commits not available: clone manager not configured")
-	}
-
 	repo, err := s.lookupRepoByProviderRoute(
 		ctx, input.Provider, input.PlatformHost, input.Owner, input.Name,
 	)
 	if err != nil {
 		return nil, providerRouteLookupError(err)
 	}
-	shas, err := s.db.GetDiffSHAsByRepoID(ctx, repo.ID, input.Number)
+	shas, err := s.visibleDiffSHAs(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("failed to look up PR")
 	}
 	if shas == nil {
 		return nil, httpapi.NotFound(httpapi.CodePullNotFound, "pull request not found", nil)
+	}
+	if s.clones == nil {
+		return nil, httpapi.ServiceUnavailable("commits not available: clone manager not configured")
 	}
 	if shas.DiffHeadSHA == "" || shas.MergeBaseSHA == "" {
 		return nil, httpapi.NotFound(httpapi.CodeNotFound, "commits not available for this pull request", nil)
@@ -2288,12 +2287,15 @@ func (s *Handler) resolveDiffRange(
 	if err != nil {
 		return nil, providerRouteLookupError(err)
 	}
-	shas, err := s.db.GetDiffSHAsByRepoID(ctx, repo.ID, input.Number)
+	shas, err := s.visibleDiffSHAs(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("failed to look up PR")
 	}
 	if shas == nil {
 		return nil, httpapi.NotFound(httpapi.CodePullNotFound, "pull request not found", nil)
+	}
+	if s.clones == nil {
+		return nil, httpapi.ServiceUnavailable("diff view not available: clone manager not configured")
 	}
 	if shas.DiffHeadSHA == "" || shas.MergeBaseSHA == "" {
 		return nil, httpapi.NotFound(httpapi.CodeNotFound, "diff not available for this pull request", nil)
@@ -2365,10 +2367,6 @@ func (s *Handler) resolveDiffRange(
 }
 
 func (s *Handler) getDiff(ctx context.Context, input *getDiffInput) (*getDiffOutput, error) {
-	if s.clones == nil {
-		return nil, httpapi.ServiceUnavailable("diff view not available: clone manager not configured")
-	}
-
 	resolved, err := s.resolveDiffRange(ctx, input)
 	if err != nil {
 		return nil, err
@@ -2416,9 +2414,6 @@ type getFilePreviewInput struct {
 type getFilePreviewOutput = httpapi.BodyOutput[filePreviewResponse]
 
 func (s *Handler) getFilePreview(ctx context.Context, input *getFilePreviewInput) (*getFilePreviewOutput, error) {
-	if s.clones == nil {
-		return nil, httpapi.ServiceUnavailable("file preview not available: clone manager not configured")
-	}
 	if strings.TrimSpace(input.Path) == "" {
 		return nil, httpapi.Validation("query.path", "path is required")
 	}
@@ -2558,22 +2553,21 @@ type getFilesInput struct {
 type getFilesOutput = httpapi.BodyOutput[filesResponse]
 
 func (s *Handler) getFiles(ctx context.Context, input *getFilesInput) (*getFilesOutput, error) {
-	if s.clones == nil {
-		return nil, httpapi.ServiceUnavailable("files view not available: clone manager not configured")
-	}
-
 	repo, err := s.lookupRepoByProviderRoute(
 		ctx, input.Provider, input.PlatformHost, input.Owner, input.Name,
 	)
 	if err != nil {
 		return nil, providerRouteLookupError(err)
 	}
-	shas, err := s.db.GetDiffSHAsByRepoID(ctx, repo.ID, input.Number)
+	shas, err := s.visibleDiffSHAs(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("failed to look up PR")
 	}
 	if shas == nil {
 		return nil, httpapi.NotFound(httpapi.CodePullNotFound, "pull request not found", nil)
+	}
+	if s.clones == nil {
+		return nil, httpapi.ServiceUnavailable("files view not available: clone manager not configured")
 	}
 	if shas.DiffHeadSHA == "" || shas.MergeBaseSHA == "" {
 		return nil, httpapi.NotFound(httpapi.CodeNotFound, "file list not available for this pull request", nil)

--- a/internal/server/workspaceapi/auto_assign.go
+++ b/internal/server/workspaceapi/auto_assign.go
@@ -19,6 +19,23 @@ func (s *Handler) autoAssignWorkspaceItem(
 	if !s.configSnapshot().AutoAssignOnCreate || s.syncer == nil {
 		return nil
 	}
+	if issue {
+		stored, err := s.db.GetVisibleIssueByRepoIDAndNumber(ctx, repo.ID, number)
+		if err != nil {
+			return fmt.Errorf("check issue visibility: %w", err)
+		}
+		if stored == nil {
+			return fmt.Errorf("issue %d is not visible", number)
+		}
+	} else {
+		stored, err := s.db.GetVisibleMergeRequestByRepoIDAndNumber(ctx, repo.ID, number)
+		if err != nil {
+			return fmt.Errorf("check pull request visibility: %w", err)
+		}
+		if stored == nil {
+			return fmt.Errorf("pull request %d is not visible", number)
+		}
+	}
 
 	kind := httpapi.ProviderKind(repo)
 	host := httpapi.ProviderHost(repo)

--- a/internal/server/workspaceapi/auto_assign_test.go
+++ b/internal/server/workspaceapi/auto_assign_test.go
@@ -149,4 +149,24 @@ func TestAutoAssignWorkspaceItemPreservesExistingAssignees(t *testing.T) {
 			assert.Equal([]string{"reviewer", "maintainer"}, tt.stored())
 		})
 	}
+
+	_, err = database.WriteDB().ExecContext(t.Context(), `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES
+			(?, 'merge_request', 7, 'pull-7', ?, ?, 'removed_upstream'),
+			(?, 'issue', 8, 'issue-8', ?, ?, 'removed_upstream')`,
+		repoID, now, now, repoID, now, now,
+	)
+	require.NoError(err)
+	provider.pullAssigned = nil
+	provider.issueAssigned = nil
+
+	err = handler.autoAssignWorkspaceItem(t.Context(), *repo, 7, false)
+	require.ErrorContains(err, "not visible")
+	err = handler.autoAssignWorkspaceItem(t.Context(), *repo, 8, true)
+	require.ErrorContains(err, "not visible")
+	assert.Empty(provider.pullAssigned)
+	assert.Empty(provider.issueAssigned)
 }

--- a/internal/server/workspaceapi/helpers.go
+++ b/internal/server/workspaceapi/helpers.go
@@ -161,6 +161,10 @@ func toWorkspaceResponse(summary *db.WorkspaceSummary) workspaceResponse {
 	if !summary.AssociatedPRVisible {
 		associatedPRNumber = nil
 	}
+	headRepoKind := ""
+	if summary.SourceItemVisible {
+		headRepoKind = mrHeadRepoKind(summary.ItemType, summary.MRHeadRepo)
+	}
 	return workspaceResponse{
 		ID: summary.ID,
 		Repo: httpapi.RepoRefResponse{
@@ -193,7 +197,7 @@ func toWorkspaceResponse(summary *db.WorkspaceSummary) workspaceResponse {
 		MRDeletions:        summary.MRDeletions,
 		AssociatedPRNumber: associatedPRNumber,
 		Kata:               summary.KataMetadata,
-		MRHeadRepoKind:     mrHeadRepoKind(summary.ItemType, summary.MRHeadRepo),
+		MRHeadRepoKind:     headRepoKind,
 	}
 }
 

--- a/internal/server/workspaceapi/helpers.go
+++ b/internal/server/workspaceapi/helpers.go
@@ -157,6 +157,10 @@ func toWorkspaceResponse(summary *db.WorkspaceSummary) workspaceResponse {
 		formatted := summary.ItemLastActivityAt.UTC().Format(time.RFC3339)
 		itemLastActivityAt = &formatted
 	}
+	associatedPRNumber := summary.AssociatedPRNumber
+	if !summary.AssociatedPRVisible {
+		associatedPRNumber = nil
+	}
 	return workspaceResponse{
 		ID: summary.ID,
 		Repo: httpapi.RepoRefResponse{
@@ -187,7 +191,7 @@ func toWorkspaceResponse(summary *db.WorkspaceSummary) workspaceResponse {
 		MRReviewDecision:   summary.MRReviewDecision,
 		MRAdditions:        summary.MRAdditions,
 		MRDeletions:        summary.MRDeletions,
-		AssociatedPRNumber: summary.AssociatedPRNumber,
+		AssociatedPRNumber: associatedPRNumber,
 		Kata:               summary.KataMetadata,
 		MRHeadRepoKind:     mrHeadRepoKind(summary.ItemType, summary.MRHeadRepo),
 	}

--- a/internal/server/workspaceapi/helpers_test.go
+++ b/internal/server/workspaceapi/helpers_test.go
@@ -56,22 +56,32 @@ func TestToWorkspaceResponseSetsMRHeadRepoKind(t *testing.T) {
 	fork := "https://example.com/attacker/repo.git"
 
 	tests := []struct {
-		name       string
-		itemType   string
-		mrHeadRepo *string
-		want       string
+		name              string
+		itemType          string
+		mrHeadRepo        *string
+		sourceItemVisible bool
+		want              string
 	}{
 		{
-			name:       "same repo pull request",
-			itemType:   db.WorkspaceItemTypePullRequest,
-			mrHeadRepo: nil,
-			want:       mrHeadRepoKindSameRepo,
+			name:              "same repo pull request",
+			itemType:          db.WorkspaceItemTypePullRequest,
+			mrHeadRepo:        nil,
+			sourceItemVisible: true,
+			want:              mrHeadRepoKindSameRepo,
 		},
 		{
-			name:       "fork pull request",
-			itemType:   db.WorkspaceItemTypePullRequest,
-			mrHeadRepo: &fork,
-			want:       mrHeadRepoKindFork,
+			name:              "fork pull request",
+			itemType:          db.WorkspaceItemTypePullRequest,
+			mrHeadRepo:        &fork,
+			sourceItemVisible: true,
+			want:              mrHeadRepoKindFork,
+		},
+		{
+			name:              "removed pull request",
+			itemType:          db.WorkspaceItemTypePullRequest,
+			mrHeadRepo:        &fork,
+			sourceItemVisible: false,
+			want:              "",
 		},
 	}
 	for _, tt := range tests {
@@ -83,6 +93,7 @@ func TestToWorkspaceResponseSetsMRHeadRepoKind(t *testing.T) {
 					ItemType:   tt.itemType,
 					MRHeadRepo: tt.mrHeadRepo,
 				},
+				SourceItemVisible: tt.sourceItemVisible,
 			}
 			got := toWorkspaceResponse(summary)
 			assert.Equal(t, tt.want, got.MRHeadRepoKind)

--- a/internal/server/workspaceapi/projects_handlers.go
+++ b/internal/server/workspaceapi/projects_handlers.go
@@ -709,7 +709,18 @@ func (s *Handler) createProjectWorktreeFromMergeRequest(
 	if err != nil {
 		return nil, providerRouteLookupError(err)
 	}
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(
+	removed, err := s.db.IsArchiveItemRemovedUpstream(
+		ctx, repo.ID, db.ArchiveItemTypeMergeRequest, input.Body.Number,
+	)
+	if err != nil {
+		return nil, httpapi.Internal("failed to check merge request visibility")
+	}
+	if removed {
+		return nil, httpapi.NotFound(
+			httpapi.CodePullNotFound, "merge request not found", nil,
+		)
+	}
+	mr, err := s.db.GetVisibleMergeRequestByRepoIDAndNumber(
 		ctx, repo.ID, input.Body.Number,
 	)
 	if err != nil {
@@ -725,7 +736,7 @@ func (s *Handler) createProjectWorktreeFromMergeRequest(
 			repo.Owner, repo.Name, input.Body.Number,
 		)
 		if syncErr == nil || errors.As(syncErr, &diffErr) {
-			mr, err = s.db.GetMergeRequestByRepoIDAndNumber(
+			mr, err = s.db.GetVisibleMergeRequestByRepoIDAndNumber(
 				ctx, repo.ID, input.Body.Number,
 			)
 			if err != nil {

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -913,7 +913,7 @@ func (s *Handler) refreshWorkspace(
 	switch summary.ItemType {
 	case db.WorkspaceItemTypeIssue:
 		if err := s.refreshWorkspaceIssue(
-			ctx, kind, host, repo.Owner, repo.Name, summary.ItemNumber,
+			ctx, repo.ID, kind, host, repo.Owner, repo.Name, summary.ItemNumber,
 		); err != nil {
 			return nil, err
 		}
@@ -960,7 +960,7 @@ func (s *Handler) refreshWorkspace(
 	}
 	if prNumber, ok := workspaceAssociatedPRNumber(refreshed); ok {
 		if err := s.refreshWorkspacePullRequest(
-			ctx, kind, host, repo.Owner, repo.Name, prNumber,
+			ctx, repo.ID, kind, host, repo.Owner, repo.Name, prNumber,
 		); err != nil {
 			return nil, err
 		}
@@ -1024,11 +1024,21 @@ func (s *Handler) refreshWorkspaceRepoIndex(
 
 func (s *Handler) refreshWorkspaceIssue(
 	ctx context.Context,
+	repoID int64,
 	kind platform.Kind,
 	host, owner, name string,
 	number int,
 ) error {
-	err := s.syncer.SyncIssueOnProvider(ctx, kind, host, owner, name, number)
+	removed, err := s.db.IsArchiveItemRemovedUpstream(
+		ctx, repoID, db.ArchiveItemTypeIssue, number,
+	)
+	if err != nil {
+		return httpapi.Internal("check issue visibility: " + err.Error())
+	}
+	if removed {
+		return nil
+	}
+	err = s.syncer.SyncIssueOnProvider(ctx, kind, host, owner, name, number)
 	if err == nil {
 		return nil
 	}
@@ -1042,12 +1052,22 @@ func (s *Handler) refreshWorkspaceIssue(
 
 func (s *Handler) refreshWorkspacePullRequest(
 	ctx context.Context,
+	repoID int64,
 	kind platform.Kind,
 	host, owner, name string,
 	number int,
 ) error {
+	removed, err := s.db.IsArchiveItemRemovedUpstream(
+		ctx, repoID, db.ArchiveItemTypeMergeRequest, number,
+	)
+	if err != nil {
+		return httpapi.Internal("check pull request visibility: " + err.Error())
+	}
+	if removed {
+		return nil
+	}
 	var diffErr *ghclient.DiffSyncError
-	err := s.syncer.SyncMROnProvider(ctx, kind, host, owner, name, number)
+	err = s.syncer.SyncMROnProvider(ctx, kind, host, owner, name, number)
 	if err != nil && !errors.As(err, &diffErr) {
 		if strings.Contains(err.Error(), "is not tracked") {
 			return httpapi.Forbidden(err.Error(), nil)

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -1618,7 +1618,7 @@ func (s *Handler) workspaceMergeTargetBranch(
 		return "", false, nil
 	}
 
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(
+	mr, err := s.db.GetVisibleMergeRequestByRepoIDAndNumber(
 		ctx, repo.ID, prNumber,
 	)
 	if err != nil {

--- a/internal/server/workspaceapi/subject_activity.go
+++ b/internal/server/workspaceapi/subject_activity.go
@@ -142,7 +142,8 @@ func ownWorkspaceSubjectKey(summary db.WorkspaceSummary) (db.WorkspaceSubjectKey
 }
 
 func resolvedWorkspaceSubjectKey(summary db.WorkspaceSummary) (db.WorkspaceSubjectKey, bool) {
-	if summary.AssociatedPRNumber != nil && *summary.AssociatedPRNumber > 0 {
+	if summary.AssociatedPRVisible &&
+		summary.AssociatedPRNumber != nil && *summary.AssociatedPRNumber > 0 {
 		return db.WorkspaceSubjectKey{
 			RepoID: summary.RepoID, ItemType: db.WorkspaceItemTypePullRequest,
 			ItemNumber: *summary.AssociatedPRNumber,

--- a/internal/server/workspaceapi/subject_activity_test.go
+++ b/internal/server/workspaceapi/subject_activity_test.go
@@ -139,6 +139,57 @@ func TestWorkspaceSubjectSnapshotResolvesAdHocAssociationAsPullReference(t *test
 	assert.Equal(WorkspaceRef{ID: "ws-adhoc", Status: "ready"}, snapshot.Subjects[key].Workspace)
 }
 
+func TestWorkspaceSubjectSnapshotFallsBackFromRemovedAssociatedPullRequest(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	h := newEnrichmentTestHandler(t, "")
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	identity := db.GitHubRepoIdentity("github.com", "acme", "widget")
+	identity.PlatformRepoID = "repo-acme-widget"
+	repoID, err := h.db.UpsertRepo(t.Context(), identity)
+	require.NoError(err)
+	_, err = h.db.UpsertIssue(t.Context(), &db.Issue{
+		RepoID: repoID, PlatformID: 7, Number: 7,
+		URL: "https://github.com/acme/widget/issues/7", Title: "Visible issue",
+		Author: "alice", State: "open", CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+	_, err = h.db.UpsertMergeRequest(t.Context(), &db.MergeRequest{
+		RepoID: repoID, PlatformID: 42, Number: 42,
+		URL: "https://github.com/acme/widget/pull/42", Title: "Removed pull",
+		Author: "alice", State: "open", CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+	associatedPR := 42
+	require.NoError(h.db.InsertWorkspace(t.Context(), &db.Workspace{
+		ID: "ws-issue", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget", ItemType: db.WorkspaceItemTypeIssue,
+		ItemNumber: 7, AssociatedPRNumber: &associatedPR,
+		GitHeadRef: "issue-7", WorktreePath: t.TempDir(), Status: "ready",
+	}))
+	_, err = h.db.WriteDB().ExecContext(t.Context(), `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES (?, 'merge_request', 42, 'pull-42', ?, ?, 'removed_upstream')`,
+		repoID, now, now,
+	)
+	require.NoError(err)
+
+	snapshot, err := h.WorkspaceSubjectSnapshot(t.Context())
+	require.NoError(err)
+	issueKey := db.WorkspaceSubjectKey{
+		RepoID: repoID, ItemType: db.WorkspaceItemTypeIssue, ItemNumber: 7,
+	}
+	removedPRKey := db.WorkspaceSubjectKey{
+		RepoID: repoID, ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: 42,
+	}
+	require.Contains(snapshot.Subjects, issueKey)
+	assert.Equal("Visible issue", snapshot.Subjects[issueKey].Subject.Title)
+	assert.Equal(WorkspaceRef{ID: "ws-issue", Status: "ready"}, snapshot.Subjects[issueKey].Workspace)
+	assert.NotContains(snapshot.Subjects, removedPRKey)
+}
+
 func TestWorkspaceSubjectSnapshotUsesStableRepositoryIdentityAfterRename(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/server/workspaceapi/workspace_pushed_head.go
+++ b/internal/server/workspaceapi/workspace_pushed_head.go
@@ -114,6 +114,10 @@ func (s *Handler) enqueueWorkspacePushedHeadRefresh(change workspace.PushedHeadU
 		key,
 		attrs,
 		func(ctx context.Context) error {
+			_, mr := s.lookupPushedHeadMR(ctx, change)
+			if mr == nil {
+				return nil
+			}
 			return s.syncer.SyncMROnProvider(
 				ctx,
 				change.Provider,
@@ -124,6 +128,10 @@ func (s *Handler) enqueueWorkspacePushedHeadRefresh(change workspace.PushedHeadU
 			)
 		},
 		func(ctx context.Context) {
+			_, mr := s.lookupPushedHeadMR(ctx, change)
+			if mr == nil {
+				return
+			}
 			if s.workspacePushedHeadObserver != nil {
 				s.workspacePushedHeadObserver.MarkRefreshSucceeded(change, s.now().UTC())
 			}
@@ -200,36 +208,52 @@ func (s *Handler) maybeEnqueuePushedHeadCIRefresh(ctx context.Context, change wo
 		key,
 		[]any{"type", "pr-ci", "provider", string(change.Provider), "platform_host", change.PlatformHost, "repo_path", change.RepoPath, "number", change.Number},
 		func(ctx context.Context) error {
+			currentRepo, currentMR := s.lookupPushedHeadMR(ctx, change)
+			if currentRepo == nil || currentMR == nil {
+				return nil
+			}
+			currentHeadSHA := currentMR.PlatformHeadSHA
+			if currentHeadSHA == "" {
+				currentHeadSHA = change.NewSHA
+			}
 			_, err := s.syncer.RefreshMRCIStatusOnProvider(
 				ctx,
 				ghclient.RepoRef{
-					Platform:           repoProviderKind(*repo),
-					Owner:              repo.Owner,
-					Name:               repo.Name,
-					PlatformHost:       repoProviderHost(*repo),
-					RepoPath:           repo.RepoPath,
-					PlatformExternalID: repo.PlatformRepoID,
-					WebURL:             repo.WebURL,
-					CloneURL:           repo.CloneURL,
-					DefaultBranch:      repo.DefaultBranch,
+					Platform:           repoProviderKind(*currentRepo),
+					Owner:              currentRepo.Owner,
+					Name:               currentRepo.Name,
+					PlatformHost:       repoProviderHost(*currentRepo),
+					RepoPath:           currentRepo.RepoPath,
+					PlatformExternalID: currentRepo.PlatformRepoID,
+					WebURL:             currentRepo.WebURL,
+					CloneURL:           currentRepo.CloneURL,
+					DefaultBranch:      currentRepo.DefaultBranch,
 				},
-				repo.ID,
+				currentRepo.ID,
 				change.Number,
-				headSHA,
+				currentHeadSHA,
 			)
 			return err
 		},
-		func(context.Context) {
+		func(ctx context.Context) {
+			currentRepo, currentMR := s.lookupPushedHeadMR(ctx, change)
+			if currentRepo == nil || currentMR == nil {
+				return
+			}
+			currentHeadSHA := currentMR.PlatformHeadSHA
+			if currentHeadSHA == "" {
+				currentHeadSHA = change.NewSHA
+			}
 			s.hub.Broadcast(Event{
 				Type: "pr_ci_refreshed",
 				Data: prCIRefreshedPayload{
-					Provider:     string(repoProviderKind(*repo)),
-					PlatformHost: repoProviderHost(*repo),
-					RepoPath:     repo.RepoPath,
-					Owner:        repo.Owner,
-					Name:         repo.Name,
+					Provider:     string(repoProviderKind(*currentRepo)),
+					PlatformHost: repoProviderHost(*currentRepo),
+					RepoPath:     currentRepo.RepoPath,
+					Owner:        currentRepo.Owner,
+					Name:         currentRepo.Name,
 					Number:       change.Number,
-					HeadSHA:      headSHA,
+					HeadSHA:      currentHeadSHA,
 					RefreshedAt:  formatUTCRFC3339(s.now().UTC()),
 					Warnings:     []string{},
 				},
@@ -264,7 +288,7 @@ func (s *Handler) lookupPushedHeadMR(ctx context.Context, change workspace.Pushe
 	if err != nil || repo == nil {
 		return nil, nil
 	}
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, change.Number)
+	mr, err := s.db.GetVisibleMergeRequestByRepoIDAndNumber(ctx, repo.ID, change.Number)
 	if err != nil {
 		return repo, nil
 	}

--- a/internal/server/workspaceapi/workspace_pushed_head_integration_test.go
+++ b/internal/server/workspaceapi/workspace_pushed_head_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/db"
 	ghclient "go.kenn.io/forge/internal/github"
+	"go.kenn.io/forge/internal/platform"
 	"go.kenn.io/forge/internal/testutil"
 	"go.kenn.io/forge/internal/testutil/dbtest"
 	"go.kenn.io/forge/internal/workspace"
@@ -24,12 +25,20 @@ import (
 type pushedHeadProviderClient struct {
 	ghclient.Client
 	getPullRequest func(context.Context, string, string, int) (*gh.PullRequest, error)
+	ciCalls        atomic.Int64
 }
 
-func (c pushedHeadProviderClient) GetPullRequest(
+func (c *pushedHeadProviderClient) GetPullRequest(
 	ctx context.Context, owner, name string, number int,
 ) (*gh.PullRequest, error) {
 	return c.getPullRequest(ctx, owner, name, number)
+}
+
+func (c *pushedHeadProviderClient) GetCombinedStatus(
+	ctx context.Context, owner, name, ref string,
+) (*gh.CombinedStatus, error) {
+	c.ciCalls.Add(1)
+	return c.Client.GetCombinedStatus(ctx, owner, name, ref)
 }
 
 type pushedHeadIntegrationFixture struct {
@@ -212,6 +221,84 @@ func TestWorkspacePushedHeadPassStopsAfterNonConvergingRefresh(t *testing.T) {
 	assert.Equal(int64(2), detailSyncCalls.Load())
 }
 
+func TestWorkspacePushedHeadPassIgnoresRemovedPullRequest(t *testing.T) {
+	require := require.New(t)
+	var detailSyncCalls atomic.Int64
+	provider := newPushedHeadProvider(func(
+		context.Context, string, string, int,
+	) (*gh.PullRequest, error) {
+		detailSyncCalls.Add(1)
+		return nil, nil
+	})
+	fixture := newPushedHeadIntegrationFixture(t, provider)
+	worktreePath, oldHead := setupPushedHeadIntegrationWorktree(t)
+	repoID := seedPushedHeadIntegrationPR(t, fixture.database, oldHead)
+	insertPushedHeadIntegrationWorkspace(t, fixture.database, worktreePath)
+	pushPushedHeadIntegrationCommit(t, worktreePath)
+	markPushedHeadIntegrationPRRemoved(t, fixture.database, repoID)
+
+	fixture.handler.runWorkspacePushedHeadObserverPass(t.Context())
+
+	require.Empty(fixture.events)
+	require.Empty(fixture.jobs)
+	require.Zero(detailSyncCalls.Load())
+	require.Zero(provider.ciCalls.Load())
+}
+
+func TestWorkspacePushedHeadQueuedRefreshRechecksRemovedPullRequest(t *testing.T) {
+	require := require.New(t)
+	var detailSyncCalls atomic.Int64
+	provider := newPushedHeadProvider(func(
+		context.Context, string, string, int,
+	) (*gh.PullRequest, error) {
+		detailSyncCalls.Add(1)
+		return nil, nil
+	})
+	fixture := newPushedHeadIntegrationFixture(t, provider)
+	worktreePath, oldHead := setupPushedHeadIntegrationWorktree(t)
+	repoID := seedPushedHeadIntegrationPR(t, fixture.database, oldHead)
+	insertPushedHeadIntegrationWorkspace(t, fixture.database, worktreePath)
+	pushPushedHeadIntegrationCommit(t, worktreePath)
+
+	fixture.handler.runWorkspacePushedHeadObserverPass(t.Context())
+	require.Len(fixture.jobs, 1)
+	markPushedHeadIntegrationPRRemoved(t, fixture.database, repoID)
+	fixture.jobs[0]()
+
+	require.Zero(detailSyncCalls.Load())
+	require.Zero(provider.ciCalls.Load())
+	require.Len(fixture.events, 2, "removed pull must not publish refresh success")
+}
+
+func TestWorkspacePushedHeadQueuedCIRefreshRechecksRemovedPullRequest(t *testing.T) {
+	require := require.New(t)
+	provider := newPushedHeadProvider(func(
+		context.Context, string, string, int,
+	) (*gh.PullRequest, error) {
+		return nil, nil
+	})
+	fixture := newPushedHeadIntegrationFixture(t, provider)
+	worktreePath, headSHA := setupPushedHeadIntegrationWorktree(t)
+	repoID := seedPushedHeadIntegrationPR(t, fixture.database, headSHA)
+	insertPushedHeadIntegrationWorkspace(t, fixture.database, worktreePath)
+	require.NoError(fixture.database.UpdateMRCIStatusForHead(
+		t.Context(), repoID, 1, headSHA, "pending", `[]`, true,
+	))
+	change := workspace.PushedHeadUpdate{
+		WorkspaceID: "ws-pr", Provider: platform.KindGitHub,
+		PlatformHost: "github.com", RepoPath: "acme/widget",
+		Owner: "acme", Name: "widget", Number: 1, NewSHA: headSHA,
+	}
+
+	fixture.handler.maybeEnqueuePushedHeadCIRefresh(t.Context(), change)
+	require.Len(fixture.jobs, 1)
+	markPushedHeadIntegrationPRRemoved(t, fixture.database, repoID)
+	fixture.jobs[0]()
+
+	require.Zero(provider.ciCalls.Load())
+	require.Len(fixture.events, 1, "removed pull must not publish CI refresh success")
+}
+
 func pushedHeadPullRequest(title, headSHA string) *gh.PullRequest {
 	state := "open"
 	body := "updated body"
@@ -311,4 +398,19 @@ func insertPushedHeadIntegrationWorkspace(
 		GitHeadRef: "feature", WorkspaceBranch: "feature",
 		WorktreePath: worktreePath, TmuxSession: "kenn-forge-ws-pr", Status: "ready",
 	}))
+}
+
+func markPushedHeadIntegrationPRRemoved(
+	t *testing.T, database *db.DB, repoID int64,
+) {
+	t.Helper()
+	now := time.Now().UTC().Truncate(time.Second)
+	_, err := database.WriteDB().ExecContext(t.Context(), `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES (?, 'merge_request', 1, 'pull-1', ?, ?, 'removed_upstream')`,
+		repoID, now, now,
+	)
+	require.NoError(t, err)
 }

--- a/internal/server/workspaceapi/workspace_visibility_test.go
+++ b/internal/server/workspaceapi/workspace_visibility_test.go
@@ -1,0 +1,63 @@
+package workspaceapi
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+)
+
+func TestWorkspaceMergeTargetBranchRejectsRemovedPullRequest(t *testing.T) {
+	require := require.New(t)
+	database := dbtest.Open(t)
+	ctx := t.Context()
+	now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	repoIdentity := db.GitHubRepoIdentity("github.com", "acme", "widget")
+	repoIdentity.PlatformRepoID = "repo-acme-widget"
+	repoID, err := database.UpsertRepo(ctx, repoIdentity)
+	require.NoError(err)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID: repoID, PlatformID: 7, Number: 7,
+		URL: "https://github.com/acme/widget/pull/7", Title: "Removed pull",
+		Author: "alice", State: "open", HeadBranch: "feature", BaseBranch: "main",
+		CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+	require.NoError(database.InsertWorkspace(ctx, &db.Workspace{
+		ID: "ws-removed-pr", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget",
+		ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: 7,
+		GitHeadRef: "feature", WorktreePath: t.TempDir(), Status: "ready",
+	}))
+	summary, err := database.GetWorkspaceSummary(ctx, "ws-removed-pr")
+	require.NoError(err)
+	require.NotNil(summary)
+	branch, available, err := (&Handler{db: database}).workspaceMergeTargetBranch(
+		ctx, summary,
+	)
+	require.NoError(err)
+	require.True(available)
+	require.Equal("main", branch)
+
+	_, err = database.WriteDB().ExecContext(ctx, `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES (?, 'merge_request', 7, 'pull-7', ?, ?, 'removed_upstream')`,
+		repoID, now, now,
+	)
+	require.NoError(err)
+	summary, err = database.GetWorkspaceSummary(ctx, "ws-removed-pr")
+	require.NoError(err)
+	require.NotNil(summary)
+
+	branch, available, err = (&Handler{db: database}).workspaceMergeTargetBranch(
+		ctx, summary,
+	)
+
+	require.NoError(err)
+	require.False(available)
+	require.Empty(branch)
+}

--- a/internal/server/workspacetest/project_worktree_from_mr_test.go
+++ b/internal/server/workspacetest/project_worktree_from_mr_test.go
@@ -459,3 +459,76 @@ func TestCreateWorktreeFromMergeRequestRouteSyncsOnDemand(t *testing.T) {
 		lifecycleRouteGit(t, dest, "rev-parse", "HEAD"),
 		"worktree starts at the merge request head")
 }
+
+func TestCreateWorktreeFromMergeRequestRouteDoesNotSyncRemovedItem(t *testing.T) {
+	acquireWorkspaceGitSlot(t)
+	require := Require.New(t)
+
+	repoPath := initLifecycleRouteRepo(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	number := 43
+	providerID := int64(9043)
+	nodeID := "PR_kwDO9043"
+	title := "removed pull"
+	state := "open"
+	url := "https://github.com/acme/widget/pull/43"
+	author := "ada"
+	headRef := "feature-y"
+	baseRef := "main"
+	cloneURL := "https://github.com/acme/widget.git"
+	fullName := "acme/widget"
+	mock := testutil.NewFixtureClient().(*testutil.FixtureClient)
+	mock.PRs["acme/widget"] = []*gh.PullRequest{{
+		ID: &providerID, NodeID: &nodeID, Number: &number,
+		HTMLURL: &url, Title: &title, State: &state,
+		User:      &gh.User{Login: &author},
+		CreatedAt: &gh.Timestamp{Time: now}, UpdatedAt: &gh.Timestamp{Time: now},
+		Head: &gh.PullRequestBranch{
+			Ref: &headRef, SHA: new(string),
+			Repo: &gh.Repository{CloneURL: &cloneURL, FullName: &fullName},
+		},
+		Base: &gh.PullRequestBranch{Ref: &baseRef},
+	}}
+	database := dbtest.Open(t)
+	repoID, err := database.UpsertRepo(
+		t.Context(), verifiedGitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+	_, err = database.WriteDB().ExecContext(t.Context(), `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES (?, 'merge_request', ?, ?, ?, ?, 'removed_upstream')`,
+		repoID, number, nodeID, now, now,
+	)
+	require.NoError(err)
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock}, database, nil,
+		[]ghclient.RepoRef{{
+			Platform: "github", PlatformHost: "github.com",
+			Owner: "acme", Name: "widget", PlatformExternalID: "repo-acme-widget",
+		}},
+		time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{
+		HostCheckAllowLoopbackAnyPort: true,
+	})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	projectID := registerIdentifiedProject(t, ts, repoPath)
+
+	body := mustMarshal(t, map[string]any{
+		"number": number, "branch": "pr-43", "path": filepath.Join(t.TempDir(), "wt"),
+	})
+	resp := httpDo(t, ts, http.MethodPost,
+		"/api/v1/projects/"+projectID+"/worktrees/from-merge-request", body)
+	logUnexpectedResponse(t, resp, http.StatusNotFound)
+	require.Equal(http.StatusNotFound, resp.StatusCode)
+	require.Equal("pullNotFound", decodeProblemCode(t, resp))
+	resp.Body.Close()
+
+	stored, err := database.GetMergeRequestByRepoIDAndNumber(t.Context(), repoID, number)
+	require.NoError(err)
+	require.Nil(stored, "removed item must be rejected before on-demand provider sync")
+}

--- a/internal/server/workspacetest/workspace_crud_test.go
+++ b/internal/server/workspacetest/workspace_crud_test.go
@@ -413,6 +413,54 @@ func TestWorkspaceCreateHidesRemovedUpstreamItems(t *testing.T) {
 	require.Empty(*listed.JSON200.Workspaces)
 }
 
+func TestWorkspaceListRetainsWorkspaceWithoutRemovedPullMetadata(t *testing.T) {
+	t.Parallel()
+	acquireWorkspaceGitSlot(t)
+
+	require := require.New(t)
+	fixture := setupWorkspaceServerFixture(t, nil)
+	ctx := t.Context()
+	repo, err := fixture.database.GetRepoByIdentity(
+		ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+	require.NotNil(repo)
+	require.NoError(fixture.database.InsertWorkspace(ctx, &db.Workspace{
+		ID: "ws-removed-pr", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget",
+		ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: 1,
+		GitHeadRef: "feature", WorktreePath: fixture.worktreeDir + "/removed-pr",
+		TmuxSession: "forge-ws-removed-pr", Status: "creating",
+	}))
+	now := time.Now().UTC().Truncate(time.Second)
+	_, err = fixture.database.WriteDB().ExecContext(ctx, `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES (?, 'merge_request', 1, 'pull-1', ?, ?, 'removed_upstream')`,
+		repo.ID, now, now,
+	)
+	require.NoError(err)
+
+	listed, err := fixture.client.HTTP.ListWorkspacesWithResponse(ctx)
+	require.NoError(err)
+	require.Equal(http.StatusOK, listed.StatusCode(), string(listed.Body))
+	require.NotNil(listed.JSON200)
+	require.NotNil(listed.JSON200.Workspaces)
+	require.Len(*listed.JSON200.Workspaces, 1)
+	workspace := (*listed.JSON200.Workspaces)[0]
+	require.Equal("ws-removed-pr", workspace.Id)
+	require.Equal(int64(1), workspace.ItemNumber)
+	require.Nil(workspace.MrTitle)
+	require.Nil(workspace.MrState)
+	require.Nil(workspace.MrIsDraft)
+	require.Nil(workspace.MrCiStatus)
+	require.Nil(workspace.MrReviewDecision)
+	require.Nil(workspace.MrAdditions)
+	require.Nil(workspace.MrDeletions)
+	require.Nil(workspace.ItemLastActivityAt)
+}
+
 func TestWorkspaceMRDetailHasWorkspace(t *testing.T) {
 	t.Parallel()
 	acquireWorkspaceGitSlot(t)

--- a/internal/server/workspacetest/workspace_crud_test.go
+++ b/internal/server/workspacetest/workspace_crud_test.go
@@ -364,6 +364,55 @@ func TestWorkspaceCreateNotFound(t *testing.T) {
 	require.Equal(http.StatusNotFound, resp2.StatusCode())
 }
 
+func TestWorkspaceCreateHidesRemovedUpstreamItems(t *testing.T) {
+	t.Parallel()
+	acquireWorkspaceGitSlot(t)
+
+	require := require.New(t)
+	fixture := setupWorkspaceServerFixture(t, nil)
+	ctx := t.Context()
+	seedIssueOnHost(t, fixture.database, "github.com", "acme", "widget", 1, "open", "Test Issue")
+	repo, err := fixture.database.GetRepoByIdentity(
+		ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+	require.NotNil(repo)
+	now := time.Now().UTC().Truncate(time.Second)
+	_, err = fixture.database.WriteDB().ExecContext(ctx, `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES
+			(?, 'merge_request', 1, 'pr-1', ?, ?, 'removed_upstream'),
+			(?, 'issue', 1, 'issue-1', ?, ?, 'removed_upstream')`,
+		repo.ID, now, now, repo.ID, now, now,
+	)
+	require.NoError(err)
+
+	prResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
+		ctx, generated.CreateWorkspaceInputBody{
+			Provider: "github", PlatformHost: "github.com",
+			Owner: "acme", Name: "widget", MrNumber: 1,
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusNotFound, prResp.StatusCode(), string(prResp.Body))
+
+	issueResp, err := fixture.client.HTTP.CreateIssueWorkspaceWithResponse(
+		ctx, "gh", "acme", "widget", 1,
+		generated.CreateIssueWorkspaceInputBody{},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusNotFound, issueResp.StatusCode(), string(issueResp.Body))
+
+	listed, err := fixture.client.HTTP.ListWorkspacesWithResponse(ctx)
+	require.NoError(err)
+	require.Equal(http.StatusOK, listed.StatusCode())
+	require.NotNil(listed.JSON200)
+	require.NotNil(listed.JSON200.Workspaces)
+	require.Empty(*listed.JSON200.Workspaces)
+}
+
 func TestWorkspaceMRDetailHasWorkspace(t *testing.T) {
 	t.Parallel()
 	acquireWorkspaceGitSlot(t)

--- a/internal/workspace/adhoc_test.go
+++ b/internal/workspace/adhoc_test.go
@@ -254,6 +254,7 @@ func TestAgentContextForAdHocWorkspaceWithDetectedPR(t *testing.T) {
 	summary.GitHeadRef = "spike/thing"
 	summary.WorkspaceBranch = "spike/thing"
 	summary.AssociatedPRNumber = &prNumber
+	summary.AssociatedPRVisible = true
 
 	rendered := RenderAgentContext(BuildAgentContext(summary))
 

--- a/internal/workspace/agent_context.go
+++ b/internal/workspace/agent_context.go
@@ -100,7 +100,7 @@ func BuildAgentContext(ws WorkspaceSummary) AgentContext {
 	switch ws.ItemType {
 	case db.WorkspaceItemTypeIssue:
 		ctx.SourceKind = AgentSourceKindProviderIssue
-		if ws.AssociatedPRNumber != nil {
+		if ws.AssociatedPRVisible && ws.AssociatedPRNumber != nil {
 			ctx.AssociatedPR = &AgentAssociatedPRContext{Number: *ws.AssociatedPRNumber}
 		}
 	case db.WorkspaceItemTypeAdHoc:
@@ -108,7 +108,7 @@ func BuildAgentContext(ws WorkspaceSummary) AgentContext {
 		// The materialized branch is authoritative once setup finished; the
 		// requested ref is all that exists before then.
 		ctx.WorkingBranch = adHocWorkingBranch(ws)
-		if ws.AssociatedPRNumber != nil {
+		if ws.AssociatedPRVisible && ws.AssociatedPRNumber != nil {
 			ctx.AssociatedPR = &AgentAssociatedPRContext{Number: *ws.AssociatedPRNumber}
 		}
 	case db.WorkspaceItemTypeKataTask:

--- a/internal/workspace/agent_context.go
+++ b/internal/workspace/agent_context.go
@@ -90,11 +90,13 @@ func BuildAgentContext(ws WorkspaceSummary) AgentContext {
 		RepoOwner:    ws.RepoOwner,
 		RepoName:     ws.RepoName,
 		ItemNumber:   ws.ItemNumber,
-		Title:        stringPtrValue(ws.SourceTitle),
-		URL:          stringPtrValue(ws.SourceURL),
 	}
-	if ctx.Title == "" {
-		ctx.Title = stringPtrValue(ws.MRTitle)
+	if ws.SourceItemVisible {
+		ctx.Title = stringPtrValue(ws.SourceTitle)
+		ctx.URL = stringPtrValue(ws.SourceURL)
+		if ctx.Title == "" {
+			ctx.Title = stringPtrValue(ws.MRTitle)
+		}
 	}
 
 	switch ws.ItemType {
@@ -126,13 +128,15 @@ func BuildAgentContext(ws WorkspaceSummary) AgentContext {
 		}
 	default:
 		ctx.SourceKind = AgentSourceKindPullRequest
-		// Prefer the currently synced PR head branch: the creation-time
-		// GitHeadRef snapshot goes stale when the head branch is renamed.
-		ctx.HeadBranch = firstNonEmpty(stringPtrValue(ws.MRHeadBranch), ws.GitHeadRef)
-		if ws.MRHeadRepo != nil && strings.TrimSpace(*ws.MRHeadRepo) == "" {
-			ctx.HeadRepoUnknown = true
-		} else if ws.MRHeadRepo != nil {
-			ctx.ForkHeadRepo = *ws.MRHeadRepo
+		if ws.SourceItemVisible {
+			// Prefer the currently synced PR head branch: the creation-time
+			// GitHeadRef snapshot goes stale when the head branch is renamed.
+			ctx.HeadBranch = firstNonEmpty(stringPtrValue(ws.MRHeadBranch), ws.GitHeadRef)
+			if ws.MRHeadRepo != nil && strings.TrimSpace(*ws.MRHeadRepo) == "" {
+				ctx.HeadRepoUnknown = true
+			} else if ws.MRHeadRepo != nil {
+				ctx.ForkHeadRepo = *ws.MRHeadRepo
+			}
 		}
 	}
 
@@ -220,6 +224,13 @@ func (m *Manager) PrepareAgentLaunchContext(
 	if err := m.RefreshWorkspaceHeadRepo(ctx, &summary.Workspace); err != nil {
 		return fmt.Errorf("refresh workspace head repository: %w", err)
 	}
+	summary, err = m.GetSummary(ctx, opts.WorkspaceID)
+	if err != nil {
+		return fmt.Errorf("reload workspace summary: %w", err)
+	}
+	if summary == nil {
+		return ErrWorkspaceNotFound
+	}
 
 	relPath := agentContextRelPath(opts.TargetKey)
 	if relPath == "" {
@@ -268,7 +279,14 @@ func (m *Manager) RenderAgentContextForWorktree(
 		if err := m.RefreshWorkspaceHeadRepo(ctx, &summaries[i].Workspace); err != nil {
 			return "", err
 		}
-		rendered := RenderAgentContext(BuildAgentContext(summaries[i]))
+		refreshed, err := m.GetSummary(ctx, summaries[i].ID)
+		if err != nil {
+			return "", err
+		}
+		if refreshed == nil {
+			return "", nil
+		}
+		rendered := RenderAgentContext(BuildAgentContext(*refreshed))
 		return strings.TrimSpace(strings.TrimPrefix(
 			rendered, generatedAgentContextMarker,
 		)), nil

--- a/internal/workspace/agent_context_test.go
+++ b/internal/workspace/agent_context_test.go
@@ -31,8 +31,9 @@ func TestBuildAgentContext(t *testing.T) {
 					RepoOwner: "acme", RepoName: "widget", ItemType: db.WorkspaceItemTypePullRequest,
 					ItemNumber: 42, GitHeadRef: "feature/widgets",
 				},
-				SourceTitle: ptr("Fix widget refresh"),
-				SourceURL:   ptr("https://github.com/acme/widget/pull/42"),
+				SourceItemVisible: true,
+				SourceTitle:       ptr("Fix widget refresh"),
+				SourceURL:         ptr("https://github.com/acme/widget/pull/42"),
 			},
 			want: []string{
 				"Source kind: pull request",
@@ -51,7 +52,8 @@ func TestBuildAgentContext(t *testing.T) {
 					ItemNumber: 43, GitHeadRef: "feature/fork-fix",
 					MRHeadRepo: ptr("github.com/contributor/widget"),
 				},
-				SourceTitle: ptr("Fix from fork"),
+				SourceItemVisible: true,
+				SourceTitle:       ptr("Fix from fork"),
 			},
 			want: []string{
 				"Source kind: pull request",
@@ -68,6 +70,7 @@ func TestBuildAgentContext(t *testing.T) {
 					ItemNumber: 44, GitHeadRef: "feature/unknown",
 					MRHeadRepo: ptr(""),
 				},
+				SourceItemVisible: true,
 			},
 			want: []string{
 				"Source kind: pull request",
@@ -83,8 +86,9 @@ func TestBuildAgentContext(t *testing.T) {
 					RepoOwner: "acme", RepoName: "widget", ItemType: db.WorkspaceItemTypeIssue,
 					ItemNumber: 7,
 				},
-				SourceTitle: ptr("Add retry controls"),
-				SourceURL:   ptr("https://git.example.test/acme/widget/issues/7"),
+				SourceItemVisible: true,
+				SourceTitle:       ptr("Add retry controls"),
+				SourceURL:         ptr("https://git.example.test/acme/widget/issues/7"),
 			},
 			want: []string{"Source kind: provider issue", "Issue: #7", "Add retry controls", "https://git.example.test/acme/widget/issues/7"},
 		},
@@ -96,6 +100,7 @@ func TestBuildAgentContext(t *testing.T) {
 					RepoOwner: "acme", RepoName: "widget", ItemType: db.WorkspaceItemTypeIssue,
 					ItemNumber: 7, AssociatedPRNumber: ptrInt(42),
 				},
+				SourceItemVisible:   true,
 				SourceTitle:         ptr("Add retry controls"),
 				AssociatedPRVisible: true,
 			},
@@ -447,6 +452,48 @@ func TestPrepareAgentLaunchContextUsesSyncedHeadBranchForPushTarget(t *testing.T
 	assert.NotContains(string(content), "Working branch")
 }
 
+func setupAgentContextRemovalDuringRefresh(
+	t *testing.T,
+) (*Manager, *Workspace, string, *bool) {
+	t.Helper()
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMR(t, d, repoID, 42, "feature/widgets")
+	_, err := d.WriteDB().ExecContext(ctx, `
+		UPDATE forge_merge_requests
+		SET url = 'https://github.com/acme/widget/pull/42'
+		WHERE repo_id = ? AND number = 42`, repoID)
+	require.NoError(err)
+	mgr := NewManager(d, t.TempDir())
+	ws, err := mgr.Create(ctx, "github", "github.com", "acme", "widget", 42)
+	require.NoError(err)
+	worktree := ws.WorktreePath
+	initWorkspaceGitRepoAt(t, worktree)
+	require.NoError(d.UpdateWorkspaceBranch(ctx, ws.ID, "feature/widgets"))
+	require.NoError(d.UpdateWorkspaceStatus(ctx, ws.ID, "ready", nil))
+
+	removed := false
+	mgr.afterHeadRepoSnapshotRead = func() {
+		if removed {
+			return
+		}
+		removed = true
+		now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+		_, insertErr := d.WriteDB().ExecContext(ctx, `
+			INSERT INTO forge_archive_items (
+				repo_id, item_type, item_number, provider_item_id,
+				provider_created_at, provider_updated_at, lifecycle_state
+			) VALUES (?, 'merge_request', 42, 'pull-42', ?, ?, 'removed_upstream')`,
+			repoID, now, now,
+		)
+		require.NoError(insertErr)
+	}
+	return mgr, ws, worktree, &removed
+}
+
 func TestPrepareAgentLaunchContextSuppressesRemovedPullPushTarget(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
@@ -481,12 +528,31 @@ func TestPrepareAgentLaunchContextSuppressesRemovedPullPushTarget(t *testing.T) 
 	content, err := os.ReadFile(filepath.Join(worktree, "AGENTS.override.md"))
 	require.NoError(err)
 	assert.NotContains(string(content), "updates this PR")
-	assert.Contains(string(content), "repository identity unavailable; no push upstream configured")
+	assert.NotContains(string(content), "PR head:")
 	stored, err := d.GetWorkspace(ctx, ws.ID)
 	require.NoError(err)
 	require.NotNil(stored)
 	require.NotNil(stored.MRHeadRepo)
 	assert.Empty(*stored.MRHeadRepo)
+}
+
+func TestPrepareAgentLaunchContextDropsMetadataRemovedDuringRefresh(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	require := require.New(t)
+	mgr, ws, worktree, removed := setupAgentContextRemovalDuringRefresh(t)
+
+	require.NoError(mgr.PrepareAgentLaunchContext(t.Context(), PrepareAgentLaunchContextOptions{
+		WorkspaceID: ws.ID,
+		TargetKey:   "codex",
+	}))
+	require.True(*removed)
+
+	content, err := os.ReadFile(filepath.Join(worktree, "AGENTS.override.md"))
+	require.NoError(err)
+	assert.NotContains(string(content), "Test PR")
+	assert.NotContains(string(content), "https://github.com/acme/widget/pull/42")
+	assert.NotContains(string(content), "feature/widgets")
 }
 
 func TestPrepareAgentLaunchContextRefreshesLegacyUnknownHeadRepo(t *testing.T) {
@@ -596,4 +662,18 @@ func TestRenderAgentContextForWorktreeUsesPersistedWorkspace(t *testing.T) {
 	assert.Contains(rendered, "Issue: #42")
 	assert.NotContains(rendered, generatedAgentContextMarker)
 	assert.NoFileExists(filepath.Join(worktree, "CLAUDE.local.md"))
+}
+
+func TestRenderAgentContextForWorktreeDropsMetadataRemovedDuringRefresh(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	require := require.New(t)
+	mgr, _, worktree, removed := setupAgentContextRemovalDuringRefresh(t)
+
+	rendered, err := mgr.RenderAgentContextForWorktree(t.Context(), worktree)
+	require.NoError(err)
+	require.True(*removed)
+	assert.NotContains(rendered, "Test PR")
+	assert.NotContains(rendered, "https://github.com/acme/widget/pull/42")
+	assert.NotContains(rendered, "feature/widgets")
 }

--- a/internal/workspace/agent_context_test.go
+++ b/internal/workspace/agent_context_test.go
@@ -96,7 +96,8 @@ func TestBuildAgentContext(t *testing.T) {
 					RepoOwner: "acme", RepoName: "widget", ItemType: db.WorkspaceItemTypeIssue,
 					ItemNumber: 7, AssociatedPRNumber: ptrInt(42),
 				},
-				SourceTitle: ptr("Add retry controls"),
+				SourceTitle:         ptr("Add retry controls"),
+				AssociatedPRVisible: true,
 			},
 			want: []string{"Source kind: provider issue", "Issue: #7", "Associated PR: #42", "Add retry controls"},
 		},
@@ -123,6 +124,23 @@ func TestBuildAgentContext(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildAgentContextOmitsRemovedAssociatedPullRequest(t *testing.T) {
+	t.Parallel()
+	associatedPR := 42
+
+	rendered := RenderAgentContext(BuildAgentContext(WorkspaceSummary{
+		Workspace: db.Workspace{
+			ID: "ws-issue-pr", Platform: "github", PlatformHost: "github.com",
+			RepoOwner: "acme", RepoName: "widget", ItemType: db.WorkspaceItemTypeIssue,
+			ItemNumber: 7, AssociatedPRNumber: &associatedPR,
+		},
+		SourceItemVisible:   true,
+		AssociatedPRVisible: false,
+	}))
+
+	assert.NotContains(t, rendered, "Associated PR: #42")
 }
 
 func TestRenderAgentContextUsesConciseSourceIdentity(t *testing.T) {

--- a/internal/workspace/agent_context_test.go
+++ b/internal/workspace/agent_context_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -426,6 +427,48 @@ func TestPrepareAgentLaunchContextUsesSyncedHeadBranchForPushTarget(t *testing.T
 	require.NoError(err)
 	assert.Contains(string(content), "Push branch: feature/widgets-renamed on origin (updates this PR)")
 	assert.NotContains(string(content), "Working branch")
+}
+
+func TestPrepareAgentLaunchContextSuppressesRemovedPullPushTarget(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMR(t, d, repoID, 42, "feature/widgets")
+	mgr := NewManager(d, t.TempDir())
+	ws, err := mgr.Create(ctx, "github", "github.com", "acme", "widget", 42)
+	require.NoError(err)
+	worktree := ws.WorktreePath
+	initWorkspaceGitRepoAt(t, worktree)
+	require.NoError(d.UpdateWorkspaceBranch(ctx, ws.ID, "feature/widgets"))
+	require.NoError(d.UpdateWorkspaceStatus(ctx, ws.ID, "ready", nil))
+	now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	_, err = d.WriteDB().ExecContext(ctx, `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES (?, 'merge_request', 42, 'pull-42', ?, ?, 'removed_upstream')`,
+		repoID, now, now,
+	)
+	require.NoError(err)
+
+	require.NoError(mgr.PrepareAgentLaunchContext(ctx, PrepareAgentLaunchContextOptions{
+		WorkspaceID: ws.ID,
+		TargetKey:   "codex",
+	}))
+
+	content, err := os.ReadFile(filepath.Join(worktree, "AGENTS.override.md"))
+	require.NoError(err)
+	assert.NotContains(string(content), "updates this PR")
+	assert.Contains(string(content), "repository identity unavailable; no push upstream configured")
+	stored, err := d.GetWorkspace(ctx, ws.ID)
+	require.NoError(err)
+	require.NotNil(stored)
+	require.NotNil(stored.MRHeadRepo)
+	assert.Empty(*stored.MRHeadRepo)
 }
 
 func TestPrepareAgentLaunchContextRefreshesLegacyUnknownHeadRepo(t *testing.T) {

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -942,6 +942,42 @@ func (m *Manager) verifyWorkspaceRouteUnoccupied(
 	)
 }
 
+func (m *Manager) verifyWorkspaceSourceVisible(
+	ctx context.Context, ws *Workspace,
+) error {
+	if ws == nil {
+		return ErrWorkspaceNotFound
+	}
+	if m.db == nil ||
+		(ws.ItemType != db.WorkspaceItemTypePullRequest &&
+			ws.ItemType != db.WorkspaceItemTypeIssue) {
+		return nil
+	}
+	repo, err := m.workspaceRepo(
+		ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+	)
+	if err != nil {
+		return fmt.Errorf("look up workspace source repository: %w", err)
+	}
+	if repo == nil {
+		return fmt.Errorf("workspace source repository is not available")
+	}
+	itemType := db.ArchiveItemTypeIssue
+	if ws.ItemType == db.WorkspaceItemTypePullRequest {
+		itemType = db.ArchiveItemTypeMergeRequest
+	}
+	removed, err := m.db.IsArchiveItemRemovedUpstream(
+		ctx, repo.ID, itemType, ws.ItemNumber,
+	)
+	if err != nil {
+		return fmt.Errorf("check workspace source item visibility: %w", err)
+	}
+	if removed {
+		return fmt.Errorf("workspace source item was removed upstream")
+	}
+	return nil
+}
+
 // verifyRepoRouteUnoccupied fails closed on routes with contested history so
 // network git operations cannot exchange data with a route's new occupant.
 // Managers without a database (unmanaged local checkouts) skip the check.
@@ -978,6 +1014,12 @@ func (m *Manager) SetupWithWorktreeBasePath(
 		ws.ID, workspaceSetupStageSetup, "started",
 		"starting workspace setup",
 	)
+	// Admission and execution are separate for initial setup, retries, and
+	// recovery. Recheck the source at execution time before any Git or provider
+	// access so a retained tombstone cannot materialize a workspace.
+	if err := m.verifyWorkspaceSourceVisible(ctx, ws); err != nil {
+		return m.failSetup(ctx, ws.ID, workspaceSetupStageSetup, err)
+	}
 	// Setup is the chokepoint for every path that fetches code — initial
 	// creation, retries, and recovery — so it re-checks the same route
 	// fail-closed condition InsertWorkspace enforced at creation time.

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -1290,10 +1290,20 @@ func (m *Manager) RefreshWorkspaceHeadRepoSnapshot(
 		}
 		cloneURL := ""
 		var snapshotRevision int64
+		removed, visibilityErr := m.db.IsArchiveItemRemovedUpstream(
+			ctx, repo.ID, db.ArchiveItemTypeMergeRequest, ws.ItemNumber,
+		)
+		if visibilityErr != nil {
+			return nil, fmt.Errorf(
+				"check workspace merge request visibility: %w", visibilityErr,
+			)
+		}
 		if mr != nil {
-			cloneURL = mr.HeadRepoCloneURL
 			snapshotRevision = mr.SnapshotRevision
-			if mr.HeadRepoIdentityStale {
+			if !removed {
+				cloneURL = mr.HeadRepoCloneURL
+			}
+			if !removed && mr.HeadRepoIdentityStale {
 				return &WorkspaceHeadRepoSnapshot{
 					SnapshotRevision: snapshotRevision,
 					MRHeadRepo:       ws.MRHeadRepo,
@@ -1319,6 +1329,7 @@ func (m *Manager) RefreshWorkspaceHeadRepoSnapshot(
 			repo.ID,
 			ws.ItemNumber,
 			snapshotRevision,
+			removed,
 			refreshed,
 		)
 		if updateErr != nil {

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -337,7 +337,7 @@ func (m *Manager) Create(
 		return nil, fmt.Errorf("%w: repository not tracked", ErrWorkspaceNotFound)
 	}
 
-	mr, err := m.db.GetMergeRequestByRepoIDAndNumber(
+	mr, err := m.db.GetVisibleMergeRequestByRepoIDAndNumber(
 		ctx, repo.ID, mrNumber,
 	)
 	if err != nil {
@@ -405,7 +405,7 @@ func (m *Manager) CreateIssue(
 		return nil, fmt.Errorf("repository not tracked")
 	}
 
-	issue, err := m.db.GetIssueByRepoIDAndNumber(
+	issue, err := m.db.GetVisibleIssueByRepoIDAndNumber(
 		ctx, repo.ID, issueNumber,
 	)
 	if err != nil {

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -7064,6 +7064,72 @@ func TestSetupFailsClosedWhenRepositoryRouteReused(t *testing.T) {
 	assert.Equal("error", stored.Status)
 }
 
+func TestSetupFailsBeforeGitWhenSourceItemWasRemovedUpstream(t *testing.T) {
+	for _, itemType := range []string{
+		db.WorkspaceItemTypePullRequest,
+		db.WorkspaceItemTypeIssue,
+	} {
+		t.Run(string(itemType), func(t *testing.T) {
+			require := require.New(t)
+			d := openTestDB(t)
+			repoID := seedRepo(t, d, "github.com", "acme", "widget")
+			if itemType == db.WorkspaceItemTypePullRequest {
+				seedMR(t, d, repoID, 7, "feature/removed")
+			} else {
+				seedIssue(t, d, repoID, 7, "Removed issue")
+			}
+
+			mgr := NewManager(d, t.TempDir())
+			var resolverCalls atomic.Int32
+			var ws *Workspace
+			var err error
+			if itemType == db.WorkspaceItemTypePullRequest {
+				ws, err = mgr.Create(
+					t.Context(), "github", "github.com", "acme", "widget", 7,
+				)
+			} else {
+				ws, err = mgr.CreateIssue(
+					t.Context(), "github.com", "acme", "widget", 7,
+					CreateIssueOptions{Provider: "github"},
+				)
+			}
+			require.NoError(err)
+			require.NotNil(ws)
+			mgr.SetWorktreeBasePathResolver(func(
+				context.Context, string, string, string, string,
+			) (string, bool, error) {
+				resolverCalls.Add(1)
+				return "", false, errors.New("git setup must not start")
+			})
+
+			archiveType := db.ArchiveItemTypeIssue
+			if itemType == db.WorkspaceItemTypePullRequest {
+				archiveType = db.ArchiveItemTypeMergeRequest
+			}
+			now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+			_, err = d.WriteDB().ExecContext(t.Context(), `
+				INSERT INTO forge_archive_items (
+					repo_id, item_type, item_number, provider_item_id,
+					provider_created_at, provider_updated_at, lifecycle_state
+				) VALUES (?, ?, ?, ?, ?, ?, 'removed_upstream')`,
+				repoID, archiveType, 7, string(archiveType)+"-7", now, now,
+			)
+			require.NoError(err)
+
+			err = mgr.Setup(t.Context(), ws)
+
+			require.ErrorContains(err, "source item")
+			require.Zero(resolverCalls.Load(),
+				"workspace setup must stop before resolving a Git base")
+			require.NoDirExists(ws.WorktreePath)
+			stored, getErr := d.GetWorkspace(t.Context(), ws.ID)
+			require.NoError(getErr)
+			require.NotNil(stored)
+			require.Equal("error", stored.Status)
+		})
+	}
+}
+
 func TestRefreshWorkspaceHeadRepoSnapshotSurvivesQueuedReconciliation(t *testing.T) {
 	require := require.New(t)
 	d := openTestDB(t)

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -1702,8 +1702,15 @@ func TestReuseExistingWorkspaceWorktreeRechecksSymlinkAfterLock(t *testing.T) {
 	mgr := NewManager(d, wtDir)
 	mgr.SetWorktreeBasePathResolver(staticBaseResolver(localRepo))
 	readyForRepoLock := make(chan struct{})
+	continueToRepoLock := make(chan struct{})
+	var continueOnce sync.Once
+	continueReuse := func() {
+		continueOnce.Do(func() { close(continueToRepoLock) })
+	}
+	defer continueReuse()
 	mgr.beforeExistingWorktreeRepoLock = func() {
 		close(readyForRepoLock)
+		<-continueToRepoLock
 	}
 	ws, err := mgr.Create(t.Context(), "github", platformHost, "acme", "widget", 42)
 	require.NoError(err)
@@ -1715,10 +1722,6 @@ func TestReuseExistingWorkspaceWorktreeRechecksSymlinkAfterLock(t *testing.T) {
 	metadataDir, err := worktreeGitDir(t.Context(), ws.WorktreePath)
 	require.NoError(err)
 
-	lockRoot := mgr.localWorktreeBaseLockRoot(localRepo)
-	require.NoError(os.MkdirAll(lockRoot, 0o755))
-	held, err := mgr.locks.Acquire(t.Context(), lockRoot)
-	require.NoError(err)
 	type reuseResult struct {
 		reused bool
 		err    error
@@ -1742,7 +1745,7 @@ func TestReuseExistingWorkspaceWorktreeRechecksSymlinkAfterLock(t *testing.T) {
 	targetPath := filepath.Join(wtDir, "replacement-target")
 	require.NoError(os.Rename(ws.WorktreePath, targetPath))
 	require.NoError(os.Symlink(targetPath, ws.WorktreePath))
-	require.NoError(held.Unlock())
+	continueReuse()
 
 	select {
 	case result := <-done:

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -696,6 +696,65 @@ func TestRefreshWorkspaceHeadRepoSnapshotRetriesAfterRevisionChange(t *testing.T
 	assert.Equal("https://github.com/forker/widget.git", *stored.MRHeadRepo)
 }
 
+func TestRefreshWorkspaceHeadRepoSnapshotRetriesAfterRemoval(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMRWithHeadRepo(
+		t,
+		d,
+		repoID,
+		42,
+		"feature/thing",
+		"https://github.com/acme/widget.git",
+	)
+	ws := &Workspace{
+		ID:           "ws-refresh-head-repo-removal-race",
+		Platform:     "github",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   42,
+		GitHeadRef:   "feature/thing",
+		WorktreePath: t.TempDir(),
+		Status:       "ready",
+	}
+	require.NoError(d.InsertWorkspace(ctx, ws))
+
+	mgr := NewManager(d, t.TempDir())
+	var removed bool
+	mgr.afterHeadRepoSnapshotRead = func() {
+		if removed {
+			return
+		}
+		removed = true
+		now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+		_, err := d.WriteDB().ExecContext(ctx, `
+			INSERT INTO forge_archive_items (
+				repo_id, item_type, item_number, provider_item_id,
+				provider_created_at, provider_updated_at, lifecycle_state
+			) VALUES (?, 'merge_request', 42, 'pull-42', ?, ?, 'removed_upstream')`,
+			repoID, now, now,
+		)
+		require.NoError(err)
+	}
+
+	snapshot, err := mgr.RefreshWorkspaceHeadRepoSnapshot(ctx, ws)
+
+	require.NoError(err)
+	require.NotNil(snapshot)
+	require.NotNil(snapshot.MRHeadRepo)
+	assert.Empty(*snapshot.MRHeadRepo)
+	stored, err := d.GetWorkspace(ctx, ws.ID)
+	require.NoError(err)
+	require.NotNil(stored)
+	require.NotNil(stored.MRHeadRepo)
+	assert.Empty(*stored.MRHeadRepo)
+}
+
 func TestCreateIssueDefaultBranchSluggified(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/workspace/pushed_head_observer.go
+++ b/internal/workspace/pushed_head_observer.go
@@ -289,7 +289,7 @@ func (o *PushedHeadObserver) resolveWorkspacePR(ctx context.Context, ws *Workspa
 		return assoc, repo, nil, false, nil
 	}
 
-	mr, err := o.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, prNumber)
+	mr, err := o.db.GetVisibleMergeRequestByRepoIDAndNumber(ctx, repo.ID, prNumber)
 	if err != nil {
 		return assoc, repo, nil, false, fmt.Errorf("get merge request: %w", err)
 	}


### PR DESCRIPTION
Archive repair keeps removed items in local storage so Forge can restore them
if they reappear. Retained data must not behave like a current repository item
after the provider confirms removal.

- Hide `removed_upstream` items from public reads, search, autocomplete,
  activity, repository summaries, archive reports, stacks, and Kata links.
- Reject public mutations, workspace creation or setup, manual refreshes, and
  item sync before provider or Git access.
- Recheck visibility when queued work runs, exclude tombstones from periodic
  repair candidates, and restore workspace head trust after archive
  reactivation.
- Keep local workspaces and worktrees, but omit removed item links and metadata,
  merge-target diff access, and stale PR push guidance. Fail closed when a
  stored repository route no longer resolves to one active repository.
- Keep `inaccessible` items visible because an access failure does not prove
  removal. Renumber filtered stack members so visible stacks stay consistent.
