### PR TITLE
fix(archive): handle issue-only GitHub repositories

### DIFF
--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -255,11 +255,6 @@ fallback repository listing.
   requests off still enters the cooldown.
   (`internal/github/native_stacks.go::decodeNativeStackHint`,
   `internal/github/sync.go::ListOpenMergeRequestsWithNativeStackHints`)
-- GitHub repositories can have pull requests disabled (issues-only trackers):
-  the pulls API 404s for every credential. A pulls-list 404 classifies as
-  merge-requests feature disabled only when the repository probe reads back
-  `has_pull_requests=false`; a bare 404 stays a transient failure
-  (`internal/github/sync.go::mergeRequestsDisabledByRepository`).
 - Preview-only GraphQL fields must be absent from disabled query shapes;
   `@include(false)` does not bypass schema validation on servers without those
   fields. Schema rejection drops the fields for that host instead of abandoning
@@ -437,6 +432,11 @@ fallback repository listing.
   success would hide a dead worker. (`internal/archive/scheduler.go::RunEligible`,
   `internal/archive/service.go::resolveRepositoriesTolerant`)
 - Initial issue and pull-request inventory includes all states in stable created-time ascending order; issue enumeration excludes PR-shaped rows. (`internal/github/pages.go::ListIssuesPage`, `internal/github/pages.go::ListMergeRequestsPage`)
+- GitHub issue-only repositories return pulls API 404; normal and archive paths
+  classify it as feature-disabled only for explicit `has_pull_requests=false`;
+  ambiguous probes preserve the failure. (`internal/github/sync.go::mergeRequestsDisabledByRepository`)
+- GitHub pull inventory admission reserves the possible metadata probe and its
+  authentication retry. (`internal/archive/scheduler.go::archiveFeatureReadAttemptCost`)
 - Every issue-only GitHub lookup rejects a PR-shaped Issues API response before normalization; `SyncItemByNumber` is the kind-dispatching exception. (`internal/github/pages.go::gitHubClientProvider.issuePullRequestOutcomeError`, `internal/github/sync.go::SyncItemByNumber`)
 - Updated issue scans query one second before the durable watermark while keeping cursor identity bound to the original boundary. Updated pull-request scans run newest-first across the same overlap. (`internal/github/pages.go::ListIssuesPage`, `internal/github/pages.go::ListMergeRequestsPage`)
 - Durable pull-request inventory bypasses the process-local list ETag cache. Archive cursors require response bodies, so a bodyless `304 Not Modified` must not turn an unchanged maintenance scan into a retryable failure. (`internal/github/pages.go::liveClient.ListInventoryPullRequestsPage`)

