### PR TITLE
Isolate Forge sessions on a dedicated tmux server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ __pycache__/
 /.roborev/
 .pi/superpowers-state.json
 .kata.local.toml
+
+# ptyowner test artifacts
+.sessions

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -151,6 +151,45 @@ still exists.
   `internal/workspace/localruntime/manager.go::Manager.Shutdown`).
 - New tmux sessions use the `forge-` prefix; persisted `middleman-` session
   names remain valid and must not be rewritten (`internal/workspace/`).
+- Forge talks to its own tmux server, not the user's global one: every
+  empty-tmux-command fallback must use `config.DefaultTmuxCommand`, never bare
+  `tmux`; a configured `[tmux] command` is used verbatim, so socket choice
+  stays with the user (`internal/config/config.go::DefaultTmuxCommand`).
+- The tmux server permanently retains its spawn environment for every pane to
+  read via `show-environment -g`, and only `new-session` clients spawn it, so
+  every Forge-issued tmux client runs with the non-secret allowlist
+  environment, minus configured token names that could hide under the admitted
+  `LC_`/`XDG_` prefixes — deny-by-default; never a bare strip list, which
+  silently leaks any credential the configuration did not name. Pane processes
+  (including the base workspace terminal, which keeps the credential-sanitized
+  full daemon environment) get their environment only through the env-file
+  handoff (`internal/workspace/localruntime/manager.go::TmuxClientEnvironment`,
+  `internal/workspace/localruntime/manager.go::NewTmuxPaneHandoff`).
+- The allowlist names exact variables only — never prefixes, which a secret
+  such as `XDG_API_TOKEN` could hide under. It must keep `TMUX_TMPDIR`: tmux
+  resolves `-L` sockets beneath it, so dropping it routes tmux clients to a
+  different server than the manager owns. Attach commands returned to external
+  callers always wrap in `env`, unsetting the caller's `TMUX` and setting or
+  unsetting `TMUX_TMPDIR` to match the daemon; the hub's SSH wrapping must
+  collapse that argv into one shell-quoted remote command because OpenSSH
+  re-splits remote arguments through the remote shell. Fake tmux test fixtures
+  bake their control paths into the script instead of smuggling them through
+  the client environment
+  (`internal/config/config.go::IsTmuxNonSecretEnvVar`,
+  `internal/server/fleetapi/fleet_ssh.go::wrapAttachSpecForSSH`).
+- The non-secret terminal environment and credential names are disjoint by
+  construction: config and Kata catalog validation reject `token_env` names
+  that appear in the allowlist, because the tmux server's retained spawn
+  environment can never be scrubbed after a name turns secret
+  (`internal/config/config.go::Config.validateTokenEnvNamesNotTerminalVars`).
+- Kata catalog `token_env` names feed every credential strip set on catalog
+  load and at boot; catalogs load lazily per request, so the boot feed keeps
+  earlier terminals covered (`internal/server/server.go::Server.updateCatalogStripEnvVars`).
+- Every attach command passes `-E`: a pane can widen the server's
+  update-environment, and without `-E` the next attach copies the attach
+  client's variables into the session environment; external attach specs
+  additionally run in the caller's unsanitized shell
+  (`internal/workspace/localruntime/tmux_launcher.go::tmuxAttachSessionCommand`).
 - Every tmux client attach must force UTF-8; service launchers may omit locale
   variables, causing tmux to replace non-ASCII output before WebSocket transport
   (`internal/workspace/localruntime/tmux_launcher.go::tmuxAttachSessionCommand`).
@@ -340,6 +379,10 @@ behavior.
   created workspaces; shutdown preserves durable base sessions, so temp-dir
   cleanup alone leaks (`internal/server/kata/testmain_test.go::TestMain`).
 - Use tmux wrappers/fakes for missing-session and dead-server cases.
+- Tests exercising the unconfigured tmux default must sandbox `TMUX_TMPDIR`
+  and probe the `kenn-forge` socket name literally; deriving the probe from
+  the default command would follow a regressed default and pass
+  (`internal/server/workspacetest/default_tmux_socket_test.go`).
 - Add frontend or Playwright coverage when the regression is visible in tab
   selection, shell drawer state, or workspace navigation.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -171,6 +171,40 @@ command = ["review-agent", "--fast"]
 
 You can also edit agents under **Settings → Agents**.
 
