### PR TITLE
test: bound local test resource usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ DEV_CLONE_FRONTEND_PORT ?= 5175
 # gotestsum prints package names on success and full output on failure,
 # while persisting raw `go test -json` events for downstream reporters.
 GOTESTSUM := go tool gotestsum --format pkgname-and-test-fails --jsonfile
-GO_TEST_P ?=
+GO_TEST_P ?= 4
 GO_TEST_P_FLAG := $(if $(GO_TEST_P),-p $(GO_TEST_P),)
 
 # Ensure go:embed has at least one file (no-op if frontend is built)

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -6,8 +6,9 @@ fixtures, or changing shell-script coverage.
 - Pass `-shuffle=on` when invoking `go test` directly; `make test` and
   `make test-short` already include it. Do not pass redundant `-count=1`; use
   `-count=N` only when `N > 1` for repeated runs.
-- Local Go hooks must use bounded concurrency and separate heavy consumers into
-  ordered priority groups; keep the shared Go cache across worktrees (`scripts/run-hook-go.sh`, `prek.toml:53`).
+- Routine local Go lanes and hooks bound package/processor concurrency and share
+  Go caches; `GO_TEST_P=` intentionally restores native package concurrency.
+  Reduce scanner pressure at source, not by redirecting `GOTMPDIR`. (`Makefile:50`, `scripts/run-hook-go.sh:12`, `prek.toml:53`)
 - `-short` must skip tests that build and launch real kenn-forge daemons or run
   load-sensitive sync E2Es; those flows belong in full Go lanes (`cmd/kenn-forge/lock_e2e_test.go::buildForgeWithLDFlags`, `internal/server/e2etest/sync_cooldown_test.go::TestTriggerSyncE2EPrioritizesNonDefaultHostFilter`).
 - Pre-commit runs frontend core checks without full-project Effect diagnostics;
@@ -37,6 +38,9 @@ fixtures, or changing shell-script coverage.
   Linux, which provide high-resolution process starts. (`internal/testutil/testtmux/process_identity.go::processIdentityStatus`)
 - Orphan recovery accepts explicit or exact server-title socket paths only when
   contained by the dedicated root. (`internal/testutil/testtmux/owner.go::reapStaleProcesses`)
+- Detached `internal/server` PTY-owner test helpers receive their launching test
+  PID explicitly and cancel on Unix reparenting; production PTY owners remain
+  durable across daemon restarts. (`internal/server/api_test.go::ptyOwnerHelperExeArgs`)
 - Use provider live or container fixtures only when fake transports cannot
   catch endpoint or authentication drift. GitHub GraphQL validation is gated by
   `KENN_FORGE_LIVE_GITHUB_TESTS=1`.

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -70,11 +70,19 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
-const serverRuntimeHelperMarker = "kenn-forge-runtime-helper"
+const (
+	serverRuntimeHelperMarker        = "kenn-forge-runtime-helper"
+	serverPtyOwnerParentHelperMarker = "kenn-forge-pty-owner-parent-helper"
+)
 
 var (
-	privateTmuxOwner *testtmux.Owner
-	ptyE2ESemaphore  = semaphore.NewWeighted(1)
+	privateTmuxOwner        *testtmux.Owner
+	ptyE2ESemaphore         = semaphore.NewWeighted(1)
+	serverPtyOwnerParentPID = flag.Int(
+		"server-pty-owner-parent-pid",
+		0,
+		"PID of the test process that launched the PTY owner helper",
+	)
 	// Root keeps only Workspace tests that cross provider, config, Kata,
 	// runtime, terminal, Fleet, or agent-context composition boundaries.
 	// Bound their Git setup independently from the workspacetest binary.
@@ -133,7 +141,9 @@ func isServerHelperProcess() bool {
 		args = args[sep+1:]
 	}
 	return len(args) > 0 &&
-		(args[0] == serverRuntimeHelperMarker || args[0] == "pty-owner")
+		(args[0] == serverRuntimeHelperMarker ||
+			args[0] == serverPtyOwnerParentHelperMarker ||
+			args[0] == "pty-owner")
 }
 
 func runParallelPTYE2E(t *testing.T) {
@@ -27210,11 +27220,16 @@ func ptyOwnerServerOptions(ptyOwnerDir string) ServerOptions {
 	return ServerOptions{
 		PtyOwnerDir:     ptyOwnerDir,
 		PtyOwnerExePath: os.Args[0],
-		PtyOwnerExeArgs: []string{
-			"-test.run=TestServerPtyOwnerHelperProcess",
-			"--",
-		},
+		PtyOwnerExeArgs: ptyOwnerHelperExeArgs(os.Getpid()),
 		PtyOwnerCommand: []string{"/bin/sh"},
+	}
+}
+
+func ptyOwnerHelperExeArgs(parentPID int) []string {
+	return []string{
+		"-test.run=TestServerPtyOwnerHelperProcess",
+		fmt.Sprintf("-server-pty-owner-parent-pid=%d", parentPID),
+		"--",
 	}
 }
 
@@ -30794,12 +30809,17 @@ func TestServerPtyOwnerHelperProcess(t *testing.T) {
 			os.Exit(2)
 		}
 	}
