### PR TITLE
Keep workspace requests moving during live updates

### DIFF
--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -399,11 +399,20 @@ server check exactly.
 - A workspace response is user-visibly stale only when a bounded, coalesced
   head-only probe confirms cached/current Git HEAD mismatch and queues refresh;
   cache age, probe timeout, and resolution failure do not warn (`internal/server/workspaceapi/workspace_diff_cache.go::workspaceDiffCache.Get`).
-- A local workspace becomes selected through its scoped SSE stream. The server
-  subscribes that stream before acquiring the selection lease, then emits
+- Local workspace selection reuses the singleton provider SSE connection;
+  workspace subscribers attach before `workspace_id` selection and release
+  with it (`frontend/src/lib/stores/events.svelte.ts::createEventsStore`).
+- Late workspace subscribers receive current connected state, so route mount
+  does not depend on a future reconnect (`frontend/src/lib/stores/events.svelte.ts::subscribeWorkspaceEvents`).
+- Workspace event fan-out is lossless while subscribed; an event burst must not
+  terminate refresh lifecycles (`frontend/src/lib/components/terminal/workspace-event-stream.ts::workspaceEventStream`).
+- The server subscribes that stream before acquiring the selection lease, then emits
   `workspace_diff_ready` only when cold/coalesced default-HEAD preparation
   completes; a warm cache hit needs no readiness event. This ordering prevents
   fast preparation from racing ahead of the selecting browser.
+  `workspace_diff_ready` belongs to selection lifetime and never cancels an
+  active read; only `workspace_diff_changed` advances the visible refresh token
+  (`frontend/src/lib/components/terminal/workspace-event-stream.ts::WorkspaceEventSignal`).
 - Fleet selection uses `/workspaces/{id}/diff/watch` through the fleet proxy to
   hold the remote lease, prewarm HEAD, and relay opaque versions. Switching
   aborts and replaces the watch, so only the selected remote workspace refreshes

--- a/frontend/src/App.workspace-launch-targets.browser.svelte.ts
+++ b/frontend/src/App.workspace-launch-targets.browser.svelte.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { page } from "vite-plus/test/browser";
 