+## Workspace terminals and tmux
+
+Workspace terminals and agent sessions run on a dedicated tmux server
+(socket name `kenn-forge`), so busy Forge sessions do not contend with
+your personal tmux server. To inspect or attach from a regular terminal:
+
+```sh
+tmux -L kenn-forge ls
+tmux -L kenn-forge attach-session -E -t <session>
+```
+
+`-E` keeps variables from your shell (including any exported provider
+tokens, if you widened tmux's `update-environment`) out of the session
+environment, which processes inside the workspace can read.
+
+Set `[tmux] command` to pick a different socket or wrap the launch; the
+configured command line is used verbatim:
+
+```toml
+[tmux]
+command = ["tmux", "-L", "kenn-forge"]
+```
+
+Wrapper commands run with a minimal non-secret environment, because the
+tmux server permanently retains the environment it was started with.
+Pass any custom data a wrapper needs as command-line arguments rather
+than environment variables. For the same reason, provider `token_env`
+names may not reuse standard terminal variables such as `EDITOR` or
+`PATH`; configuration validation rejects the collision.
+
+Sessions started by versions that used the default tmux server keep
+running there after an upgrade, but kenn-forge no longer sees them.
+Reattach or clean them up with plain `tmux ls` and `tmux kill-session`.
+
 ## Docs folders
 
 Register local Markdown folders from the CLI:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3020,13 +3020,23 @@ var tmuxNonSecretEnvVars = []string{
 
 // IsTmuxNonSecretEnvVar reports whether name belongs to the non-secret
 // environment contract for tmux clients and terminal sessions. The
-// comparison is case-insensitive on every platform: Windows resolves
-// environment names case-insensitively, so "path" is PATH there, and a
-// case-folded reserved set costs nothing elsewhere.
+// comparison is case-insensitive on every platform because this
+// predicate REJECTS: token names may never collide with a reserved name
+// in any casing (Windows resolves env names case-insensitively), and
+// over-rejection is safe. Environment ADMISSION must not use this
+// predicate on case-sensitive platforms — use
+// IsTmuxNonSecretEnvVarExact there, or a Unix variable literally named
+// "editor" would be admitted into tmux's retained environment.
 func IsTmuxNonSecretEnvVar(name string) bool {
 	return slices.ContainsFunc(tmuxNonSecretEnvVars, func(v string) bool {
 		return strings.EqualFold(v, name)
 	})
+}
+
+// IsTmuxNonSecretEnvVarExact is the exact-case admission predicate for
+// case-sensitive platforms.
+func IsTmuxNonSecretEnvVarExact(name string) bool {
+	return slices.Contains(tmuxNonSecretEnvVars, name)
 }
 
 // TmuxCommand returns the command + argv prefix used to invoke tmux.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1210,7 +1210,10 @@ func writeExclusive(src, dst string) error {
 func Load(path string) (*Config, error) {
 	cfg, err := load(path)
 	if err != nil {
-		return nil, err
+		// cfg is non-nil for post-decode rejections (deprecated keys);
+		// callers treat any error as failure but reload-side stripping
+		// may still read declared token names from the candidate.
+		return cfg, err
 	}
 	return cfg, cfg.validate()
 }
@@ -1240,7 +1243,10 @@ func load(path string) (*Config, error) {
 		return nil, fmt.Errorf("parsing config %s: %w", path, err)
 	}
 	if err := rejectDeprecatedConfigKeys(meta); err != nil {
-		return nil, fmt.Errorf("parsing config %s: %w", path, err)
+		// The decode succeeded, so return the populated config with the
+		// rejection: a reload must still see a rejected candidate's
+		// declared token env names to keep stripping them.
+		return cfg, fmt.Errorf("parsing config %s: %w", path, err)
 	}
 
 	if cfg.Repos == nil {
@@ -1261,7 +1267,9 @@ func load(path string) (*Config, error) {
 	cfg.dataDirWasRelative = !filepath.IsAbs(cfg.DataDir)
 	canonicalDir, err := CanonicalDataDir(cfg.DataDir)
 	if err != nil {
-		return nil, err
+		// The decode succeeded; return the config with the error so a
+		// rejected reload can still see its declared token names.
+		return cfg, err
 	}
 	cfg.DataDir = canonicalDir
 
@@ -1378,6 +1386,9 @@ func (c *Config) validate() error {
 		return err
 	}
 	if err := c.validateGitHubOwnerTokens(); err != nil {
+		return err
+	}
+	if err := c.validateTokenEnvNamesNotTerminalVars(); err != nil {
 		return err
 	}
 	if err := c.validateGitHubApps(); err != nil {
@@ -1788,6 +1799,26 @@ func (c *Config) validatePlatforms() error {
 			)
 		}
 		seen[key] = desc
+	}
+	return nil
+}
+
+// validateTokenEnvNamesNotTerminalVars rejects token env names that
+// collide with the non-secret environment passed to terminal sessions.
+// The tmux server permanently retains its spawn environment, so a
+// variable on that list could never be scrubbed once declared secret;
+// rejecting the collision keeps the two contracts disjoint by
+// construction.
+func (c *Config) validateTokenEnvNamesNotTerminalVars() error {
+	for _, name := range c.TokenEnvNames() {
+		if IsTmuxNonSecretEnvVar(strings.TrimSpace(name)) {
+			return fmt.Errorf(
+				"config: token env name %q collides with the non-secret "+
+					"environment passed to terminal sessions; use a "+
+					"dedicated variable name",
+				name,
+			)
+		}
 	}
 	return nil
 }
@@ -2744,6 +2775,16 @@ func (c *Config) TokenEnvNames() []string {
 	for _, r := range c.Repos {
 		names = appendTokenEnvNamesFromDescriptor(names, c.ResolveRepoTokenSource(r))
 	}
+	// Explicitly declared names are collected verbatim as well:
+	// descriptor resolution returns nothing for invalid provider
+	// identities, and a rejected candidate's declared credential names
+	// must still reach strip accumulation and collision validation.
+	for _, p := range c.Platforms {
+		names = appendTokenEnvName(names, strings.TrimSpace(p.TokenEnv))
+	}
+	for _, r := range c.Repos {
+		names = appendTokenEnvName(names, strings.TrimSpace(r.TokenEnv))
+	}
 	return names
 }
 
@@ -2907,12 +2948,95 @@ func (c *Config) RoborevEndpoint() string {
 	return "http://127.0.0.1:7373"
 }
 
-// TmuxCommand returns the command + argv prefix used to invoke
-// tmux. Defaults to ["tmux"] when c is nil or the setting is
-// unconfigured. The returned slice is a copy, safe to append to.
+// DefaultTmuxCommand returns the command + argv prefix used to invoke
+// tmux when no [tmux] command is configured. The -L socket isolates
+// kenn-forge sessions on a dedicated tmux server so heavy Forge
+// activity does not contend with the user's global tmux server. The
+// returned slice is a fresh copy, safe to append to.
+func DefaultTmuxCommand() []string {
+	return []string{"tmux", "-L", "kenn-forge"}
+}
+
+// tmuxNonSecretEnvVars names every variable admitted into tmux client
+// environments and, transitively, the tmux server's permanently
+// retained spawn environment — exact names only, never prefixes, which
+// a secret could hide under. Because these values are deliberately
+// non-secret, config validation rejects token env names that collide
+// with them: a running tmux server retains its spawn environment, so a
+// name on this list could never be scrubbed once declared secret.
+var tmuxNonSecretEnvVars = []string{
+	"COLORTERM",
+	"EDITOR",
+	"HOME",
+	// Locale: LANG/LANGUAGE plus the POSIX and glibc LC_* categories.
+	"LANG",
+	"LANGUAGE",
+	"LC_ADDRESS",
+	"LC_ALL",
+	"LC_COLLATE",
+	"LC_CTYPE",
+	"LC_IDENTIFICATION",
+	"LC_MEASUREMENT",
+	"LC_MESSAGES",
+	"LC_MONETARY",
+	"LC_NAME",
+	"LC_NUMERIC",
+	"LC_PAPER",
+	"LC_TELEPHONE",
+	"LC_TIME",
+	"LESS",
+	"LOGNAME",
+	"NO_COLOR",
+	"PAGER",
+	"PATH",
+	"SHELL",
+	"SSH_AUTH_SOCK",
+	"TERM",
+	"TMP",
+	"TMPDIR",
+	// tmux resolves -L sockets under TMUX_TMPDIR; dropping it would
+	// route the tmux client to a different server than the manager
+	// owns.
+	"TMUX_TMPDIR",
+	"TEMP",
+	"USER",
+	"VISUAL",
+	// XDG base directories and session identity.
+	"XDG_CACHE_HOME",
+	"XDG_CONFIG_DIRS",
+	"XDG_CONFIG_HOME",
+	"XDG_CURRENT_DESKTOP",
+	"XDG_DATA_DIRS",
+	"XDG_DATA_HOME",
+	"XDG_RUNTIME_DIR",
+	"XDG_SEAT",
+	"XDG_SESSION_CLASS",
+	"XDG_SESSION_DESKTOP",
+	"XDG_SESSION_ID",
+	"XDG_SESSION_TYPE",
+	"XDG_STATE_HOME",
+	"XDG_VTNR",
+}
+
+// IsTmuxNonSecretEnvVar reports whether name belongs to the non-secret
+// environment contract for tmux clients and terminal sessions. The
+// comparison is case-insensitive on every platform: Windows resolves
+// environment names case-insensitively, so "path" is PATH there, and a
+// case-folded reserved set costs nothing elsewhere.
+func IsTmuxNonSecretEnvVar(name string) bool {
+	return slices.ContainsFunc(tmuxNonSecretEnvVars, func(v string) bool {
+		return strings.EqualFold(v, name)
+	})
+}
+
+// TmuxCommand returns the command + argv prefix used to invoke tmux.
+// Defaults to DefaultTmuxCommand when c is nil or the setting is
+// unconfigured; an explicitly configured command is returned verbatim,
+// so choosing a socket (or the global server) stays with the user. The
+// returned slice is a copy, safe to append to.
 func (c *Config) TmuxCommand() []string {
 	if c == nil || len(c.Tmux.Command) == 0 {
-		return []string{"tmux"}
+		return DefaultTmuxCommand()
 	}
 	return slices.Clone(c.Tmux.Command)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3186,7 +3186,7 @@ func TestLoadTmuxCommandOmitted(t *testing.T) {
 	cfg, err := Load(path)
 	require.NoError(t, err)
 	assert.Empty(cfg.Tmux.Command)
-	assert.Equal([]string{"tmux"}, cfg.TmuxCommand())
+	assert.Equal([]string{"tmux", "-L", "kenn-forge"}, cfg.TmuxCommand())
 	assert.True(cfg.TmuxAgentSessionsEnabled())
 }
 
@@ -3198,7 +3198,7 @@ command = []
 `)
 	cfg, err := Load(path)
 	require.NoError(t, err)
-	assert.Equal([]string{"tmux"}, cfg.TmuxCommand())
+	assert.Equal([]string{"tmux", "-L", "kenn-forge"}, cfg.TmuxCommand())
 }
 
 func TestLoadTmuxAgentSessionsDisabled(t *testing.T) {
@@ -3250,7 +3250,14 @@ func TestTmuxCommandDefensiveCopy(t *testing.T) {
 func TestTmuxCommandNilReceiver(t *testing.T) {
 	assert := assert.New(t)
 	var cfg *Config
-	assert.Equal([]string{"tmux"}, cfg.TmuxCommand())
+	assert.Equal([]string{"tmux", "-L", "kenn-forge"}, cfg.TmuxCommand())
+}
+
+func TestDefaultTmuxCommandDefensiveCopy(t *testing.T) {
+	assert := assert.New(t)
+	first := DefaultTmuxCommand()
+	first[0] = "hacked"
+	assert.Equal([]string{"tmux", "-L", "kenn-forge"}, DefaultTmuxCommand())
 }
 
 func TestLoadTmuxCommandRejectsEmptyFirstElement(t *testing.T) {

--- a/internal/config/tmux_env_contract_test.go
+++ b/internal/config/tmux_env_contract_test.go
@@ -28,12 +28,18 @@ func TestIsTmuxNonSecretEnvVarExactNamesOnly(t *testing.T) {
 	assert := assert.New(t)
 	assert.True(IsTmuxNonSecretEnvVar("EDITOR"))
 	assert.True(IsTmuxNonSecretEnvVar("TMUX_TMPDIR"))
-	// Case-insensitive on every platform: Windows resolves env names
-	// case-insensitively, so "path" is PATH there.
+	// The rejection predicate folds case on every platform: token names
+	// may never collide with a reserved name in any casing.
 	assert.True(IsTmuxNonSecretEnvVar("path"))
 	assert.True(IsTmuxNonSecretEnvVar("Editor"))
 	assert.False(IsTmuxNonSecretEnvVar("XDG_API_TOKEN"))
 	assert.False(IsTmuxNonSecretEnvVar("GITHUB_TOKEN"))
+	// The admission predicate is exact: on case-sensitive platforms a
+	// variable literally named "editor" is unrelated to EDITOR and must
+	// not enter tmux's retained environment.
+	assert.True(IsTmuxNonSecretEnvVarExact("EDITOR"))
+	assert.False(IsTmuxNonSecretEnvVarExact("editor"))
+	assert.False(IsTmuxNonSecretEnvVarExact("path"))
 }
 
 // TestValidateRejectsWhitespacePaddedCollisions pins normalization

--- a/internal/config/tmux_env_contract_test.go
+++ b/internal/config/tmux_env_contract_test.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateRejectsTokenEnvNamesCollidingWithTerminalVars pins the
+// disjointness contract: the tmux server permanently retains its spawn
+// environment, so a variable in the non-secret terminal set could never
+// be scrubbed once declared secret. Collisions are rejected up front,
+// at boot and on reload alike.
+func TestValidateRejectsTokenEnvNamesCollidingWithTerminalVars(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+github_token_env = "EDITOR"
+`), 0o600))
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "collides with the non-secret environment")
+}
+
+func TestIsTmuxNonSecretEnvVarExactNamesOnly(t *testing.T) {
+	assert := assert.New(t)
+	assert.True(IsTmuxNonSecretEnvVar("EDITOR"))
+	assert.True(IsTmuxNonSecretEnvVar("TMUX_TMPDIR"))
+	// Case-insensitive on every platform: Windows resolves env names
+	// case-insensitively, so "path" is PATH there.
+	assert.True(IsTmuxNonSecretEnvVar("path"))
+	assert.True(IsTmuxNonSecretEnvVar("Editor"))
+	assert.False(IsTmuxNonSecretEnvVar("XDG_API_TOKEN"))
+	assert.False(IsTmuxNonSecretEnvVar("GITHUB_TOKEN"))
+}
+
+// TestValidateRejectsWhitespacePaddedCollisions pins normalization
+// order: " PATH " normalizes to PATH later, so collision validation
+// must compare trimmed names.
+func TestValidateRejectsWhitespacePaddedCollisions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+[[repos]]
+owner = "acme"
+name = "widget"
+token_env = " PATH "
+`), 0o600))
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "collides with the non-secret environment")
+}
+
+// TestTokenEnvNamesIncludesExplicitDeclarationsForInvalidProviders pins
+// that declared credential names survive provider-identity problems:
+// descriptor resolution returns nothing for unknown platforms, but a
+// rejected candidate's names must still reach strip accumulation.
+func TestTokenEnvNamesIncludesExplicitDeclarationsForInvalidProviders(
+	t *testing.T,
+) {
+	cfg := &Config{
+		Platforms: []PlatformConfig{{
+			Type: "unknown-provider", Host: "example.com",
+			TokenEnv: " WKSP_DECLARED_PLATFORM_TOKEN ",
+		}},
+		Repos: []Repo{{
+			Platform: "unknown-provider", PlatformHost: "example.com",
+			Owner: "acme", Name: "widget",
+			TokenEnv: "WKSP_DECLARED_REPO_TOKEN",
+		}},
+	}
+	names := cfg.TokenEnvNames()
+	assert.Contains(t, names, "WKSP_DECLARED_PLATFORM_TOKEN")
+	assert.Contains(t, names, "WKSP_DECLARED_REPO_TOKEN")
+}

--- a/internal/fleet/probe.go
+++ b/internal/fleet/probe.go
@@ -2,12 +2,15 @@ package fleet
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"slices"
 	"strings"
 	"time"
 
+	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/procutil"
+	"go.kenn.io/forge/internal/workspace/localruntime"
 )
 
 // probeCommandTimeout bounds each version-probe subprocess. Probe runs while
@@ -22,11 +25,12 @@ const probeCommandTimeout = 5 * time.Second
 // probe command runs under ctx with a short timeout and the shared
 // subprocess limiter.
 //
-// tmuxCmd is the configured tmux command and argv prefix (e.g. ["tmux"]
-// or a wrapper such as ["systemd-run", "--user", "--scope", "tmux"]). An
-// empty slice falls back to the bare "tmux" binary, so a server with a
-// custom tmux.command is not misreported as lacking tmux and does not have
-// its session operations disabled in the snapshot.
+// tmuxCmd is the configured tmux command and argv prefix (e.g.
+// ["tmux", "-L", "kenn-forge"] or a wrapper such as ["systemd-run",
+// "--user", "--scope", "tmux"]). An empty slice falls back to
+// config.DefaultTmuxCommand, so a server with a custom tmux.command is
+// not misreported as lacking tmux and does not have its session
+// operations disabled in the snapshot.
 func Probe(ctx context.Context, tmuxCmd []string) Capabilities {
 	tmuxCmd = tmuxCommandOrDefault(tmuxCmd)
 	deps := DependencyCapabilities{
@@ -72,7 +76,9 @@ func commandsForDeps(deps DependencyCapabilities) CommandCapabilities {
 }
 
 // commandSucceeds reports whether executable is on PATH and exits 0 for
-// the given version-probe arguments within the probe timeout.
+// the given version-probe arguments within the probe timeout. git and
+// gh probes keep the daemon environment: their installations may depend
+// on it, and version probes spawn no environment-retaining server.
 func commandSucceeds(ctx context.Context, executable string, args ...string) bool {
 	if _, err := exec.LookPath(executable); err != nil {
 		return false
@@ -83,20 +89,30 @@ func commandSucceeds(ctx context.Context, executable string, args ...string) boo
 	return procutil.Run(probeCtx, cmd, "fleet capability probe") == nil
 }
 
-// tmuxCommandOrDefault returns tmuxCmd, or ["tmux"] when it is empty or its
-// executable is blank, mirroring (*config.Config).TmuxCommand's default.
+// tmuxCommandOrDefault returns tmuxCmd, or config.DefaultTmuxCommand when it
+// is empty or its executable is blank, mirroring
+// (*config.Config).TmuxCommand's default.
 func tmuxCommandOrDefault(tmuxCmd []string) []string {
 	if len(tmuxCmd) == 0 || tmuxCmd[0] == "" {
-		return []string{"tmux"}
+		return config.DefaultTmuxCommand()
 	}
 	return tmuxCmd
 }
 
 // tmuxCommandSucceeds reports whether the configured tmux command runs and
 // exits 0 for `-V`. tmuxCmd must be non-empty (see tmuxCommandOrDefault).
+// tmux probes run with the sanitized tmux client environment like every
+// other Forge-issued tmux invocation.
 func tmuxCommandSucceeds(ctx context.Context, tmuxCmd []string) bool {
+	if _, err := exec.LookPath(tmuxCmd[0]); err != nil {
+		return false
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, probeCommandTimeout)
+	defer cancel()
 	args := append(slices.Clone(tmuxCmd[1:]), "-V")
-	return commandSucceeds(ctx, tmuxCmd[0], args...)
+	cmd := procutil.CommandContext(probeCtx, tmuxCmd[0], args...)
+	cmd.Env = localruntime.TmuxClientEnvironment(os.Environ(), nil)
+	return procutil.Run(probeCtx, cmd, "fleet capability probe") == nil
 }
 
 // tmuxVersionString returns the version token from the configured tmux
@@ -107,6 +123,7 @@ func tmuxVersionString(ctx context.Context, tmuxCmd []string) string {
 	probeCtx, cancel := context.WithTimeout(ctx, probeCommandTimeout)
 	defer cancel()
 	cmd := procutil.CommandContext(probeCtx, tmuxCmd[0], args...)
+	cmd.Env = localruntime.TmuxClientEnvironment(os.Environ(), nil)
 	out, err := procutil.Output(probeCtx, cmd, "fleet capability probe")
 	if err != nil {
 		return ""

--- a/internal/fleet/probe_test.go
+++ b/internal/fleet/probe_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/config"
 )
 
 // TestCommandsForDeps table-tests the pure dependency->capability
@@ -62,9 +63,10 @@ func TestProbeDerivesCommandsFromDeps(t *testing.T) {
 
 func TestTmuxCommandOrDefault(t *testing.T) {
 	assert := assert.New(t)
-	assert.Equal([]string{"tmux"}, tmuxCommandOrDefault(nil), "nil falls back to bare tmux")
-	assert.Equal([]string{"tmux"}, tmuxCommandOrDefault([]string{}), "empty falls back to bare tmux")
-	assert.Equal([]string{"tmux"}, tmuxCommandOrDefault([]string{""}), "blank executable falls back to bare tmux")
+	forgeDefault := config.DefaultTmuxCommand()
+	assert.Equal(forgeDefault, tmuxCommandOrDefault(nil), "nil falls back to the kenn-forge tmux server")
+	assert.Equal(forgeDefault, tmuxCommandOrDefault([]string{}), "empty falls back to the kenn-forge tmux server")
+	assert.Equal(forgeDefault, tmuxCommandOrDefault([]string{""}), "blank executable falls back to the kenn-forge tmux server")
 	wrapper := []string{"systemd-run", "--user", "--scope", "tmux"}
 	assert.Equal(wrapper, tmuxCommandOrDefault(wrapper), "a configured command is used verbatim")
 }

--- a/internal/kata/catalog.go
+++ b/internal/kata/catalog.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"go.kenn.io/forge/internal/config"
 )
 
 const catalogSource = "kata catalog"
@@ -47,18 +48,34 @@ func LoadCatalog() (Catalog, error) {
 		return Catalog{}, fmt.Errorf("parse kata config %s: %w", path, err)
 	}
 	trimCatalog(&cat)
+	// declaredOnly carries the decoded token_env names through
+	// validation rejections: a decoded-but-invalid catalog's declared
+	// credentials must still reach terminal-environment stripping, so
+	// every post-decode error returns it alongside the error. Callers
+	// treat any error as failure and must not use these daemons.
+	declaredOnly := Catalog{}
+	for _, e := range cat.Daemons {
+		// Collect every decoded token_env, including entries that
+		// validation will reject (for example local=true with a URL):
+		// a declared credential name must reach stripping regardless.
+		if e.TokenEnv != "" {
+			declaredOnly.Daemons = append(
+				declaredOnly.Daemons, Daemon{TokenEnv: e.TokenEnv},
+			)
+		}
+	}
 	seen := make(map[string]struct{}, len(cat.Daemons))
 	out := make([]Daemon, 0, len(cat.Daemons))
 	for i, e := range cat.Daemons {
 		if e.Name == "" {
-			return Catalog{}, fmt.Errorf("kata catalog daemon %d: name is required", i)
+			return declaredOnly, fmt.Errorf("kata catalog daemon %d: name is required", i)
 		}
 		if _, dup := seen[e.Name]; dup {
-			return Catalog{}, fmt.Errorf("kata catalog: duplicate daemon name %q", e.Name)
+			return declaredOnly, fmt.Errorf("kata catalog: duplicate daemon name %q", e.Name)
 		}
 		seen[e.Name] = struct{}{}
 		if e.Local == (e.URL != "") {
-			return Catalog{}, fmt.Errorf(
+			return declaredOnly, fmt.Errorf(
 				"kata catalog daemon %q: exactly one of local or url is required", e.Name)
 		}
 		daemon := Daemon{
@@ -70,8 +87,14 @@ func LoadCatalog() (Catalog, error) {
 		}
 		if !e.Local {
 			if e.Token != "" && e.TokenEnv != "" {
-				return Catalog{}, fmt.Errorf(
+				return declaredOnly, fmt.Errorf(
 					"kata catalog daemon %q: token and token_env are mutually exclusive", e.Name)
+			}
+			if config.IsTmuxNonSecretEnvVar(e.TokenEnv) {
+				return declaredOnly, fmt.Errorf(
+					"kata catalog daemon %q: token_env %q collides with the "+
+						"non-secret environment passed to terminal sessions; "+
+						"use a dedicated variable name", e.Name, e.TokenEnv)
 			}
 			daemon.Token = e.Token
 			daemon.TokenEnv = e.TokenEnv
@@ -80,11 +103,24 @@ func LoadCatalog() (Catalog, error) {
 	}
 	if cat.ActiveDaemon != "" {
 		if _, ok := seen[cat.ActiveDaemon]; !ok {
-			return Catalog{}, fmt.Errorf(
+			return declaredOnly, fmt.Errorf(
 				"kata catalog: active_daemon %q is not in the catalog", cat.ActiveDaemon)
 		}
 	}
 	return Catalog{Daemons: out, Source: catalogSource}, nil
+}
+
+// TokenEnvNames returns the non-empty daemon token_env names in the
+// catalog; they name credentials the daemon may resolve and must be
+// stripped from terminal environments.
+func (c Catalog) TokenEnvNames() []string {
+	names := make([]string, 0, len(c.Daemons))
+	for _, d := range c.Daemons {
+		if d.TokenEnv != "" {
+			names = append(names, d.TokenEnv)
+		}
+	}
+	return names
 }
 
 func trimCatalog(cat *catalogFile) {

--- a/internal/kata/catalog_contract_test.go
+++ b/internal/kata/catalog_contract_test.go
@@ -1,0 +1,74 @@
+package kata
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCatalogRejectsTokenEnvCollidingWithTerminalVars mirrors the
+// config-side contract for externally cataloged daemon credentials.
+func TestCatalogRejectsTokenEnvCollidingWithTerminalVars(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("KATA_HOME", dir)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "config.toml"), []byte(`
+[[daemon]]
+name = "prod"
+url = "https://kata.example.com"
+token_env = "EDITOR"
+`), 0o600))
+	_, err := LoadCatalog()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "collides with the non-secret environment")
+}
+
+func TestCatalogTokenEnvNames(t *testing.T) {
+	cat := Catalog{Daemons: []Daemon{
+		{TokenEnv: "KATA_PROD_TOKEN"},
+		{TokenEnv: ""},
+		{TokenEnv: "KATA_STAGING_TOKEN"},
+	}}
+	assert.Equal(t,
+		[]string{"KATA_PROD_TOKEN", "KATA_STAGING_TOKEN"},
+		cat.TokenEnvNames(),
+	)
+}
+
+// TestLoadCatalogCarriesDeclaredNamesThroughRejection pins that a
+// decoded-but-invalid catalog still exposes its declared token_env
+// names so stripping covers a rejected catalog's credentials.
+func TestLoadCatalogCarriesDeclaredNamesThroughRejection(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dir := t.TempDir()
+	t.Setenv("KATA_HOME", dir)
+	require.NoError(os.WriteFile(
+		filepath.Join(dir, "config.toml"), []byte(`
+[[daemon]]
+name = "prod"
+url = "https://kata.example.com"
+token_env = "KATA_REJECTED_TOKEN"
+
+[[daemon]]
+name = "prod"
+url = "https://kata2.example.com"
+
+[[daemon]]
+name = "confused"
+local = true
+url = "https://kata3.example.com"
+token_env = "KATA_LOCAL_CONFUSED_TOKEN"
+`), 0o600))
+	cat, err := LoadCatalog()
+	require.Error(err)
+	assert.Contains(err.Error(), "duplicate daemon name")
+	assert.Equal(
+		[]string{"KATA_REJECTED_TOKEN", "KATA_LOCAL_CONFUSED_TOKEN"},
+		cat.TokenEnvNames(),
+		"declared names must include entries validation rejects",
+	)
+}

--- a/internal/ptyowner/client.go
+++ b/internal/ptyowner/client.go
@@ -17,18 +17,56 @@ import (
 	"syscall"
 	"time"
 
+	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/procutil"
 )
 
 type Client struct {
-	Root         string
-	ExePath      string
-	ExeArgs      []string
-	ManagerPath  string
-	Command      []string
+	Root        string
+	ExePath     string
+	ExeArgs     []string
+	ManagerPath string
+	Command     []string
+	// StripEnvVars holds the configured token env names removed from
+	// owner session environments. Set it at construction; after that,
+	// widen it only through UpdateStripEnvVars.
 	StripEnvVars []string
 	ExtraEnv     map[string]string
 	InProcess    bool
+
+	stripMu sync.RWMutex
+}
+
+// UpdateStripEnvVars merges names into the credential strip set applied
+// to owner session environments. Names accumulate monotonically so a
+// config reload can only widen stripping, mirroring the tmux and
+// runtime managers.
+func (c *Client) UpdateStripEnvVars(names []string) {
+	c.stripMu.Lock()
+	defer c.stripMu.Unlock()
+	merged := slices.Clone(c.StripEnvVars)
+	for _, name := range names {
+		// Non-secret terminal variables are never credentials; see
+		// workspace.Manager.UpdateTmuxStripEnvVars.
+		if name == "" || config.IsTmuxNonSecretEnvVar(name) ||
+			slices.Contains(merged, name) {
+			continue
+		}
+		merged = append(merged, name)
+	}
+	c.StripEnvVars = merged
+}
+
+// StripEnvVarsSnapshot returns a copy of the current strip set for
+// callers deriving per-launch clients.
+func (c *Client) StripEnvVarsSnapshot() []string {
+	return c.currentStripEnvVars()
+}
+
+func (c *Client) currentStripEnvVars() []string {
+	c.stripMu.RLock()
+	defer c.stripMu.RUnlock()
+	return slices.Clone(c.StripEnvVars)
 }
 
 const (
@@ -102,7 +140,7 @@ func (c *Client) Ensure(ctx context.Context, session, cwd string) error {
 				Session:      session,
 				Cwd:          cwd,
 				Command:      command,
-				StripEnvVars: c.StripEnvVars,
+				StripEnvVars: c.currentStripEnvVars(),
 				ExtraEnv:     c.ExtraEnv,
 			})
 		}()
@@ -479,9 +517,9 @@ func ownerHelperEnvironment(env []string) []string {
 	return sessionEnvironment(env, nil)
 }
 
-func (c Client) ownerHelperEnvironment(env []string) []string {
+func (c *Client) ownerHelperEnvironment(env []string) []string {
 	return mergeEnvironment(
-		sessionEnvironment(env, c.StripEnvVars), c.ExtraEnv,
+		sessionEnvironment(env, c.currentStripEnvVars()), c.ExtraEnv,
 	)
 }
 

--- a/internal/ptyowner/client_strip_test.go
+++ b/internal/ptyowner/client_strip_test.go
@@ -1,0 +1,36 @@
+package ptyowner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestClientUpdateStripEnvVarsWidensMonotonically pins reload behavior:
+// token names added after construction must strip from later owner
+// sessions, and earlier names must never drop.
+func TestClientUpdateStripEnvVarsWidensMonotonically(t *testing.T) {
+	client := &Client{StripEnvVars: []string{"BOOT_TOKEN"}}
+	client.UpdateStripEnvVars([]string{"RELOAD_TOKEN", ""})
+	client.UpdateStripEnvVars([]string{"RELOAD_TOKEN"})
+
+	out := client.ownerHelperEnvironment([]string{
+		"PATH=/usr/bin",
+		"BOOT_TOKEN=a",
+		"RELOAD_TOKEN=b",
+		"KEEP=value",
+	})
+
+	assert.ElementsMatch(t, []string{
+		"PATH=/usr/bin",
+		"KEEP=value",
+	}, out)
+}
+
+// TestPtyOwnerShouldStripSessionVarFold mirrors the localruntime check:
+// Windows resolves env var names case-insensitively.
+func TestPtyOwnerShouldStripSessionVarFold(t *testing.T) {
+	assert.True(t, shouldStripSessionVarFold("github_token", nil, true))
+	assert.True(t, shouldStripSessionVarFold("my_token", []string{"MY_TOKEN"}, true))
+	assert.False(t, shouldStripSessionVarFold("github_token", nil, false))
+}

--- a/internal/ptyowner/owner.go
+++ b/internal/ptyowner/owner.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -628,14 +629,29 @@ func defaultShellCommand() []string {
 	return []string{"/bin/sh"}
 }
 
+// sessionVarPrefixes mirrors the localruntime denylist: every built-in
+// daemon credential source, current and legacy. Keep the two lists in
+// sync so tmux-less and Windows hosts strip the same credentials from
+// panes as tmux-backed ones.
 var sessionVarPrefixes = []string{
 	"KENN_FORGE_GITHUB_TOKEN",
+	"KENN_FORGE_GITLAB_TOKEN",
+	"KENN_FORGE_FORGEJO_TOKEN",
+	"KENN_FORGE_GITEA_TOKEN",
+	"MIDDLEMAN_GITHUB_TOKEN",
+	"MIDDLEMAN_GITLAB_TOKEN",
+	"MIDDLEMAN_FORGEJO_TOKEN",
+	"MIDDLEMAN_GITEA_TOKEN",
 	"GITHUB_TOKEN",
+	"GITLAB_TOKEN",
+	"FORGEJO_TOKEN",
+	"GITEA_TOKEN",
 	"GH_TOKEN",
 	"GH_PAT",
 	"GITHUB_PAT",
 	"GITHUB_ENTERPRISE_TOKEN",
 	"GH_ENTERPRISE_TOKEN",
+	"KATA_AUTH_TOKEN",
 }
 
 func sessionEnvironment(env []string, extraStrip []string) []string {
@@ -656,12 +672,37 @@ func sessionEnvironment(env []string, extraStrip []string) []string {
 }
 
 func shouldStripSessionVar(key string, extraStrip []string) bool {
+	return shouldStripSessionVarFold(
+		key, extraStrip, runtime.GOOS == "windows",
+	)
+}
+
+// shouldStripSessionVarFold matches case-insensitively when fold is
+// set: Windows resolves environment variables case-insensitively, so a
+// token stored as github_token is the same credential as GITHUB_TOKEN.
+func shouldStripSessionVarFold(
+	key string, extraStrip []string, fold bool,
+) bool {
+	match := func(a, b string) bool {
+		if fold {
+			return strings.EqualFold(a, b)
+		}
+		return a == b
+	}
+	hasPrefix := func(value, prefix string) bool {
+		if len(value) < len(prefix) {
+			return false
+		}
+		return match(value[:len(prefix)], prefix)
+	}
 	for _, prefix := range sessionVarPrefixes {
-		if key == prefix || strings.HasPrefix(key, prefix+"_") {
+		if match(key, prefix) || hasPrefix(key, prefix+"_") {
 			return true
 		}
 	}
-	return slices.Contains(extraStrip, key)
+	return slices.ContainsFunc(extraStrip, func(name string) bool {
+		return match(key, name)
+	})
 }
 
 func waitExitCode(waitErr error) int {

--- a/internal/ptyowner/owner_test.go
+++ b/internal/ptyowner/owner_test.go
@@ -38,7 +38,7 @@ func TestOwnerAttachInputAndReplay(t *testing.T) {
 		})
 	}()
 
-	client := Client{Root: root}
+	client := &Client{Root: root}
 	waitOwnerReady(t, done, client, "kenn-forge-test")
 
 	first, err := client.Attach(context.Background(), "kenn-forge-test", 120, 30)
@@ -85,7 +85,7 @@ func TestOwnerStopWhileRunOwnerReturns(t *testing.T) {
 		})
 	}()
 
-	client := Client{Root: root}
+	client := &Client{Root: root}
 	waitOwnerReady(t, done, client, "kenn-forge-stop-race")
 
 	require.NoError(client.Stop(context.Background(), "kenn-forge-stop-race"))
@@ -118,7 +118,7 @@ func TestOwnerQuickExitRemainsAttachable(t *testing.T) {
 		})
 	}()
 
-	client := Client{Root: root}
+	client := &Client{Root: root}
 	waitOwnerReady(t, done, client, session)
 
 	attach, err := client.Attach(context.Background(), session, 120, 30)
@@ -167,7 +167,7 @@ func TestOwnerPTYEOFClosesAttachmentBeforeProcessWait(t *testing.T) {
 		})
 	}()
 
-	client := Client{Root: root}
+	client := &Client{Root: root}
 	waitOwnerReady(t, done, client, session)
 
 	attach, err := client.Attach(context.Background(), session, 120, 30)
@@ -221,7 +221,7 @@ func TestOwnerDetachedBeforeExitKeepsPostExitAttachWindow(t *testing.T) {
 		})
 	}()
 
-	client := Client{Root: root}
+	client := &Client{Root: root}
 	waitOwnerReady(t, done, client, session)
 
 	first, err := client.Attach(context.Background(), session, 120, 30)
@@ -346,7 +346,7 @@ func TestOwnerRejectsOversizedUnauthenticatedRequest(t *testing.T) {
 		})
 	}()
 
-	client := Client{Root: root}
+	client := &Client{Root: root}
 	require.Eventually(func() bool {
 		return client.Ping(context.Background(), session) == nil
 	}, 2*time.Second, 20*time.Millisecond)
@@ -387,6 +387,10 @@ func TestOwnerHelperEnvironmentStripsCredentials(t *testing.T) {
 		"KENN_FORGE_GITHUB_TOKEN=secret-1",
 		"GITHUB_TOKEN=secret-2",
 		"GH_TOKEN_WORK=secret-3",
+		"KATA_AUTH_TOKEN=secret-4",
+		"KENN_FORGE_FORGEJO_TOKEN=secret-5",
+		"GITLAB_TOKEN=secret-6",
+		"MIDDLEMAN_GITEA_TOKEN=secret-7",
 		"KEEP=value",
 	})
 
@@ -397,7 +401,7 @@ func TestOwnerHelperEnvironmentStripsCredentials(t *testing.T) {
 }
 
 func TestClientOwnerHelperEnvironmentAppliesSessionEnvironmentPolicy(t *testing.T) {
-	client := Client{
+	client := &Client{
 		StripEnvVars: []string{"WORKSPACE_TOKEN"},
 		ExtraEnv:     map[string]string{"KENN_FORGE_RUNTIME_SESSION_KEY": "runtime-1"},
 	}
@@ -586,7 +590,7 @@ func TestClientPingHonorsContextAfterConnect(t *testing.T) {
 func TestClientOwnerCommandUsesExternalManagerDirectly(t *testing.T) {
 	assert := assert.New(t)
 
-	client := Client{
+	client := &Client{
 		Root:        "/tmp/owner-root",
 		ExeArgs:     []string{"kept"},
 		ManagerPath: "/tmp/kenn-forge-pty-manager",
@@ -666,7 +670,7 @@ func TestClientEnsuresExternalManager(t *testing.T) {
 	}
 
 	root := t.TempDir()
-	client := Client{
+	client := &Client{
 		Root:        root,
 		ManagerPath: managerPath,
 		Command: []string{
@@ -703,7 +707,7 @@ func TestClientEnsuresExternalManagerWithPowerShell(t *testing.T) {
 
 	root := filepath.Join(t.TempDir(), strings.Repeat("long-owner-root-", 8))
 	require.NoError(os.MkdirAll(root, 0o755))
-	client := Client{
+	client := &Client{
 		Root:        root,
 		ManagerPath: managerPath,
 		Command: []string{
@@ -739,7 +743,7 @@ func TestClientEnsuresExternalManagerWithGoTestHelper(t *testing.T) {
 
 	root := filepath.Join(t.TempDir(), strings.Repeat("long-owner-root-", 8))
 	require.NoError(os.MkdirAll(root, 0o755))
-	client := Client{
+	client := &Client{
 		Root:        root,
 		ManagerPath: managerPath,
 		Command: []string{
@@ -855,7 +859,7 @@ func TestExternalManagerAttachmentWritesUseAttachConnection(t *testing.T) {
 		}
 	}()
 
-	client := Client{
+	client := &Client{
 		Root:        root,
 		ManagerPath: "/tmp/kenn-forge-pty-manager",
 	}
@@ -902,7 +906,7 @@ func readUntil(t *testing.T, output <-chan []byte, needle string) string {
 func waitOwnerReady(
 	t *testing.T,
 	done <-chan error,
-	client Client,
+	client *Client,
 	session string,
 ) {
 	t.Helper()

--- a/internal/ptyowner/runtime/runtime.go
+++ b/internal/ptyowner/runtime/runtime.go
@@ -100,16 +100,22 @@ func (o owner) Start(
 		"cwd", cwd,
 		"pty_backend", "pty_owner",
 	)
-	client := *o.client
-	client.ExeArgs = append([]string(nil), o.client.ExeArgs...)
-	client.Command = resolvedCommand
-	client.ExtraEnv = map[string]string{
-		agentactivity.RuntimeSessionKeyEnv: session,
+	// Build a fresh per-launch client rather than copying o.client: the
+	// shared client carries a mutex guarding its reloadable strip set.
+	client := ptyowner.Client{
+		Root:        o.client.Root,
+		ExePath:     o.client.ExePath,
+		ExeArgs:     append([]string(nil), o.client.ExeArgs...),
+		ManagerPath: o.client.ManagerPath,
+		InProcess:   o.client.InProcess,
+		Command:     resolvedCommand,
+		ExtraEnv: map[string]string{
+			agentactivity.RuntimeSessionKeyEnv: session,
+		},
+		StripEnvVars: append(
+			o.client.StripEnvVarsSnapshot(), stripEnvVars...,
+		),
 	}
-	client.StripEnvVars = append(
-		append([]string(nil), o.client.StripEnvVars...),
-		stripEnvVars...,
-	)
 	if err := client.Ensure(ctx, session, cwd); err != nil {
 		return nil, err
 	}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -26688,6 +26688,7 @@ func TestWorkspaceServerFixtureCleansUpTmuxSessions(t *testing.T) {
 	record := filepath.Join(dir, "record")
 	script := filepath.Join(dir, "fake-tmux")
 	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "has-session" ]; then` + "\n" +