-	if err := ptyowner.RunOwner(context.Background(), ptyowner.Options{
+	ownerCtx, cancel := testPtyOwnerParentContext(*serverPtyOwnerParentPID)
+	defer cancel()
+	if ownerCtx.Err() != nil {
+		os.Exit(0)
+	}
+	if err := ptyowner.RunOwner(ownerCtx, ptyowner.Options{
 		Root:    *root,
 		Session: *session,
 		Cwd:     *cwd,
 		Command: command,
-	}); err != nil {
+	}); err != nil && !errors.Is(err, context.Canceled) {
 		os.Exit(1)
 	}
 	os.Exit(0)

--- a/internal/server/pty_owner_parent_unix_test.go
+++ b/internal/server/pty_owner_parent_unix_test.go
@@ -34,7 +34,7 @@ func TestServerPtyOwnerHelperStopsWhenParentKilled(t *testing.T) {
 		"-root", root,
 		"-session", session,
 	)
-	var output bytes.Buffer
+	var output lockedBuffer
 	cmd.Stdout = &output
 	cmd.Stderr = &output
 	require.NoError(cmd.Start())

--- a/internal/server/pty_owner_parent_unix_test.go
+++ b/internal/server/pty_owner_parent_unix_test.go
@@ -1,0 +1,128 @@
+//go:build !windows
+
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"os"
+	"slices"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/procutil"
+	"go.kenn.io/forge/internal/ptyowner"
+)
+
+func TestServerPtyOwnerHelperStopsWhenParentKilled(t *testing.T) {
+	require := require.New(t)
+	root := t.TempDir()
+	session := "test-parent-loss"
+	paths, err := ptyowner.NewSessionPaths(root, session)
+	require.NoError(err)
+
+	cmd := procutil.Command(
+		os.Args[0],
+		"-test.run=TestServerPtyOwnerParentHelperProcess",
+		"--",
+		serverPtyOwnerParentHelperMarker,
+		"-root", root,
+		"-session", session,
+	)
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	require.NoError(cmd.Start())
+	waited := false
+	t.Cleanup(func() {
+		if !waited && cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+		stopCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = ptyowner.NewClient(root, []string{"/bin/sh"}).Stop(stopCtx, session)
+	})
+
+	type ownerProcessState struct {
+		PID int `json:"pid"`
+	}
+	var state ownerProcessState
+	require.Eventually(func() bool {
+		data, readErr := os.ReadFile(paths.StatePath)
+		if readErr != nil {
+			return false
+		}
+		return json.Unmarshal(data, &state) == nil && state.PID > 0
+	}, 5*time.Second, 20*time.Millisecond, "owner did not start: %s", output.String())
+
+	require.NoError(syscall.Kill(cmd.Process.Pid, syscall.SIGKILL))
+	require.Error(cmd.Wait())
+	waited = true
+
+	require.Eventually(func() bool {
+		processErr := syscall.Kill(state.PID, 0)
+		_, stateErr := os.Stat(paths.Dir)
+		_, socketErr := os.Stat(paths.Socket)
+		return errors.Is(processErr, syscall.ESRCH) &&
+			os.IsNotExist(stateErr) &&
+			os.IsNotExist(socketErr)
+	}, 5*time.Second, 20*time.Millisecond, "owner survived parent loss: %s", output.String())
+}
+
+func TestServerPtyOwnerParentHelperProcess(t *testing.T) {
+	args := os.Args
+	sep := slices.Index(args, "--")
+	if sep < 0 || len(args) <= sep+1 ||
+		args[sep+1] != serverPtyOwnerParentHelperMarker {
+		return
+	}
+	args = args[sep+2:]
+	fs := flag.NewFlagSet("test pty-owner parent", flag.ContinueOnError)
+	fs.SetOutput(&bytes.Buffer{})
+	root := fs.String("root", "", "pty owner state root")
+	session := fs.String("session", "", "session name")
+	require.NoError(t, fs.Parse(args))
+
+	client := &ptyowner.Client{
+		Root:    *root,
+		ExePath: os.Args[0],
+		ExeArgs: ptyOwnerHelperExeArgs(os.Getpid()),
+		Command: []string{"/bin/sh"},
+	}
+	require.NoError(t, client.Ensure(context.Background(), *session, os.TempDir()))
+	blockServerRuntimeHelper()
+}
+
+func testPtyOwnerParentContext(parentPID int) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	if parentPID <= 0 {
+		return ctx, cancel
+	}
+	if os.Getppid() != parentPID {
+		cancel()
+		return ctx, cancel
+	}
+
+	go func() {
+		ticker := time.NewTicker(50 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if os.Getppid() != parentPID {
+					cancel()
+					return
+				}
+			}
+		}
+	}()
+	return ctx, cancel
+}

