### PR TITLE
perf: compress workspace terminal streams

### DIFF
--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -31,6 +31,15 @@ Rules:
   survive kenn-forge server restarts until the shell exits or the workspace is
   deleted.
 
+## Terminal Transport
+
+- Every terminal WebSocket leg negotiates RFC 7692 `permessage-deflate` with
+  context takeover; Fleet relays apply the same policy to their separately
+  terminated upstream leg. (`internal/terminalwebsocket/`)
+- Use standard negotiation, not an application compression envelope: context
+  takeover shares a dictionary across PTY messages, while unsupported peers
+  continue with an ordinary uncompressed WebSocket.
+
 ## Natural Exit Rules
 
 Natural process exit should collapse stale runtime state quickly.

--- a/internal/server/fleetapi/fleet_proxy.go
+++ b/internal/server/fleetapi/fleet_proxy.go
@@ -25,6 +25,7 @@ import (
 	"go.kenn.io/forge/internal/procutil"
 	"go.kenn.io/forge/internal/server/httpapi"
 	"go.kenn.io/forge/internal/server/workspaceapi"
+	"go.kenn.io/forge/internal/terminalwebsocket"
 	"go.kenn.io/forge/internal/tracing"
 )
 
@@ -829,9 +830,7 @@ func (s *Handler) serveFleetWebSocketProxy(
 	dialHeader := make(http.Header)
 	copyProxyWebSocketRequestHeaders(dialHeader, r.Header)
 	dialHeader.Set("X-Kenn-Forge-Fleet-Host", target.peer.Key)
-	peerConn, _, err := websocket.Dial(r.Context(), peerURL, &websocket.DialOptions{
-		HTTPHeader: dialHeader,
-	})
+	peerConn, _, err := terminalwebsocket.Dial(r.Context(), peerURL, dialHeader)
 	if err != nil {
 		attachSpan.SetAttributes(attribute.Bool("error", true))
 		writeProblemResponse(w, httpapi.NewProblem(
@@ -844,9 +843,7 @@ func (s *Handler) serveFleetWebSocketProxy(
 	}
 	defer peerConn.Close(websocket.StatusNormalClosure, "hub detached")
 
-	clientConn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-		InsecureSkipVerify: true,
-	})
+	clientConn, err := terminalwebsocket.Accept(w, r)
 	if err != nil {
 		attachSpan.SetAttributes(attribute.Bool("error", true))
 		slog.Debug(
@@ -958,9 +955,7 @@ func (s *Handler) serveSSHFleetWebSocketTerminal(
 		return
 	}
 
-	clientConn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-		InsecureSkipVerify: true,
-	})
+	clientConn, err := terminalwebsocket.Accept(w, r)
 	if err != nil {
 		attachSpan.SetAttributes(attribute.Bool("error", true))
 		attach.close()

--- a/internal/server/fleetapi/fleet_proxy_test.go
+++ b/internal/server/fleetapi/fleet_proxy_test.go
@@ -1,14 +1,94 @@
 package fleetapi
 
 import (
+	"context"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/coder/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/forge/internal/config"
 )
+
+func TestFleetWebSocketProxyNegotiatesContextTakeoverOnBothLegs(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	peerExtensions := make(chan string, 1)
+	peerErrors := make(chan error, 1)
+	peer := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+				InsecureSkipVerify: true,
+				CompressionMode:    websocket.CompressionContextTakeover,
+			})
+			if err != nil {
+				peerErrors <- err
+				return
+			}
+			defer conn.Close(websocket.StatusNormalClosure, "done")
+			peerExtensions <- w.Header().Get("Sec-WebSocket-Extensions")
+
+			typ, payload, err := conn.Read(r.Context())
+			if err != nil {
+				peerErrors <- err
+				return
+			}
+			if err := conn.Write(r.Context(), typ, payload); err != nil {
+				peerErrors <- err
+			}
+		},
+	))
+	t.Cleanup(peer.Close)
+
+	srv, _ := setupTestServer(t)
+	setTestFleetConfig(srv, func(cfg *config.Config) {
+		cfg.Fleet.Enabled = true
+		cfg.Fleet.Peers = []config.FleetPeer{
+			{Key: "member", BaseURL: peer.URL},
+		}
+	})
+	hub := httptest.NewServer(srv.localHandler())
+	t.Cleanup(hub.Close)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	wsURL := "ws" + strings.TrimPrefix(hub.URL, "http") +
+		"/ws/v1/fleet/hosts/member/workspaces/ws_1/runtime/sessions/sess-1/terminal"
+	conn, resp, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+		CompressionMode: websocket.CompressionContextTakeover,
+	})
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+	require.NotNil(resp)
+
+	clientExtensions := resp.Header.Get("Sec-WebSocket-Extensions")
+	assert.Contains(clientExtensions, "permessage-deflate")
+	assert.NotContains(clientExtensions, "client_no_context_takeover")
+	assert.NotContains(clientExtensions, "server_no_context_takeover")
+
+	select {
+	case extensions := <-peerExtensions:
+		assert.Contains(extensions, "permessage-deflate")
+		assert.NotContains(extensions, "client_no_context_takeover")
+		assert.NotContains(extensions, "server_no_context_takeover")
+	case err := <-peerErrors:
+		require.NoError(err)
+	case <-ctx.Done():
+		require.Fail("peer websocket handshake did not complete")
+	}
+
+	want := []byte("fleet-compression-round-trip")
+	require.NoError(conn.Write(ctx, websocket.MessageBinary, want))
+	typ, got, err := conn.Read(ctx)
+	require.NoError(err)
+	assert.Equal(websocket.MessageBinary, typ)
+	assert.Equal(want, got)
+}
 
 // TestCopyProxyRequestHeadersStripsBrowserHeaders verifies the hub does not
 // forward a browser's Origin or Sec-Fetch-* metadata onto a server-to-server