--- a/internal/archive/inventory.go
+++ b/internal/archive/inventory.go
@@ -31,7 +31,7 @@ func (s *Service) inventoryPage(ctx context.Context, repo resolvedRepository, st
 	} else {
 		requestCtx, complete, err := s.admit(
 			withInventoryProbe(ctx), repo, itemType,
-			archiveFeatureReadAttemptCost(repo.Ref.Platform),
+			archiveFeatureReadAttemptCost(repo.Ref.Platform, itemType),
 		)
 		if err != nil {
 			if errors.Is(err, errAdmissionDeferred) {

--- a/internal/archive/maintenance.go
+++ b/internal/archive/maintenance.go
@@ -98,7 +98,7 @@ func (s *Service) promptPages(
 		}
 		requestCtx, complete, err := s.admit(
 			withInventoryProbe(ctx), repo, itemType,
-			archiveFeatureReadAttemptCost(repo.Ref.Platform),
+			archiveFeatureReadAttemptCost(repo.Ref.Platform, itemType),
 		)
 		if err != nil {
 			if errors.Is(err, errAdmissionDeferred) {

--- a/internal/archive/scheduler.go
+++ b/internal/archive/scheduler.go
@@ -371,9 +371,9 @@ func archiveAttemptCost(logical int) int {
 	return logical * 2
 }
 
-func archiveFeatureReadAttemptCost(kind platform.Kind) int {
+func archiveFeatureReadAttemptCost(kind platform.Kind, itemType db.ArchiveItemType) int {
 	logicalRequests := 1
-	if kind != platform.KindGitHub {
+	if kind != platform.KindGitHub || itemType == db.ArchiveItemTypeMergeRequest {
 		logicalRequests++ // repository metadata confirmation after a candidate feature error
 	}
 	return archiveAttemptCost(logicalRequests)

--- a/internal/archive/service_test.go
+++ b/internal/archive/service_test.go
@@ -822,11 +822,12 @@ func TestArchiveBudgetDeferralDoesNotIncrementAttempts(t *testing.T) {
 	assert.Empty(provider.calls)
 }
 
-func TestArchiveInventoryAdmissionReservesProviderConfirmationAttempts(t *testing.T) {
+func TestArchiveInventoryAdmissionReservesGitHubMergeRequestConfirmationAttempts(t *testing.T) {
+	assert := assert.New(t)
 	require := require.New(t)
 	database := dbtest.Open(t)
 	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
-	ref := archiveServiceRef(platform.KindGitLab, "gitlab.test", "repo")
+	ref := archiveServiceRef(platform.KindGitHub, "github.test", "repo")
 	archiveServiceSeedRepo(t, database, ref)
 	provider := newArchiveServiceProvider(ref.Platform, ref.Host)
 	registry, err := platform.NewRegistry(provider)
@@ -838,9 +839,10 @@ func TestArchiveInventoryAdmissionReservesProviderConfirmationAttempts(t *testin
 	require.NoError(err)
 
 	require.NoError(service.RunEligible(t.Context()))
+	require.NoError(service.RunEligible(t.Context()))
 
-	require.NotEmpty(admission.costs)
-	assert.Equal(t, 4, admission.costs[0])
+	require.Len(admission.costs, 2)
+	assert.Equal([]int{2, 4}, admission.costs)
 }
 
 func TestArchivePausePreventsFutureProviderReads(t *testing.T) {

--- a/internal/github/pages.go
+++ b/internal/github/pages.go
@@ -325,6 +325,9 @@ func (p *gitHubClientProvider) listInventoryMergeRequestsPage(
 		ctx, ref.Owner, ref.Name, sortBy, state.Page,
 	)
 	if err != nil {
+		if disabledErr := p.mergeRequestsDisabledByRepository(ctx, ref, err); disabledErr != nil {
+			return platform.Page[platform.MergeRequest]{}, disabledErr
+		}
 		return platform.Page[platform.MergeRequest]{}, p.archiveTransportError(platform.ArchiveCapabilityHistoricalMergeRequests, err)
 	}
 	out := make([]platform.MergeRequest, 0, len(items))

--- a/internal/github/pages_test.go
+++ b/internal/github/pages_test.go
@@ -59,6 +59,85 @@ func TestGitHubRepositoryFeatureDisabled(t *testing.T) {
 	}
 }
 
+func TestGitHubArchiveMergeRequestInventoryClassifiesIssueOnlyRepository(t *testing.T) {
+	tests := []struct {
+		name               string
+		repositoryStatus   int
+		repositoryResponse string
+		wantDisabled       bool
+	}{
+		{
+			name:             "disabled",
+			repositoryStatus: http.StatusOK,
+			repositoryResponse: `{
+				"id":1,"node_id":"R_widget","name":"widget","full_name":"acme/widget",
+				"owner":{"login":"acme"},"has_pull_requests":false
+			}`,
+			wantDisabled: true,
+		},
+		{
+			name:             "enabled",
+			repositoryStatus: http.StatusOK,
+			repositoryResponse: `{
+				"id":1,"node_id":"R_widget","name":"widget","full_name":"acme/widget",
+				"owner":{"login":"acme"},"has_pull_requests":true
+			}`,
+		},
+		{
+			name:             "unknown",
+			repositoryStatus: http.StatusOK,
+			repositoryResponse: `{
+				"id":1,"node_id":"R_widget","name":"widget","full_name":"acme/widget",
+				"owner":{"login":"acme"}
+			}`,
+		},
+		{
+			name:               "unreadable",
+			repositoryStatus:   http.StatusForbidden,
+			repositoryResponse: `{"message":"Forbidden"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			repositoryRequests := 0
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/api/v3/repos/acme/widget/pulls":
+					http.Error(w, `{"message":"Not Found"}`, http.StatusNotFound)
+				case "/api/v3/repos/acme/widget":
+					repositoryRequests++
+					w.WriteHeader(tt.repositoryStatus)
+					_, _ = w.Write([]byte(tt.repositoryResponse))
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer srv.Close()
+
+			provider := newArchiveTestGitHubProvider(t, srv.URL)
+			_, err := provider.ListMergeRequestsPage(
+				t.Context(), pagesTestRef(), platform.ItemPageQuery{Order: platform.ItemOrderCreated},
+			)
+
+			assert.Equal(1, repositoryRequests)
+			if tt.wantDisabled {
+				require.ErrorIs(err, platform.ErrRepositoryFeatureDisabled)
+				var platformErr *platform.Error
+				require.ErrorAs(err, &platformErr)
+				assert.Equal(platform.RepositoryFeatureMergeRequests, platformErr.Capability)
+				return
+			}
+			require.Error(err)
+			require.NotErrorIs(err, platform.ErrRepositoryFeatureDisabled)
+			assert.Equal(http.StatusNotFound, githubStatusCode(err))
+		})
+	}
+}
+
 // requestRecorder captures the method, path, and raw query of every request a
 // test server receives so parity tests can assert the canonical method and the
 // legacy delegate issued identical requests.

--- a/internal/server/e2etest/archive_disabled_feature_test.go
+++ b/internal/server/e2etest/archive_disabled_feature_test.go
@@ -109,13 +109,13 @@ func TestArchiveAPIRecoversWhenGitHubIssuesAreReenabledE2E(t *testing.T) {
 				updatedIssueSucceededOnce.Do(func() { close(updatedIssueSucceeded) })
 			}
 		case "/api/v3/repos/acme/widget/pulls":
-			_, _ = w.Write([]byte(`[]`))
+			http.Error(w, `{"message":"Not Found"}`, http.StatusNotFound)
 		case "/api/v3/rate_limit":
 			_, _ = w.Write([]byte(`{"resources":{"core":{"limit":5000,"remaining":4999,"reset":4102444800}}}`))
 		case "/api/v3/repos/acme/widget":
 			_, _ = w.Write([]byte(`{
 				"id":1,"node_id":"R_widget","name":"widget","full_name":"acme/widget",
-				"owner":{"login":"acme"}
+				"owner":{"login":"acme"},"has_pull_requests":false
 			}`))
 		case "/api/v3/repos/acme/widget/issues/17":
 			issueDetailCalls.Add(1)
@@ -228,6 +228,7 @@ func TestArchiveAPIRecoversWhenGitHubIssuesAreReenabledE2E(t *testing.T) {
 		ready := stateErr == nil && len(states) == 1 &&
 			historicalIssueListCalls.Load() >= 1 &&
 			states[0].IssuesCoverage == db.ArchiveCoverageUnsupported &&
+			states[0].MergeRequestsCoverage == db.ArchiveCoverageUnsupported &&
 			states[0].IssueInventory.Complete() && states[0].InitialCompletedAt != nil
 		if ready {
 			unsupportedGeneration = states[0].IssueInventory.Generation
@@ -258,6 +259,7 @@ func TestArchiveAPIRecoversWhenGitHubIssuesAreReenabledE2E(t *testing.T) {
 	require.NoError(err)
 	require.Len(states, 1)
 	assert.Equal(db.ArchiveCoverageSupported, states[0].IssuesCoverage)
+	assert.Equal(db.ArchiveCoverageUnsupported, states[0].MergeRequestsCoverage)
 	assert.True(states[0].IssueInventory.Complete())
 	assert.Greater(states[0].IssueInventory.Generation, unsupportedGeneration,
 		"successful maintenance must reopen the unsupported historical inventory")
@@ -269,6 +271,6 @@ func TestArchiveAPIRecoversWhenGitHubIssuesAreReenabledE2E(t *testing.T) {
 	require.Eventually(func() bool {
 		status, statusErr := api.HTTP.ListArchiveStatusWithResponse(ctx, nil)
 		return statusErr == nil && status.JSON200 != nil && len(*status.JSON200) == 1 &&
-			(*status.JSON200)[0].Status == generated.ArchiveStatusResponseStatusCurrent
+			(*status.JSON200)[0].Status == generated.ArchiveStatusResponseStatusPartial
 	}, 3*time.Second, 10*time.Millisecond)
 }


### PR DESCRIPTION
GitHub issue-only repositories return a bare 404 from the pulls API. Forge's archive worker treated that response as a repository failure, repeatedly logged warnings, and could not finish archive progress.

- Confirm the 404 against repository metadata and mark pull-request coverage unsupported only when GitHub explicitly reports `has_pull_requests=false`.
- Preserve ambiguous 404 failures so missing repositories and access problems remain visible.
- Reserve the metadata confirmation request in archive admission so authentication retries remain inside the protected request ceiling.

The repository remains tracked and issue archive collection continues. Archive status is partial because pull-request coverage is intentionally unsupported.

<sup>generated by a clanker</sup>