--- a/internal/server/pty_owner_parent_windows_test.go
+++ b/internal/server/pty_owner_parent_windows_test.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package server
+
+import "context"
+
+func testPtyOwnerParentContext(_ int) (context.Context, context.CancelFunc) {
+	return context.WithCancel(context.Background())
+}

--- a/scripts/run-hook-go.sh
+++ b/scripts/run-hook-go.sh
@@ -10,6 +10,6 @@ case "$hook_concurrency" in
 esac
 
 export GOMAXPROCS=${GOMAXPROCS:-$hook_concurrency}
-export GO_TEST_P=${GO_TEST_P:-$hook_concurrency}
+export GO_TEST_P=${GO_TEST_P-$hook_concurrency}
 
 exec "$@"

--- a/scripts/run-hook-go.test.mjs
+++ b/scripts/run-hook-go.test.mjs
@@ -6,15 +6,15 @@ import test from "node:test";
 const script = fileURLToPath(new URL("./run-hook-go.sh", import.meta.url));
 
 function run(env = {}) {
+  const childEnv = { ...process.env };
+  delete childEnv.GOMAXPROCS;
+  delete childEnv.GO_TEST_P;
+  delete childEnv.KENN_FORGE_HOOK_GO_CONCURRENCY;
+  Object.assign(childEnv, env);
+
   return spawnSync(script, ["sh", "-c", "printf '%s|%s' \"$GOMAXPROCS\" \"$GO_TEST_P\""], {
     encoding: "utf8",
-    env: {
-      ...process.env,
-      GOMAXPROCS: "",
-      GO_TEST_P: "",
-      KENN_FORGE_HOOK_GO_CONCURRENCY: "",
-      ...env,
-    },
+    env: childEnv,
   });
 }
 
@@ -45,4 +45,11 @@ test("Go hooks preserve explicit tool-specific limits", () => {
 
   assertSucceeded(result);
   assert.equal(result.stdout, "3|5");
+});
+
+test("Go hooks preserve an explicitly empty package limit", () => {
+  const result = run({ GO_TEST_P: "" });
+
+  assertSucceeded(result);
+  assert.equal(result.stdout, "4|");
 });


### PR DESCRIPTION
Routine local test runs could fan out across all Go packages while detached
PTY-owner test helpers survived a killed test binary. On developer machines,
that amplified CPU, process, and security-scanner contention.

This change defaults direct Make test lanes to four-package concurrency and
preserves `GO_TEST_P=` as the explicit native-concurrency override, including
through hooks. It keeps Go's shared cache and normal temporary paths rather
than relocating executables.

Test-only PTY owners now receive the exact launcher PID and stop when Unix
reparents them after a parent is killed. Production PTY owners remain detached
and continue surviving Forge restarts. Windows test builds use a no-op parent
watcher because this reparenting contract is Unix-specific.