--- a/internal/server/fleetapi/fleet_ssh_test.go
+++ b/internal/server/fleetapi/fleet_ssh_test.go
@@ -896,9 +896,16 @@ func TestSSHFleetWebSocketTerminalUsesAttachSpecCommand(t *testing.T) {
 		"?cols=80&rows=24" +
 		"&traceparent=00-33333333333333333333333333333333-4444444444444444-01" +
 		"&baggage=interaction%3Dworkspace-switch%2Chost.key%3Depyc"
-	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	conn, resp, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+		CompressionMode: websocket.CompressionContextTakeover,
+	})
 	require.NoError(err)
 	defer conn.Close(websocket.StatusNormalClosure, "test done")
+	require.NotNil(resp)
+	extensions := resp.Header.Get("Sec-WebSocket-Extensions")
+	assert.Contains(extensions, "permessage-deflate")
+	assert.NotContains(extensions, "client_no_context_takeover")
+	assert.NotContains(extensions, "server_no_context_takeover")
 
 	require.NoError(conn.Write(ctx, websocket.MessageBinary, []byte("ping\n")))
 	readWebSocketBinaryUntil(t, ctx, conn, 5*time.Second, "echo:ping")

--- a/internal/server/workspaceapi/workspace_runtime_terminal.go
+++ b/internal/server/workspaceapi/workspace_runtime_terminal.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/terminalwebsocket"
 	"go.kenn.io/forge/internal/tracing"
 	"go.kenn.io/forge/internal/workspace/localruntime"
 )
