### PR TITLE
Fix documentation promotion with project-scoped credentials

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -53,7 +53,7 @@ jobs:
     needs: validate-release
     runs-on: ubuntu-latest
     outputs:
-      deployment-url: ${{ steps.deploy.outputs.url }}
+      deployment-id: ${{ steps.deploy.outputs.id }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -72,8 +72,9 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: |
           set -euo pipefail
-          deployment_url="$(bunx --bun vercel@58.0.0 deploy --prod --skip-domain --yes --token "$VERCEL_TOKEN")"
-          echo "url=$deployment_url" >> "$GITHUB_OUTPUT"
+          deployment="$(bunx --bun vercel@58.0.0 deploy --prod --skip-domain --yes --format=json --token "$VERCEL_TOKEN")"
+          deployment_id="$(jq -er '.deployment.id // .id' <<< "$deployment")"
+          echo "id=$deployment_id" >> "$GITHUB_OUTPUT"
 
   promote:
     needs: [validate-release, build]
@@ -87,10 +88,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
           ref: ${{ needs.validate-release.outputs.release-sha }}
-
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: "1.3.14"
 
       - name: Verify the release is still latest
         env:
@@ -115,11 +112,16 @@ jobs:
 
       - name: Promote documentation
         env:
-          DEPLOYMENT_URL: ${{ needs.build.outputs.deployment-url }}
+          DEPLOYMENT_ID: ${{ needs.build.outputs.deployment-id }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-        run: bunx --bun vercel@58.0.0 promote "$DEPLOYMENT_URL" --yes --token "$VERCEL_TOKEN"
+        run: |
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --header "Authorization: Bearer $VERCEL_TOKEN" \
+            --header "Content-Type: application/json" \
+            --data '{}' \
+            "https://api.vercel.com/v10/projects/$VERCEL_PROJECT_ID/promote/$DEPLOYMENT_ID"
 
       - name: Verify promoted release remains latest
         env:

--- a/context/docs-authoring.md
+++ b/context/docs-authoring.md
@@ -45,7 +45,9 @@ screenshots, or the Zensical site.
   and WebKit. (`scripts/vercel-build-docs.sh`, `.github/workflows/ci.yml::docs`)
 - Production docs use a default-branch `workflow_run`; the released SHA must be
   on `main` and latest before build and before/after promotion. A stale attempt
-  dispatches trusted latest-release reconciliation. No Vercel Git app or GitHub environment. (`.github/workflows/deploy-docs.yml`)
+  dispatches trusted latest-release reconciliation. Promotion uses Vercel's
+  project endpoint so project-scoped tokens avoid the CLI's user lookup. No
+  Vercel Git app or GitHub environment. (`.github/workflows/deploy-docs.yml`)
 - Download links retain a static GitHub Releases fallback and enhance to the
   matching `browser_download_url` returned by the latest-release API because a
   release or the API may be unavailable. Automatic platform selection occurs

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,8 @@ The Vercel project serves production deployments at `forge.kenn.io`. A
 successful tagged release starts a default-branch workflow that verifies the
 released commit belongs to `main` and still backs GitHub's latest release. It
 builds that exact checkout on Vercel without changing the production alias,
-then rechecks the latest release tag and commit before promotion.
+then rechecks the latest release tag and commit before promoting it through
+Vercel's project API.
 The workflow checks again after promotion; if a newer release was published
 during that interval, it dispatches a trusted workflow that resolves and
 deploys the actual latest release. Promotion attempts are not placed in a


### PR DESCRIPTION
The release docs build accepted the project-scoped Vercel token, but promotion failed before reaching the project endpoint because the Vercel CLI first queried a user-level resource.

- Carry the built deployment ID into the promotion job.
- Promote through Vercel's project API so the token remains project-scoped.
- Preserve the existing latest-release checks and reconciliation behavior.

<sup>generated by a clanker</sup>