-import { mountBrowserApp, resetKeyboardModuleState, type MountedBrowserApp } from "./test/browserAppHarness.js";
+import {
+  getBrowserEventSourceCount,
+  mountBrowserApp,
+  resetKeyboardModuleState,
+  type MountedBrowserApp,
+} from "./test/browserAppHarness.js";
 import { jsonResponse, type MockRouteOverride } from "./test/mockApiFetch.js";
 
 const workspace = {
@@ -122,6 +127,7 @@ describe("workspace launch targets (browser)", () => {
     await vi.waitFor(
       () => {
         expect(page.getByRole("region", { name: "Worktree Home" }).element()).toBeTruthy();
+        expect(getBrowserEventSourceCount()).toBe(1);
       },
       { timeout: 10_000, interval: 50 },
     );

--- a/frontend/src/lib/components/terminal/WorkspaceHost.browser.svelte.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceHost.browser.svelte.ts
@@ -20,6 +20,10 @@ import InlineWorkspacePaneHarness from "./InlineWorkspacePaneHarness.svelte";
 import { createPaneLayoutStore } from "../../stores/paneLayout.svelte.js";
 
 const WAIT = 10_000;
+const eventsStore = {
+  selectWorkspace: () => () => undefined,
+  subscribeWorkspaceEvents: () => () => undefined,
+};
 
 const identityA = {
   provider: "github",
@@ -163,7 +167,7 @@ describe("WorkspaceHost", () => {
     instance = mount(WorkspaceHost, {
       target: hostContainer,
       props: { runtime },
-      context: new Map([[STORES_KEY, { settings: settingsStore }]]),
+      context: new Map([[STORES_KEY, { events: eventsStore, settings: settingsStore }]]),
     });
 
     navigate("/terminal/ws-1");
@@ -218,7 +222,7 @@ describe("WorkspaceHost", () => {
     instance = mount(WorkspaceHost, {
       target: hostContainer,
       props: { runtime },
-      context: new Map([[STORES_KEY, { settings: settingsStore }]]),
+      context: new Map([[STORES_KEY, { events: eventsStore, settings: settingsStore }]]),
     });
 
     const prs = getInlineWorkspaceController("prs");
@@ -264,7 +268,7 @@ describe("WorkspaceHost", () => {
     instance = mount(WorkspaceHost, {
       target: hostContainer,
       props: { runtime },
-      context: new Map([[STORES_KEY, { settings: settingsStore }]]),
+      context: new Map([[STORES_KEY, { events: eventsStore, settings: settingsStore }]]),
     });
 
     const prs = getInlineWorkspaceController("prs");
@@ -314,7 +318,7 @@ describe("WorkspaceHost", () => {
     instance = mount(WorkspaceHost, {
       target: hostContainer,
       props: { runtime },
-      context: new Map([[STORES_KEY, { settings: settingsStore }]]),
+      context: new Map([[STORES_KEY, { events: eventsStore, settings: settingsStore }]]),
     });
 
     navigate("/terminal/ws-1");
@@ -401,7 +405,7 @@ describe("WorkspaceHost", () => {
       instance = mount(WorkspaceHost, {
         target: hostContainer,
         props: { runtime },
-        context: new Map([[STORES_KEY, { settings: settingsStore }]]),
+        context: new Map([[STORES_KEY, { events: eventsStore, settings: settingsStore }]]),
       });
 
       prs.claim(identityA, { id: "ws-1", status: "ready" });
@@ -449,7 +453,7 @@ describe("WorkspaceHost", () => {
       instance = mount(WorkspaceHost, {
         target: hostContainer,
         props: { runtime },
-        context: new Map([[STORES_KEY, { settings: settingsStore, diff: diffStore }]]),
+        context: new Map([[STORES_KEY, { events: eventsStore, settings: settingsStore, diff: diffStore }]]),
       });
 
       navigate("/terminal/ws-1");

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -12,13 +12,12 @@
     type NewWorkspaceRepoSeed,
   } from "../../stores/new-workspace.svelte.js";
   import { onMount, tick } from "svelte";
-  import { Effect, Schedule, Stream } from "effect";
+  import { Effect, Stream } from "effect";
   import { navigate } from "../../stores/router.svelte.ts";
   import GitBranchIcon from "@lucide/svelte/icons/git-branch";
   import ArrowUpIcon from "@lucide/svelte/icons/arrow-up";
   import ArrowDownIcon from "@lucide/svelte/icons/arrow-down";
   import { apiErrorMessage } from "../../api/runtime.js";
-  import { configuredAPIPath } from "../../api/runtime-base.js";
   import { ApiProblemError } from "../../api/effect-errors.js";
   import {
     executeGeneratedApiRequest,
@@ -26,7 +25,7 @@
     type GeneratedApi,
   } from "../../api/generated-api.js";
   import { getAppRuntime } from "../../app/runtime-context.js";
-  import { eventSourceStream } from "../../browser/event-source.js";
+  import { getStores } from "../../context.js";
   import { showFlash } from "../../stores/flash.svelte.js";
   import type { components } from "../../api/generated/schema.js";
   import { DiffStats, FilterDropdown, ScrollBox, SidebarToggle } from "@kenn-io/kit-ui";
@@ -55,6 +54,7 @@
     makeWorkspaceRefreshCoordinator,
     workspaceListLifecycle,
   } from "./workspace-list-workflow.js";
+  import { workspaceEventStream } from "./workspace-event-stream.js";
   import { decodeWorkspaceList, type WorkspaceListItem } from "./workspace-list-schema.js";
   import { parseRepoFilterValue } from "../../stores/filter.svelte.js";
   import {
@@ -121,6 +121,7 @@
   }: Props = $props();
 
   const runtime = getAppRuntime();
+  const { events: eventsStore } = getStores();
 
   const doneAcknowledgementsStorageKey =
     "kenn-forge:workspace-agent-done-acknowledgements/v1";
@@ -1313,10 +1314,8 @@
   }
 
   onMount(() => {
-    const evtUrl = configuredAPIPath("/events");
-    const workspaceEvents = eventSourceStream(evtUrl, "workspace_status").pipe(
-      Stream.retry(Schedule.exponential("1 second").pipe(Schedule.jittered)),
-      Stream.catch(() => Stream.empty),
+    const workspaceEvents = workspaceEventStream(eventsStore.subscribeWorkspaceEvents).pipe(
+      Stream.filter((signal) => signal._tag === "Status"),
     );
     const execution = runtime.runCommand(
       Effect.scoped(

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -18,6 +18,14 @@ const mockGet = vi.fn();
 const mockPost = vi.fn();
 const mockDelete = vi.fn();
 const mockNavigate = vi.fn();
+const subscribeWorkspaceEvents = vi.fn();
+let workspaceEventsSubscriber: ((event: unknown) => void) | undefined;
+
+vi.mock("../../context.js", () => ({
+  getStores: () => ({
+    events: { subscribeWorkspaceEvents },
+  }),
+}));
 
 vi.mock("../../api/runtime.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../api/runtime.js")>();
@@ -37,15 +45,8 @@ vi.mock("../../stores/router.svelte.ts", () => ({
   navigate: (path: string) => mockNavigate(path),
 }));
 
-class MockEventSource {
-  static instances: MockEventSource[] = [];
-  addEventListener = vi.fn();
-  removeEventListener = vi.fn();
-  close = vi.fn();
-
-  constructor(readonly url: string) {
-    MockEventSource.instances.push(this);
-  }
+function emitWorkspaceStatus(): void {
+  workspaceEventsSubscriber?.({ type: "workspace_status", payload: {} });
 }
 
 interface WorkspaceFixtureOptions {
@@ -216,12 +217,18 @@ describe("WorkspaceListSidebar", () => {
     mockPost.mockReset();
     mockDelete.mockReset();
     mockNavigate.mockReset();
-    MockEventSource.instances.length = 0;
+    workspaceEventsSubscriber = undefined;
+    subscribeWorkspaceEvents.mockReset();
+    subscribeWorkspaceEvents.mockImplementation((subscriber: (event: unknown) => void) => {
+      workspaceEventsSubscriber = subscriber;
+      return () => {
+        if (workspaceEventsSubscriber === subscriber) workspaceEventsSubscriber = undefined;
+      };
+    });
     resetNewWorkspaceDialogState();
     setWorkspaceRepoCatalog(undefined, false);
     localStorage.clear();
     sessionStorage.clear();
-    vi.stubGlobal("EventSource", MockEventSource);
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: { writeText: vi.fn().mockResolvedValue(undefined) },
@@ -302,13 +309,9 @@ describe("WorkspaceListSidebar", () => {
     await waitFor(() => expect(mockGet).toHaveBeenCalledWith("/workspaces", expect.anything()));
     mockGet.mockClear();
 
-    const source = MockEventSource.instances[0];
-    const listener = source?.addEventListener.mock.calls.find(([type]) => type === "workspace_status")?.[1] as
-      | ((event: MessageEvent) => void)
-      | undefined;
-    listener?.(new MessageEvent("workspace_status"));
-    listener?.(new MessageEvent("workspace_status"));
-    listener?.(new MessageEvent("workspace_status"));
+    emitWorkspaceStatus();
+    emitWorkspaceStatus();
+    emitWorkspaceStatus();
     const workspaceRequestCount = () => mockGet.mock.calls.filter(([path]) => path === "/workspaces").length;
 
     await new Promise((resolve) => setTimeout(resolve, 15));
@@ -754,11 +757,7 @@ describe("WorkspaceListSidebar", () => {
     expect(await screen.findByText("Initial local workspace")).toBeTruthy();
     await waitFor(() => expect(peerLoads).toBe(1));
 
-    const source = MockEventSource.instances[0];
-    const listener = source?.addEventListener.mock.calls.find(([type]) => type === "workspace_status")?.[1] as
-      | ((event: MessageEvent) => void)
-      | undefined;
-    listener?.(new MessageEvent("workspace_status"));
+    emitWorkspaceStatus();
 
     expect(await screen.findByText("Updated local workspace")).toBeTruthy();
   });
@@ -825,11 +824,7 @@ describe("WorkspaceListSidebar", () => {
     render(WorkspaceListSidebar, { props: { selectedId: "" } });
     expect(await screen.findByText("Last known remote workspace")).toBeTruthy();
 
-    const source = MockEventSource.instances[0];
-    const listener = source?.addEventListener.mock.calls.find(([type]) => type === "workspace_status")?.[1] as
-      | ((event: MessageEvent) => void)
-      | undefined;
-    listener?.(new MessageEvent("workspace_status"));
+    emitWorkspaceStatus();
 
     await waitFor(() => expect(peerLoads).toBe(2));
     expect(screen.getByText("Last known remote workspace")).toBeTruthy();

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.host-visible.browser.svelte.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.host-visible.browser.svelte.ts
@@ -13,6 +13,10 @@ import { createMockApiFetch, jsonResponse, type MockRouteOverride } from "../../
 import WorkspaceTerminalView from "./WorkspaceTerminalViewTestHarness.svelte";
 
 const WAIT = 10_000;
+const eventsStore = {
+  selectWorkspace: () => () => undefined,
+  subscribeWorkspaceEvents: () => () => undefined,
+};
 
 const workspace = {
   id: "ws-1",
@@ -178,7 +182,7 @@ describe("WorkspaceTerminalView hostVisible", () => {
         hideWorkspaceList: true,
         hideRightSidebar: true,
       },
-      context: new Map([[STORES_KEY, { settings: settingsStore }]]),
+      context: new Map([[STORES_KEY, { events: eventsStore, settings: settingsStore }]]),
     });
 
     try {
@@ -247,7 +251,7 @@ describe("WorkspaceTerminalView hostVisible", () => {
           return hostVisible;
         },
       },
-      context: new Map([[STORES_KEY, { settings: settingsStore }]]),
+      context: new Map([[STORES_KEY, { events: eventsStore, settings: settingsStore }]]),
     });
 
     try {
@@ -313,7 +317,7 @@ describe("WorkspaceTerminalView hostVisible", () => {
           return hostVisible;
         },
       },
-      context: new Map([[STORES_KEY, { settings: settingsStore }]]),
+      context: new Map([[STORES_KEY, { events: eventsStore, settings: settingsStore }]]),
     });
 
     try {
@@ -387,7 +391,7 @@ describe("WorkspaceTerminalView hostVisible", () => {
           return hostVisible;
         },
       },
-      context: new Map([[STORES_KEY, { settings: settingsStore, diff: diffStore }]]),
+      context: new Map([[STORES_KEY, { events: eventsStore, settings: settingsStore, diff: diffStore }]]),
     });
 
     const pressSidebarToggle = () => {
@@ -471,7 +475,7 @@ describe("WorkspaceTerminalView hostVisible", () => {
         hideWorkspaceList: true,
         hideRightSidebar: false,
       },
-      context: new Map([[STORES_KEY, { settings: settingsStore, diff: diffStore }]]),
+      context: new Map([[STORES_KEY, { events: eventsStore, settings: settingsStore, diff: diffStore }]]),
     });
 
     const resizeWindow = () => {
@@ -540,7 +544,7 @@ describe("WorkspaceTerminalView hostVisible", () => {
           return hostVisible;
         },
       },
-      context: new Map([[STORES_KEY, { settings: settingsStore }]]),
+      context: new Map([[STORES_KEY, { events: eventsStore, settings: settingsStore }]]),
     });
 
     try {
@@ -625,7 +629,7 @@ describe("WorkspaceTerminalView hostVisible", () => {
         hideWorkspaceList: true,
         hideRightSidebar: true,
       },
-      context: new Map([[STORES_KEY, { settings: settingsStore }]]),
+      context: new Map([[STORES_KEY, { events: eventsStore, settings: settingsStore }]]),
     });
 
     try {
@@ -692,7 +696,7 @@ describe("WorkspaceTerminalView hostVisible", () => {
         hideWorkspaceList: true,
         hideRightSidebar: true,
       },
-      context: new Map([[STORES_KEY, { settings: settingsStore }]]),
+      context: new Map([[STORES_KEY, { events: eventsStore, settings: settingsStore }]]),
     });
 
     try {
@@ -752,7 +756,7 @@ describe("WorkspaceTerminalView hostVisible", () => {
           return hostVisible;
         },
       },
-      context: new Map([[STORES_KEY, { settings: settingsStore }]]),
+      context: new Map([[STORES_KEY, { events: eventsStore, settings: settingsStore }]]),
     });
 
     try {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.layout-flip.browser.svelte.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.layout-flip.browser.svelte.ts
@@ -10,6 +10,10 @@ import type { WorkspaceRuntimeState } from "../../api/workspace-runtime.ts";
 import WorkspaceTerminalView from "./WorkspaceTerminalViewTestHarness.svelte";
 
 const WAIT = 10_000;
+const eventsStore = {
+  selectWorkspace: () => () => undefined,
+  subscribeWorkspaceEvents: () => () => undefined,
+};
 
 const workspace = {
   id: "ws-1",
@@ -94,7 +98,7 @@ describe("WorkspaceTerminalView layout flip", () => {
 
     const screen = render(WorkspaceTerminalView, {
       props: { runtime, workspaceId: "ws-1", hideWorkspaceList: false, hideRightSidebar: true },
-      context: new Map([[STORES_KEY, { settings: settingsStore }]]),
+      context: new Map([[STORES_KEY, { events: eventsStore, settings: settingsStore }]]),
     });
 
     try {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -121,7 +121,6 @@
   } from "../../icons.ts";
   import { apiErrorMessage } from "../../api/runtime.js";
   import { ProblemCodes } from "../../api/problems.js";
-  import { configuredAPIPath } from "../../api/runtime-base.js";
   import {
     executeGeneratedApiRequest,
     executeOpaqueGeneratedApiRequest,
@@ -229,7 +228,7 @@
   const basePath = (
     window.__BASE_PATH__ ?? "/"
   ).replace(/\/$/, "");
-  const { settings: settingsStore } = getStores();
+  const { events: eventsStore, settings: settingsStore } = getStores();
   const appRuntime = getAppRuntime();
   const runtimeOwner = makeWorkspaceRuntimeOwner("workspace-view");
   const runtimePresenterID = makeWorkspaceRuntimePresenterID();
@@ -3884,15 +3883,14 @@
         )
       : null;
 
-    const evtUrl = new URL(configuredAPIPath("/events"), window.location.origin);
-    if (!hostKey) {
-      evtUrl.searchParams.set("workspace_id", id);
-    }
     const workspaceLifecycle = appRuntime.runCommand(
       Effect.gen(function* () {
         const initialWorkspace = yield* Deferred.make<Workspace | null>();
         const events = Stream.runForEach(
-          workspaceEventStream(`${evtUrl.pathname}${evtUrl.search}`),
+          workspaceEventStream(
+            eventsStore.subscribeWorkspaceEvents,
+            hostKey ? undefined : () => eventsStore.selectWorkspace(id),
+          ),
           (signal) => {
             switch (signal._tag) {
               case "Open":
@@ -3925,6 +3923,17 @@
                     }),
                   ),
                 );
+              case "DiffReady":
+                return Effect.sync(() => {
+                  if (
+                    signal.workspaceId !== id ||
+                    signal.version === undefined ||
+                    signal.version === ""
+                  ) {
+                    return;
+                  }
+                  lastDiffSnapshotVersion = signal.version;
+                });
               case "DiffChanged":
                 return Effect.sync(() => {
                   if (

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -48,8 +48,10 @@ const mocks = vi.hoisted(() => ({
   mockUpdateSettings: vi.fn(),
   renameWorkspaceSession: vi.fn(),
   runtime: undefined as unknown as OwnedAppRuntime,
+  selectWorkspace: vi.fn(),
   showFlash: vi.fn(),
   stopWorkspaceSession: vi.fn(),
+  subscribeWorkspaceEvents: vi.fn(),
   terminalWrite: vi.fn(),
   diffStore: null as unknown as ReturnType<typeof createDiffStore>,
   workspaceSidebarPreference: "diff" as "diff" | "item",
@@ -169,6 +171,10 @@ vi.mock("../../context.js", async (importOriginal) => {
         }),
       },
       diff: mocks.diffStore,
+      events: {
+        selectWorkspace: mocks.selectWorkspace,
+        subscribeWorkspaceEvents: mocks.subscribeWorkspaceEvents,
+      },
     }),
   };
 });
@@ -632,27 +638,26 @@ type RecordedEventSource = {
 
 function installEventSourceRecorder(): RecordedEventSource[] {
   const sources: RecordedEventSource[] = [];
-  vi.stubGlobal(
-    "EventSource",
-    class {
-      readonly record: RecordedEventSource;
-
-      constructor(url: string) {
-        this.record = { url, listeners: {} };
-        sources.push(this.record);
-      }
-
-      addEventListener(type: string, callback: RecordedEventListener): void {
-        this.record.listeners[type] = callback;
-      }
-
-      removeEventListener(type: string, callback: RecordedEventListener): void {
-        if (this.record.listeners[type] === callback) delete this.record.listeners[type];
-      }
-
-      close(): void {}
-    },
-  );
+  mocks.subscribeWorkspaceEvents.mockImplementation((subscriber: (event: unknown) => void) => {
+    const record: RecordedEventSource = {
+      url: "shared-provider-events",
+      listeners: {
+        open: () => subscriber({ type: "open" }),
+        "reconnect.stale": () => subscriber({ type: "reconnect.stale" }),
+        workspace_status: (event) => subscriber({ type: "workspace_status", payload: JSON.parse(event?.data ?? "{}") }),
+        workspace_pr_associated: (event) =>
+          subscriber({ type: "workspace_pr_associated", payload: JSON.parse(event?.data ?? "{}") }),
+        workspace_diff_ready: (event) =>
+          subscriber({ type: "workspace_diff_ready", payload: JSON.parse(event?.data ?? "{}") }),
+        workspace_diff_changed: (event) =>
+          subscriber({ type: "workspace_diff_changed", payload: JSON.parse(event?.data ?? "{}") }),
+      },
+    };
+    sources.push(record);
+    return () => {
+      for (const type of Object.keys(record.listeners)) delete record.listeners[type];
+    };
+  });
   return sources;
 }
 
@@ -716,6 +721,8 @@ describe("WorkspaceTerminalView", () => {
     mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithStaleSession());
     mocks.launchWorkspaceSession.mockReset();
     mocks.renameWorkspaceSession.mockReset();
+    mocks.selectWorkspace.mockReset();
+    mocks.selectWorkspace.mockReturnValue(() => undefined);
     mocks.showFlash.mockReset();
     mocks.renameWorkspaceSession.mockImplementation(
       async (_workspaceId: string, sessionKey: string, label: string) => ({
@@ -725,6 +732,8 @@ describe("WorkspaceTerminalView", () => {
       }),
     );
     mocks.stopWorkspaceSession.mockReset();
+    mocks.subscribeWorkspaceEvents.mockReset();
+    mocks.subscribeWorkspaceEvents.mockReturnValue(() => undefined);
     mocks.terminalWrite.mockReset();
     mocks.mockTerminalInstances.length = 0;
     mocks.mockSetTerminalSettings.mockReset();
@@ -1357,23 +1366,67 @@ describe("WorkspaceTerminalView", () => {
   });
 
   it("scopes only local workspace event streams for diff prewarming", async () => {
-    const urls: string[] = [];
-    vi.stubGlobal(
-      "EventSource",
-      class {
-        constructor(url: string) {
-          urls.push(url);
-        }
-        addEventListener(): void {}
-        close(): void {}
-      },
-    );
-
+    const releaseSelection = vi.fn();
+    mocks.selectWorkspace.mockReturnValue(releaseSelection);
     const { rerender } = render(WorkspaceTerminalView, { props: { workspaceId: "ws-1" } });
-    await waitFor(() => expect(urls).toContain("/api/v1/events?workspace_id=ws-1"));
+    await waitFor(() => expect(mocks.selectWorkspace).toHaveBeenCalledWith("ws-1"));
 
     await rerender({ workspaceId: "ws-1", workspaceHostKey: "member" });
-    await waitFor(() => expect(urls.at(-1)).toBe("/api/v1/events"));
+    await waitFor(() => expect(releaseSelection).toHaveBeenCalledOnce());
+    expect(mocks.selectWorkspace).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps an active diff load when selected prewarming becomes ready", async () => {
+    window.__BASE_PATH__ = window.location.origin;
+    localStorage.setItem("kenn-forge-workspace-sidebar-open", "true");
+    localStorage.setItem("kenn-forge-workspace-sidebar-tab:ws-1", "diff");
+    const eventSources = installEventSourceRecorder();
+    const loadWorkspaceDiff = vi.spyOn(mocks.diffStore, "loadWorkspaceDiff").mockResolvedValue();
+    const cancelWorkspaceDiff = vi.spyOn(mocks.diffStore, "cancelWorkspaceDiff");
+
+    render(WorkspaceTerminalView, {
+      props: { workspaceId: "ws-1" },
+      context: new Map([[STORES_KEY, { diff: mocks.diffStore }]]),
+    });
+
+    await waitFor(() => expect(loadWorkspaceDiff).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(latestWorkspaceEventListeners(eventSources).workspace_diff_ready).toBeTypeOf("function"),
+    );
+    const listeners = latestWorkspaceEventListeners(eventSources);
+    listeners.workspace_diff_ready?.(
+      new MessageEvent("workspace_diff_ready", {
+        data: JSON.stringify({ workspace_id: "ws-1", version: "generation:ready" }),
+      }),
+    );
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockClear();
+    listeners.workspace_status?.(
+      new MessageEvent("workspace_status", {
+        data: JSON.stringify({ id: "ws-1" }),
+      }),
+    );
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([input]) => fetchPath(input).endsWith("/workspaces/ws-1"))).toBe(true),
+    );
+    expect(loadWorkspaceDiff).toHaveBeenCalledTimes(1);
+    expect(cancelWorkspaceDiff).not.toHaveBeenCalled();
+
+    listeners.workspace_diff_changed?.(
+      new MessageEvent("workspace_diff_changed", {
+        data: JSON.stringify({ workspace_id: "ws-1", version: "generation:changed" }),
+      }),
+    );
+
+    await waitFor(() => expect(loadWorkspaceDiff.mock.calls.length).toBeGreaterThan(1));
+    expect(loadWorkspaceDiff).toHaveBeenCalledTimes(2);
+    expect(cancelWorkspaceDiff).toHaveBeenCalledTimes(1);
+    expect(loadWorkspaceDiff).toHaveBeenLastCalledWith(
+      "ws-1",
+      "head",
+      false,
+      expect.objectContaining({ preserveVisible: true }),
+    );
   });
 
   it("prewarms a selected fleet diff and reloads it when the remote watch advances", async () => {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalViewEmbed.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalViewEmbed.test.ts
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
     DELETE: vi.fn(),
   },
   showFlash: vi.fn(),
+  workspaceEventsSubscriber: undefined as ((event: unknown) => void) | undefined,
 }));
 const runtimeState = vi.hoisted<{ appRuntime?: OwnedAppRuntime }>(() => ({}));
 
@@ -100,6 +101,15 @@ vi.mock("../../context.js", async (importOriginal) => {
   return {
     ...actual,
     getStores: () => ({
+      events: {
+        selectWorkspace: () => () => undefined,
+        subscribeWorkspaceEvents: (subscriber: (event: unknown) => void) => {
+          mocks.workspaceEventsSubscriber = subscriber;
+          return () => {
+            if (mocks.workspaceEventsSubscriber === subscriber) mocks.workspaceEventsSubscriber = undefined;
+          };
+        },
+      },
       settings: {
         getTerminalSettings: () => ({
           font_family: "",
@@ -180,6 +190,7 @@ describe("WorkspaceTerminalView embed props", () => {
     mocks.runtimeClient.POST.mockReset();
     mocks.runtimeClient.DELETE.mockReset();
     mocks.showFlash.mockReset();
+    mocks.workspaceEventsSubscriber = undefined;
     mocks.runtimeClient.GET.mockResolvedValue({
       data: readyWorkspaceData,
       error: undefined,
@@ -376,19 +387,6 @@ describe("WorkspaceTerminalView embed props", () => {
       }
       return { data: workspaceWithRepo, error: undefined, response: { status: 200 } };
     });
-    const listeners = new Map<string, (event?: MessageEvent) => void>();
-    vi.stubGlobal(
-      "EventSource",
-      class {
-        addEventListener(type: string, cb: (event?: MessageEvent) => void): void {
-          listeners.set(type, cb);
-        }
-        removeEventListener(type: string, cb: (event?: MessageEvent) => void): void {
-          if (listeners.get(type) === cb) listeners.delete(type);
-        }
-        close(): void {}
-      },
-    );
     const onWorkspaceDeleted = vi.fn();
 
     render(WorkspaceTerminalView, {
@@ -397,8 +395,8 @@ describe("WorkspaceTerminalView embed props", () => {
     await waitFor(() => expect(screen.getAllByText("feature/embed-props").length).toBeGreaterThan(0));
 
     gone = true;
-    await waitFor(() => expect(listeners.get("workspace_status")).toBeTypeOf("function"));
-    listeners.get("workspace_status")?.(new MessageEvent("workspace_status", { data: JSON.stringify({ id: "ws-1" }) }));
+    await waitFor(() => expect(mocks.workspaceEventsSubscriber).toBeTypeOf("function"));
+    mocks.workspaceEventsSubscriber?.({ type: "workspace_status", payload: { id: "ws-1" } });
 
     await waitFor(() => {
       expect(onWorkspaceDeleted).toHaveBeenCalledWith(

--- a/frontend/src/lib/components/terminal/workspace-event-stream.test.ts
+++ b/frontend/src/lib/components/terminal/workspace-event-stream.test.ts
@@ -1,0 +1,62 @@
+import { Effect, Stream } from "effect";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import type { WorkspaceEventsNotification } from "../../stores/events.svelte.js";
+import { workspaceEventStream } from "./workspace-event-stream.js";
+
+describe("workspaceEventStream", () => {
+  it("subscribes before selecting the workspace and releases both together", async () => {
+    let subscriber: ((event: WorkspaceEventsNotification) => void) | undefined;
+    const unsubscribe = vi.fn();
+    const releaseSelection = vi.fn();
+
+    const signals = await Effect.runPromise(
+      workspaceEventStream(
+        (next) => {
+          subscriber = next;
+          return unsubscribe;
+        },
+        () => {
+          subscriber?.({
+            type: "workspace_diff_ready",
+            payload: { workspace_id: "ws-1", version: "generation:ready" },
+          });
+          return releaseSelection;
+        },
+      ).pipe(Stream.take(1), Stream.runCollect, Effect.timeout("1 second")),
+    );
+
+    expect(signals).toEqual([{ _tag: "DiffReady", workspaceId: "ws-1", version: "generation:ready" }]);
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(releaseSelection).toHaveBeenCalledOnce();
+  });
+
+  it("delivers a burst without terminating the workspace stream", async () => {
+    let subscriber: ((event: WorkspaceEventsNotification) => void) | undefined;
+
+    const signals = await Effect.runPromise(
+      workspaceEventStream(
+        (next) => {
+          subscriber = next;
+          return () => {};
+        },
+        () => {
+          for (let index = 0; index < 100; index += 1) {
+            subscriber?.({
+              type: "workspace_diff_changed",
+              payload: { workspace_id: "ws-1", version: `generation:${index}` },
+            });
+          }
+          return () => {};
+        },
+      ).pipe(Stream.take(100), Stream.runCollect, Effect.timeout("1 second")),
+    );
+
+    expect(signals).toHaveLength(100);
+    expect(signals.at(-1)).toEqual({
+      _tag: "DiffChanged",
+      workspaceId: "ws-1",
+      version: "generation:99",
+    });
+  });
+});

--- a/frontend/src/lib/components/terminal/workspace-event-stream.ts
+++ b/frontend/src/lib/components/terminal/workspace-event-stream.ts
@@ -1,19 +1,5 @@
-import { Cause, Effect, Option, Queue, Schema, Stream } from "effect";
-import { TransientTransportError } from "../../api/effect-errors.js";
-import { openEventSource, type EventSourceFactory } from "../../browser/event-source.js";
-
-class WorkspaceStatusPayload extends Schema.Class<WorkspaceStatusPayload>("WorkspaceStatusPayload")({
-  id: Schema.optionalKey(Schema.String),
-}) {}
-
-class WorkspaceAssociatedPayload extends Schema.Class<WorkspaceAssociatedPayload>("WorkspaceAssociatedPayload")({
-  workspace_id: Schema.optionalKey(Schema.String),
-}) {}
-
-class WorkspaceDiffPayload extends Schema.Class<WorkspaceDiffPayload>("WorkspaceDiffPayload")({
-  workspace_id: Schema.optionalKey(Schema.String),
-  version: Schema.optionalKey(Schema.String),
-}) {}
+import { Effect, Queue, Stream } from "effect";
+import type { WorkspaceEventsNotification } from "../../stores/events.svelte.js";
 
 export type WorkspaceEventSignal =
   | { readonly _tag: "Open" }
@@ -21,70 +7,60 @@ export type WorkspaceEventSignal =
   | { readonly _tag: "Associated"; readonly workspaceId?: string | undefined }
   | { readonly _tag: "ReconnectStale" }
   | {
-      readonly _tag: "DiffChanged";
+      readonly _tag: "DiffReady" | "DiffChanged";
       readonly workspaceId?: string | undefined;
       readonly version?: string | undefined;
     };
 
-export const workspaceEventStream = (
-  url: string,
-): Stream.Stream<WorkspaceEventSignal, TransientTransportError, EventSourceFactory> =>
-  Stream.callback<WorkspaceEventSignal, TransientTransportError, EventSourceFactory>(
-    (queue) =>
-      Effect.gen(function* () {
-        const source = yield* openEventSource(url);
-        const offer = (signal: WorkspaceEventSignal): void => {
-          if (Queue.offerUnsafe(queue, signal)) return;
-          Queue.failCauseUnsafe(
-            queue,
-            Cause.fail(
-              TransientTransportError.make({
-                operation: `buffer workspace events ${url}`,
-                cause: new Error("Workspace event buffer overflow"),
-              }),
-            ),
-          );
-        };
-        const onOpen = (): void => offer({ _tag: "Open" });
-        const onStatus = (event: Event): void => {
-          if (!(event instanceof MessageEvent) || typeof event.data !== "string") return;
-          const decoded = Schema.decodeUnknownOption(Schema.fromJsonString(WorkspaceStatusPayload))(event.data);
-          if (Option.isSome(decoded)) offer({ _tag: "Status", workspaceId: decoded.value.id });
-        };
-        const onAssociated = (event: Event): void => {
-          if (!(event instanceof MessageEvent) || typeof event.data !== "string") return;
-          const decoded = Schema.decodeUnknownOption(Schema.fromJsonString(WorkspaceAssociatedPayload))(event.data);
-          if (Option.isSome(decoded)) offer({ _tag: "Associated", workspaceId: decoded.value.workspace_id });
-        };
-        const onReconnectStale = (): void => offer({ _tag: "ReconnectStale" });
-        const onDiffChanged = (event: Event): void => {
-          if (!(event instanceof MessageEvent) || typeof event.data !== "string") return;
-          const decoded = Schema.decodeUnknownOption(Schema.fromJsonString(WorkspaceDiffPayload))(event.data);
-          if (Option.isSome(decoded)) {
-            offer({
-              _tag: "DiffChanged",
-              workspaceId: decoded.value.workspace_id,
-              version: decoded.value.version,
-            });
-          }
-        };
+type WorkspaceEventsSubscription = (subscriber: (event: WorkspaceEventsNotification) => void) => () => void;
+type WorkspaceSelection = () => () => void;
 
-        source.addEventListener("open", onOpen);
-        source.addEventListener("workspace_status", onStatus);
-        source.addEventListener("workspace_pr_associated", onAssociated);
-        source.addEventListener("reconnect.stale", onReconnectStale);
-        source.addEventListener("workspace_diff_ready", onDiffChanged);
-        source.addEventListener("workspace_diff_changed", onDiffChanged);
-        yield* Effect.addFinalizer(() =>
-          Effect.sync(() => {
-            source.removeEventListener("open", onOpen);
-            source.removeEventListener("workspace_status", onStatus);
-            source.removeEventListener("workspace_pr_associated", onAssociated);
-            source.removeEventListener("reconnect.stale", onReconnectStale);
-            source.removeEventListener("workspace_diff_ready", onDiffChanged);
-            source.removeEventListener("workspace_diff_changed", onDiffChanged);
-          }),
-        );
-      }),
-    { bufferSize: 64, strategy: "dropping" },
+function workspaceEventSignal(event: WorkspaceEventsNotification): WorkspaceEventSignal | undefined {
+  switch (event.type) {
+    case "open":
+      return { _tag: "Open" };
+    case "workspace_status":
+      return { _tag: "Status", workspaceId: event.payload.id };
+    case "workspace_pr_associated":
+      return { _tag: "Associated", workspaceId: event.payload.workspace_id };
+    case "reconnect.stale":
+      return { _tag: "ReconnectStale" };
+    case "workspace_diff_ready":
+      return {
+        _tag: "DiffReady",
+        workspaceId: event.payload.workspace_id,
+        version: event.payload.version,
+      };
+    case "workspace_diff_changed":
+      return {
+        _tag: "DiffChanged",
+        workspaceId: event.payload.workspace_id,
+        version: event.payload.version,
+      };
+    default:
+      return undefined;
+  }
+}
+
+export const workspaceEventStream = (
+  subscribe: WorkspaceEventsSubscription,
+  selectWorkspace?: WorkspaceSelection,
+): Stream.Stream<WorkspaceEventSignal> =>
+  Stream.callback<WorkspaceEventSignal>((queue) =>
+    Effect.gen(function* () {
+      const offer = (signal: WorkspaceEventSignal): void => {
+        Queue.offerUnsafe(queue, signal);
+      };
+      const unsubscribe = yield* Effect.sync(() =>
+        subscribe((event) => {
+          const signal = workspaceEventSignal(event);
+          if (signal !== undefined) offer(signal);
+        }),
+      );
+      yield* Effect.addFinalizer(() => Effect.sync(unsubscribe));
+      if (selectWorkspace !== undefined) {
+        const releaseSelection = yield* Effect.sync(selectWorkspace);
+        yield* Effect.addFinalizer(() => Effect.sync(releaseSelection));
+      }
+    }),
   );

--- a/frontend/src/lib/stores/events.svelte.test.ts
+++ b/frontend/src/lib/stores/events.svelte.test.ts
@@ -137,6 +137,30 @@ describe("createEventsStore URL building", () => {
 });
 
 describe("createEventsStore event dispatch", () => {
+  it("fans workspace diff events out from the shared provider stream", async () => {
+    const received: unknown[] = [];
+    const store = createEventsStore();
+    const unsubscribe = store.subscribeWorkspaceEvents((event) => {
+      received.push(event);
+    });
+    start(store);
+    const source = await awaitSource();
+
+    emit(source, "workspace_diff_ready", {
+      data: JSON.stringify({ workspace_id: "ws-1", version: "generation:ready" }),
+    });
+
+    await vi.waitFor(() =>
+      expect(received).toEqual([
+        {
+          type: "workspace_diff_ready",
+          payload: { workspace_id: "ws-1", version: "generation:ready" },
+        },
+      ]),
+    );
+    unsubscribe();
+  });
+
   it("fires onDataChanged for data_changed frames", async () => {
     const onDataChanged = vi.fn(() => Effect.void);
     const store = createEventsStore({ onDataChanged });
@@ -342,6 +366,35 @@ describe("createEventsStore event dispatch", () => {
 });
 
 describe("createEventsStore connection lifecycle", () => {
+  it("replays the open signal to a subscriber that mounts after connection", async () => {
+    const store = createEventsStore();
+    start(store);
+    emit(await awaitSource(), "open", {});
+    await vi.waitFor(() => expect(store.getConnectionState()).toBe("connected"));
+
+    const received: unknown[] = [];
+    store.subscribeWorkspaceEvents((event) => received.push(event));
+
+    expect(received).toEqual([{ type: "open" }]);
+  });
+
+  it("moves workspace selection onto the singleton provider stream", async () => {
+    const store = createEventsStore();
+    start(store);
+    const initial = await awaitSource();
+
+    const releaseSelection = store.selectWorkspace("ws-1");
+    const selected = await awaitSource(1);
+
+    expect(initial.closed).toBe(true);
+    expect(selected.url).toBe("/api/v1/events?workspace_id=ws-1");
+
+    releaseSelection();
+    const released = await awaitSource(2);
+    expect(selected.closed).toBe(true);
+    expect(released.url).toBe("/api/v1/events");
+  });
+
   it("connection state reflects open and error events", async () => {
     const store = createEventsStore();
     start(store);

--- a/frontend/src/lib/stores/events.svelte.ts
+++ b/frontend/src/lib/stores/events.svelte.ts
@@ -52,65 +52,101 @@ export interface EventsStoreOptions {
   readonly onRecoverableFailure?: (message: string) => void;
 }
 
+export type WorkspaceEventsNotification = { readonly type: "open" } | ProviderEvent;
+
 export function createEventsStore(opts: EventsStoreOptions) {
   const getBasePath = opts.getBasePath ?? (() => "/");
   let connectionState = $state<ProviderEventsConnectionState>("disconnected");
   let lastError = $state<string | null>(null);
   let reconnectSignal: Deferred.Deferred<void> | null = null;
+  let streamRestartSignal: Deferred.Deferred<void> | null = null;
+  let workspaceSelectionSequence = 0;
+  const workspaceSelections = new Map<number, string>();
+  const workspaceEventSubscribers = new Set<(event: WorkspaceEventsNotification) => void>();
+
+  function notifyWorkspaceEventSubscribers(event: WorkspaceEventsNotification): void {
+    for (const subscriber of workspaceEventSubscribers) subscriber(event);
+  }
+
+  function selectedWorkspaceId(): string | undefined {
+    return Array.from(workspaceSelections.values()).at(-1);
+  }
 
   function buildURL(): string {
     const base = getBasePath().replace(/\/$/, "");
-    return `${base}/api/v1/events`;
+    const url = `${base}/api/v1/events`;
+    const workspaceId = selectedWorkspaceId();
+    return workspaceId === undefined ? url : `${url}?workspace_id=${encodeURIComponent(workspaceId)}`;
   }
 
   function dispatch(event: ProviderEvent): Effect.Effect<void, ProviderEventsError, AppServices> {
-    switch (event.type) {
-      case "data_changed":
-        return opts.onDataChanged?.() ?? Effect.void;
-      case "sync_status":
-        return opts.onSyncStatus?.(event.payload) ?? Effect.void;
-      case "config.changed":
-        return opts.onConfigChanged?.(event.payload) ?? Effect.void;
-      case "reconnect.stale":
-        return opts.onReconnectStale?.() ?? Effect.void;
-      case "workspace_created":
-        return opts.onWorkspaceCreated?.(event.payload) ?? Effect.void;
-      case "workspace_status":
-        return opts.onWorkspaceStatus?.(event.payload) ?? Effect.void;
-      case "workspace_deleted":
-        return opts.onWorkspaceDeleted?.(event.payload) ?? Effect.void;
-      case "workspace_pushed_head_changed":
-        return opts.onWorkspacePushedHeadChanged?.(event.payload) ?? Effect.void;
-      case "workspace_pr_associated":
-        return opts.onWorkspacePRAssociated?.(event.payload) ?? Effect.void;
-      case "workspace_pr_refresh_queued":
-        return opts.onWorkspacePRRefreshQueued?.(event.payload) ?? Effect.void;
-      case "pr_detail_refreshed":
-        return opts.onPRDetailRefreshed?.(event.payload) ?? Effect.void;
-      case "pr_ci_refresh_queued":
-        return opts.onPRCIRefreshQueued?.(event.payload) ?? Effect.void;
-      case "pr_ci_refreshed":
-        return opts.onPRCIRefreshed?.(event.payload) ?? Effect.void;
-      case "deferred_merge_completed":
-        return opts.onDeferredMergeCompleted?.(event.payload) ?? Effect.void;
-    }
+    const consequence = (() => {
+      switch (event.type) {
+        case "data_changed":
+          return opts.onDataChanged?.() ?? Effect.void;
+        case "sync_status":
+          return opts.onSyncStatus?.(event.payload) ?? Effect.void;
+        case "config.changed":
+          return opts.onConfigChanged?.(event.payload) ?? Effect.void;
+        case "reconnect.stale":
+          return opts.onReconnectStale?.() ?? Effect.void;
+        case "workspace_created":
+          return opts.onWorkspaceCreated?.(event.payload) ?? Effect.void;
+        case "workspace_status":
+          return opts.onWorkspaceStatus?.(event.payload) ?? Effect.void;
+        case "workspace_deleted":
+          return opts.onWorkspaceDeleted?.(event.payload) ?? Effect.void;
+        case "workspace_pushed_head_changed":
+          return opts.onWorkspacePushedHeadChanged?.(event.payload) ?? Effect.void;
+        case "workspace_pr_associated":
+          return opts.onWorkspacePRAssociated?.(event.payload) ?? Effect.void;
+        case "workspace_pr_refresh_queued":
+          return opts.onWorkspacePRRefreshQueued?.(event.payload) ?? Effect.void;
+        case "pr_detail_refreshed":
+          return opts.onPRDetailRefreshed?.(event.payload) ?? Effect.void;
+        case "pr_ci_refresh_queued":
+          return opts.onPRCIRefreshQueued?.(event.payload) ?? Effect.void;
+        case "pr_ci_refreshed":
+          return opts.onPRCIRefreshed?.(event.payload) ?? Effect.void;
+        case "deferred_merge_completed":
+          return opts.onDeferredMergeCompleted?.(event.payload) ?? Effect.void;
+        case "workspace_diff_ready":
+        case "workspace_diff_changed":
+          return Effect.void;
+      }
+    })();
+    return Effect.sync(() => notifyWorkspaceEventSubscribers(event)).pipe(Effect.andThen(consequence));
   }
 
-  const streamAttempt = Effect.suspend(() => {
+  const streamAttempt = Effect.gen(function* () {
     lastError = null;
-    const url = buildURL();
-    return providerEventsProgram({
-      url,
-      onState: (state) => {
-        connectionState = state;
-      },
-      onEvent: dispatch,
-      onConsequenceFailure: (failure) => {
-        const message = `A live update could not refresh ${failure.operation}; later updates will continue.`;
-        lastError = message;
-        opts.onRecoverableFailure?.(message);
-      },
+    const restart = yield* Deferred.make<void>();
+    yield* Effect.sync(() => {
+      streamRestartSignal = restart;
     });
+    const url = buildURL();
+    yield* Effect.raceFirst(
+      providerEventsProgram({
+        url,
+        onState: (state) => {
+          connectionState = state;
+          if (state === "connected") notifyWorkspaceEventSubscribers({ type: "open" });
+        },
+        onEvent: dispatch,
+        onConsequenceFailure: (failure) => {
+          const message = `A live update could not refresh ${failure.operation}; later updates will continue.`;
+          lastError = message;
+          opts.onRecoverableFailure?.(message);
+        },
+      }),
+      Deferred.await(restart),
+    ).pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          if (streamRestartSignal === restart) streamRestartSignal = null;
+        }),
+      ),
+    );
   });
 
   const waitForReconnect = Effect.gen(function* () {
@@ -153,6 +189,35 @@ export function createEventsStore(opts: EventsStoreOptions) {
     });
   }
 
+  function restartForWorkspaceSelection(): void {
+    const signal = streamRestartSignal;
+    if (signal === null) return;
+    opts.runtime.runCommand(Deferred.succeed(signal, undefined), {
+      operation: "reconnect provider events for workspace selection",
+      safeContext: {},
+      onFailure: () => {},
+    });
+  }
+
+  function selectWorkspace(workspaceId: string): () => void {
+    const previous = selectedWorkspaceId();
+    workspaceSelectionSequence += 1;
+    const selection = workspaceSelectionSequence;
+    workspaceSelections.set(selection, workspaceId);
+    if (selectedWorkspaceId() !== previous) restartForWorkspaceSelection();
+    return () => {
+      const beforeRelease = selectedWorkspaceId();
+      workspaceSelections.delete(selection);
+      if (selectedWorkspaceId() !== beforeRelease) restartForWorkspaceSelection();
+    };
+  }
+
+  function subscribeWorkspaceEvents(subscriber: (event: WorkspaceEventsNotification) => void): () => void {
+    workspaceEventSubscribers.add(subscriber);
+    if (connectionState === "connected") subscriber({ type: "open" });
+    return () => workspaceEventSubscribers.delete(subscriber);
+  }
+
   function getConnectionState(): ProviderEventsConnectionState {
     return connectionState;
   }
@@ -161,7 +226,14 @@ export function createEventsStore(opts: EventsStoreOptions) {
     return lastError;
   }
 
-  return { streamEffect, reconnect, getConnectionState, getLastError };
+  return {
+    streamEffect,
+    reconnect,
+    getConnectionState,
+    getLastError,
+    selectWorkspace,
+    subscribeWorkspaceEvents,
+  };
 }
 
 export type EventsStore = ReturnType<typeof createEventsStore>;

--- a/frontend/src/lib/stores/provider-events-workflow.ts
+++ b/frontend/src/lib/stores/provider-events-workflow.ts
@@ -57,6 +57,11 @@ export class WorkspaceStatusEvent extends Schema.Class<WorkspaceStatusEvent>("Wo
   status: Schema.optionalKey(Schema.String),
 }) {}
 
+export class WorkspaceDiffEvent extends Schema.Class<WorkspaceDiffEvent>("WorkspaceDiffEvent")({
+  workspace_id: Schema.String,
+  version: Schema.String,
+}) {}
+
 export class WorkspaceDeletedEvent extends Schema.Class<WorkspaceDeletedEvent>("WorkspaceDeletedEvent")({
   workspace_id: Schema.String,
   ...providerItemFields,
@@ -124,6 +129,8 @@ export type ProviderEvent =
   | { readonly type: "reconnect.stale" }
   | { readonly type: "workspace_created"; readonly payload: WorkspaceCreatedEvent }
   | { readonly type: "workspace_status"; readonly payload: WorkspaceStatusEvent }
+  | { readonly type: "workspace_diff_ready"; readonly payload: WorkspaceDiffEvent }
+  | { readonly type: "workspace_diff_changed"; readonly payload: WorkspaceDiffEvent }
   | { readonly type: "workspace_deleted"; readonly payload: WorkspaceDeletedEvent }
   | { readonly type: "workspace_pushed_head_changed"; readonly payload: WorkspacePushedHeadChangedEvent }
   | { readonly type: "workspace_pr_associated"; readonly payload: WorkspacePRAssociatedEvent }
@@ -228,6 +235,8 @@ const providerEventTypes: ReadonlyArray<ProviderEventType> = [
   "reconnect.stale",
   "workspace_created",
   "workspace_status",
+  "workspace_diff_ready",
+  "workspace_diff_changed",
   "workspace_deleted",
   "workspace_pushed_head_changed",
   "workspace_pr_associated",
@@ -316,6 +325,14 @@ const decodeProviderEvent = Effect.fn("ProviderEvents.decodeFrame")(function* (f
       return {
         type: "workspace_status",
         payload: yield* Schema.decodeUnknownEffect(WorkspaceStatusEvent)(payload).pipe(
+          Effect.mapError((cause) => invalidFrame(frame, cause)),
+        ),
+      } satisfies ProviderEvent;
+    case "workspace_diff_ready":
+    case "workspace_diff_changed":
+      return {
+        type: frame.type,
+        payload: yield* Schema.decodeUnknownEffect(WorkspaceDiffEvent)(payload).pipe(
           Effect.mapError((cause) => invalidFrame(frame, cause)),
         ),
       } satisfies ProviderEvent;

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -1143,6 +1143,9 @@ func (s *Handler) getWorkspaceFiles(
 		ctx, s.workspaceDiffCacheKey(req, hideWhitespace),
 	)
 	if diffErr != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		if errors.Is(diffErr, errWorkspaceDiffBaseUnavailable) {
 			return nil, workspaceDiffBaseUnavailable(req.Base)
 		}
@@ -1184,6 +1187,9 @@ func (s *Handler) watchWorkspaceDiff(
 
 	snapshot, _, err := s.workspaceDiffCache.Get(ctx, key)
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		if errors.Is(err, errWorkspaceDiffBaseUnavailable) {
 			return nil, workspaceDiffBaseUnavailable(req.Base)
 		}
@@ -1225,6 +1231,9 @@ func (s *Handler) watchWorkspaceDiff(
 			}
 			current, _, getErr := s.workspaceDiffCache.Get(ctx, key)
 			if getErr != nil {
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return nil, ctxErr
+				}
 				return nil, httpapi.Upstream("failed to read selected workspace diff", "", "")
 			}
 			if current.Version == input.Version {
@@ -1256,6 +1265,9 @@ func (s *Handler) getWorkspaceDiff(
 		ctx, s.workspaceDiffCacheKey(req, hideWhitespace),
 	)
 	if diffErr != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		if errors.Is(diffErr, errWorkspaceDiffBaseUnavailable) {
 			return nil, workspaceDiffBaseUnavailable(req.Base)
 		}
@@ -1331,6 +1343,9 @@ func (s *Handler) getWorkspaceFilePreview(
 		}
 	}
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		if errors.Is(err, errWorkspaceDiffBaseUnavailable) {
 			return nil, workspaceDiffBaseUnavailable(req.Base)
 		}

--- a/internal/server/workspaceapi/routes_handlers_test.go
+++ b/internal/server/workspaceapi/routes_handlers_test.go
@@ -1,0 +1,63 @@
+package workspaceapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/gitclone"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+	"go.kenn.io/forge/internal/workspace"
+)
+
+func TestGetWorkspaceFilesPropagatesCanceledRequest(t *testing.T) {
+	require := require.New(t)
+	database := dbtest.Open(t)
+	manager := workspace.NewManager(database, t.TempDir())
+	require.NoError(database.InsertWorkspace(t.Context(), &db.Workspace{
+		ID:           "ws-canceled-diff",
+		Platform:     "github",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   1,
+		WorktreePath: t.TempDir(),
+		Status:       "ready",
+	}))
+
+	requestCtx, cancelRequest := context.WithCancel(t.Context())
+	releasePreparation := make(chan struct{})
+	cacheCtx, cancelCache := context.WithCancel(context.Background())
+	cache := newWorkspaceDiffCache(cacheCtx, workspaceDiffCacheDeps{
+		resolve: func(context.Context, workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error) {
+			return workspaceDiffTestResolved(), true, nil
+		},
+		fingerprint: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (workspace.DiffFingerprint, error) {
+			return "v1", nil
+		},
+		prepare: func(ctx context.Context, _ workspace.ResolvedDiffSnapshotSpec) (*gitclone.DiffResult, error) {
+			select {
+			case <-releasePreparation:
+				return workspaceDiffTestResult("one.txt"), nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		},
+		onColdWait: cancelRequest,
+	})
+	t.Cleanup(func() {
+		close(releasePreparation)
+		cancelCache()
+		cache.Wait()
+	})
+	handler := &Handler{workspaces: manager, workspaceDiffCache: cache}
+
+	_, err := handler.getWorkspaceFiles(requestCtx, &getWorkspaceFilesInput{
+		ID:   "ws-canceled-diff",
+		Base: "head",
+	})
+
+	require.ErrorIs(err, context.Canceled)
+}


### PR DESCRIPTION
Workspace pages could open multiple long-lived event streams to the same server. Browsers could then queue ordinary requests behind those streams, leaving Diff, extra-session creation, and pull request details stuck without a browser-console error.

- Reuse the application event stream for workspace status and diff notifications.
- Keep workspace selection and subscribers in the same scoped lifetime, including late subscribers and event bursts.
- Treat canceled diff reads as cancellations instead of upstream failures.

This changes no visible layout. It removes redundant browser connections and preserves the refresh signals that move workspace screens out of loading states.

<sup>generated by a clanker</sup>