@@ -114,9 +115,7 @@ func (s *Handler) serveRuntimeTerminal(
 	attachSpan trace.Span,
 	endAttachSpan func(),
 ) {
-	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-		InsecureSkipVerify: true,
-	})
+	conn, err := terminalwebsocket.Accept(w, r)
 	if err != nil {
 		slog.Error("websocket accept", "err", err)
 		attachSpan.SetAttributes(attribute.Bool("error", true))

--- a/internal/server/workspaceapi/workspace_runtime_terminal_test.go
+++ b/internal/server/workspaceapi/workspace_runtime_terminal_test.go
@@ -19,6 +19,36 @@ import (
 	"go.kenn.io/forge/internal/workspace/localruntime"
 )
 
+func TestServeRuntimeTerminalNegotiatesCompression(t *testing.T) {
+	require := require.New(t)
+	attachment := localruntime.NewAttachmentForTesting(
+		localruntime.AttachmentForTestingOptions{
+			Output: make(chan []byte),
+			Done:   make(chan struct{}),
+		},
+	)
+	wsURL, handlerDone := runtimeTerminalTestServer(t, attachment)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	conn, resp, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+		CompressionMode: websocket.CompressionContextTakeover,
+	})
+	require.NoError(err)
+	require.NotNil(resp)
+	require.Contains(
+		resp.Header.Get("Sec-WebSocket-Extensions"),
+		"permessage-deflate",
+	)
+
+	require.NoError(conn.Close(websocket.StatusNormalClosure, "done"))
+	select {
+	case <-handlerDone:
+	case <-ctx.Done():
+		require.Fail("terminal handler did not return")
+	}
+}
+
 func TestServeRuntimeTerminalForwardsBufferedReplayBeforeRefresh(t *testing.T) {
 	require := require.New(t)
 	replay := []byte("buffered replay")

--- a/internal/terminal/handler.go
+++ b/internal/terminal/handler.go
@@ -16,6 +16,7 @@ import (
 
 	"go.kenn.io/forge/internal/procutil"
 	"go.kenn.io/forge/internal/ptyowner"
+	"go.kenn.io/forge/internal/terminalwebsocket"
 	"go.kenn.io/forge/internal/tracing"
 	"go.kenn.io/forge/internal/workspace"
 )
@@ -109,9 +110,7 @@ func (h *Handler) ServeHTTP(
 	}
 	defer releaseTerminal()
 
-	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-		InsecureSkipVerify: true,
-	})
+	conn, err := terminalwebsocket.Accept(w, r)
 	if err != nil {
 		slog.Error("websocket accept", "err", err)
 		attachSpan.SetAttributes(attribute.Bool("error", true))

--- a/internal/terminal/handler_test.go
+++ b/internal/terminal/handler_test.go
@@ -202,14 +202,20 @@ func TestHandlerAttachesPtyOwnerTerminal(t *testing.T) {
 	server := httptest.NewServer(mux)
 	t.Cleanup(server.Close)
 
-	conn, _, err := websocket.Dial(
+	conn, resp, err := websocket.Dial(
 		t.Context(),
 		"ws"+strings.TrimPrefix(server.URL, "http")+
 			"/api/v1/workspaces/"+ws.ID+"/terminal",
-		nil,
+		&websocket.DialOptions{
+			CompressionMode: websocket.CompressionContextTakeover,
+		},
 	)
 	require.NoError(err)
 	defer conn.Close(websocket.StatusNormalClosure, "done")
+	require.Contains(
+		resp.Header.Get("Sec-WebSocket-Extensions"),
+		"permessage-deflate",
+	)
 
 	require.Contains(readWebSocketUntil(t, conn, "ready"), "ready")
 	require.NoError(conn.Write(

--- a/internal/terminalwebsocket/terminalwebsocket.go
+++ b/internal/terminalwebsocket/terminalwebsocket.go
@@ -1,0 +1,31 @@
+// Package terminalwebsocket owns the transport policy for terminal streams.
+package terminalwebsocket
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/coder/websocket"
+)
+
+// Accept upgrades a terminal connection with compression suited to repetitive
+// terminal repaint streams.
+func Accept(w http.ResponseWriter, r *http.Request) (*websocket.Conn, error) {
+	return websocket.Accept(w, r, &websocket.AcceptOptions{
+		InsecureSkipVerify: true,
+		CompressionMode:    websocket.CompressionContextTakeover,
+	})
+}
+
+// Dial opens an upstream terminal connection with the same compression policy
+// used for browser-facing terminal connections.
+func Dial(
+	ctx context.Context,
+	url string,
+	header http.Header,
+) (*websocket.Conn, *http.Response, error) {
+	return websocket.Dial(ctx, url, &websocket.DialOptions{
+		HTTPHeader:      header,
+		CompressionMode: websocket.CompressionContextTakeover,
+	})
+}


### PR DESCRIPTION
Active phone terminal sessions currently receive each PTY output chunk uncompressed, even though agent interfaces repeatedly redraw similar terminal state. This follow-up to #905 enables standard WebSocket `permessage-deflate` with context takeover for base terminals, runtime sessions, and Fleet relay legs.

A controlled Chromium comparison delivered identical decoded terminal output while reducing wire traffic:

- JSON-like agent output: 16.44 MB/hour to 2.29 MB/hour (86% reduction).
- TUI repaint output: 32.29 MB/hour to 7.84 MB/hour (76% reduction).

Compression is negotiated automatically, so unsupported clients continue with an ordinary WebSocket. This deliberately avoids a custom compression envelope and output batching: sub-128-byte messages accounted for only 1.1% of sampled payload bytes. Background polling remains a separate concern; this change targets the active terminal stream.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<sup>generated by a clanker</sup>