@@ -26699,7 +26700,6 @@ func TestWorkspaceServerFixtureCleansUpTmuxSessions(t *testing.T) {
 	require.NoError(os.WriteFile(script, []byte(body), 0o755))
 
 	t.Run("fixture", func(t *testing.T) {
-		t.Setenv("TMUX_RECORD", record)
 		cfg := &config.Config{
 			Tmux: config.Tmux{Command: []string{script}},
 		}
@@ -26730,6 +26730,7 @@ func TestCleanupWorkspaceServerFixtureArtifactsKeepsDeletingAfterError(
 	record := filepath.Join(dir, "record")
 	script := filepath.Join(dir, "fake-tmux")
 	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`if [ "$1" = "kill-session" ] && [ "$3" = "kenn-forge-fails" ]; then` + "\n" +
 		`  echo "permission denied" >&2` + "\n" +
@@ -26737,7 +26738,6 @@ func TestCleanupWorkspaceServerFixtureArtifactsKeepsDeletingAfterError(
 		`fi` + "\n" +
 		"exit 0\n"
 	require.NoError(os.WriteFile(script, []byte(body), 0o755))
-	t.Setenv("TMUX_RECORD", record)
 
 	database := dbtest.Open(t)
 
@@ -28055,8 +28055,9 @@ func TestWorkspaceRuntimeNaturalTmuxAgentExitForgetsStoredSessionE2E(
 	dir := t.TempDir()
 	record := filepath.Join(dir, "tmux-record")
 	tmuxPath := filepath.Join(dir, "fake-tmux")
-	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
-printf '%s\0' "$@" >> "$TMUX_RECORD"
+	require.NoError(os.WriteFile(tmuxPath, []byte("#!/bin/sh\n"+
+		"TMUX_RECORD="+shellquote.Join(record)+"\n"+
+		`printf '%s\0' "$@" >> "$TMUX_RECORD"
 if [ "$1" = "-u" ]; then shift; fi
 case "$1" in
   has-session)
@@ -28069,7 +28070,6 @@ case "$1" in
 esac
 exit 0
 `), 0o755))
-	t.Setenv("TMUX_RECORD", record)
 
 	cfg := &config.Config{
 		Agents: []config.Agent{{
@@ -28119,12 +28119,19 @@ func TestWorkspaceRuntimeIncludesStoredRuntimeSessionsAfterReloadE2E(t *testing.
 	assert := assert.New(t)
 	dir := t.TempDir()
 	tmuxPath := filepath.Join(dir, "fake-tmux")
-	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
-if [ "$1" = "-u" ]; then shift; fi
+	database := dbtest.Open(t)
+	seedPR(t, database, "acme", "widget", 1)
+	worktreeDir := filepath.Join(dir, "worktrees")
+	ownerMarker := workspace.NewManager(database, worktreeDir).TmuxOwnerMarker()
+	restoredSession := runtimeTmuxSessionNameForTest("0000000000000001", "helper")
+	require.NoError(os.WriteFile(tmuxPath, []byte("#!/bin/sh\n"+
+		"TMUX_TEST_OWNER_MARKER="+shellquote.Join(ownerMarker)+"\n"+
+		"TMUX_TEST_RESTORED_SESSION="+shellquote.Join(restoredSession)+"\n"+
+		`if [ "$1" = "-u" ]; then shift; fi
 case "$1" in
   list-sessions)
     printf '%s\n' kenn-forge-0000000000000001
-    printf '%s\n' "$RESTORED_TMUX_SESSION"
+    printf '%s\n' "$TMUX_TEST_RESTORED_SESSION"
     exit 0
     ;;
   attach-session)
@@ -28132,7 +28139,7 @@ case "$1" in
     exit 0
     ;;
   show-options)
-    printf '%s\n' "$KENN_FORGE_TMUX_OWNER"
+    printf '%s\n' "$TMUX_TEST_OWNER_MARKER"
     exit 0
     ;;
   kill-session)
@@ -28142,11 +28149,6 @@ esac
 exit 0
 `), 0o755))
 
-	database := dbtest.Open(t)
-	seedPR(t, database, "acme", "widget", 1)
-	worktreeDir := filepath.Join(dir, "worktrees")
-	ownerMarker := workspace.NewManager(database, worktreeDir).TmuxOwnerMarker()
-	t.Setenv("KENN_FORGE_TMUX_OWNER", ownerMarker)
 	cfg := &config.Config{Agents: []config.Agent{{
 		Key:     "helper",
 		Label:   "Helper",
@@ -28167,9 +28169,8 @@ exit 0
 		Status:          "ready",
 	}
 	require.NoError(database.InsertWorkspace(ctx, ws))
-	tmuxSession := runtimeTmuxSessionNameForTest(ws.ID, "helper")
+	tmuxSession := restoredSession
 	sessionKey := ws.ID + "_restoredhelper01"
-	t.Setenv("RESTORED_TMUX_SESSION", tmuxSession)
 	createdAt := time.Now().UTC().Add(-time.Minute)
 	require.NoError(database.UpsertWorkspaceRuntimeSession(
 		ctx,
@@ -28360,8 +28361,15 @@ func TestServerStartupReapsUnrecordedRuntimeTmuxSessionE2E(t *testing.T) {
 	dir := t.TempDir()
 	record := filepath.Join(dir, "record")
 	tmuxPath := filepath.Join(dir, "fake-tmux")
+	database := dbtest.Open(t)
+	seedPR(t, database, "acme", "widget", 1)
+
+	worktreeDir := filepath.Join(dir, "worktrees")
+	ownerMarker := workspace.NewManager(database, worktreeDir).TmuxOwnerMarker()
 	require.NoError(os.WriteFile(tmuxPath, fmt.Appendf(nil, `#!/bin/sh
-printf '%%s\0' "$#" "$@" >> %s
+TMUX_RECORD=%s
+TMUX_TEST_OWNER_MARKER=%s
+printf '%%s\0' "$#" "$@" >> "$TMUX_RECORD"
 target=""
 prev=""
 for a in "$@"; do
@@ -28370,8 +28378,8 @@ for a in "$@"; do
 done
 case "$1" in
   list-sessions)
-    printf 'middleman-0000000000000001:%%s\n' "$KENN_FORGE_TMUX_OWNER"
-    printf 'forge-0000000000000001-0123456789abcdef:%%s\n' "$KENN_FORGE_TMUX_OWNER"
+    printf 'middleman-0000000000000001:%%s\n' "$TMUX_TEST_OWNER_MARKER"
+    printf 'forge-0000000000000001-0123456789abcdef:%%s\n' "$TMUX_TEST_OWNER_MARKER"
     exit 0
     ;;
   kill-session)
@@ -28379,14 +28387,7 @@ case "$1" in
     ;;
 esac
 exit 0
-`, shellquote.Join(record)), 0o755))
-
-	database := dbtest.Open(t)
-	seedPR(t, database, "acme", "widget", 1)
-
-	worktreeDir := filepath.Join(dir, "worktrees")
-	ownerMarker := workspace.NewManager(database, worktreeDir).TmuxOwnerMarker()
-	t.Setenv("KENN_FORGE_TMUX_OWNER", ownerMarker)
+`, shellquote.Join(record), shellquote.Join(ownerMarker)), 0o755))
 	ws := &workspace.Workspace{
 		ID:              "0000000000000001",
 		PlatformHost:    "github.com",
@@ -28444,8 +28445,13 @@ func TestWorkspaceResponseProbesStoredRuntimeTmuxSessionWithoutBaseE2E(
 	dir := t.TempDir()
 	record := filepath.Join(dir, "record")
 	tmuxPath := filepath.Join(dir, "fake-tmux")
-	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
-printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"
+	database := dbtest.Open(t)
+	worktreeDir := filepath.Join(dir, "worktrees")
+	ownerMarker := workspace.NewManager(database, worktreeDir).TmuxOwnerMarker()
+	require.NoError(os.WriteFile(tmuxPath, []byte("#!/bin/sh\n"+
+		"TMUX_RECORD="+shellquote.Join(record)+"\n"+
+		"TMUX_TEST_OWNER_MARKER="+shellquote.Join(ownerMarker)+"\n"+
+		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"
 target=""
 mode=""
 prev=""
@@ -28462,7 +28468,7 @@ case "$1" in
     exit 0
     ;;
   show-options)
-    printf '%s\n' "$KENN_FORGE_TMUX_OWNER"
+    printf '%s\n' "$TMUX_TEST_OWNER_MARKER"
     exit 0
     ;;
   attach-session)
@@ -28483,14 +28489,9 @@ if [ "$mode" = "capture-pane" ]; then
 fi
 exit 0
 `), 0o755))
-	t.Setenv("TMUX_RECORD", record)
 
-	database := dbtest.Open(t)
 	seedPR(t, database, "acme", "widget", 1)
 
-	worktreeDir := filepath.Join(dir, "worktrees")
-	ownerMarker := workspace.NewManager(database, worktreeDir).TmuxOwnerMarker()
-	t.Setenv("KENN_FORGE_TMUX_OWNER", ownerMarker)
 	ws := &workspace.Workspace{
 		ID:              "0000000000000001",
 		PlatformHost:    "github.com",
@@ -28984,8 +28985,10 @@ func TestWorkspaceResponseUsesStoredRuntimeTmuxSessionsAfterRestartE2E(
 	assert := assert.New(t)
 	dir := t.TempDir()
 	tmuxPath := filepath.Join(dir, "fake-tmux")
-	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
-target=""
+	liveSessionsFile := filepath.Join(dir, "live-sessions")
+	require.NoError(os.WriteFile(tmuxPath, []byte("#!/bin/sh\n"+
+		"TMUX_LIVE_SESSIONS_FILE="+shellquote.Join(liveSessionsFile)+"\n"+
+		`target=""
 mode=""
 prev=""
 for a in "$@"; do
@@ -28993,7 +28996,7 @@ for a in "$@"; do
   if [ "$a" = "display-message" ]; then mode="display-message"; fi
   if [ "$a" = "capture-pane" ]; then mode="capture-pane"; fi
   if [ "$a" = "list-sessions" ]; then
-    printf '%s\n' "$TMUX_LIVE_SESSIONS"
+    [ -f "$TMUX_LIVE_SESSIONS_FILE" ] && cat "$TMUX_LIVE_SESSIONS_FILE"
     exit 0
   fi
   prev="$a"
@@ -29016,14 +29019,11 @@ exit 0
 	ctx := context.Background()
 	ws := createReadyWorkspace(t, ctx, client)
 	require.NotEmpty(ws.TmuxSession)
-	t.Setenv(
-		"TMUX_LIVE_SESSIONS",
-		strings.Join([]string{
-			ws.TmuxSession,
-			ws.TmuxSession + "-codex",
-			ws.TmuxSession + "-claude",
-		}, "\n"),
-	)
+	require.NoError(os.WriteFile(liveSessionsFile, []byte(strings.Join([]string{
+		ws.TmuxSession,
+		ws.TmuxSession + "-codex",
+		ws.TmuxSession + "-claude",
+	}, "\n")+"\n"), 0o644))
 	recordRuntimeTmuxSessionForServerTest(
 		t, database, ws.Id, "", "codex", ws.TmuxSession+"-codex", time.Time{},
 	)
@@ -29743,10 +29743,11 @@ func TestWorkspaceRuntimePlainShellRecordFailureCleansCreatedTmuxShellE2E(t *tes
 	require := require.New(t)
 
 	tmuxPath := writeFakeWorkspaceRuntimeTmux(t)
-	attachGate := filepath.Join(t.TempDir(), "attach-gate")
+	attachGate := os.Getenv("KENN_FORGE_FAKE_TMUX_ATTACH_GATE")
 	require.NoError(os.WriteFile(attachGate, []byte("wait"), 0o600))
-	t.Setenv("KENN_FORGE_FAKE_TMUX_ATTACH_GATE", attachGate)
-	t.Setenv("KENN_FORGE_FAKE_TMUX_ATTACH_EXIT", "1")
+	require.NoError(os.WriteFile(
+		os.Getenv("KENN_FORGE_FAKE_TMUX_ATTACH_EXIT"), []byte("1"), 0o600,
+	))
 	cfg := &config.Config{
 		Tmux: config.Tmux{Command: []string{tmuxPath}},
 		Shell: config.Shell{
@@ -30969,10 +30970,20 @@ func writeFakeWorkspaceRuntimeTmux(t *testing.T) string {
 	dir := t.TempDir()
 	stateDir := filepath.Join(dir, "sessions")
 	require.NoError(t, os.MkdirAll(stateDir, 0o755))
+	attachGate := filepath.Join(dir, "attach-gate")
+	attachExit := filepath.Join(dir, "attach-exit")
+	// The tmux client runs with the non-secret allowlist environment,
+	// so control paths are baked into the script; the env vars below
+	// only let tests locate the control files.
 	t.Setenv("KENN_FORGE_FAKE_TMUX_STATE", stateDir)
+	t.Setenv("KENN_FORGE_FAKE_TMUX_ATTACH_GATE", attachGate)
+	t.Setenv("KENN_FORGE_FAKE_TMUX_ATTACH_EXIT", attachExit)
 	path := filepath.Join(dir, "tmux")
-	require.NoError(t, os.WriteFile(path, []byte(`#!/bin/sh
-set -eu
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\n"+
+		"KENN_FORGE_FAKE_TMUX_STATE="+shellquote.Join(stateDir)+"\n"+
+		"KENN_FORGE_FAKE_TMUX_ATTACH_GATE="+shellquote.Join(attachGate)+"\n"+
+		"KENN_FORGE_FAKE_TMUX_ATTACH_EXIT="+shellquote.Join(attachExit)+"\n"+
+		`set -eu
 state_dir="${KENN_FORGE_FAKE_TMUX_STATE:?}"
 mkdir -p "$state_dir"
 session_arg() {
@@ -31072,12 +31083,10 @@ case "$cmd" in
       exit 1
     fi
     printf 'attached:%s\n' "$session"
-    if [ -n "${KENN_FORGE_FAKE_TMUX_ATTACH_GATE:-}" ]; then
-      while [ -e "$KENN_FORGE_FAKE_TMUX_ATTACH_GATE" ]; do
-        sleep 0.01
-      done
-    fi
-    if [ "${KENN_FORGE_FAKE_TMUX_ATTACH_EXIT:-}" = "1" ]; then
+    while [ -e "$KENN_FORGE_FAKE_TMUX_ATTACH_GATE" ]; do
+      sleep 0.01
+    done
+    if [ -e "$KENN_FORGE_FAKE_TMUX_ATTACH_EXIT" ]; then
       exit 0
     fi
     while [ -e "$state_dir/$session" ]; do

--- a/internal/server/config_reload.go
+++ b/internal/server/config_reload.go
@@ -334,6 +334,14 @@ func (s *Server) handleConfigFileChanged() {
 // handleConfigFileChanged) so a slow subscriber cannot stall the daemon.
 func (s *Server) applyConfigChange(ctx context.Context) configChangedEvent {
 	newCfg, err := config.Load(s.cfgPath)
+	// Accumulate the candidate's token env names from any parseable
+	// candidate — config.Load returns the parsed config alongside
+	// structural validation errors — before every failure path: a
+	// rejected reload must still stop those names from reaching future
+	// tmux panes, since the user just declared them credentials. The
+	// lists are monotonic, so over-stripping from a rejected candidate
+	// is safe.
+	s.updateRuntimeStripEnvVars(newCfg)
 	if err != nil {
 		slog.Warn(
 			"config reload failed; keeping last-known-good",
@@ -381,7 +389,6 @@ func (s *Server) applyConfigChange(ctx context.Context) configChangedEvent {
 	}
 	s.cfgMu.Unlock()
 
-	s.updateRuntimeStripEnvVars(newCfg)
 	s.updateTokenSourcesForReload(newCfg)
 	restartRequired := s.bootCfgSnapshot.restartRequiredFor(newCfg)
 	if s.reloadCredentialNeedsClientRebuild(ctx, newCfg) {
@@ -426,8 +433,15 @@ func (s *Server) applyConfigChange(ctx context.Context) configChangedEvent {
 		newCfg.PullRequests.PreferGitHubNativeStacks,
 	)
 	s.refreshRuntimeTargetsLocked()
+	stripEnvVars := s.updateRuntimeStripEnvVarsLocked(newCfg)
+	if s.workspaces != nil {
+		s.workspaces.UpdateTmuxStripEnvVars(stripEnvVars)
+	}
+	if s.ptyOwnerClient != nil {
+		s.ptyOwnerClient.UpdateStripEnvVars(stripEnvVars)
+	}
 	if s.runtime != nil {
-		s.runtime.UpdateStripEnvVars(s.updateRuntimeStripEnvVarsLocked(newCfg))
+		s.runtime.UpdateStripEnvVars(stripEnvVars)
 	}
 	s.applyWorkspaceConfigLocked()
 	s.applyFleetConfigLocked()

--- a/internal/server/config_reload.go
+++ b/internal/server/config_reload.go
@@ -12,6 +12,7 @@ import (
 	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/configwatch"
 	ghclient "go.kenn.io/forge/internal/github"
+	katacatalog "go.kenn.io/forge/internal/kata"
 	"go.kenn.io/forge/internal/platform"
 	"go.kenn.io/forge/internal/server/docsapi"
 	"go.kenn.io/forge/internal/tokenauth"
@@ -395,6 +396,13 @@ func (s *Server) applyConfigChange(ctx context.Context) configChangedEvent {
 		restartRequired = true
 	}
 	docsapi.WarnDaemonBindings(newCfg.DocFolders)
+	// Kata catalogs load lazily on Kata routes; a catalog edited since
+	// boot may declare new token names. Refresh the catalog-derived
+	// strip names on every config reload so terminals never race a
+	// catalog edit; rejected catalogs still carry declared names.
+	if catalog, err := katacatalog.LoadCatalog(); err == nil || len(catalog.TokenEnvNames()) > 0 {
+		s.updateCatalogStripEnvVars(catalog.TokenEnvNames())
+	}
 
 	// Resolve the new repo set against the boot-time registry. Repos
 	// whose (platform, host) the registry never learned about cannot

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -2405,3 +2405,141 @@ func TestConfigReload_SettingsSavePreservesRestartRequiredFields(t *testing.T) {
 	assert.Equal("flat", reloaded.Activity.ViewMode)
 	assert.Equal("30d", reloaded.Activity.TimeRange)
 }
+
+// A rejected reload must still accumulate the candidate's token env
+// names: the user just declared them credentials, and a later base
+// terminal pane must not inherit them from the daemon environment.
+func TestConfigReloadRejectedCandidateStillStripsItsTokenNames(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	t.Setenv("KENN_FORGE_GITHUB_TOKEN", "")
+	t.Setenv("KENN_FORGE_REPO_TOKEN", "old")
+
+	srv, _, cfgPath := setupTestServerWithConfigContentAndOptions(
+		t, validReloadConfigRepoTokenEnv, &mockGH{}, ServerOptions{
+			HostCheckAllowLoopbackAnyPort:      true,
+			WorktreeDir:                        t.TempDir(),
+			DisableWorkspaceBackgroundMonitors: true,
+		},
+	)
+	sourceSet := tokenauth.NewSourceSet(tokenauth.Options{})
+	srv.cfgMu.Lock()
+	desc := srv.cfg.ResolveRepoTokenSource(srv.cfg.Repos[0])
+	srv.cfgMu.Unlock()
+	sourceSet.Upsert(desc)
+	srv.tokenSources = sourceSet
+
+	writeConfigToml(t, cfgPath, `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+token_env = "WKSP_CANDIDATE_ONLY_TOKEN"
+`)
+	event := srv.applyConfigChange(t.Context())
+	require.False(event.Valid, "reload with an unset token env must be rejected")
+	assert.Contains(srv.workspaces.TmuxStripEnvVars(),
+		"WKSP_CANDIDATE_ONLY_TOKEN",
+		"a rejected candidate's token names must still be stripped from panes")
+}
+
+// A structurally invalid candidate still parses — config.Load returns
+// the parsed config alongside validation errors — so its newly declared
+// token names must be stripped from future panes even though the reload
+// is rejected before any other validation runs.
+func TestConfigReloadStructurallyInvalidCandidateStillStripsItsTokenNames(
+	t *testing.T,
+) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv, _, cfgPath := setupTestServerWithConfigContentAndOptions(
+		t, validReloadConfig, &mockGH{}, ServerOptions{
+			HostCheckAllowLoopbackAnyPort:      true,
+			WorktreeDir:                        t.TempDir(),
+			DisableWorkspaceBackgroundMonitors: true,
+		},
+	)
+	writeConfigToml(t, cfgPath, `
+sync_interval = "5m"
+github_token_env = "WKSP_INVALID_CANDIDATE_TOKEN"
+host = "not-an-ip"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+`)
+	event := srv.applyConfigChange(t.Context())
+	require.False(event.Valid, "structurally invalid candidate must be rejected")
+	assert.Contains(srv.workspaces.TmuxStripEnvVars(),
+		"WKSP_INVALID_CANDIDATE_TOKEN",
+		"an invalid candidate's token names must still be stripped from panes")
+}
+
+// A candidate rejected at the load stage for deprecated keys still
+// decodes, so its newly declared token names must reach strip
+// accumulation like validation-stage rejections.
+func TestConfigReloadDeprecatedKeyCandidateStillStripsItsTokenNames(
+	t *testing.T,
+) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv, _, cfgPath := setupTestServerWithConfigContentAndOptions(
+		t, validReloadConfig, &mockGH{}, ServerOptions{
+			HostCheckAllowLoopbackAnyPort:      true,
+			WorktreeDir:                        t.TempDir(),
+			DisableWorkspaceBackgroundMonitors: true,
+		},
+	)
+	writeConfigToml(t, cfgPath, `
+sync_interval = "5m"
+github_token_env = "WKSP_DEPRECATED_CANDIDATE_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[notebooks]]
+id = "notes"
+path = "/tmp/notes"
+`)
+	event := srv.applyConfigChange(t.Context())
+	require.False(event.Valid, "deprecated keys must reject the reload")
+	assert.Contains(srv.workspaces.TmuxStripEnvVars(),
+		"WKSP_DEPRECATED_CANDIDATE_TOKEN",
+		"a load-stage-rejected candidate's token names must still be stripped")
+}
+
+// A rejected candidate declaring a non-secret terminal variable as a
+// token must not poison the strip sets: stripping PATH or TMUX_TMPDIR
+// would break terminals and tmux socket routing while the
+// last-known-good config stays active.
+func TestConfigReloadRejectedCollisionDoesNotPoisonStripSets(
+	t *testing.T,
+) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv, _, cfgPath := setupTestServerWithConfigContentAndOptions(
+		t, validReloadConfig, &mockGH{}, ServerOptions{
+			HostCheckAllowLoopbackAnyPort:      true,
+			WorktreeDir:                        t.TempDir(),
+			DisableWorkspaceBackgroundMonitors: true,
+		},
+	)
+	writeConfigToml(t, cfgPath, `
+sync_interval = "5m"
+github_token_env = "TMUX_TMPDIR"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+`)
+	event := srv.applyConfigChange(t.Context())
+	require.False(event.Valid, "terminal-variable token names must be rejected")
+	assert.NotContains(srv.workspaces.TmuxStripEnvVars(), "TMUX_TMPDIR",
+		"rejected collisions must never enter the strip sets")
+}

--- a/internal/server/fleetapi/fleet_ssh.go
+++ b/internal/server/fleetapi/fleet_ssh.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	shellquote "github.com/kballard/go-shellquote"
+
 	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/fleet"
 	"go.kenn.io/forge/internal/server/httpapi"
@@ -508,7 +510,14 @@ func wrapAttachSpecForSSH(
 	if len(spec.Command) == 0 {
 		return nil, false
 	}
-	spec.Command = append(append([]string(nil), sshCommand...), spec.Command...)
+	// OpenSSH joins remote arguments with spaces and hands the result
+	// to the remote shell, so the attach argv must collapse into one
+	// shell-quoted remote command or arguments containing whitespace
+	// or metacharacters are re-split and interpreted remotely.
+	spec.Command = append(
+		append([]string(nil), sshCommand...),
+		shellquote.Join(spec.Command...),
+	)
 	spec.RequiresLocalHost = false
 	wrapped, err := json.Marshal(spec)
 	if err != nil {

--- a/internal/server/fleetapi/fleet_ssh_test.go
+++ b/internal/server/fleetapi/fleet_ssh_test.go
@@ -1108,7 +1108,9 @@ done
 if [ "$#" -gt 0 ]; then
   shift
 fi
-exec "$@"
+# Real OpenSSH joins the remote arguments with spaces and hands the
+# result to the remote shell; mirror that so quoting behavior matches.
+exec sh -c "$*"
 `
 	require.NoError(t, os.WriteFile(path, []byte(script), 0o755))
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))

--- a/internal/server/fleetapi/fleet_ssh_wrap_test.go
+++ b/internal/server/fleetapi/fleet_ssh_wrap_test.go
@@ -1,0 +1,45 @@
+package fleetapi
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/server/workspaceapi"
+)
+
+// TestWrapAttachSpecForSSHQuotesRemoteCommand pins remote-argument
+// quoting: OpenSSH joins remote arguments with spaces and hands the
+// result to the remote shell, so attach-spec arguments containing
+// whitespace or metacharacters must collapse into one shell-quoted
+// remote command or the remote shell re-splits and interprets them.
+func TestWrapAttachSpecForSSHQuotesRemoteCommand(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	spec := workspaceapi.RuntimeAttachSpecResponse{
+		Version:     1,
+		Kind:        "tmux",
+		TmuxSession: "mm-s1",
+		Command: []string{
+			"env", "-u", "TMUX", "TMUX_TMPDIR=/socket dir/with'quote",
+			"tmux", "-u", "attach-session", "-E", "-t", "mm-s1",
+		},
+	}
+	body, err := json.Marshal(spec)
+	require.NoError(err)
+
+	wrapped, ok := wrapAttachSpecForSSH(body, []string{"ssh", "-t", "peer"})
+	require.True(ok)
+	var got workspaceapi.RuntimeAttachSpecResponse
+	require.NoError(json.Unmarshal(wrapped, &got))
+
+	require.Len(got.Command, 4,
+		"the remote command must collapse into a single quoted ssh argument")
+	assert.Equal([]string{"ssh", "-t", "peer"}, got.Command[:3])
+	remote := got.Command[3]
+	assert.Contains(remote, `'TMUX_TMPDIR=/socket dir/with'\''quote'`,
+		"metacharacter values must reach the remote shell quoted")
+	assert.Contains(remote, "attach-session")
+	assert.False(got.RequiresLocalHost)
+}

--- a/internal/server/fleetapi/fleet_tmux_monitor.go
+++ b/internal/server/fleetapi/fleet_tmux_monitor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"maps"
+	"os"
 	"os/exec"
 	"regexp"
 	"slices"
@@ -12,8 +13,10 @@ import (
 	"sync"
 	"time"
 
+	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/fleet"
 	"go.kenn.io/forge/internal/procutil"
+	"go.kenn.io/forge/internal/workspace/localruntime"
 )
 
 const (
@@ -102,7 +105,7 @@ func newFleetTmuxMonitor(
 		clock = time.Now
 	}
 	if len(tmuxCmd) == 0 {
-		tmuxCmd = []string{"tmux"}
+		tmuxCmd = config.DefaultTmuxCommand()
 	}
 	return &fleetTmuxMonitor{
 		tmuxCmd:                 slices.Clone(tmuxCmd),
@@ -334,13 +337,16 @@ func tmuxEmptyServerError(err error) bool {
 }
 
 func (m *fleetTmuxMonitor) tmuxCommand(ctx context.Context, args ...string) *exec.Cmd {
-	if len(m.tmuxCmd) == 0 {
-		return procutil.CommandContext(ctx, "tmux", args...)
+	command := m.tmuxCmd
+	if len(command) == 0 {
+		command = config.DefaultTmuxCommand()
 	}
-	cmdArgs := make([]string, 0, len(m.tmuxCmd)-1+len(args))
-	cmdArgs = append(cmdArgs, m.tmuxCmd[1:]...)
+	cmdArgs := make([]string, 0, len(command)-1+len(args))
+	cmdArgs = append(cmdArgs, command[1:]...)
 	cmdArgs = append(cmdArgs, args...)
-	return procutil.CommandContext(ctx, m.tmuxCmd[0], cmdArgs...)
+	cmd := procutil.CommandContext(ctx, command[0], cmdArgs...)
+	cmd.Env = localruntime.TmuxClientEnvironment(os.Environ(), nil)
+	return cmd
 }
 
 func parseFleetTmuxInventory(

--- a/internal/server/kata/catalog_strip_test.go
+++ b/internal/server/kata/catalog_strip_test.go
@@ -1,0 +1,64 @@
+package kata
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	katacatalog "go.kenn.io/forge/internal/kata"
+)
+
+// TestHandlerReportsCatalogTokenEnvNamesOnLoad pins the catalog-to-strip
+// boundary: every successful catalog load reports the daemons' token_env
+// names so credential stripping tracks catalog edits; failed loads
+// report nothing.
+func TestHandlerReportsCatalogTokenEnvNamesOnLoad(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var reported [][]string
+	loadErr := error(nil)
+	h := New(Deps{
+		LoadCatalog: func() (katacatalog.Catalog, error) {
+			if loadErr != nil {
+				return katacatalog.Catalog{}, loadErr
+			}
+			return katacatalog.Catalog{Daemons: []katacatalog.Daemon{
+				{TokenEnv: "KATA_PROD_TOKEN"},
+			}}, nil
+		},
+		OnCatalogTokenEnvNames: func(names []string) {
+			reported = append(reported, names)
+		},
+	})
+
+	_, err := h.loadCatalog()
+	require.NoError(err)
+	assert.Equal([][]string{{"KATA_PROD_TOKEN"}}, reported)
+
+	loadErr = errors.New("catalog unreadable")
+	_, err = h.loadCatalog()
+	require.Error(err)
+	assert.Len(reported, 1, "undecodable loads must not report names")
+}
+
+// TestHandlerReportsDeclaredNamesFromRejectedCatalogs pins the
+// decoded-but-invalid case: a rejected catalog's declared token names
+// must still reach stripping.
+func TestHandlerReportsDeclaredNamesFromRejectedCatalogs(t *testing.T) {
+	var reported [][]string
+	h := New(Deps{
+		LoadCatalog: func() (katacatalog.Catalog, error) {
+			return katacatalog.Catalog{Daemons: []katacatalog.Daemon{
+					{TokenEnv: "KATA_REJECTED_TOKEN"},
+				}},
+				errors.New("catalog invalid")
+		},
+		OnCatalogTokenEnvNames: func(names []string) {
+			reported = append(reported, names)
+		},
+	})
+	_, err := h.loadCatalog()
+	require.Error(t, err)
+	assert.Equal(t, [][]string{{"KATA_REJECTED_TOKEN"}}, reported)
+}

--- a/internal/server/kata/handler.go
+++ b/internal/server/kata/handler.go
@@ -20,12 +20,16 @@ import (
 // Defaults preserve the normal local Kata discovery behavior while allowing
 // tests and alternate composition roots to supply owned transports/catalogs.
 type Deps struct {
-	DB                     *db.DB
-	Resolver               *httpapi.RepositoryResolver
-	Config                 ConfigSnapshot
-	Workspaces             *workspace.Manager
-	WorkspaceAPI           *workspaceapi.Handler
-	LoadCatalog            func() (katacatalog.Catalog, error)
+	DB           *db.DB
+	Resolver     *httpapi.RepositoryResolver
+	Config       ConfigSnapshot
+	Workspaces   *workspace.Manager
+	WorkspaceAPI *workspaceapi.Handler
+	LoadCatalog  func() (katacatalog.Catalog, error)
+	// OnCatalogTokenEnvNames receives the catalog's daemon token_env
+	// names after every successful catalog load so credential stripping
+	// covers externally cataloged tokens, including catalog edits.
+	OnCatalogTokenEnvNames func([]string)
 	ResolveDaemon          func(katacatalog.Daemon) (katacatalog.Daemon, error)
 	DiscoverLocalDaemonURL func() string
 	NewHTTPTransport       func() http.RoundTripper
@@ -67,6 +71,20 @@ func New(deps Deps) *Handler {
 	loadCatalog := deps.LoadCatalog
 	if loadCatalog == nil {
 		loadCatalog = katacatalog.LoadCatalog
+	}
+	if deps.OnCatalogTokenEnvNames != nil {
+		inner := loadCatalog
+		onNames := deps.OnCatalogTokenEnvNames
+		loadCatalog = func() (katacatalog.Catalog, error) {
+			cat, err := inner()
+			// Decoded-but-invalid catalogs still carry declared
+			// token_env names; report them so a rejected catalog's
+			// credentials keep being stripped from terminals.
+			if names := cat.TokenEnvNames(); len(names) > 0 {
+				onNames(names)
+			}
+			return cat, err
+		}
 	}
 	resolveDaemon := deps.ResolveDaemon
 	if resolveDaemon == nil {

--- a/internal/server/kata_boot_strip_test.go
+++ b/internal/server/kata_boot_strip_test.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestServerBootAppliesInvalidCatalogTokenNames pins boot-time catalog
+// stripping: a decoded-but-invalid Kata catalog still declares token
+// env names, and terminals created before any Kata request must strip
+// them.
+func TestServerBootAppliesInvalidCatalogTokenNames(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("KATA_HOME", dir)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "config.toml"), []byte(`
+[[daemon]]
+name = "prod"
+url = "https://kata.example.com"
+token_env = "KATA_BOOT_REJECTED_TOKEN"
+
+[[daemon]]
+name = "prod"
+url = "https://kata2.example.com"
+`), 0o600))
+
+	srv, _, _ := setupTestServerWithConfigContentAndOptions(
+		t, validReloadConfig, &mockGH{}, ServerOptions{
+			HostCheckAllowLoopbackAnyPort:      true,
+			WorktreeDir:                        t.TempDir(),
+			DisableWorkspaceBackgroundMonitors: true,
+		},
+	)
+	assert.Contains(t, srv.workspaces.TmuxStripEnvVars(),
+		"KATA_BOOT_REJECTED_TOKEN",
+		"invalid catalogs' declared names must strip from boot")
+}

--- a/internal/server/projects_handlers_test.go
+++ b/internal/server/projects_handlers_test.go
@@ -243,8 +243,9 @@ func TestProjectWorktreeRuntimeAttachSpecUsesStoredTmuxSession(t *testing.T) {
 	assert.Equal("project-runtime-live", spec.TmuxSession)
 	assert.Equal(
 		[]string{
+			"env", "-u", "TMUX", "-u", "TMUX_TMPDIR",
 			tmuxScript, "--socket", "runtime",
-			"-u", "attach-session", "-t", "project-runtime-live",
+			"-u", "attach-session", "-E", "-t", "project-runtime-live",
 		},
 		spec.Command,
 	)
@@ -310,9 +311,7 @@ func TestProjectWorktreeRuntimeStopFallsBackToStoredTmuxSession(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	record := filepath.Join(t.TempDir(), "tmux-record")
-	tmuxScript := writeProjectRuntimeTmuxRecorder(t)
-	t.Setenv("TMUX_RECORD", record)
+	tmuxScript, record := writeProjectRuntimeTmuxRecorder(t)
 	srv, projectID, worktreeID := setupProjectWorktreeRuntimeTestWithTmux(
 		t, []string{tmuxScript},
 	)
@@ -486,14 +485,19 @@ func createRuntimeTestProject(t *testing.T, database *db.DB, localPath string) *
 	return project
 }
 
-func writeProjectRuntimeTmuxRecorder(t *testing.T) string {
+func writeProjectRuntimeTmuxRecorder(t *testing.T) (script, record string) {
 	t.Helper()
-	script := filepath.Join(t.TempDir(), "fake-tmux")
+	dir := t.TempDir()
+	record = filepath.Join(dir, "tmux-record")
+	script = filepath.Join(dir, "fake-tmux")
+	// The record path is baked: tmux clients run with the allowlist
+	// environment, so fixtures cannot pass it through env vars.
 	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellQuoteTest(record) + "\n" +
 		`printf '%s\n' "$*" >> "$TMUX_RECORD"` + "\n" +
 		"exit 0\n"
 	require.NoError(t, os.WriteFile(script, []byte(body), 0o755))
-	return script
+	return script, record
 }
 
 func writeProjectRuntimeTmuxProbe(

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,6 +30,7 @@ import (
 	"go.kenn.io/forge/internal/docs"
 	"go.kenn.io/forge/internal/gitclone"
 	ghclient "go.kenn.io/forge/internal/github"
+	katacatalog "go.kenn.io/forge/internal/kata"
 	"go.kenn.io/forge/internal/platform"
 	"go.kenn.io/forge/internal/projects"
 	"go.kenn.io/forge/internal/ptyowner"
@@ -185,6 +186,7 @@ type Server struct {
 	// surface restart_required to the UI without ever mutating them.
 	bootCfgSnapshot     startupConfigSnapshot
 	runtimeStripEnvVars []string
+	ptyOwnerClient      *ptyowner.Client
 	configWatcher       *configwatch.Watcher
 	basePath            string
 	options             ServerOptions
@@ -699,6 +701,25 @@ func fleetConfigSnapshot(cfg *config.Config, tmuxCommand []string) fleetapi.Conf
 	}
 }
 
+// updateCatalogStripEnvVars widens every credential strip set with
+// externally cataloged token env names (Kata daemon catalogs). All
+// consumers accumulate monotonically, so stale catalog names only
+// over-strip.
+func (s *Server) updateCatalogStripEnvVars(names []string) {
+	if len(names) == 0 {
+		return
+	}
+	if s.workspaces != nil {
+		s.workspaces.UpdateTmuxStripEnvVars(names)
+	}
+	if s.runtime != nil {
+		s.runtime.UpdateStripEnvVars(names)
+	}
+	if s.ptyOwnerClient != nil {
+		s.ptyOwnerClient.UpdateStripEnvVars(names)
+	}
+}
+
 func (s *Server) applyWorkspaceConfigLocked() {
 	if s.workspaceAPI != nil {
 		s.workspaceAPI.ApplyConfig(workspaceConfigSnapshot(s.cfg, s.tmuxCmd))
@@ -853,8 +874,8 @@ func newServer(
 		)
 	}
 
-	// (*Config).TmuxCommand handles a nil receiver and returns the
-	// default ["tmux"]. Compute once so the workspace, runtime, and
+	// (*Config).TmuxCommand handles a nil receiver and returns
+	// config.DefaultTmuxCommand. Compute once so the workspace, runtime, and
 	// terminal handler all share the same value and the nil-safety
 	// of the call is explicit at this level.
 	tmuxCmd := cfg.TmuxCommand()
@@ -901,6 +922,7 @@ func newServer(
 	if options.WorktreeDir != "" {
 		s.workspaces = workspace.NewManager(database, options.WorktreeDir)
 		s.workspaces.SetTmuxCommand(tmuxCmd)
+		s.workspaces.UpdateTmuxStripEnvVars(s.runtimeStripEnvVars)
 		s.workspaces.SetHideTmuxStatus(hideTmuxStatus)
 		s.workspaces.SetIssueBranchSlugEnabled(
 			cfg.IssueWorkspaceBranchSlugEnabled(),
@@ -918,8 +940,12 @@ func newServer(
 			ExeArgs:     append([]string(nil), options.PtyOwnerExeArgs...),
 			ManagerPath: options.PtyOwnerManagerPath,
 			Command:     append([]string(nil), options.PtyOwnerCommand...),
-			InProcess:   options.PtyOwnerInProcess,
+			// Configured token names must vanish from tmux-less base
+			// terminals just like tmux-backed ones.
+			StripEnvVars: slices.Clone(s.runtimeStripEnvVars),
+			InProcess:    options.PtyOwnerInProcess,
 		}
+		s.ptyOwnerClient = ptyOwnerClient
 		if preferPtyOwnerForWorkspaces(runtime.GOOS, tmuxAvailable, options) {
 			s.workspaces.SetPtyOwnerClient(ptyOwnerClient)
 		} else {
@@ -991,14 +1017,27 @@ func newServer(
 		EnqueueDetailSync:       s.enqueueDetailSyncWithCompletion,
 	})
 	s.kataAPI = kata.New(kata.Deps{
-		DB:               database,
-		Resolver:         repoResolver,
-		Config:           kataConfigSnapshot(cfg),
-		Workspaces:       s.workspaces,
-		WorkspaceAPI:     s.workspaceAPI.Workspaces(),
-		SamePlatformHost: samePlatformHost,
-		ConfigRepoPath:   configRepoPath,
+		DB:                     database,
+		Resolver:               repoResolver,
+		Config:                 kataConfigSnapshot(cfg),
+		Workspaces:             s.workspaces,
+		WorkspaceAPI:           s.workspaceAPI.Workspaces(),
+		SamePlatformHost:       samePlatformHost,
+		ConfigRepoPath:         configRepoPath,
+		OnCatalogTokenEnvNames: s.updateCatalogStripEnvVars,
 	})
+	// Kata catalogs load lazily per request; feed their token env names
+	// into stripping at boot too so terminals created before the first
+	// Kata route never see cataloged credentials. Decoded-but-invalid
+	// catalogs still carry their declared names, so apply them
+	// regardless of the load error.
+	bootCatalog, err := katacatalog.LoadCatalog()
+	if err != nil {
+		slog.Debug(
+			"kata catalog boot load for credential stripping", "err", err,
+		)
+	}
+	s.updateCatalogStripEnvVars(bootCatalog.TokenEnvNames())
 	s.pullAPI = pullapi.New(pullapi.Deps{
 		DB:                     database,
 		Resolver:               repoResolver,

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -1001,7 +1001,16 @@ func (s *Server) bootTmuxCommand() []string {
 }
 
 func (s *Server) updateRuntimeStripEnvVars(cfg *config.Config) {
-	if s.runtime == nil || cfg == nil {
+	if cfg == nil {
+		return
+	}
+	if s.workspaces != nil {
+		s.workspaces.UpdateTmuxStripEnvVars(cfg.TokenEnvNames())
+	}
+	if s.ptyOwnerClient != nil {
+		s.ptyOwnerClient.UpdateStripEnvVars(cfg.TokenEnvNames())
+	}
+	if s.runtime == nil {
 		return
 	}
 	s.runtime.UpdateStripEnvVars(cfg.TokenEnvNames())

--- a/internal/server/tmux_wrapper_test.go
+++ b/internal/server/tmux_wrapper_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+	shellquote "github.com/kballard/go-shellquote"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -62,7 +63,12 @@ func writeTmuxRecorder(t *testing.T) (script, record string) {
 	dir := t.TempDir()
 	record = filepath.Join(dir, "record")
 	script = filepath.Join(dir, "fake-tmux")
+	// Control paths are baked into the script and dynamic pane title /
+	// output values are read from files derived from the record path:
+	// tmux clients run with the non-secret allowlist environment, so
+	// fixtures cannot smuggle state through custom env vars.
 	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`session_file="${TMUX_RECORD}.sessions"` + "\n" +
 		`new_session=""` + "\n" +
@@ -78,11 +84,19 @@ func writeTmuxRecorder(t *testing.T) (script, record string) {
 		`    exit 1` + "\n" +
 		`  fi` + "\n" +
 		`  if [ "$a" = "display-message" ]; then` + "\n" +
-		`    printf '%s\n' "$TMUX_PANE_TITLE"` + "\n" +
+		`    if [ -f "${TMUX_RECORD}.pane-title" ]; then` + "\n" +
+		`      cat "${TMUX_RECORD}.pane-title"` + "\n" +
+		`    else` + "\n" +
+		`      printf '\n'` + "\n" +
+		`    fi` + "\n" +
 		`    exit 0` + "\n" +
 		`  fi` + "\n" +
 		`  if [ "$a" = "capture-pane" ]; then` + "\n" +
-		`    printf '%s\n' "$TMUX_PANE_OUTPUT"` + "\n" +
+		`    if [ -f "${TMUX_RECORD}.pane-output" ]; then` + "\n" +
+		`      cat "${TMUX_RECORD}.pane-output"` + "\n" +
+		`    else` + "\n" +
+		`      printf '\n'` + "\n" +
+		`    fi` + "\n" +
 		`    exit 0` + "\n" +
 		`  fi` + "\n" +
 		`  prev="$a"` + "\n" +
@@ -90,8 +104,25 @@ func writeTmuxRecorder(t *testing.T) (script, record string) {
 		`if [ -n "$new_session" ]; then printf '%s\n' "$new_session" >> "$session_file"; fi` + "\n" +
 		"exit 0\n"
 	require.NoError(t, os.WriteFile(script, []byte(body), 0o755))
-	t.Setenv("TMUX_RECORD", record)
 	return script, record
+}
+
+// setTmuxRecorderPaneTitle sets the value the fake tmux returns for
+// display-message pane-title probes.
+func setTmuxRecorderPaneTitle(t *testing.T, record, title string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(
+		record+".pane-title", []byte(title+"\n"), 0o644,
+	))
+}
+
+// setTmuxRecorderPaneOutput sets the value the fake tmux returns for
+// capture-pane probes.
+func setTmuxRecorderPaneOutput(t *testing.T, record, output string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(
+		record+".pane-output", []byte(output+"\n"), 0o644,
+	))
 }
 
 func readTmuxRecord(t *testing.T, path string) [][]string {
@@ -353,8 +384,10 @@ func TestTmuxWrapperNewSession(t *testing.T) {
 		}
 	}
 
-	// "wrap" prefix, then "new-session -d -s <id> -c <path> <shell> -l"
-	require.GreaterOrEqual(len(newSession), 9)
+	// "wrap" prefix, then "new-session -d -s <id> -c <path> <handoff>"
+	// where <handoff> is the /bin/sh env-file bootstrap that delivers
+	// the credential-sanitized environment and login shell to the pane.
+	require.Len(newSession, 8)
 	assert.Equal("wrap", newSession[0])
 	assert.Equal("new-session", newSession[1])
 	assert.Equal("-d", newSession[2])
@@ -362,17 +395,15 @@ func TestTmuxWrapperNewSession(t *testing.T) {
 	assert.NotEmpty(newSession[4])
 	assert.Equal("-c", newSession[5])
 	assert.NotEmpty(newSession[6])
-	assert.NotEmpty(newSession[7])
-	assert.Equal("-l", newSession[8])
+	assert.Contains(newSession[7], "/bin/sh ")
 }
 
 func TestWorkspaceResponseIncludesTmuxWorkingState(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
-	t.Setenv("TMUX_PANE_TITLE", "⠴ t3code-b5014b03")
-	t.Setenv("TMUX_PANE_OUTPUT", "stable output")
-
-	client, _, _ := setupWrapperServer(t)
+	client, _, record := setupWrapperServer(t)
+	setTmuxRecorderPaneTitle(t, record, "⠴ t3code-b5014b03")
+	setTmuxRecorderPaneOutput(t, record, "stable output")
 	ctx := context.Background()
 
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
@@ -434,8 +465,8 @@ func TestWorkspaceResponseIncludesTmuxWorkingState(t *testing.T) {
 func TestFilteredActivityIncrementalPollRetainsWorkspaceSubject(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
-	t.Setenv("TMUX_PANE_OUTPUT", "baseline output")
-	script, _ := writeTmuxRecorder(t)
+	script, record := writeTmuxRecorder(t)
+	setTmuxRecorderPaneOutput(t, record, "baseline output")
 	client, _, database, srv := setupWrapperServerWithScriptAndDBAndServer(t, script)
 	srv.cfgMu.Lock()
 	srv.cfg.Activity.UseWorkspaceActivityForRecency = true
@@ -475,7 +506,7 @@ func TestFilteredActivityIncrementalPollRetainsWorkspaceSubject(t *testing.T) {
 		activity := getRawWorkspaceActivity(t, client, ctx, workspaceID)
 		return activity.TmuxActivitySource == "none" && activity.TmuxLastOutputAt == nil
 	}, 3*time.Second, 50*time.Millisecond, "tmux baseline was not observed")
-	t.Setenv("TMUX_PANE_OUTPUT", "changed output")
+	setTmuxRecorderPaneOutput(t, record, "changed output")
 
 	search := "search-reviewer"
 	since := now.Add(-time.Hour).Format(time.RFC3339)
@@ -552,8 +583,8 @@ func TestFilteredActivityIncrementalPollRetainsWorkspaceSubject(t *testing.T) {
 func TestActivityAuthorsIncludeWorkspaceOnlySubject(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
-	t.Setenv("TMUX_PANE_OUTPUT", "baseline output")
-	script, _ := writeTmuxRecorder(t)
+	script, record := writeTmuxRecorder(t)
+	setTmuxRecorderPaneOutput(t, record, "baseline output")
 	client, _, database, srv := setupWrapperServerWithScriptAndDBAndServer(t, script)
 	srv.cfgMu.Lock()
 	srv.cfg.Activity.UseWorkspaceActivityForRecency = true
@@ -586,7 +617,7 @@ func TestActivityAuthorsIncludeWorkspaceOnlySubject(t *testing.T) {
 		return activity.TmuxActivitySource == "none" && activity.TmuxLastOutputAt == nil
 	}, 3*time.Second, 50*time.Millisecond, "tmux baseline was not observed")
 	since := time.Now().UTC().Format(time.RFC3339Nano)
-	t.Setenv("TMUX_PANE_OUTPUT", "workspace-only activity")
+	setTmuxRecorderPaneOutput(t, record, "workspace-only activity")
 
 	params := &generated.ListActivityAuthorsParams{Since: &since}
 	var response *generated.ListActivityAuthorsResponse
@@ -631,8 +662,8 @@ func TestActivityAuthorsIncludeWorkspaceOnlySubject(t *testing.T) {
 func TestWorkspaceActivityNumberSearchIncludesEventlessSubject(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
-	t.Setenv("TMUX_PANE_OUTPUT", "baseline output")
-	script, _ := writeTmuxRecorder(t)
+	script, record := writeTmuxRecorder(t)
+	setTmuxRecorderPaneOutput(t, record, "baseline output")
 	client, _, database, srv := setupWrapperServerWithScriptAndDBAndServer(t, script)
 	srv.cfgMu.Lock()
 	srv.cfg.Activity.UseWorkspaceActivityForRecency = true
@@ -669,7 +700,7 @@ func TestWorkspaceActivityNumberSearchIncludesEventlessSubject(t *testing.T) {
 		return activity.TmuxActivitySource == "none" && activity.TmuxLastOutputAt == nil
 	}, 3*time.Second, 50*time.Millisecond, "tmux baseline was not observed")
 	since := time.Now().UTC().Format(time.RFC3339Nano)
-	t.Setenv("TMUX_PANE_OUTPUT", "changed output")
+	setTmuxRecorderPaneOutput(t, record, "changed output")
 
 	for _, search := range []string{"1", "#1"} {
 		var response *generated.ListActivityResponse
@@ -863,6 +894,7 @@ func TestWorkspaceShutdownCancellationPersistsFailureViaAPI(t *testing.T) {
 	record := filepath.Join(dir, "record")
 	script := filepath.Join(dir, "fake-tmux")
 	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "has-session" ]; then` + "\n" +
@@ -875,7 +907,6 @@ func TestWorkspaceShutdownCancellationPersistsFailureViaAPI(t *testing.T) {
 		"done\n" +
 		"exit 0\n"
 	require.NoError(os.WriteFile(script, []byte(body), 0o755))
-	t.Setenv("TMUX_RECORD", record)
 
 	client, _, database, srv := setupWrapperServerWithScriptAndDBAndServer(
 		t, script,
@@ -1060,6 +1091,9 @@ func TestWorkspaceRetryWhileCreatingQueuesAndRunsAfterFailureViaAPI(t *testing.T
 	countFile := filepath.Join(dir, "new-session-count")
 	script := filepath.Join(dir, "fake-tmux")
 	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
+		"TMUX_RELEASE=" + shellquote.Join(release) + "\n" +
+		"TMUX_COUNT=" + shellquote.Join(countFile) + "\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "has-session" ]; then` + "\n" +
@@ -1080,9 +1114,6 @@ func TestWorkspaceRetryWhileCreatingQueuesAndRunsAfterFailureViaAPI(t *testing.T
 		"done\n" +
 		"exit 0\n"
 	require.NoError(os.WriteFile(script, []byte(body), 0o755))
-	t.Setenv("TMUX_RECORD", record)
-	t.Setenv("TMUX_RELEASE", release)
-	t.Setenv("TMUX_COUNT", countFile)
 
 	client, _, database := setupWrapperServerWithScriptAndDB(
 		t, script,
@@ -1176,6 +1207,7 @@ func TestWorkspaceShutdownCancellationDoesNotPersistAfterDeadlineBudgetExhausted
 	record := filepath.Join(dir, "record")
 	script := filepath.Join(dir, "fake-tmux")
 	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "has-session" ]; then` + "\n" +
@@ -1188,7 +1220,6 @@ func TestWorkspaceShutdownCancellationDoesNotPersistAfterDeadlineBudgetExhausted
 		"done\n" +
 		"exit 0\n"
 	require.NoError(os.WriteFile(script, []byte(body), 0o755))
-	t.Setenv("TMUX_RECORD", record)
 
 	client, baseURL, database, srv := setupWrapperServerWithScriptAndDBAndServer(
 		t, script,
@@ -1375,12 +1406,13 @@ func TestTmuxWrapperAttachSession(t *testing.T) {
 		}
 	}
 	require.NotNil(attach, "attach-session argv not recorded")
-	require.Len(attach, 5)
+	require.Len(attach, 6)
 	assert.Equal("wrap", attach[0])
 	assert.Equal("-u", attach[1])
 	assert.Equal("attach-session", attach[2])
-	assert.Equal("-t", attach[3])
-	assert.NotEmpty(attach[4])
+	assert.Equal("-E", attach[3])
+	assert.Equal("-t", attach[4])
+	assert.NotEmpty(attach[5])
 }
 
 func TestTerminalRouteE2EPropagatesWorkspaceID(t *testing.T) {
@@ -1408,6 +1440,7 @@ func TestWorkspaceSetupResourceExhaustionGetsHelpfulErrorViaAPI(t *testing.T) {
 	record := filepath.Join(dir, "record")
 	script := filepath.Join(dir, "fake-tmux")
 	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "new-session" ]; then` + "\n" +
@@ -1421,7 +1454,6 @@ func TestWorkspaceSetupResourceExhaustionGetsHelpfulErrorViaAPI(t *testing.T) {
 		"done\n" +
 		"exit 0\n"
 	require.NoError(os.WriteFile(script, []byte(body), 0o755))
-	t.Setenv("TMUX_RECORD", record)
 
 	client, _, _ := setupWrapperServerWithScriptAndDB(t, script)
 	ctx := context.Background()
@@ -1888,7 +1920,9 @@ func TestDeleteErroredWorkspaceAllowsUnavailableTmux(t *testing.T) {
 // the terminal handler sees the error and closes the WebSocket with
 // StatusInternalError.
 func TestTmuxWrapperAttachSurfacesWrapperFailure(t *testing.T) {
+	record := filepath.Join(t.TempDir(), "record")
 	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "has-session" ]; then exit 127; fi` + "\n" +
@@ -1909,10 +1943,8 @@ func attachWebsocketAndExpectInternalError(t *testing.T, scriptBody string) {
 	require := require.New(t)
 
 	dir := t.TempDir()
-	record := filepath.Join(dir, "record")
 	script := filepath.Join(dir, "fake-tmux")
 	require.NoError(os.WriteFile(script, []byte(scriptBody), 0o755))
-	t.Setenv("TMUX_RECORD", record)
 
 	client, baseURL := setupWrapperServerWithScript(t, script)
 	ctx := t.Context()
@@ -1982,7 +2014,9 @@ func attachWebsocketAndExpectInternalError(t *testing.T, scriptBody string) {
 // reviewer flagged — shell wrappers often exit 1 for their own
 // generic errors.
 func TestTmuxWrapperAttachSurfacesExit1Failure(t *testing.T) {
+	record := filepath.Join(t.TempDir(), "record")
 	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "has-session" ]; then` + "\n" +
@@ -2001,7 +2035,9 @@ func TestTmuxWrapperAttachSurfacesExit1Failure(t *testing.T) {
 // "session absent." Pairs with the unit-level
 // TestManagerEnsureTmuxIgnoresAbsencePhraseOnStdout.
 func TestTmuxWrapperAttachIgnoresAbsencePhraseOnStdout(t *testing.T) {
+	record := filepath.Join(t.TempDir(), "record")
 	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "has-session" ]; then` + "\n" +

--- a/internal/server/workspaceapi/projects_handlers.go
+++ b/internal/server/workspaceapi/projects_handlers.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/fleet"
 	ghclient "go.kenn.io/forge/internal/github"
@@ -1649,7 +1650,7 @@ func killProjectRuntimeTmuxSession(
 		return nil
 	}
 	if len(command) == 0 {
-		command = []string{"tmux"}
+		command = config.DefaultTmuxCommand()
 	}
 	if command[0] == "" {
 		return nil
@@ -1657,6 +1658,7 @@ func killProjectRuntimeTmuxSession(
 	args := append([]string{}, command[1:]...)
 	args = append(args, "kill-session", "-t", session)
 	cmd := procutil.CommandContext(ctx, command[0], args...)
+	cmd.Env = localruntime.TmuxClientEnvironment(os.Environ(), nil)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	err := procutil.Run(ctx, cmd, "project worktree runtime tmux cleanup")

--- a/internal/server/workspaceapi/runtime_attach_spec.go
+++ b/internal/server/workspaceapi/runtime_attach_spec.go
@@ -5,11 +5,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
+	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/procutil"
 	"go.kenn.io/forge/internal/server/httpapi"
+	"go.kenn.io/forge/internal/workspace/localruntime"
 )
 
 func runtimeAttachSpec(
@@ -66,11 +69,28 @@ type RuntimeAttachSpecOutput = httpapi.BodyOutput[runtimeAttachSpecResponse]
 func runtimeAttachCommand(tmuxCommand []string, tmuxSession string) []string {
 	command := append([]string{}, tmuxCommand...)
 	if len(command) == 0 {
-		command = []string{"tmux"}
+		command = config.DefaultTmuxCommand()
 	}
 	// Remote consumers may launch this command without locale variables.
-	// Force UTF-8 so tmux preserves non-ASCII terminal output.
-	return append(command, "-u", "attach-session", "-t", tmuxSession)
+	// Force UTF-8 so tmux preserves non-ASCII terminal output. This
+	// command runs in the caller's own shell, whose environment is not
+	// sanitized; -E stops a widened update-environment from copying the
+	// caller's variables (including provider tokens) into the session
+	// environment where pane processes could read them back.
+	command = append(command, "-u", "attach-session", "-E", "-t", tmuxSession)
+	// The command runs in the caller's shell, whose environment must
+	// not steer the attach: TMUX would make tmux refuse the nested
+	// attach, and tmux resolves -L sockets under TMUX_TMPDIR, so the
+	// caller's value must be replaced by the daemon's — set when the
+	// daemon has one, unset when it does not — or the attach targets a
+	// different tmux server than the daemon owns.
+	envPrefix := []string{"env", "-u", "TMUX"}
+	if dir := os.Getenv("TMUX_TMPDIR"); dir != "" {
+		envPrefix = append(envPrefix, "TMUX_TMPDIR="+dir)
+	} else {
+		envPrefix = append(envPrefix, "-u", "TMUX_TMPDIR")
+	}
+	return append(envPrefix, command...)
 }
 
 func attachSpecTmuxSessionExists(
@@ -80,7 +100,7 @@ func attachSpecTmuxSessionExists(
 ) (bool, error) {
 	command = append([]string{}, command...)
 	if len(command) == 0 {
-		command = []string{"tmux"}
+		command = config.DefaultTmuxCommand()
 	}
 	if strings.TrimSpace(command[0]) == "" {
 		return false, errors.New("tmux command is empty")
@@ -88,6 +108,7 @@ func attachSpecTmuxSessionExists(
 	args := append([]string{}, command[1:]...)
 	args = append(args, "has-session", "-t", session)
 	cmd := procutil.CommandContext(ctx, command[0], args...)
+	cmd.Env = localruntime.TmuxClientEnvironment(os.Environ(), nil)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	err := procutil.Run(ctx, cmd, "runtime attach tmux probe")

--- a/internal/server/workspaceapi/runtime_attach_spec_env_test.go
+++ b/internal/server/workspaceapi/runtime_attach_spec_env_test.go
@@ -1,0 +1,43 @@
+package workspaceapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRuntimeAttachCommandPinsTmuxTmpdir pins socket routing for
+// externally returned attach commands: tmux resolves -L sockets under
+// TMUX_TMPDIR, and the caller's shell may not share the daemon's value,
+// so the command must carry it explicitly.
+func TestRuntimeAttachCommandPinsTmuxTmpdir(t *testing.T) {
+	t.Setenv("TMUX_TMPDIR", "/custom/socket-dir")
+	assert.Equal(t,
+		[]string{
+			"env", "-u", "TMUX", "TMUX_TMPDIR=/custom/socket-dir",
+			"tmux", "-L", "kenn-forge",
+			"-u", "attach-session", "-E", "-t", "forge-abc",
+		},
+		runtimeAttachCommand(
+			[]string{"tmux", "-L", "kenn-forge"}, "forge-abc",
+		),
+	)
+}
+
+// TestRuntimeAttachCommandWithoutTmpdirUnsetsCallerValue pins the
+// symmetric case: the caller's shell may carry TMUX_TMPDIR (or run
+// inside tmux with TMUX set) while the daemon does not, which would
+// route the attach to a different socket directory or refuse nesting.
+func TestRuntimeAttachCommandWithoutTmpdirUnsetsCallerValue(t *testing.T) {
+	t.Setenv("TMUX_TMPDIR", "")
+	assert.Equal(t,
+		[]string{
+			"env", "-u", "TMUX", "-u", "TMUX_TMPDIR",
+			"tmux", "-L", "kenn-forge",
+			"-u", "attach-session", "-E", "-t", "forge-abc",
+		},
+		runtimeAttachCommand(
+			[]string{"tmux", "-L", "kenn-forge"}, "forge-abc",
+		),
+	)
+}

--- a/internal/server/workspacetest/default_tmux_socket_test.go
+++ b/internal/server/workspacetest/default_tmux_socket_test.go
@@ -1,0 +1,132 @@
+package workspacetest
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/apiclient/generated"
+	"go.kenn.io/forge/internal/config"
+	"go.kenn.io/forge/internal/procutil"
+	"go.kenn.io/forge/internal/server"
+)
+
+// TestWorkspaceUnconfiguredTmuxUsesForgeSocketE2E proves that a server
+// without a configured [tmux] command runs workspace sessions on the
+// dedicated kenn-forge tmux socket, not the user's global server. The
+// socket name is hardcoded on purpose: deriving it from
+// config.DefaultTmuxCommand would follow a regressed default and pass.
+// TMUX_TMPDIR points the -L socket directory at a private sandbox so the
+// test never touches a real kenn-forge server.
+func TestWorkspaceUnconfiguredTmuxUsesForgeSocketE2E(t *testing.T) {
+	if len(workspaceTestTmuxCommand) == 0 {
+		t.Skip("tmux is required")
+	}
+	require := require.New(t)
+	tmuxPath := workspaceTestTmuxCommand[0]
+
+	sockDir, err := os.MkdirTemp("/tmp", "kenn-forge-default-tmux-*")
+	require.NoError(err)
+	t.Setenv("TMUX_TMPDIR", sockDir)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		killCmd := procutil.CommandContext(
+			ctx, tmuxPath, "-L", "kenn-forge", "kill-server",
+		)
+		killCmd.Env = append(os.Environ(), "TMUX_TMPDIR="+sockDir)
+		_ = procutil.Run(ctx, killCmd, "kill sandboxed kenn-forge tmux server")
+		_ = os.RemoveAll(sockDir)
+	})
+
+	fixture := setupWorkspaceServerFixtureUnconfiguredTmux(t, &config.Config{
+		Agents: []config.Agent{{
+			Key:     "helper",
+			Label:   "Helper",
+			Command: workspaceRuntimeHelperCommand("echo"),
+		}},
+	}, server.ServerOptions{
+		DisableWorkspaceBackgroundMonitors: true,
+		PtyOwnerInProcess:                  true,
+		HostCheckAllowLoopbackAnyPort:      true,
+	})
+	ctx := t.Context()
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+
+	// Attaching the base workspace terminal creates the tmux session
+	// through the server's default tmux command.
+	ts := httptest.NewServer(fixture.server)
+	t.Cleanup(ts.Close)
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
+		"/ws/v1/workspaces/" + ws.Id + "/terminal?cols=80&rows=24"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	hasSessionOnForgeSocket := func() bool {
+		probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		cmd := procutil.CommandContext(
+			probeCtx, tmuxPath, "-L", "kenn-forge",
+			"has-session", "-t", ws.TmuxSession,
+		)
+		cmd.Env = append(os.Environ(), "TMUX_TMPDIR="+sockDir)
+		return procutil.Run(
+			probeCtx, cmd, "probe sandboxed kenn-forge tmux server",
+		) == nil
+	}
+	require.Eventually(
+		hasSessionOnForgeSocket, 15*time.Second, 100*time.Millisecond,
+		"workspace session %s never appeared on the kenn-forge socket",
+		ws.TmuxSession,
+	)
+
+	require.NoError(conn.Close(websocket.StatusNormalClosure, "done"))
+
+	// A tmux-wrapped agent launch must land on the same sandboxed
+	// kenn-forge socket: the launcher's tmux client resolves -L under
+	// TMUX_TMPDIR, so a client environment that dropped it would create
+	// the session on a different tmux server than the manager owns.
+	launch, err := fixture.client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{TargetKey: "helper"},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launch.StatusCode(), string(launch.Body))
+	agentSessionPrefix := "forge-" + ws.Id + "-"
+	require.Eventually(func() bool {
+		probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		cmd := procutil.CommandContext(
+			probeCtx, tmuxPath, "-L", "kenn-forge",
+			"list-sessions", "-F", "#{session_name}",
+		)
+		cmd.Env = append(os.Environ(), "TMUX_TMPDIR="+sockDir)
+		var stdout bytes.Buffer
+		cmd.Stdout = &stdout
+		if procutil.Run(
+			probeCtx, cmd, "list sandboxed kenn-forge tmux sessions",
+		) != nil {
+			return false
+		}
+		return strings.Contains(stdout.String(), agentSessionPrefix)
+	}, 15*time.Second, 100*time.Millisecond,
+		"agent session %s* never appeared on the sandboxed kenn-forge socket",
+		agentSessionPrefix,
+	)
+
+	deleteWorkspaceForPtyOwnerTest(t, ctx, fixture, ws.Id)
+	require.Eventually(
+		func() bool { return !hasSessionOnForgeSocket() },
+		15*time.Second, 100*time.Millisecond,
+		"workspace deletion left session %s on the kenn-forge socket",
+		ws.TmuxSession,
+	)
+}

--- a/internal/server/workspacetest/fixtures_test.go
+++ b/internal/server/workspacetest/fixtures_test.go
@@ -41,6 +41,33 @@ func setupWorkspaceServerFixture(
 	serverOptions ...server.ServerOptions,
 ) workspaceServerFixture {
 	t.Helper()
+	return setupWorkspaceServerFixtureWithTmuxInjection(
+		t, cfg, true, serverOptions...,
+	)
+}
+
+// setupWorkspaceServerFixtureUnconfiguredTmux leaves [tmux] command unset so
+// the server resolves config.DefaultTmuxCommand. The caller must point
+// TMUX_TMPDIR at a private directory first so the kenn-forge socket resolves
+// inside the test sandbox instead of the developer's real socket directory.
+func setupWorkspaceServerFixtureUnconfiguredTmux(
+	t *testing.T,
+	cfg *config.Config,
+	serverOptions ...server.ServerOptions,
+) workspaceServerFixture {
+	t.Helper()
+	return setupWorkspaceServerFixtureWithTmuxInjection(
+		t, cfg, false, serverOptions...,
+	)
+}
+
+func setupWorkspaceServerFixtureWithTmuxInjection(
+	t *testing.T,
+	cfg *config.Config,
+	injectTestTmux bool,
+	serverOptions ...server.ServerOptions,
+) workspaceServerFixture {
+	t.Helper()
 
 	if testing.Short() {
 		t.Skip("workspace e2e tests skipped in short mode")
@@ -51,7 +78,7 @@ func setupWorkspaceServerFixture(
 		clone := *cfg
 		cfg = &clone
 	}
-	if len(cfg.Tmux.Command) == 0 {
+	if injectTestTmux && len(cfg.Tmux.Command) == 0 {
 		cfg.Tmux.Command = append([]string(nil), workspaceTestTmuxCommand...)
 	}
 

--- a/internal/server/workspacetest/tmux_server_env_test.go
+++ b/internal/server/workspacetest/tmux_server_env_test.go
@@ -1,0 +1,156 @@
+package workspacetest
+
+import (
+	"bytes"
+	"context"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/config"
+	"go.kenn.io/forge/internal/procutil"
+	"go.kenn.io/forge/internal/server"
+)
+
+// TestWorkspaceTmuxServerEnvironmentExcludesTokensE2E proves the tmux
+// server spawned for a workspace never sees provider tokens from the
+// daemon environment. tmux retains its spawn environment globally
+// (`show-environment -g`), so an agent inside any pane could otherwise
+// read tokens the runtime environment stripping already hides from pane
+// processes. The test uses a test-scoped socket rather than the shared
+// package server so the spawn happens inside this test with the token
+// variables present in the daemon (test process) environment.
+func TestWorkspaceTmuxServerEnvironmentExcludesTokensE2E(t *testing.T) {
+	if len(workspaceTestTmuxCommand) == 0 {
+		t.Skip("tmux is required")
+	}
+	require := require.New(t)
+	assert := assert.New(t)
+	tmuxPath := workspaceTestTmuxCommand[0]
+
+	t.Setenv("GITHUB_TOKEN", "workspacetest-builtin-secret")
+	t.Setenv("WORKSPACETEST_CUSTOM_TOKEN", "workspacetest-custom-secret")
+	// The server environment is allowlisted, not strip-listed: secrets
+	// the config never names must stay out too.
+	t.Setenv("KATA_AUTH_TOKEN", "workspacetest-kata-secret")
+	t.Setenv("KENN_FORGE_FORGEJO_TOKEN", "workspacetest-forgejo-secret")
+	t.Setenv("WORKSPACETEST_UNDECLARED_SECRET", "workspacetest-undeclared")
+	// A configured token name hiding under an allowlisted prefix must
+	// still be stripped, and benign daemon variables must reach the
+	// base terminal pane through the env-file handoff.
+	t.Setenv("XDG_WORKSPACETEST_TOKEN", "workspacetest-xdg-secret")
+	t.Setenv("WKSP_BENIGN_PROXY", "workspacetest-proxy-value")
+
+	sockDir, err := os.MkdirTemp("/tmp", "kenn-forge-tmux-env-*")
+	require.NoError(err)
+	socket := filepath.Join(sockDir, "tmux.sock")
+	tmuxCommand := []string{tmuxPath, "-f", "/dev/null", "-S", socket}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = procutil.Run(ctx, procutil.CommandContext(
+			ctx, tmuxPath, "-f", "/dev/null", "-S", socket, "kill-server",
+		), "kill test-scoped tmux server")
+		_ = os.RemoveAll(sockDir)
+	})
+
+	fixture := setupWorkspaceServerFixture(t, &config.Config{
+		GitHubTokenEnv: "WORKSPACETEST_CUSTOM_TOKEN",
+		GitHubOwnerTokens: []config.GitHubOwnerTokenConfig{
+			{Owner: "acme", TokenEnv: "XDG_WORKSPACETEST_TOKEN"},
+		},
+		Tmux: config.Tmux{Command: tmuxCommand},
+	}, server.ServerOptions{
+		DisableWorkspaceBackgroundMonitors: true,
+		PtyOwnerInProcess:                  true,
+		HostCheckAllowLoopbackAnyPort:      true,
+	})
+	ctx := t.Context()
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+
+	// Attaching the base workspace terminal spawns the tmux server on
+	// the test-scoped socket via the manager's new-session path.
+	ts := httptest.NewServer(fixture.server)
+	t.Cleanup(ts.Close)
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
+		"/ws/v1/workspaces/" + ws.Id + "/terminal?cols=80&rows=24"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	require.Eventually(func() bool {
+		probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		return procutil.Run(probeCtx, procutil.CommandContext(
+			probeCtx, tmuxPath, "-f", "/dev/null", "-S", socket,
+			"has-session", "-t", ws.TmuxSession,
+		), "probe test-scoped tmux server") == nil
+	}, 15*time.Second, 100*time.Millisecond,
+		"workspace session never appeared on the test-scoped socket")
+
+	envCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	envCmd := procutil.CommandContext(
+		envCtx, tmuxPath, "-f", "/dev/null", "-S", socket,
+		"show-environment", "-g",
+	)
+	var stdout bytes.Buffer
+	envCmd.Stdout = &stdout
+	require.NoError(procutil.Run(
+		envCtx, envCmd, "read tmux server global environment",
+	))
+	globalEnv := stdout.String()
+
+	require.Contains(globalEnv, "PATH=",
+		"probe must return a real global environment")
+	assert.NotContains(globalEnv, "GITHUB_TOKEN",
+		"built-in token variables must not reach the tmux server environment")
+	assert.NotContains(globalEnv, "WORKSPACETEST_CUSTOM_TOKEN",
+		"configured token variables must not reach the tmux server environment")
+	assert.NotContains(globalEnv, "workspacetest-builtin-secret")
+	assert.NotContains(globalEnv, "workspacetest-custom-secret")
+	assert.NotContains(globalEnv, "KATA_AUTH_TOKEN",
+		"Kata credentials must not reach the tmux server environment")
+	assert.NotContains(globalEnv, "KENN_FORGE_FORGEJO_TOKEN",
+		"provider tokens must not reach the tmux server environment even when unconfigured")
+	assert.NotContains(globalEnv, "WORKSPACETEST_UNDECLARED_SECRET",
+		"variables outside the allowlist must never reach the tmux server environment")
+	assert.NotContains(globalEnv, "workspacetest-kata-secret")
+	assert.NotContains(globalEnv, "workspacetest-forgejo-secret")
+	assert.NotContains(globalEnv, "workspacetest-undeclared")
+	assert.NotContains(globalEnv, "XDG_WORKSPACETEST_TOKEN",
+		"configured token names must be stripped even under allowlisted prefixes")
+	assert.NotContains(globalEnv, "workspacetest-xdg-secret")
+
+	// The base terminal pane receives the credential-sanitized full
+	// daemon environment through the env-file handoff: benign daemon
+	// variables stay usable while tokens never appear.
+	probe := "printf 'PROBE:%s:%s:%s:%s:%s:%s:%s\\n' \"$WKSP_BENIGN_PROXY\" " +
+		"\"${GITHUB_TOKEN:-unset}\" \"${KATA_AUTH_TOKEN:-unset}\" " +
+		"\"${KENN_FORGE_FORGEJO_TOKEN:-unset}\" " +
+		"\"${WORKSPACETEST_CUSTOM_TOKEN:-unset}\" " +
+		"\"${XDG_WORKSPACETEST_TOKEN:-unset}\" " +
+		"\"${TMUX:+tmux-set}\"\r"
+	require.NoError(conn.Write(ctx, websocket.MessageBinary, []byte(probe)))
+	readCtx, cancelRead := context.WithTimeout(ctx, 15*time.Second)
+	defer cancelRead()
+	var seen strings.Builder
+	for !strings.Contains(
+		seen.String(),
+		"PROBE:workspacetest-proxy-value:unset:unset:unset:unset:unset:tmux-set",
+	) {
+		typ, data, readErr := conn.Read(readCtx)
+		require.NoError(readErr,
+			"terminal closed before the env probe answered: %s", seen.String())
+		if typ != websocket.MessageBinary {
+			continue
+		}
+		seen.Write(data)
+	}
+}

--- a/internal/server/workspacetest/workspace_test.go
+++ b/internal/server/workspacetest/workspace_test.go
@@ -293,8 +293,9 @@ func TestWorkspaceRuntimeAttachSpecUsesStoredTmuxSessionE2E(t *testing.T) {
 	assert.Equal("workspace-runtime-live", spec.TmuxSession)
 	assert.Equal(
 		[]string{
+			"env", "-u", "TMUX", "-u", "TMUX_TMPDIR",
 			tmuxPath, "--socket", "workspace",
-			"-u", "attach-session", "-t", "workspace-runtime-live",
+			"-u", "attach-session", "-E", "-t", "workspace-runtime-live",
 		},
 		spec.Command,
 	)

--- a/internal/terminal/handler.go
+++ b/internal/terminal/handler.go
@@ -14,11 +14,13 @@ import (
 	"github.com/creack/pty/v2"
 	"go.opentelemetry.io/otel/attribute"
 
+	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/procutil"
 	"go.kenn.io/forge/internal/ptyowner"
 	"go.kenn.io/forge/internal/terminalwebsocket"
 	"go.kenn.io/forge/internal/tracing"
 	"go.kenn.io/forge/internal/workspace"
+	"go.kenn.io/forge/internal/workspace/localruntime"
 )
 
 // Handler serves WebSocket connections that bridge a
@@ -172,11 +174,20 @@ func (h *Handler) ServeHTTP(
 
 	prefix := h.TmuxCommand
 	if len(prefix) == 0 {
-		prefix = []string{"tmux"}
+		prefix = config.DefaultTmuxCommand()
 	}
 	argv := tmuxAttachCommand(prefix, ws.TmuxSession)
 	cmd := procutil.CommandContext(ctx, argv[0], argv[1:]...)
-	cmd.Env = append(os.Environ(), "TERM=xterm-256color")
+	// Attach cannot spawn the tmux server, but a user tmux.conf with a
+	// widened update-environment could copy client variables into the
+	// session environment; give the attach client only the non-secret
+	// allowlist.
+	cmd.Env = append(
+		localruntime.TmuxClientEnvironment(
+			os.Environ(), h.Workspaces.TmuxStripEnvVars(),
+		),
+		"TERM=xterm-256color",
+	)
 	logWebsocketDebug(
 		"workspace terminal starting tmux attach",
 		"workspace_id", id,
@@ -315,7 +326,10 @@ func tmuxAttachCommand(prefix []string, session string) []string {
 	argv = append(argv, prefix...)
 	// Kenn Forge may run as a service without locale variables. Force UTF-8 so
 	// tmux does not replace non-ASCII terminal output with underscores.
-	return append(argv, "-u", "attach-session", "-t", session)
+	// -E disables update-environment: a pane can widen that server
+	// option, and without -E the next attach would copy the attach
+	// client's variables into the session environment.
+	return append(argv, "-u", "attach-session", "-E", "-t", session)
 }
 
 func bridgePtyOwnerAttachment(

--- a/internal/terminal/handler_test.go
+++ b/internal/terminal/handler_test.go
@@ -138,7 +138,7 @@ func TestTmuxAttachCommandForcesUTF8(t *testing.T) {
 		t,
 		[]string{
 			"/usr/bin/env", "tmux", "-u",
-			"attach-session", "-t", "kenn-forge-test",
+			"attach-session", "-E", "-t", "kenn-forge-test",
 		},
 		tmuxAttachCommand(
 			[]string{"/usr/bin/env", "tmux"},

--- a/internal/workspace/localruntime/command_session.go
+++ b/internal/workspace/localruntime/command_session.go
@@ -9,6 +9,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"go.kenn.io/forge/internal/config"
 )
 
 // ErrSessionKeyConflict reports a caller-supplied session key that is
@@ -263,7 +265,7 @@ func (m *Manager) commandSessionLaunch(
 ) (launchCommand, error) {
 	tmuxCommand := slices.Clone(m.tmuxCommand)
 	if len(tmuxCommand) == 0 {
-		tmuxCommand = []string{"tmux"}
+		tmuxCommand = config.DefaultTmuxCommand()
 	}
 	tmuxCommand, err := resolveTmuxCommand(tmuxCommand)
 	if err != nil {

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -22,6 +23,7 @@ import (
 	"github.com/creack/pty/v2"
 
 	"go.kenn.io/forge/internal/agentactivity"
+	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/procutil"
 	ptyownerruntime "go.kenn.io/forge/internal/ptyowner/runtime"
 )
@@ -661,7 +663,7 @@ func (m *Manager) restoredRuntimeCommand(
 	}
 	command := slices.Clone(m.tmuxCommand)
 	if len(command) == 0 {
-		command = []string{"tmux"}
+		command = config.DefaultTmuxCommand()
 	}
 	return tmuxAttachSessionCommand(command, restored.TmuxSession), nil
 }
@@ -728,8 +730,17 @@ func cloneLaunchTargetSet(
 }
 
 func (m *Manager) UpdateStripEnvVars(names []string) {
+	// Non-secret terminal variables are never credentials; see
+	// workspace.Manager.UpdateTmuxStripEnvVars.
+	filtered := make([]string, 0, len(names))
+	for _, name := range names {
+		if name == "" || config.IsTmuxNonSecretEnvVar(name) {
+			continue
+		}
+		filtered = append(filtered, name)
+	}
 	m.mu.Lock()
-	m.stripEnvVars = dedupeStrings(append(slices.Clone(m.stripEnvVars), names...))
+	m.stripEnvVars = dedupeStrings(append(slices.Clone(m.stripEnvVars), filtered...))
 	m.mu.Unlock()
 }
 
@@ -1015,7 +1026,7 @@ func (m *Manager) tmuxSessionLaunchID(
 	}
 	command := slices.Clone(m.tmuxCommand)
 	if len(command) == 0 {
-		command = []string{"tmux"}
+		command = config.DefaultTmuxCommand()
 	}
 	if len(command) == 0 || command[0] == "" {
 		return "", false, nil
@@ -1029,6 +1040,7 @@ func (m *Manager) tmuxSessionLaunchID(
 		command[1:], "show-options", "-qv", "-t", session, "@forge_launch",
 	)
 	cmd := procutil.CommandContext(ctx, command[0], args...)
+	cmd.Env = TmuxClientEnvironment(os.Environ(), m.currentStripEnvVars())
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -1056,7 +1068,7 @@ func (m *Manager) killTmuxSession(
 	}
 	command := slices.Clone(m.tmuxCommand)
 	if len(command) == 0 {
-		command = []string{"tmux"}
+		command = config.DefaultTmuxCommand()
 	}
 	if len(command) == 0 || command[0] == "" {
 		return nil
@@ -1068,6 +1080,7 @@ func (m *Manager) killTmuxSession(
 	}
 	args := append(command[1:], "kill-session", "-t", session)
 	cmd := procutil.CommandContext(ctx, command[0], args...)
+	cmd.Env = TmuxClientEnvironment(os.Environ(), m.currentStripEnvVars())
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	err = procutil.Run(ctx, cmd, "tmux subprocess capacity")
@@ -1104,7 +1117,7 @@ func (m *Manager) refreshTmuxSessionClients(
 	}
 	command := slices.Clone(m.tmuxCommand)
 	if len(command) == 0 {
-		command = []string{"tmux"}
+		command = config.DefaultTmuxCommand()
 	}
 	if len(command) == 0 || command[0] == "" {
 		return nil
@@ -1115,6 +1128,7 @@ func (m *Manager) refreshTmuxSessionClients(
 		"list-clients", "-t", session, "-F", "#{client_tty}",
 	)
 	listCmd := procutil.CommandContext(ctx, command[0], listArgs...)
+	listCmd.Env = TmuxClientEnvironment(os.Environ(), m.currentStripEnvVars())
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	listCmd.Stdout = &stdout
@@ -1139,6 +1153,7 @@ func (m *Manager) refreshTmuxSessionClients(
 		refreshCmd := procutil.CommandContext(
 			ctx, command[0], refreshArgs...,
 		)
+		refreshCmd.Env = TmuxClientEnvironment(os.Environ(), m.currentStripEnvVars())
 		var refreshStderr bytes.Buffer
 		refreshCmd.Stderr = &refreshStderr
 		if err := procutil.Run(
@@ -1472,7 +1487,7 @@ func (m *Manager) shellLaunchCommand(
 		tmuxCommand = slices.Clone(tmux.Command)
 	}
 	if len(tmuxCommand) == 0 {
-		tmuxCommand = []string{"tmux"}
+		tmuxCommand = config.DefaultTmuxCommand()
 	}
 	tmuxCommand, err = resolveTmuxCommand(tmuxCommand)
 	if err != nil {
@@ -1650,7 +1665,7 @@ func (m *Manager) launchCommand(
 		tmuxCommand = slices.Clone(tmux.Command)
 	}
 	if len(tmuxCommand) == 0 {
-		tmuxCommand = []string{"tmux"}
+		tmuxCommand = config.DefaultTmuxCommand()
 	}
 	tmuxCommand, err = resolveTmuxCommand(tmuxCommand)
 	if err != nil {
@@ -2587,12 +2602,43 @@ func resolveTmuxCommand(command []string) ([]string, error) {
 // workspace must not be able to read.
 var sessionVarPrefixes = []string{
 	"KENN_FORGE_GITHUB_TOKEN",
+	"KENN_FORGE_GITLAB_TOKEN",
+	"KENN_FORGE_FORGEJO_TOKEN",
+	"KENN_FORGE_GITEA_TOKEN",
+	"MIDDLEMAN_GITHUB_TOKEN",
+	"MIDDLEMAN_GITLAB_TOKEN",
+	"MIDDLEMAN_FORGEJO_TOKEN",
+	"MIDDLEMAN_GITEA_TOKEN",
 	"GITHUB_TOKEN",
+	"GITLAB_TOKEN",
+	"FORGEJO_TOKEN",
+	"GITEA_TOKEN",
 	"GH_TOKEN",
 	"GITHUB_PAT",
 	"GH_PAT",
 	"GITHUB_ENTERPRISE_TOKEN",
 	"GH_ENTERPRISE_TOKEN",
+	"KATA_AUTH_TOKEN",
+}
+
+// TmuxClientEnvironment reduces env to the non-secret tmux session
+// allowlist, additionally stripping the configured token names in
+// extraStrip: the allowlist admits LC_ and XDG_ prefixes, which a
+// configured token name could hide under. Every tmux client invocation
+// that can spawn the tmux server must use it: the server retains its
+// spawn environment for any pane to read via `show-environment -g`,
+// and an allowlist cannot leak a credential the configuration never
+// named.
+func TmuxClientEnvironment(env []string, extraStrip []string) []string {
+	return tmuxSessionEnvironment(env, extraStrip)
+}
+
+// SessionEnvironment returns a copy of env with credential-shaped
+// variables removed (matched by the built-in prefix list and any names
+// in extraStrip). Other variables are preserved; pane processes use it
+// so benign daemon variables stay usable in terminals.
+func SessionEnvironment(env []string, extraStrip []string) []string {
+	return sessionEnvironment(env, extraStrip)
 }
 
 // sessionEnvironment returns a copy of env with credential-shaped
@@ -2616,12 +2662,37 @@ func sessionEnvironment(env []string, extraStrip []string) []string {
 }
 
 func shouldStripSessionVar(key string, extraStrip []string) bool {
+	return shouldStripSessionVarFold(
+		key, extraStrip, runtime.GOOS == "windows",
+	)
+}
+
+// shouldStripSessionVarFold matches case-insensitively when fold is
+// set: Windows resolves environment variables case-insensitively, so a
+// token stored as github_token is the same credential as GITHUB_TOKEN.
+func shouldStripSessionVarFold(
+	key string, extraStrip []string, fold bool,
+) bool {
+	match := func(a, b string) bool {
+		if fold {
+			return strings.EqualFold(a, b)
+		}
+		return a == b
+	}
+	hasPrefix := func(value, prefix string) bool {
+		if len(value) < len(prefix) {
+			return false
+		}
+		return match(value[:len(prefix)], prefix)
+	}
 	for _, prefix := range sessionVarPrefixes {
-		if key == prefix || strings.HasPrefix(key, prefix+"_") {
+		if match(key, prefix) || hasPrefix(key, prefix+"_") {
 			return true
 		}
 	}
-	return slices.Contains(extraStrip, key)
+	return slices.ContainsFunc(extraStrip, func(name string) bool {
+		return match(key, name)
+	})
 }
 
 func defaultShellCommand() []string {

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -386,7 +386,7 @@ exit 0
 	sessionName := tmuxSessionName("ws:alpha", "codex")
 
 	assert.Equal(
-		[]string{tmuxPath, "-u", "attach-session", "-t", sessionName},
+		[]string{tmuxPath, "-u", "attach-session", "-E", "-t", sessionName},
 		launch.Command,
 	)
 	assert.Equal(sessionName, launch.TmuxSession)
@@ -510,7 +510,7 @@ exit 0
 	sessionName := tmuxSessionName("ws-1", "codex")
 
 	assert.Equal(
-		[]string{tmuxPath, "-u", "attach-session", "-t", sessionName},
+		[]string{tmuxPath, "-u", "attach-session", "-E", "-t", sessionName},
 		launch.Command,
 	)
 	assert.Equal(sessionName, launch.TmuxSession)
@@ -649,7 +649,7 @@ func TestManagerRestoredRuntimeCommandForcesUTF8(t *testing.T) {
 	assert.Equal(t,
 		[]string{
 			"/usr/bin/tmux", "-L", "kenn-forge-test",
-			"-u", "attach-session", "-t", "kenn-forge-ws-1-shell",
+			"-u", "attach-session", "-E", "-t", "kenn-forge-ws-1-shell",
 		},
 		command,
 	)
@@ -1100,10 +1100,13 @@ func TestTmuxLauncherCopiesClientEnvWithoutGlobalUpdateEnvironment(t *testing.T)
 	}.prepare(context.Background())
 	require.NoError(err)
 
+	// Poll for content, not existence: the shell creates the file via
+	// the > redirect before printf writes, so an existence check can
+	// read the file empty under load.
 	require.Eventually(func() bool {
-		_, err := os.Stat(output)
-		return err == nil
-	}, 2*time.Second, 20*time.Millisecond)
+		data, err := os.ReadFile(output)
+		return err == nil && len(data) > 0
+	}, 5*time.Second, 20*time.Millisecond)
 	data, err := os.ReadFile(output)
 	require.NoError(err)
 	require.Equal("client-visible-value\nunset\nunset\n", string(data))
@@ -1371,10 +1374,10 @@ func TestManagerShutdownLeavesTmuxSessionsRunning(t *testing.T) {
 	tmuxPath := filepath.Join(dir, "tmux-records")
 	require.NoError(os.WriteFile(
 		tmuxPath,
-		[]byte("#!/bin/sh\nprintf '%s\\0' \"$@\" >> \"$TMUX_RECORD\"\n"),
+		[]byte("#!/bin/sh\nTMUX_RECORD="+shellquote.Join(record)+
+			"\nprintf '%s\\0' \"$@\" >> \"$TMUX_RECORD\"\n"),
 		0o755,
 	))
-	t.Setenv("TMUX_RECORD", record)
 	mgr := NewManager(Options{
 		TmuxCommand:                    []string{tmuxPath},
 		DetachSessionsForServerRestart: true,

--- a/internal/workspace/localruntime/targets.go
+++ b/internal/workspace/localruntime/targets.go
@@ -99,7 +99,7 @@ func shellTarget(
 ) LaunchTarget {
 	command := slices.Clone(tmuxCommand)
 	if len(command) == 0 {
-		command = []string{"tmux"}
+		command = config.DefaultTmuxCommand()
 	}
 	target := LaunchTarget{
 		Key: "shell", Label: "Shell", Kind: LaunchTargetShell,

--- a/internal/workspace/localruntime/tmux_launcher.go
+++ b/internal/workspace/localruntime/tmux_launcher.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	shellquote "github.com/kballard/go-shellquote"
+	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/procutil"
 )
 
@@ -22,6 +23,17 @@ type tmuxPaneEnvironment struct {
 	keys        []string
 	paneCommand string
 	commandEnv  []string
+	// clientEnv feeds tmux client processes. It is derived from the
+	// policy environment before caller-supplied launch extras are
+	// applied: extras come from API request bodies and reach only the
+	// pane via the env-file handoff, never the tmux client, whose
+	// environment can seed the server's retained global environment or
+	// steer socket resolution.
+	clientEnv []string
+	// paneLocalKeys are captured from the pane's own environment before
+	// the env file is sourced and re-applied after the env -i wipe, so
+	// tmux's per-pane variables survive the sanitized handoff.
+	paneLocalKeys []string
 }
 
 var (
@@ -50,6 +62,7 @@ func (p tmuxEnvPolicy) paneEnvironmentWithExtra(
 	extraEnv map[string]string,
 ) tmuxPaneEnvironment {
 	env := p.environment(baseEnv, extraStripVars)
+	clientEnv := append(slices.Clone(env), "TERM=xterm-256color")
 	filtered := env[:0]
 	for _, value := range env {
 		key, _, found := strings.Cut(value, "=")
@@ -69,26 +82,53 @@ func (p tmuxEnvPolicy) paneEnvironmentWithExtra(
 	for _, key := range keys {
 		env = append(env, key+"="+extraEnv[key])
 	}
-	return paneEnvironmentFromEnv(env, command)
+	pane := paneEnvironmentFromEnv(env, command)
+	pane.clientEnv = clientEnv
+	return pane
 }
 
 func paneEnvironmentFromEnv(
 	env []string,
 	command []string,
 ) tmuxPaneEnvironment {
+	return paneEnvironmentFromEnvWithPaneLocals(env, command, nil)
+}
+
+func paneEnvironmentFromEnvWithPaneLocals(
+	env []string,
+	command []string,
+	paneLocals []string,
+) tmuxPaneEnvironment {
 	envWithTerm := append(slices.Clone(env), "TERM=xterm-256color")
 	keys := tmuxEnvironmentKeys(envWithTerm)
-	parts := make([]string, 0, len(keys)+4)
+	parts := make([]string, 0, len(keys)+len(paneLocals)+4)
 	parts = append(parts, "exec", "env", "-i")
 	for _, key := range keys {
 		parts = append(parts, key+"=\"${"+key+"-}\"")
 	}
+	// Pane-local re-applications come last so they win over the
+	// file-sourced values; TERM falls back to the xterm.js default when
+	// the pane somehow carries none.
+	for _, key := range paneLocals {
+		if key == "TERM" {
+			parts = append(parts,
+				"TERM=\"${"+paneLocalCaptureVar(key)+":-xterm-256color}\"")
+			continue
+		}
+		parts = append(parts, key+"=\"${"+paneLocalCaptureVar(key)+"-}\"")
+	}
 	parts = append(parts, shellCommand(command))
 	return tmuxPaneEnvironment{
-		keys:        keys,
-		paneCommand: strings.Join(parts, " "),
-		commandEnv:  envWithTerm,
+		keys:          keys,
+		paneCommand:   strings.Join(parts, " "),
+		commandEnv:    envWithTerm,
+		clientEnv:     envWithTerm,
+		paneLocalKeys: slices.Clone(paneLocals),
 	}
+}
+
+func paneLocalCaptureVar(key string) string {
+	return "__kenn_forge_pane_" + key
 }
 
 func (p tmuxEnvPolicy) keys(extraStripVars []string) []string {
@@ -104,6 +144,13 @@ func tmuxEnvironmentKeys(env []string) []string {
 		}
 		key := kv[:eq]
 		if !isShellIdentifier(key) {
+			continue
+		}
+		// Reserved handoff-internal names must never be sourced from
+		// the env file: the cleanup trap removes the file paths they
+		// hold, so an API-supplied override could aim rm at arbitrary
+		// caller-selected paths.
+		if strings.HasPrefix(key, "__kenn_forge") {
 			continue
 		}
 		keysByName[key] = struct{}{}
@@ -274,7 +321,12 @@ func (l tmuxLauncher) output(
 		return nil, fmt.Errorf("tmux command is empty")
 	}
 	cmd := procutil.CommandContext(ctx, command[0], command[1:]...)
-	cmd.Env = l.Pane.commandEnv
+	// The pane command receives its environment through the env-file
+	// handoff; the tmux client itself gets only the non-secret
+	// allowlist of the pre-extras policy environment, because a client
+	// that spawns the server seeds the server's permanently retained
+	// global environment and its TMUX_TMPDIR steers socket resolution.
+	cmd.Env = tmuxSessionEnvironment(l.Pane.clientEnv, nil)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -307,13 +359,34 @@ func (e tmuxCommandError) Unwrap() error {
 }
 
 func (l tmuxLauncher) newSessionPaneCommand() (string, func(), error) {
-	path, err := writeTmuxPaneEnvironment(l.Pane.commandEnv, l.Pane.keys)
+	return paneHandoffCommand(l.Pane)
+}
+
+// NewTmuxPaneHandoff builds the pane shell-command that delivers env to
+// the pane's process through a self-deleting env file, keeping values
+// out of tmux argv and out of the tmux server's retained environment.
+// tmux's per-pane variables (TERM, TMUX, TMUX_PANE) are preserved from
+// the pane's own environment so the base terminal's shell keeps nesting
+// detection and tmux's terminal capabilities. The returned cleanup
+// removes the handoff files; call it when the pane was never started.
+func NewTmuxPaneHandoff(
+	env []string, command []string,
+) (string, func(), error) {
+	return paneHandoffCommand(paneEnvironmentFromEnvWithPaneLocals(
+		env, command, []string{"TERM", "TMUX", "TMUX_PANE"},
+	))
+}
+
+func paneHandoffCommand(pane tmuxPaneEnvironment) (string, func(), error) {
+	path, err := writeTmuxPaneEnvironment(pane.commandEnv, pane.keys)
 	if err != nil {
 		return "", nil, fmt.Errorf("write tmux pane environment: %w", err)
 	}
 	// tmux parses shell-command with its default shell, which may not be
 	// POSIX-compatible. Keep the POSIX handoff in a script run by /bin/sh.
-	scriptPath, err := writeTmuxPaneScript(path, l.Pane.paneCommand)
+	scriptPath, err := writeTmuxPaneScript(
+		path, pane.paneCommand, pane.paneLocalKeys,
+	)
 	if err != nil {
 		_ = os.Remove(path)
 		return "", nil, fmt.Errorf("write tmux pane script: %w", err)
@@ -325,7 +398,9 @@ func (l tmuxLauncher) newSessionPaneCommand() (string, func(), error) {
 	return shellCommand([]string{"/bin/sh", scriptPath}), cleanup, nil
 }
 
-func writeTmuxPaneScript(envPath string, paneCommand string) (string, error) {
+func writeTmuxPaneScript(
+	envPath string, paneCommand string, paneLocals []string,
+) (string, error) {
 	file, err := os.CreateTemp(tmuxPaneEnvironmentTempDir(), "kenn-forge-tmux-pane-*")
 	if err != nil {
 		return "", err
@@ -337,7 +412,14 @@ func writeTmuxPaneScript(envPath string, paneCommand string) (string, error) {
 		return "", err
 	}
 
-	content := strings.Join([]string{
+	// Capture pane-local values before the env file overwrites them.
+	captures := make([]string, 0, len(paneLocals))
+	for _, key := range paneLocals {
+		captures = append(
+			captures, paneLocalCaptureVar(key)+"=\"${"+key+"-}\"",
+		)
+	}
+	content := strings.Join(append(captures, []string{
 		"__kenn_forge_env_file=" + shellCommand([]string{envPath}),
 		"__kenn_forge_script_file=" + shellCommand([]string{path}),
 		`__kenn_forge_cleanup_tmux_files() { /bin/rm -f "$__kenn_forge_env_file" "$__kenn_forge_script_file"; }`,
@@ -350,7 +432,7 @@ func writeTmuxPaneScript(envPath string, paneCommand string) (string, error) {
 		`unset __kenn_forge_env_file`,
 		`unset __kenn_forge_script_file`,
 		paneCommand,
-	}, "\n")
+	}...), "\n")
 	if _, err := file.WriteString(content); err != nil {
 		_ = file.Close()
 		_ = os.Remove(path)
@@ -474,9 +556,12 @@ func (l tmuxLauncher) attachSessionCommand() []string {
 func tmuxAttachSessionCommand(command []string, session string) []string {
 	// Kenn Forge may run as a service without locale variables. Force UTF-8 so
 	// tmux does not replace non-ASCII terminal output with underscores.
+	// -E disables update-environment: a pane can widen that server
+	// option, and without -E the next attach would copy the attach
+	// client's variables into the session environment.
 	return append(
 		slices.Clone(command),
-		"-u", "attach-session", "-t", session,
+		"-u", "attach-session", "-E", "-t", session,
 	)
 }
 
@@ -525,41 +610,6 @@ func isShellIdentifier(value string) bool {
 	return true
 }
 
-var tmuxSessionEnvAllowlist = []string{
-	"COLORTERM",
-	"EDITOR",
-	"HOME",
-	"LANG",
-	"LC_ALL",
-	"LC_CTYPE",
-	"LESS",
-	"LOGNAME",
-	"NO_COLOR",
-	"PAGER",
-	"PATH",
-	"SHELL",
-	"SSH_AUTH_SOCK",
-	"TERM",
-	"TMP",
-	"TMPDIR",
-	"TEMP",
-	"USER",
-	"VISUAL",
-}
-
-var tmuxSessionEnvPrefixAllowlist = []string{
-	"LC_",
-	"XDG_",
-}
-
 func shouldAllowTmuxSessionVar(key string) bool {
-	if slices.Contains(tmuxSessionEnvAllowlist, key) {
-		return true
-	}
-	for _, prefix := range tmuxSessionEnvPrefixAllowlist {
-		if strings.HasPrefix(key, prefix) {
-			return true
-		}
-	}
-	return false
+	return config.IsTmuxNonSecretEnvVar(key)
 }

--- a/internal/workspace/localruntime/tmux_launcher.go
+++ b/internal/workspace/localruntime/tmux_launcher.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"slices"
 	"strings"
 	"time"
@@ -611,5 +612,17 @@ func isShellIdentifier(value string) bool {
 }
 
 func shouldAllowTmuxSessionVar(key string) bool {
-	return config.IsTmuxNonSecretEnvVar(key)
+	return shouldAllowTmuxSessionVarFold(key, runtime.GOOS == "windows")
+}
+
+// shouldAllowTmuxSessionVarFold admits by exact name on case-sensitive
+// platforms; on Windows, where environment names resolve
+// case-insensitively, "Path" is PATH and folding is correct. Admission
+// must stay exact elsewhere or unrelated variables such as a Unix
+// "editor" would enter tmux's retained environment.
+func shouldAllowTmuxSessionVarFold(key string, fold bool) bool {
+	if fold {
+		return config.IsTmuxNonSecretEnvVar(key)
+	}
+	return config.IsTmuxNonSecretEnvVarExact(key)
 }

--- a/internal/workspace/localruntime/tmux_launcher_test.go
+++ b/internal/workspace/localruntime/tmux_launcher_test.go
@@ -118,7 +118,7 @@ func TestTmuxLauncherAttachForcesUTF8(t *testing.T) {
 	assert.Equal(t,
 		[]string{
 			"/usr/bin/tmux", "-L", "kenn-forge-test",
-			"-u", "attach-session", "-t", "kenn-forge-test",
+			"-u", "attach-session", "-E", "-t", "kenn-forge-test",
 		},
 		launcher.attachSessionCommand(),
 	)
@@ -131,8 +131,11 @@ func TestTmuxLauncherCleansUpWhenHideStatusFails(t *testing.T) {
 	record := filepath.Join(dir, "tmux-record")
 	created := filepath.Join(dir, "created")
 	tmuxPath := filepath.Join(dir, "tmux")
-	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
-printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"
+	require.NoError(os.WriteFile(tmuxPath, []byte("#!/bin/sh\n"+
+		"TMUX_RECORD="+shellquote.Join(record)+"\n"+
+		"TMUX_CREATED="+shellquote.Join(created)+"\n"+
+		"TMUX_EXISTING_OWNER='kenn-forge:test-owner'\n"+
+		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"
 case "$1" in
   has-session)
     if [ -f "$TMUX_CREATED" ]; then exit 0; fi
@@ -179,12 +182,7 @@ exit 0
 		Pane: tmuxPaneEnvironment{
 			paneCommand: "exec /bin/sh",
 			keys:        []string{"PATH", "TERM"},
-			commandEnv: append(
-				os.Environ(),
-				"TMUX_RECORD="+record,
-				"TMUX_CREATED="+created,
-				"TMUX_EXISTING_OWNER=kenn-forge:test-owner",
-			),
+			commandEnv:  os.Environ(),
 		},
 		OwnerMarker: "kenn-forge:test-owner",
 		HideStatus:  true,
@@ -199,7 +197,7 @@ exit 0
 		"kill-session", "-t", "kenn-forge-test",
 	})
 	assert.NotContains(records, []string{
-		"-u", "attach-session", "-t", "kenn-forge-test",
+		"-u", "attach-session", "-E", "-t", "kenn-forge-test",
 	})
 	assert.NoFileExists(created)
 }
@@ -214,8 +212,13 @@ func TestTmuxLauncherCleansUpCreatedSessionAfterLaunchContextCancellation(
 	createdSessionState := filepath.Join(dir, "created-session")
 	statusStarted := filepath.Join(dir, "status-started")
 	tmuxPath := filepath.Join(dir, "tmux")
-	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
-printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"
+	statusRelease := filepath.Join(dir, "status-release")
+	require.NoError(os.WriteFile(tmuxPath, []byte("#!/bin/sh\n"+
+		"TMUX_RECORD="+shellquote.Join(record)+"\n"+
+		"TMUX_CREATED="+shellquote.Join(createdSessionState)+"\n"+
+		"TMUX_STATUS_STARTED="+shellquote.Join(statusStarted)+"\n"+
+		"TMUX_STATUS_RELEASE="+shellquote.Join(statusRelease)+"\n"+
+		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"
 case "$1" in
   has-session)
     if [ -f "$TMUX_CREATED" ]; then exit 0; fi
@@ -252,10 +255,6 @@ exit 0
 			commandEnv: []string{
 				"PATH=" + os.Getenv("PATH"),
 				"TERM=xterm-256color",
-				"TMUX_RECORD=" + record,
-				"TMUX_CREATED=" + createdSessionState,
-				"TMUX_STATUS_STARTED=" + statusStarted,
-				"TMUX_STATUS_RELEASE=" + filepath.Join(dir, "status-release"),
 			},
 		},
 		HideStatus: true,
@@ -296,8 +295,9 @@ func TestTmuxLauncherDoesNotKillSessionAfterNewSessionError(t *testing.T) {
 	dir := t.TempDir()
 	record := filepath.Join(dir, "tmux-record")
 	tmuxPath := filepath.Join(dir, "tmux")
-	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
-printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"
+	require.NoError(os.WriteFile(tmuxPath, []byte("#!/bin/sh\n"+
+		"TMUX_RECORD="+shellquote.Join(record)+"\n"+
+		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"
 case "$1" in
   has-session)
     echo "can't find session: $3" >&2
@@ -323,7 +323,6 @@ exit 0
 			commandEnv: []string{
 				"PATH=" + os.Getenv("PATH"),
 				"TERM=xterm-256color",
-				"TMUX_RECORD=" + record,
 			},
 		},
 	}
@@ -363,8 +362,10 @@ func TestTmuxLauncherRejectsUnownedExistingSession(t *testing.T) {
 	dir := t.TempDir()
 	record := filepath.Join(dir, "tmux-record")
 	tmuxPath := filepath.Join(dir, "tmux")
-	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
-printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"
+	require.NoError(os.WriteFile(tmuxPath, []byte("#!/bin/sh\n"+
+		"TMUX_RECORD="+shellquote.Join(record)+"\n"+
+		"TMUX_EXISTING_OWNER='other-owner'\n"+
+		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"
 case "$1" in
   has-session)
     exit 0
@@ -386,11 +387,7 @@ exit 0
 		Pane: tmuxPaneEnvironment{
 			paneCommand: "exec /bin/sh",
 			keys:        []string{"PATH", "TERM"},
-			commandEnv: append(
-				os.Environ(),
-				"TMUX_RECORD="+record,
-				"TMUX_EXISTING_OWNER=other-owner",
-			),
+			commandEnv:  os.Environ(),
 		},
 		OwnerMarker: "kenn-forge:test-owner",
 	}
@@ -406,7 +403,7 @@ exit 0
 		"show-options", "-qv", "-t", "kenn-forge-test", "@forge_owner",
 	})
 	assert.NotContains(records, []string{
-		"-u", "attach-session", "-t", "kenn-forge-test",
+		"-u", "attach-session", "-E", "-t", "kenn-forge-test",
 	})
 	assert.NotContains(records, []string{
 		"new-session", "-e", "PATH", "-e", "TERM",
@@ -471,4 +468,126 @@ func containsArgvSequence(argv []string, sequence []string) bool {
 		}
 	}
 	return false
+}
+
+// TestTmuxAgentPolicyPreservesTmuxTmpdirInClientEnv pins socket routing:
+// tmux resolves -L sockets under TMUX_TMPDIR, so the launcher's tmux
+// client must see the daemon's value or agent sessions land on a
+// different tmux server than the manager-owned base sessions, breaking
+// attachment and orphan reaping.
+func TestTmuxAgentPolicyPreservesTmuxTmpdirInClientEnv(t *testing.T) {
+	assert := assert.New(t)
+	env := []string{
+		"PATH=/usr/bin",
+		"TMUX_TMPDIR=/private/socket-dir",
+		"GITHUB_TOKEN=agent-secret",
+	}
+	pane := tmuxAgentEnvPolicy.paneEnvironment(env, []string{"agent"}, nil)
+	joined := strings.Join(pane.commandEnv, "\n")
+	assert.Contains(joined, "TMUX_TMPDIR=/private/socket-dir",
+		"tmux client must resolve the same socket directory as the daemon")
+	assert.NotContains(joined, "GITHUB_TOKEN",
+		"credential stripping must survive the socket-routing fix")
+	client := TmuxClientEnvironment(
+		append(env,
+			"TMUX_GITHUB_TOKEN=sneaky",
+			"XDG_CONFIGURED_TOKEN=xdg-sneaky",
+			"XDG_RUNTIME_DIR=/run/user/1000",
+		),
+		[]string{"XDG_CONFIGURED_TOKEN"},
+	)
+	clientJoined := strings.Join(client, "\n")
+	assert.Contains(clientJoined, "TMUX_TMPDIR=/private/socket-dir")
+	assert.Contains(clientJoined, "XDG_RUNTIME_DIR=/run/user/1000")
+	assert.NotContains(clientJoined, "TMUX_GITHUB_TOKEN",
+		"the allowlist must name exact variables, not a TMUX_ wildcard a secret could hide under")
+	assert.NotContains(clientJoined, "XDG_CONFIGURED_TOKEN",
+		"configured token names must be stripped even under allowlisted prefixes")
+	undeclared := TmuxClientEnvironment(
+		append(env,
+			"XDG_API_TOKEN=undeclared-xdg-secret",
+			"LC_SECRET_TOKEN=undeclared-lc-secret",
+			"XDG_RUNTIME_DIR=/run/user/1000",
+			"LC_ALL=en_US.UTF-8",
+		),
+		nil,
+	)
+	undeclaredJoined := strings.Join(undeclared, "\n")
+	assert.Contains(undeclaredJoined, "XDG_RUNTIME_DIR=/run/user/1000")
+	assert.Contains(undeclaredJoined, "LC_ALL=en_US.UTF-8")
+	assert.NotContains(undeclaredJoined, "XDG_API_TOKEN",
+		"the allowlist must name exact XDG variables, not a prefix a secret could hide under")
+	assert.NotContains(undeclaredJoined, "LC_SECRET_TOKEN",
+		"the allowlist must name exact locale variables, not a prefix a secret could hide under")
+}
+
+// TestTmuxAttachSessionCommandDisablesUpdateEnvironment pins -E on every
+// daemon-side attach: a pane can widen the server's update-environment,
+// and without -E the next attach would copy the attach client's
+// variables into the session environment where panes read them back.
+func TestTmuxAttachSessionCommandDisablesUpdateEnvironment(t *testing.T) {
+	assert.Equal(t,
+		[]string{"tmux", "-L", "sock", "-u", "attach-session", "-E", "-t", "kenn-forge-test"},
+		tmuxAttachSessionCommand(
+			[]string{"tmux", "-L", "sock"}, "kenn-forge-test",
+		),
+	)
+}
+
+// TestTmuxPaneEnvironmentExtraNeverReachesClientEnv pins the client/pane
+// split: launch extras come from API request bodies, so they may only
+// reach the pane via the env-file handoff. The tmux client environment
+// must derive from the pre-extras policy env, or an extra such as
+// TMUX_TMPDIR could steer new-session to a different socket than the
+// daemon's own management clients.
+func TestTmuxPaneEnvironmentExtraNeverReachesClientEnv(t *testing.T) {
+	assert := assert.New(t)
+	pane := tmuxAgentEnvPolicy.paneEnvironmentWithExtra(
+		[]string{"PATH=/usr/bin", "TMUX_TMPDIR=/daemon/sockets"},
+		[]string{"/bin/sh"}, nil,
+		map[string]string{
+			"TMUX_TMPDIR": "/attacker/sockets",
+			"HOME":        "/attacker/home",
+		},
+	)
+
+	clientJoined := strings.Join(pane.clientEnv, "\n")
+	assert.Contains(clientJoined, "TMUX_TMPDIR=/daemon/sockets")
+	assert.NotContains(clientJoined, "/attacker/sockets")
+	assert.NotContains(clientJoined, "/attacker/home")
+	// The pane still receives the extras through the handoff env.
+	commandJoined := strings.Join(pane.commandEnv, "\n")
+	assert.Contains(commandJoined, "TMUX_TMPDIR=/attacker/sockets")
+	assert.Contains(commandJoined, "HOME=/attacker/home")
+}
+
+// TestShouldStripSessionVarFold pins Windows semantics: environment
+// variable names resolve case-insensitively there, so github_token is
+// the same credential as GITHUB_TOKEN.
+func TestShouldStripSessionVarFold(t *testing.T) {
+	assert := assert.New(t)
+	assert.True(shouldStripSessionVarFold("github_token", nil, true))
+	assert.True(shouldStripSessionVarFold("Kata_Auth_Token", nil, true))
+	assert.True(shouldStripSessionVarFold("my_token", []string{"MY_TOKEN"}, true))
+	assert.False(shouldStripSessionVarFold("github_token", nil, false))
+	assert.True(shouldStripSessionVarFold("GITHUB_TOKEN", nil, false))
+}
+
+// TestTmuxEnvironmentKeysRejectsReservedHandoffNames pins that
+// handoff-internal variables can never be sourced from the env file:
+// the cleanup trap removes the paths they hold, so an API-supplied
+// override could aim rm at caller-selected files.
+func TestTmuxEnvironmentKeysRejectsReservedHandoffNames(t *testing.T) {
+	pane := tmuxAgentEnvPolicy.paneEnvironmentWithExtra(
+		[]string{"PATH=/usr/bin"},
+		[]string{"/bin/sh"}, nil,
+		map[string]string{
+			"__kenn_forge_env_file":    "/victim/path",
+			"__kenn_forge_script_file": "/victim/script",
+		},
+	)
+	assert := assert.New(t)
+	assert.NotContains(pane.keys, "__kenn_forge_env_file")
+	assert.NotContains(pane.keys, "__kenn_forge_script_file")
+	assert.NotContains(pane.paneCommand, "__kenn_forge_env_file=")
 }

--- a/internal/workspace/localruntime/tmux_launcher_test.go
+++ b/internal/workspace/localruntime/tmux_launcher_test.go
@@ -591,3 +591,17 @@ func TestTmuxEnvironmentKeysRejectsReservedHandoffNames(t *testing.T) {
 	assert.NotContains(pane.keys, "__kenn_forge_script_file")
 	assert.NotContains(pane.paneCommand, "__kenn_forge_env_file=")
 }
+
+// TestShouldAllowTmuxSessionVarFold pins admission casing: exact names
+// on case-sensitive platforms, folded on Windows where environment
+// names resolve case-insensitively.
+func TestShouldAllowTmuxSessionVarFold(t *testing.T) {
+	assert := assert.New(t)
+	assert.True(shouldAllowTmuxSessionVarFold("EDITOR", false))
+	assert.False(shouldAllowTmuxSessionVarFold("editor", false),
+		"a Unix variable named editor is unrelated to EDITOR")
+	assert.False(shouldAllowTmuxSessionVarFold("path", false))
+	assert.True(shouldAllowTmuxSessionVarFold("Path", true),
+		"Windows resolves Path as PATH")
+	assert.True(shouldAllowTmuxSessionVarFold("editor", true))
+}

--- a/internal/workspace/localruntime/tmux_runtime.go
+++ b/internal/workspace/localruntime/tmux_runtime.go
@@ -64,8 +64,11 @@ func startTmuxAttachSession(
 	)
 
 	cmd := procutil.Command(resolvedPath, command[1:]...)
+	// tmux clients get only the non-secret allowlist; the attach also
+	// passes -E, so nothing from this environment can be copied into
+	// the session environment.
 	cmd.Env = append(
-		sessionEnvironment(os.Environ(), extraStripVars),
+		TmuxClientEnvironment(os.Environ(), extraStripVars),
 		"TERM=xterm-256color",
 	)
 

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -3967,6 +3967,17 @@ func (m *Manager) PruneMissingTmuxSessions(ctx context.Context) (bool, error) {
 		changed = changed || deleted
 	}
 
+	// A server with zero live sessions is the bulk-gone case: machine
+	// reboot, or first boot after the dedicated-socket upgrade while
+	// old sessions remain on the previous server. Base sessions are
+	// recreated lazily on terminal attach, so ready workspaces stay
+	// ready and self-heal; marking them all errored would invite retry,
+	// whose cleanup force-removes worktrees. Individual missing
+	// sessions on a live server remain real anomalies and are errored
+	// below.
+	if len(live) == 0 {
+		return changed, nil
+	}
 	workspaces, err := m.db.ListWorkspaces(ctx)
 	if err != nil {
 		return changed, fmt.Errorf("list workspaces: %w", err)

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -21,10 +21,12 @@ import (
 	"sync"
 	"time"
 
+	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/gitclone"
 	"go.kenn.io/forge/internal/platform"
 	"go.kenn.io/forge/internal/procutil"
+	"go.kenn.io/forge/internal/workspace/localruntime"
 	gitcmd "go.kenn.io/kit/git/cmd"
 	gitremote "go.kenn.io/kit/git/remote"
 )
@@ -41,6 +43,8 @@ type Manager struct {
 	clones                    *gitclone.Manager
 	locks                     *FileLockManager
 	tmuxCmd                   []string
+	tmuxStripEnvMu            sync.RWMutex
+	tmuxStripEnvVars          []string
 	hideTmuxStatusMu          sync.RWMutex
 	hideTmuxStatus            bool
 	ptyOwner                  PtyOwnerClient
@@ -280,9 +284,50 @@ func (m *Manager) worktreeLockRoot(ctx context.Context, gitDir string) (string, 
 
 // SetTmuxCommand sets the command + argv prefix for every tmux
 // invocation the manager issues. When nil/empty, the manager uses
-// ["tmux"] — preserving today's behavior.
+// config.DefaultTmuxCommand — the dedicated kenn-forge tmux server.
 func (m *Manager) SetTmuxCommand(cmd []string) {
 	m.tmuxCmd = slices.Clone(cmd)
+}
+
+// UpdateTmuxStripEnvVars merges names into the configured provider
+// token env var names stripped from tmux client and base-pane
+// environments; the client allowlist admits LC_ and XDG_ prefixes a
+// configured token name could hide under. Names accumulate
+// monotonically so reload ordering can never stop stripping a
+// previously configured name.
+func (m *Manager) UpdateTmuxStripEnvVars(names []string) {
+	m.tmuxStripEnvMu.Lock()
+	defer m.tmuxStripEnvMu.Unlock()
+	merged := slices.Clone(m.tmuxStripEnvVars)
+	for _, name := range names {
+		// Never accumulate non-secret terminal variables: validation
+		// rejects such token names, but a rejected candidate's names
+		// are accumulated before rejection, and stripping PATH or
+		// TMUX_TMPDIR would break terminals and socket routing.
+		if name == "" || config.IsTmuxNonSecretEnvVar(name) ||
+			slices.Contains(merged, name) {
+			continue
+		}
+		merged = append(merged, name)
+	}
+	m.tmuxStripEnvVars = merged
+}
+
+func (m *Manager) currentTmuxStripEnvVars() []string {
+	m.tmuxStripEnvMu.RLock()
+	defer m.tmuxStripEnvMu.RUnlock()
+	return m.tmuxStripEnvVars
+}
+
+// TmuxStripEnvVars returns the accumulated configured token env var
+// names. The returned slice is a copy, safe for callers to retain.
+func (m *Manager) TmuxStripEnvVars() []string {
+	if m == nil {
+		return nil
+	}
+	m.tmuxStripEnvMu.RLock()
+	defer m.tmuxStripEnvMu.RUnlock()
+	return slices.Clone(m.tmuxStripEnvVars)
 }
 
 // SetHideTmuxStatus controls whether newly-created tmux sessions hide
@@ -300,22 +345,30 @@ func (m *Manager) currentHideTmuxStatus() bool {
 }
 
 // tmuxExec builds an *exec.Cmd for a tmux invocation: the
-// configured prefix + extra args. Defaults to ["tmux"] when
-// unconfigured. Returning the *exec.Cmd directly (rather than a
-// []string that callers index) keeps the first-element access
-// inside this function where the branch structure makes it
-// statically safe — NilAway cannot prove safety through an indexed
-// slice return.
+// configured prefix + extra args. Defaults to
+// config.DefaultTmuxCommand when unconfigured. Returning the
+// *exec.Cmd directly (rather than a []string that callers index)
+// keeps the first-element access inside this function where the
+// branch structure makes it statically safe — NilAway cannot prove
+// safety through an indexed slice return.
 func (m *Manager) tmuxExec(
 	ctx context.Context, extra ...string,
 ) *exec.Cmd {
-	if len(m.tmuxCmd) == 0 {
-		return procutil.CommandContext(ctx, "tmux", extra...)
+	command := m.tmuxCmd
+	if len(command) == 0 {
+		command = config.DefaultTmuxCommand()
 	}
-	args := make([]string, 0, len(m.tmuxCmd)-1+len(extra))
-	args = append(args, m.tmuxCmd[1:]...)
+	args := make([]string, 0, len(command)-1+len(extra))
+	args = append(args, command[1:]...)
 	args = append(args, extra...)
-	return procutil.CommandContext(ctx, m.tmuxCmd[0], args...)
+	cmd := procutil.CommandContext(ctx, command[0], args...)
+	// Any invocation can be the one that spawns the tmux server, which
+	// retains its spawn environment globally; give the client only the
+	// non-secret allowlist so no credential can ever enter it.
+	cmd.Env = localruntime.TmuxClientEnvironment(
+		os.Environ(), m.currentTmuxStripEnvVars(),
+	)
+	return cmd
 }
 
 // Create persists a PR-backed kenn-forge workspace.
@@ -4396,16 +4449,36 @@ func (m *Manager) newTmuxSession(
 	ctx context.Context, session, cwd string,
 ) error {
 	shell := userLoginShell()
+	// The pane receives the credential-sanitized full daemon
+	// environment through the env-file handoff, matching runtime shell
+	// sessions: benign daemon variables stay usable in the base
+	// terminal while the tmux client itself stays allowlisted.
+	paneCommand, cleanupHandoff, err := localruntime.NewTmuxPaneHandoff(
+		localruntime.SessionEnvironment(
+			os.Environ(), m.currentTmuxStripEnvVars(),
+		),
+		[]string{shell, "-l"},
+	)
+	if err != nil {
+		return fmt.Errorf("prepare base tmux pane environment: %w", err)
+	}
+	created := false
+	defer func() {
+		if !created {
+			cleanupHandoff()
+		}
+	}()
 	cmd := m.tmuxExec(
 		ctx,
 		"new-session", "-d",
 		"-s", session,
 		"-c", cwd,
-		shell, "-l",
+		paneCommand,
 	)
 	if err := runBuiltCmd(ctx, cmd); err != nil {
 		return err
 	}
+	created = true
 	if err := m.setTmuxOwnerMarker(ctx, session); err != nil {
 		if killErr := m.killTmuxSession(ctx, session); killErr != nil &&
 			!isTmuxKillSessionGone(killErr) {

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	shellquote "github.com/kballard/go-shellquote"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -4689,11 +4690,14 @@ func writeRecorderScript(t *testing.T) (scriptPath, recordPath string) {
 	dir := t.TempDir()
 	recordPath = filepath.Join(dir, "record")
 	scriptPath = filepath.Join(dir, "fake-tmux")
+	// The record path is baked into the script: tmux clients run with
+	// the non-secret allowlist environment, so fixtures cannot smuggle
+	// paths through custom env vars.
 	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(recordPath) + "\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		"exit 0\n"
 	require.NoError(t, os.WriteFile(scriptPath, []byte(body), 0o755))
-	t.Setenv("TMUX_RECORD", recordPath)
 	return scriptPath, recordPath
 }
 
@@ -4919,6 +4923,7 @@ func TestManagerDeleteAllowsMissingTmuxSession(t *testing.T) {
 	record := filepath.Join(dir, "record")
 	script := filepath.Join(dir, "fake-tmux")
 	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "kill-session" ]; then` + "\n" +
@@ -4928,7 +4933,6 @@ func TestManagerDeleteAllowsMissingTmuxSession(t *testing.T) {
 		"done\n" +
 		"exit 0\n"
 	require.NoError(os.WriteFile(script, []byte(body), 0o755))
-	t.Setenv("TMUX_RECORD", record)
 
 	d := openTestDB(t)
 	repoID := seedRepo(t, d, "github.com", "acme", "widget")
@@ -4965,6 +4969,7 @@ func TestManagerDeleteFailsWhenTmuxKillFails(t *testing.T) {
 	record := filepath.Join(dir, "record")
 	script := filepath.Join(dir, "fake-tmux")
 	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "kill-session" ]; then` + "\n" +
@@ -4974,7 +4979,6 @@ func TestManagerDeleteFailsWhenTmuxKillFails(t *testing.T) {
 		"done\n" +
 		"exit 0\n"
 	require.NoError(os.WriteFile(script, []byte(body), 0o755))
-	t.Setenv("TMUX_RECORD", record)
 
 	d := openTestDB(t)
 	repoID := seedRepo(t, d, "github.com", "acme", "widget")
@@ -5047,6 +5051,7 @@ func TestManagerDeleteTreatsTmuxServerExitDuringKillAsGone(t *testing.T) {
 	record := filepath.Join(dir, "record")
 	script := filepath.Join(dir, "fake-tmux")
 	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "kill-session" ]; then` + "\n" +
@@ -5056,7 +5061,6 @@ func TestManagerDeleteTreatsTmuxServerExitDuringKillAsGone(t *testing.T) {
 		"done\n" +
 		"exit 0\n"
 	require.NoError(os.WriteFile(script, []byte(body), 0o755))
-	t.Setenv("TMUX_RECORD", record)
 
 	d := openTestDB(t)
 	repoID := seedRepo(t, d, "github.com", "acme", "widget")
@@ -5138,26 +5142,25 @@ func TestManagerReapOrphanTmuxSessionsKillsUnknownManagedSessions(t *testing.T) 
 	dir := t.TempDir()
 	record := filepath.Join(dir, "record")
 	script := filepath.Join(dir, "fake-tmux")
+	d := openTestDB(t)
+	mgr := NewManager(d, t.TempDir())
 	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
+		"TMUX_TEST_OWNER_MARKER=" + shellquote.Join(mgr.tmuxOwnerMarker()) + "\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "list-sessions" ]; then` + "\n" +
-		`    printf 'forge-0000000000000001:%s\n' "$KENN_FORGE_TMUX_OWNER"` + "\n" +
+		`    printf 'forge-0000000000000001:%s\n' "$TMUX_TEST_OWNER_MARKER"` + "\n" +
 		`    printf 'forge-ffffffffffffffff\n'` + "\n" +
-		`    printf 'forge-aaaaaaaaaaaaaaaa-0123456789abcdef:%s\n' "$KENN_FORGE_TMUX_OWNER"` + "\n" +
-		`    printf 'forge-aaaaaaaaaaaaaaaa-claude:%s\n' "$KENN_FORGE_TMUX_OWNER"` + "\n" +
+		`    printf 'forge-aaaaaaaaaaaaaaaa-0123456789abcdef:%s\n' "$TMUX_TEST_OWNER_MARKER"` + "\n" +
+		`    printf 'forge-aaaaaaaaaaaaaaaa-claude:%s\n' "$TMUX_TEST_OWNER_MARKER"` + "\n" +
 		`    printf 'forge-notes\nother-session\n'` + "\n" +
 		`    exit 0` + "\n" +
 		`  fi` + "\n" +
 		"done\n" +
 		"exit 0\n"
 	require.NoError(os.WriteFile(script, []byte(body), 0o755))
-	t.Setenv("TMUX_RECORD", record)
-
-	d := openTestDB(t)
-	mgr := NewManager(d, t.TempDir())
 	mgr.SetTmuxCommand([]string{script, "wrap"})
-	t.Setenv("KENN_FORGE_TMUX_OWNER", mgr.tmuxOwnerMarker())
 
 	live := &Workspace{
 		ID:           "ws-live",
@@ -5210,32 +5213,10 @@ func TestManagerReapOrphanTmuxSessionsKeepsStoredRuntimeSessions(
 	dir := t.TempDir()
 	record := filepath.Join(dir, "record")
 	script := filepath.Join(dir, "fake-tmux")
-	body := "#!/bin/sh\n" +
-		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
-		`for a in "$@"; do` + "\n" +
-		`  if [ "$a" = "list-sessions" ]; then` + "\n" +
-		`    printf 'middleman-0000000000000001:%s\n' "$KENN_FORGE_TMUX_OWNER"` + "\n" +
-		`    printf 'middleman-0000000000000001-57de4cf40144bdf7:%s\n' "$KENN_FORGE_TMUX_OWNER"` + "\n" +
-		`    printf '%s:%s\n' "$STORED_HOST_SESSION" "$KENN_FORGE_TMUX_OWNER"` + "\n" +
-		`    printf '%s:%s\n' "$STORED_PROJECT_SESSION" "$KENN_FORGE_TMUX_OWNER"` + "\n" +
-		`    printf '%s:%s\n' "$ORPHAN_HOST_SESSION" "$KENN_FORGE_TMUX_OWNER"` + "\n" +
-		`    printf '%s:%s\n' "$ORPHAN_PROJECT_SESSION" "$KENN_FORGE_TMUX_OWNER"` + "\n" +
-		`    printf 'forge-aaaaaaaaaaaaaaaa-c857d09db23e6822:%s\n' "$KENN_FORGE_TMUX_OWNER"` + "\n" +
-		`    exit 0` + "\n" +
-		`  fi` + "\n" +
-		"done\n" +
-		"exit 0\n"
-	require.NoError(os.WriteFile(script, []byte(body), 0o755))
-	t.Setenv("TMUX_RECORD", record)
-
 	d := openTestDB(t)
 	mgr := NewManager(d, t.TempDir())
-	mgr.SetTmuxCommand([]string{script, "wrap"})
-	t.Setenv("KENN_FORGE_TMUX_OWNER", mgr.tmuxOwnerMarker())
 	storedHostSession := "forge-host-1111111111111111"
 	orphanHostSession := "forge-host-2222222222222222"
-	t.Setenv("STORED_HOST_SESSION", storedHostSession)
-	t.Setenv("ORPHAN_HOST_SESSION", orphanHostSession)
 
 	require.NoError(d.InsertWorkspace(context.Background(), &Workspace{
 		ID:           "0000000000000001",
@@ -5276,8 +5257,6 @@ func TestManagerReapOrphanTmuxSessionsKeepsStoredRuntimeSessions(
 	storedProjectSession := "forge-project-worktree-" + worktree.ID +
 		"-3333333333333333"
 	orphanProjectSession := "forge-project-worktree-unrecorded-4444444444444444"
-	t.Setenv("STORED_PROJECT_SESSION", storedProjectSession)
-	t.Setenv("ORPHAN_PROJECT_SESSION", orphanProjectSession)
 	require.NoError(d.UpsertProjectWorktreeTmuxSession(
 		context.Background(), &db.ProjectWorktreeTmuxSession{
 			WorktreeID:  worktree.ID,
@@ -5285,6 +5264,28 @@ func TestManagerReapOrphanTmuxSessionsKeepsStoredRuntimeSessions(
 			SessionName: storedProjectSession,
 		},
 	))
+
+	owner := mgr.tmuxOwnerMarker()
+	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
+		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
+		`for a in "$@"; do` + "\n" +
+		`  if [ "$a" = "list-sessions" ]; then` + "\n" +
+		"    cat <<'SESSIONS'\n" +
+		"middleman-0000000000000001:" + owner + "\n" +
+		"middleman-0000000000000001-57de4cf40144bdf7:" + owner + "\n" +
+		storedHostSession + ":" + owner + "\n" +
+		storedProjectSession + ":" + owner + "\n" +
+		orphanHostSession + ":" + owner + "\n" +
+		orphanProjectSession + ":" + owner + "\n" +
+		"forge-aaaaaaaaaaaaaaaa-c857d09db23e6822:" + owner + "\n" +
+		"SESSIONS\n" +
+		`    exit 0` + "\n" +
+		`  fi` + "\n" +
+		"done\n" +
+		"exit 0\n"
+	require.NoError(os.WriteFile(script, []byte(body), 0o755))
+	mgr.SetTmuxCommand([]string{script, "wrap"})
 
 	require.NoError(mgr.ReapOrphanTmuxSessions(context.Background()))
 
@@ -5321,6 +5322,7 @@ func TestManagerPruneMissingTmuxSessionsRemovesStaleRecords(
 	record := filepath.Join(dir, "record")
 	script := filepath.Join(dir, "fake-tmux")
 	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "list-sessions" ]; then` + "\n" +
@@ -5330,7 +5332,6 @@ func TestManagerPruneMissingTmuxSessionsRemovesStaleRecords(
 		"done\n" +
 		"exit 0\n"
 	require.NoError(os.WriteFile(script, []byte(body), 0o755))
-	t.Setenv("TMUX_RECORD", record)
 
 	d := openTestDB(t)
 	mgr := NewManager(d, t.TempDir())
@@ -5440,7 +5441,11 @@ func TestManagerTmuxSessionListSurvivesTmux36Sanitization(t *testing.T) {
 	dir := t.TempDir()
 	record := filepath.Join(dir, "record")
 	script := filepath.Join(dir, "fake-tmux")
+	d := openTestDB(t)
+	mgr := NewManager(d, t.TempDir())
 	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
+		"TMUX_TEST_OWNER_MARKER=" + shellquote.Join(mgr.tmuxOwnerMarker()) + "\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`fmt=''` + "\n" +
 		`prev=''` + "\n" +
@@ -5453,7 +5458,7 @@ func TestManagerTmuxSessionListSurvivesTmux36Sanitization(t *testing.T) {
 		`    for name in middleman-0000000000000001 forge-aaaaaaaaaaaaaaaa; do` + "\n" +
 		`      printf '%s\n' "$fmt" \` + "\n" +
 		`        | sed -e "s|#{session_name}|$name|" \` + "\n" +
-		`              -e "s|#{@forge_owner}|$KENN_FORGE_TMUX_OWNER|" \` + "\n" +
+		`              -e "s|#{@forge_owner}|$TMUX_TEST_OWNER_MARKER|" \` + "\n" +
 		`        | tr '\t' '_'` + "\n" +
 		`    done` + "\n" +
 		`    exit 0` + "\n" +
@@ -5461,12 +5466,7 @@ func TestManagerTmuxSessionListSurvivesTmux36Sanitization(t *testing.T) {
 		`done` + "\n" +
 		"exit 0\n"
 	require.NoError(os.WriteFile(script, []byte(body), 0o755))
-	t.Setenv("TMUX_RECORD", record)
-
-	d := openTestDB(t)
-	mgr := NewManager(d, t.TempDir())
 	mgr.SetTmuxCommand([]string{script, "wrap"})
-	t.Setenv("KENN_FORGE_TMUX_OWNER", mgr.tmuxOwnerMarker())
 	ctx := context.Background()
 
 	require.NoError(d.InsertWorkspace(ctx, &Workspace{
@@ -5635,10 +5635,10 @@ func TestManagerCleanupTmuxSessionKillsRuntimeSessionsForWorkspace(
 	record := filepath.Join(dir, "record")
 	script := filepath.Join(dir, "fake-tmux")
 	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		"exit 0\n"
 	require.NoError(os.WriteFile(script, []byte(body), 0o755))
-	t.Setenv("TMUX_RECORD", record)
 
 	d := openTestDB(t)
 	mgr := NewManager(d, t.TempDir())
@@ -5700,6 +5700,7 @@ func TestManagerCleanupTmuxSessionPreservesStoredRowsAfterRuntimeKillFailure(
 	record := filepath.Join(dir, "record")
 	script := filepath.Join(dir, "fake-tmux")
 	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`target=""` + "\n" +
 		`prev=""` + "\n" +
@@ -5721,7 +5722,6 @@ func TestManagerCleanupTmuxSessionPreservesStoredRowsAfterRuntimeKillFailure(
 		`fi` + "\n" +
 		"exit 0\n"
 	require.NoError(os.WriteFile(script, []byte(body), 0o755))
-	t.Setenv("TMUX_RECORD", record)
 
 	d := openTestDB(t)
 	mgr := NewManager(d, t.TempDir())
@@ -5852,6 +5852,8 @@ func TestManagerForgetRuntimeSessionAfterExitKeepsLiveTmuxSession(
 	existsFile := filepath.Join(dir, "exists")
 	script := filepath.Join(dir, "fake-tmux")
 	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
+		"TMUX_EXISTS_FILE=" + shellquote.Join(existsFile) + "\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`if [ "$1" = "has-session" ]; then` + "\n" +
 		`  if [ -f "$TMUX_EXISTS_FILE" ]; then exit 0; fi` + "\n" +
@@ -5860,8 +5862,6 @@ func TestManagerForgetRuntimeSessionAfterExitKeepsLiveTmuxSession(
 		`fi` + "\n" +
 		`exit 0` + "\n"
 	require.NoError(os.WriteFile(script, []byte(body), 0o755))
-	t.Setenv("TMUX_RECORD", record)
-	t.Setenv("TMUX_EXISTS_FILE", existsFile)
 	mgr.SetTmuxCommand([]string{script})
 
 	require.NoError(os.WriteFile(existsFile, []byte("1"), 0o644))
@@ -5897,6 +5897,7 @@ func TestManagerRequestRetryFailsWhenTmuxCleanupFails(t *testing.T) {
 	record := filepath.Join(dir, "record")
 	script := filepath.Join(dir, "fake-tmux")
 	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "kill-session" ]; then` + "\n" +
@@ -5906,7 +5907,6 @@ func TestManagerRequestRetryFailsWhenTmuxCleanupFails(t *testing.T) {
 		"done\n" +
 		"exit 0\n"
 	require.NoError(os.WriteFile(script, []byte(body), 0o755))
-	t.Setenv("TMUX_RECORD", record)
 
 	d := openTestDB(t)
 	mgr := NewManager(d, t.TempDir())
@@ -5969,6 +5969,9 @@ func TestManagerRequestRetryConsumesQueuedRetryWhenCleanupFails(t *testing.T) {
 	count := filepath.Join(dir, "count")
 	script := filepath.Join(dir, "fake-tmux")
 	body := "#!/bin/sh\n" +
+		"TMUX_STARTED=" + shellquote.Join(started) + "\n" +
+		"TMUX_RELEASE=" + shellquote.Join(release) + "\n" +
+		"TMUX_COUNT=" + shellquote.Join(count) + "\n" +
 		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "kill-session" ]; then` + "\n" +
 		`    n=0` + "\n" +
@@ -5985,9 +5988,6 @@ func TestManagerRequestRetryConsumesQueuedRetryWhenCleanupFails(t *testing.T) {
 		"done\n" +
 		"exit 0\n"
 	require.NoError(os.WriteFile(script, []byte(body), 0o755))
-	t.Setenv("TMUX_STARTED", started)
-	t.Setenv("TMUX_RELEASE", release)
-	t.Setenv("TMUX_COUNT", count)
 
 	d := openTestDB(t)
 	mgr := NewManager(d, t.TempDir())
@@ -6373,6 +6373,7 @@ func TestManagerEnsureTmuxCreatesSessionOnMiss(t *testing.T) {
 	record := filepath.Join(dir, "record")
 	script := filepath.Join(dir, "fake-tmux")
 	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "has-session" ]; then` + "\n" +
@@ -6382,7 +6383,6 @@ func TestManagerEnsureTmuxCreatesSessionOnMiss(t *testing.T) {
 		"done\n" +
 		"exit 0\n"
 	require.NoError(os.WriteFile(script, []byte(body), 0o755))
-	t.Setenv("TMUX_RECORD", record)
 
 	d := openTestDB(t)
 	mgr := NewManager(d, t.TempDir())
@@ -6397,18 +6397,17 @@ func TestManagerEnsureTmuxCreatesSessionOnMiss(t *testing.T) {
 		[]string{"has-session", "-t", "sess-B"},
 		argvs[0],
 	)
-	// new-session argv: "new-session -d -s sess-B -c /tmp/cwd <shell> -l"
-	// We check the prefix up to the shell; the shell resolves per
-	// runtime so just assert it is non-empty and ends with "-l".
-	require.GreaterOrEqual(len(argvs[1]), 8)
+	// new-session argv: "new-session -d -s sess-B -c /tmp/cwd <handoff>"
+	// where <handoff> is the /bin/sh env-file bootstrap that delivers
+	// the credential-sanitized environment and login shell to the pane.
+	require.Len(argvs[1], 7)
 	assert.Equal("new-session", argvs[1][0])
 	assert.Equal("-d", argvs[1][1])
 	assert.Equal("-s", argvs[1][2])
 	assert.Equal("sess-B", argvs[1][3])
 	assert.Equal("-c", argvs[1][4])
 	assert.Equal("/tmp/cwd", argvs[1][5])
-	assert.NotEmpty(argvs[1][6])
-	assert.Equal("-l", argvs[1][7])
+	assert.Contains(argvs[1][6], "/bin/sh ")
 	assert.Equal(
 		[]string{
 			"set-option", "-t", "sess-B",
@@ -6430,6 +6429,7 @@ func TestManagerEnsureTmuxCreatesSessionOnMacOSMissingServer(t *testing.T) {
 	record := filepath.Join(dir, "record")
 	script := filepath.Join(dir, "fake-tmux")
 	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "has-session" ]; then` + "\n" +
@@ -6439,7 +6439,6 @@ func TestManagerEnsureTmuxCreatesSessionOnMacOSMissingServer(t *testing.T) {
 		"done\n" +
 		"exit 0\n"
 	require.NoError(os.WriteFile(script, []byte(body), 0o755))
-	t.Setenv("TMUX_RECORD", record)
 
 	d := openTestDB(t)
 	mgr := NewManager(d, t.TempDir())

--- a/internal/workspace/tmux_prune_upgrade_test.go
+++ b/internal/workspace/tmux_prune_upgrade_test.go
@@ -1,0 +1,67 @@
+package workspace
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	shellquote "github.com/kballard/go-shellquote"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/db"
+	"os"
+)
+
+// TestPruneMissingTmuxSessionsKeepsReadyWorkspacesWhenServerIsEmpty pins
+// the bulk-gone case: after a machine reboot or the dedicated-socket
+// upgrade, no session lives, base sessions recreate lazily on attach,
+// and ready workspaces must stay ready rather than flip to an error
+// whose retry force-removes worktrees.
+func TestPruneMissingTmuxSessionsKeepsReadyWorkspacesWhenServerIsEmpty(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	dir := t.TempDir()
+	record := filepath.Join(dir, "record")
+	script := filepath.Join(dir, "fake-tmux")
+	body := "#!/bin/sh\n" +
+		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
+		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
+		`for a in "$@"; do` + "\n" +
+		`  if [ "$a" = "list-sessions" ]; then` + "\n" +
+		`    echo "no server running on /tmp/sock" >&2` + "\n" +
+		`    exit 1` + "\n" +
+		`  fi` + "\n" +
+		"done\n" +
+		"exit 0\n"
+	require.NoError(os.WriteFile(script, []byte(body), 0o755))
+
+	d := openTestDB(t)
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{script})
+	ctx := context.Background()
+	require.NoError(d.InsertWorkspace(ctx, &Workspace{
+		ID:           "0000000000000009",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   9,
+		GitHeadRef:   "feature/upgrade",
+		WorktreePath: filepath.Join(t.TempDir(), "wt"),
+		TmuxSession:  "kenn-forge-0000000000000009",
+		Status:       "ready",
+	}))
+
+	changed, err := mgr.PruneMissingTmuxSessions(ctx)
+	require.NoError(err)
+	assert.False(changed)
+
+	ws, err := mgr.Get(ctx, "0000000000000009")
+	require.NoError(err)
+	require.NotNil(ws)
+	assert.Equal("ready", ws.Status,
+		"an empty server must not error ready workspaces")
+}

--- a/internal/workspace/tmux_strip_env_test.go
+++ b/internal/workspace/tmux_strip_env_test.go
@@ -1,0 +1,35 @@
+package workspace
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTmuxExecUsesAllowlistedClientEnvironment pins that manager tmux
+// invocations carry only the non-secret allowlist. The client that
+// spawns the tmux server seeds the server's permanently retained
+// global environment (readable in panes via `show-environment -g`),
+// and an allowlist cannot leak a credential the configuration never
+// named.
+func TestTmuxExecUsesAllowlistedClientEnvironment(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "builtin-secret")
+	t.Setenv("KATA_AUTH_TOKEN", "kata-secret")
+	t.Setenv("WKSP_UNDECLARED_SECRET", "undeclared-secret")
+
+	m := NewManager(nil, t.TempDir())
+	cmd := m.tmuxExec(t.Context(), "has-session", "-t", "forge-test")
+	require.NotNil(t, cmd)
+	env := strings.Join(cmd.Env, "\n")
+
+	assert := assert.New(t)
+	assert.Contains(env, "PATH=", "allowlisted variables must survive")
+	assert.NotContains(env, "GITHUB_TOKEN")
+	assert.NotContains(env, "KATA_AUTH_TOKEN")
+	assert.NotContains(env, "WKSP_UNDECLARED_SECRET")
+	assert.NotContains(env, "builtin-secret")
+	assert.NotContains(env, "kata-secret")
+	assert.NotContains(env, "undeclared-secret")
+}

--- a/scripts/e2e/fleet/seed/main.go
+++ b/scripts/e2e/fleet/seed/main.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/procutil"
 )
@@ -226,11 +227,17 @@ func resetFixtureRows(ctx context.Context, database *db.DB, projectPath string) 
 }
 
 func startWorkspaceTmux(ctx context.Context, session, worktreePath string) error {
-	_ = procutil.CommandContext(ctx, "tmux", "kill-session", "-t", session).Run()
-	cmd := procutil.CommandContext(
-		ctx,
-		"tmux", "new-session", "-d", "-s", session, "-c", worktreePath, "sh",
+	// The fleet daemons run with an unconfigured [tmux] command, so
+	// seeded sessions must land on the same dedicated kenn-forge
+	// server the fleet monitor reads, not the global tmux server.
+	tmuxCmd := config.DefaultTmuxCommand()
+	killArgs := append(tmuxCmd[1:], "kill-session", "-t", session)
+	_ = procutil.CommandContext(ctx, tmuxCmd[0], killArgs...).Run()
+	newArgs := append(
+		config.DefaultTmuxCommand()[1:],
+		"new-session", "-d", "-s", session, "-c", worktreePath, "sh",
 	)
+	cmd := procutil.CommandContext(ctx, tmuxCmd[0], newArgs...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("start tmux session %q: %w: %s", session, err, output)


### PR DESCRIPTION
Forge previously shared the user's global tmux server, so heavy workspace and agent activity contended with personal tmux sessions.

- Workspace terminals, agent sessions, and fleet tmux probes default to a dedicated tmux server (`tmux -L kenn-forge`). Every empty-command fallback shares `config.DefaultTmuxCommand`, and an explicitly configured `[tmux] command` line is used verbatim. Sessions started by older versions stay on the global server and are no longer visible to Forge; `docs/configuration.md` covers cleanup.
- The tmux server permanently retains its spawn environment, so every Forge-issued tmux client (creation, attach, probes, kills, fleet inventory) runs with an exact-name, non-secret allowlist environment. Pane processes receive their real environment only through a self-deleting env-file handoff; the base workspace terminal keeps the credential-sanitized full daemon environment plus tmux's per-pane `TERM`, `TMUX`, and `TMUX_PANE`.
- Credential names and the terminal environment are disjoint by construction: config and Kata catalog validation reject `token_env` names that collide with the allowlist. Configured token names, built-in provider/Kata credentials (case-folded on Windows), and Kata catalog `token_env` names feed monotonic strip sets covering tmux, runtime, and ptyowner sessions, updated at boot and on config or catalog reload. Launch environment from API request bodies reaches only panes, never tmux clients.
- Attach commands pass `-E` and normalize the caller environment (`env -u TMUX`, pinned or unset `TMUX_TMPDIR`); fleet SSH wrapping shell-quotes the remote command.
- Wrapper `[tmux] command`s run with the minimal non-secret environment; custom wrapper data belongs in argv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)