### PR TITLE
feat: add manual detail refresh controls

### DIFF
--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -15,9 +15,12 @@ Use this document as the intent-level guide for frontend UI work in `kenn-forge`
 - Layouts should feel compact, deliberate, and information-rich.
 - Visual emphasis should come from hierarchy and semantic color, not oversized controls or decorative effects.
 - Light and dark themes should express the same UI language through shared tokens.
-- PR detail background refresh has one progress surface: the metadata-row
-  `Syncing` indicator; do not add a second stale-data banner or spinner
-  (`frontend/src/lib/components/detail/PullDetail.svelte`).
+- Detail background refresh uses the metadata-row `Syncing` indicator; a manual
+  Activity refresh reports progress only in its initiating icon button. Do not
+  add stale-data banners or other progress surfaces. Keep the manual control
+  disabled while detail is loading, stale for the current route, or already
+  syncing (`frontend/src/lib/components/detail/PullDetail.svelte::refreshDetail`,
+  `frontend/src/lib/components/detail/IssueDetail.svelte::refreshDetail`).
 - Inline conditional notices occupy layout only while active; do not reserve
   invisible rows for them (`frontend/src/lib/components/diff/DiffView.svelte`).
 

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -923,6 +923,9 @@ Not every visibility control means "remove this entity entirely."
   cannot surface newly persisted events older than unrelated leading rows.
   Selection generations gate only detail installation, not successful-read or
   successful-sync invalidation (`frontend/src/lib/stores/detail.svelte.ts::reconcileListsAfterDetailSync`, `frontend/src/lib/stores/issues.svelte.ts::reconcileListsAfterDetailSync`).
+- Detail poll paths — scheduled cycles and sync-completion refreshes — skip while provider
+  synchronization is active; overlap lets cached data supersede the authoritative response
+  (`frontend/src/lib/stores/detail.svelte.ts::startDetailPolling`, `frontend/src/lib/stores/issues.svelte.ts::startIssueDetailPolling`).
 - Activity full-snapshot projections are latest-successful-request-wins across
   foreground and convergence reads. Incremental polling neither claims snapshot
   authority nor overwrites a later claimed snapshot; replacement polling does

--- a/frontend/src/lib/components/detail/DetailRefreshButton.svelte
+++ b/frontend/src/lib/components/detail/DetailRefreshButton.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import RefreshCwIcon from "@lucide/svelte/icons/refresh-cw";
+  import { IconButton, Spinner } from "@kenn-io/kit-ui";
+
+  interface Props {
+    disabled?: boolean;
+    refreshing: boolean;
+    onRefresh: () => void;
+  }
+
+  let { disabled = false, refreshing, onRefresh }: Props = $props();
+</script>
+
+<IconButton
+  size="sm"
+  ariaLabel="Refresh detail"
+  title="Refresh detail"
+  disabled={disabled || refreshing}
+  onclick={onRefresh}
+>
+  {#if refreshing}
+    <Spinner size={14} label="Refreshing detail" />
+  {:else}
+    <RefreshCwIcon size={14} strokeWidth={2} aria-hidden="true" />
+  {/if}
+</IconButton>

--- a/frontend/src/lib/components/detail/DetailRefreshButton.test.ts
+++ b/frontend/src/lib/components/detail/DetailRefreshButton.test.ts
@@ -1,0 +1,34 @@
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { describe, expect, it, vi } from "vite-plus/test";
+import DetailRefreshButton from "./DetailRefreshButton.svelte";
+
+describe("DetailRefreshButton", () => {
+  it("requests a detail refresh from an accessible icon button", async () => {
+    const onRefresh = vi.fn();
+    render(DetailRefreshButton, { props: { refreshing: false, onRefresh } });
+
+    const button = screen.getByRole("button", { name: "Refresh detail" });
+    expect((button as HTMLButtonElement).disabled).toBe(false);
+    expect(button.getAttribute("title")).toBe("Refresh detail");
+
+    await fireEvent.click(button);
+
+    expect(onRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("disables repeat refreshes and exposes the busy state", () => {
+    render(DetailRefreshButton, { props: { refreshing: true, onRefresh: vi.fn() } });
+
+    expect((screen.getByRole("button", { name: "Refresh detail" }) as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByLabelText("Refreshing detail")).not.toBeNull();
+  });
+
+  it("can be disabled without presenting background work as a manual refresh", () => {
+    render(DetailRefreshButton, {
+      props: { disabled: true, refreshing: false, onRefresh: vi.fn() },
+    });
+
+    expect((screen.getByRole("button", { name: "Refresh detail" }) as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.queryByLabelText("Refreshing detail")).toBeNull();
+  });
+});

--- a/frontend/src/lib/components/detail/IssueDetail.svelte
+++ b/frontend/src/lib/components/detail/IssueDetail.svelte
@@ -25,6 +25,7 @@
   import EventTimeline from "./EventTimeline.svelte";
   import CollapsibleDescription from "./CollapsibleDescription.svelte";
   import DetailActivityViewMenu from "./DetailActivityViewMenu.svelte";
+  import DetailRefreshButton from "./DetailRefreshButton.svelte";
   import IssueCommentBox from "./IssueCommentBox.svelte";
   import WorkspaceCreateSplitButton from "../workspace/WorkspaceCreateSplitButton.svelte";
     import { Button, Chip, Modal } from "@kenn-io/kit-ui";
@@ -66,6 +67,47 @@
   const actions = getActions();
   const uiConfig = getUIConfig();
   const navigate = getNavigate();
+  let manualRefreshPending = $state(false);
+  let manualRefreshGeneration = 0;
+
+  function isCurrentManualRefresh(
+    requestGeneration: number,
+    requestIdentity: WorkspaceItemIdentity,
+  ): boolean {
+    return !componentDestroyed
+      && requestGeneration === manualRefreshGeneration
+      && identityEquals(requestIdentity, $state.snapshot(itemIdentity));
+  }
+
+  function refreshDetail(): void {
+    if (
+      manualRefreshPending
+      || issues.isIssueDetailLoading()
+      || issues.isIssueDetailSyncing()
+      || staleIssue
+    ) return;
+    const requestIdentity = $state.snapshot(itemIdentity);
+    const requestGeneration = ++manualRefreshGeneration;
+    manualRefreshPending = true;
+    issues.syncIssueDetailNow(
+      owner,
+      name,
+      number,
+      { provider, platformHost, repoPath },
+      {
+        onFailure: (message) => {
+          if (isCurrentManualRefresh(requestGeneration, requestIdentity)) {
+            showFlash(message, { tone: "danger" });
+          }
+        },
+        onSettled: () => {
+          if (isCurrentManualRefresh(requestGeneration, requestIdentity)) {
+            manualRefreshPending = false;
+          }
+        },
+      },
+    );
+  }
 
   const defaultProviderCapabilities: ProviderCapabilities = {
     read_repositories: true,
@@ -232,6 +274,9 @@
     issues.deleteIssueComment(owner, name, number, event.PlatformID, callbacks);
   }
 
+  let lastDetailLoadIdentity: WorkspaceItemIdentity | null = null;
+  let lastDetailLoadAutoSync: IssueDetailSyncMode | undefined;
+
   $effect(() => {
     const requestOwner = owner;
     const requestName = name;
@@ -240,18 +285,29 @@
     const requestPlatformHost = platformHost;
     const requestRepoPath = repoPath;
     const requestAutoSync = autoSync;
+    const requestIdentity = $state.snapshot(itemIdentity);
+    const shouldLoad =
+      lastDetailLoadIdentity === null
+      || !identityEquals(lastDetailLoadIdentity, requestIdentity)
+      || lastDetailLoadAutoSync !== requestAutoSync;
+    if (shouldLoad) {
+      lastDetailLoadIdentity = requestIdentity;
+      lastDetailLoadAutoSync = requestAutoSync;
+    }
     untrack(() => {
-      issues.loadIssueDetail(
-        requestOwner,
-        requestName,
-        requestNumber,
-        {
-          sync: requestAutoSync,
-          provider: requestProvider,
-          platformHost: requestPlatformHost,
-          repoPath: requestRepoPath,
-        },
-      );
+      if (shouldLoad) {
+        issues.loadIssueDetail(
+          requestOwner,
+          requestName,
+          requestNumber,
+          {
+            sync: requestAutoSync,
+            provider: requestProvider,
+            platformHost: requestPlatformHost,
+            repoPath: requestRepoPath,
+          },
+        );
+      }
       issues.startIssueDetailPolling(
         requestOwner,
         requestName,
@@ -287,6 +343,8 @@
     const current = $state.snapshot(itemIdentity);
     if (lastResetIdentity !== null && identityEquals(lastResetIdentity, current)) return;
     lastResetIdentity = current;
+    manualRefreshGeneration += 1;
+    manualRefreshPending = false;
     workspaceRequestGen += 1;
     branchConflict = null;
     pendingWorkspaceLaunchTarget = null;
@@ -1143,7 +1201,7 @@
           Couldn't load this issue: {issues.getIssueDetailError()}
         </div>
       {/if}
-      {#if issues.isIssueStaleRefreshing()}
+      {#if issues.isIssueStaleRefreshing() && !manualRefreshPending}
         <div class="refresh-banner">
           <StatusDot status="working" label="Refreshing issue details" size={5} />
           <span aria-hidden="true">Refreshing...</span>
@@ -1260,7 +1318,7 @@
             </div>
           {/if}
         {/if}
-        {#if issues.isIssueDetailSyncing()}
+        {#if issues.isIssueDetailSyncing() && !manualRefreshPending}
           <span class="meta-sep">·</span>
           <span class="sync-indicator" title="Syncing from GitHub">
             <Spinner size={12} label="Syncing" />
@@ -1460,10 +1518,17 @@
       <div class="section">
         <div class="section-title-row">
           <h3 class="section-title">Activity</h3>
-          <DetailActivityViewMenu
-            viewMode={detailActivityView.getMode()}
-            onViewChange={(mode) => detailActivityView.setMode(mode)}
-          />
+          <div class="section-title-actions">
+            <DetailRefreshButton
+              disabled={issues.isIssueDetailLoading() || issues.isIssueDetailSyncing() || staleIssue}
+              refreshing={manualRefreshPending}
+              onRefresh={refreshDetail}
+            />
+            <DetailActivityViewMenu
+              viewMode={detailActivityView.getMode()}
+              onViewChange={(mode) => detailActivityView.setMode(mode)}
+            />
+          </div>
         </div>
         {#if issues.getIssueDetailLoaded()}
           <EventTimeline
@@ -1788,6 +1853,12 @@
     align-items: center;
     justify-content: space-between;
     gap: 12px;
+  }
+
+  .section-title-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
   }
 
   .section-title {

--- a/frontend/src/lib/components/detail/IssueDetail.test.ts
+++ b/frontend/src/lib/components/detail/IssueDetail.test.ts
@@ -8,6 +8,7 @@ import type { IssueDetail, Label } from "../../api/types.js";
 import type { MutationCallbacks } from "../../stores/ordered-mutations.js";
 import { ACTIONS_KEY, NAVIGATE_KEY, STORES_KEY, UI_CONFIG_KEY } from "../../context.js";
 import { createDetailActivityViewStore } from "../../stores/detail-activity-view.svelte.js";
+import { createIssuesStore } from "../../stores/issues.svelte.js";
 import { makeTestAppRuntime } from "../../testing/effect-layers.js";
 import { dismissFlash, getFlashes } from "../../stores/flash.svelte.js";
 import {
@@ -182,6 +183,10 @@ function renderIssueDetail(
   ),
   options: {
     staleRefreshing?: boolean;
+    detailLoading?: boolean;
+    detailSyncing?: boolean;
+    deferRefresh?: boolean;
+    refreshFailure?: string;
     inlineWorkspace?: InlineWorkspaceController | null;
     actions?: ActionRegistry;
     runtimeClient?: GeneratedClient;
@@ -192,17 +197,30 @@ function renderIssueDetail(
   },
 ) {
   let envelopeTick = 0;
+  let pendingRefreshCallbacks: MutationCallbacks | null = null;
   const issuesStore = {
     loadIssueDetail: vi.fn(),
     startIssueDetailPolling: vi.fn(),
     stopIssueDetailPolling: vi.fn(),
     getIssueDetail: () => detail,
     getIssueDetailEnvelopeTick: () => envelopeTick,
-    isIssueDetailLoading: () => false,
+    isIssueDetailLoading: () => options.detailLoading ?? false,
     getIssueDetailError: () => null,
     isIssueStaleRefreshing: () => options.staleRefreshing ?? false,
-    isIssueDetailSyncing: () => false,
+    isIssueDetailSyncing: () => options.detailSyncing ?? false,
     getIssueDetailLoaded: () => true,
+    syncIssueDetailNow: vi.fn(
+      (_owner: string, _name: string, _number: number, _identity: unknown, callbacks: MutationCallbacks) => {
+        if (options.deferRefresh) {
+          options.detailSyncing = true;
+          pendingRefreshCallbacks = callbacks;
+          return;
+        }
+        if (options.refreshFailure) callbacks.onFailure?.(options.refreshFailure);
+        else callbacks.onSuccess?.();
+        callbacks.onSettled?.();
+      },
+    ),
     loadIssues: vi.fn(),
     updateIssueKanbanState: vi.fn(),
     toggleIssueStar: vi.fn(),
@@ -259,6 +277,18 @@ function renderIssueDetail(
     deleteIssueComment,
     issuesStore,
     navigate,
+    settleRefresh: () => {
+      options.detailSyncing = false;
+      pendingRefreshCallbacks?.onSuccess?.();
+      pendingRefreshCallbacks?.onSettled?.();
+      pendingRefreshCallbacks = null;
+    },
+    failRefresh: (message: string) => {
+      options.detailSyncing = false;
+      pendingRefreshCallbacks?.onFailure?.(message);
+      pendingRefreshCallbacks?.onSettled?.();
+      pendingRefreshCallbacks = null;
+    },
     setEnvelopeTick: (tick: number) => {
       envelopeTick = tick;
     },
@@ -272,6 +302,7 @@ describe("IssueDetail activity view", () => {
 
   afterEach(() => {
     cleanup();
+    for (const item of getFlashes()) dismissFlash(item.id);
   });
 
   it("offers compact activity rows from the shared View menu without PR filters", async () => {
@@ -288,6 +319,153 @@ describe("IssueDetail activity view", () => {
     expect(localStorage.getItem("kenn-forge-detail-activity-view")).toBe("compact");
     expect(container.querySelectorAll(".event-card--compact-row")).toHaveLength(1);
     expect(container.textContent).toContain("Issue activity preview");
+  });
+
+  it("refreshes the whole selected issue from the Activity header", async () => {
+    const { issuesStore } = renderIssueDetail(issueDetail());
+
+    await fireEvent.click(screen.getByRole("button", { name: "Refresh detail" }));
+
+    expect(issuesStore.syncIssueDetailNow).toHaveBeenCalledWith(
+      "acme",
+      "widget",
+      7,
+      {
+        provider: "github",
+        platformHost: "github.com",
+        repoPath: "acme/widget",
+      },
+      expect.objectContaining({ onFailure: expect.any(Function) }),
+    );
+  });
+
+  it("tracks manual refresh progress separately and reports issue sync failures", async () => {
+    renderIssueDetail(issueDetail(), undefined, { refreshFailure: "provider unavailable" });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Refresh detail" }));
+    expect(getFlashes()).toEqual([expect.objectContaining({ message: "provider unavailable", tone: "danger" })]);
+
+    cleanup();
+    const { settleRefresh } = renderIssueDetail(issueDetail(), undefined, { deferRefresh: true });
+    await fireEvent.click(screen.getByRole("button", { name: "Refresh detail" }));
+    expect((screen.getByRole("button", { name: "Refresh detail" }) as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByLabelText("Refreshing detail")).toBeTruthy();
+    expect(document.querySelector(".sync-indicator")).toBeNull();
+
+    settleRefresh();
+    await waitFor(() => {
+      expect((screen.getByRole("button", { name: "Refresh detail" }) as HTMLButtonElement).disabled).toBe(false);
+    });
+  });
+
+  it("does not present a background issue sync as a manual refresh", () => {
+    renderIssueDetail(issueDetail(), undefined, { detailSyncing: true });
+
+    expect((screen.getByRole("button", { name: "Refresh detail" }) as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.queryByLabelText("Refreshing detail")).toBeNull();
+    expect(document.querySelector(".sync-indicator")?.textContent).toContain("Syncing");
+  });
+
+  it("blocks manual refresh while issue detail navigation is loading or stale", async () => {
+    const loading = renderIssueDetail(issueDetail(), undefined, { detailLoading: true });
+    const loadingButton = screen.getByRole("button", { name: "Refresh detail" });
+
+    expect((loadingButton as HTMLButtonElement).disabled).toBe(true);
+    await fireEvent.click(loadingButton);
+    expect(loading.issuesStore.syncIssueDetailNow).not.toHaveBeenCalled();
+
+    cleanup();
+    const navigating = renderIssueDetail(issueDetail());
+    await navigating.rerender({ number: 8 });
+    const staleButton = screen.getByRole("button", { name: "Refresh detail" });
+
+    expect((staleButton as HTMLButtonElement).disabled).toBe(true);
+    await fireEvent.click(staleButton);
+    expect(navigating.issuesStore.syncIssueDetailNow).not.toHaveBeenCalled();
+  });
+
+  it("drops pending manual refresh UI and late failures after an issue reroute", async () => {
+    const { failRefresh, rerender } = renderIssueDetail(issueDetail(), undefined, { deferRefresh: true });
+    await fireEvent.click(screen.getByRole("button", { name: "Refresh detail" }));
+    expect(screen.getByLabelText("Refreshing detail")).toBeTruthy();
+
+    await rerender({ number: 8 });
+
+    await waitFor(() => expect(screen.queryByLabelText("Refreshing detail")).toBeNull());
+
+    failRefresh("old issue failed");
+    expect(getFlashes()).toHaveLength(0);
+  });
+
+  it("drops a manual refresh failure after the issue detail unmounts", async () => {
+    const { failRefresh, unmount } = renderIssueDetail(issueDetail(), undefined, { deferRefresh: true });
+    await fireEvent.click(screen.getByRole("button", { name: "Refresh detail" }));
+
+    unmount();
+    failRefresh("unmounted issue failed");
+
+    expect(getFlashes()).toHaveLength(0);
+  });
+
+  it("keeps a pending issue refresh across an equivalent route alias", async () => {
+    const { failRefresh, rerender } = renderIssueDetail(issueDetail(), undefined, { deferRefresh: true });
+    await fireEvent.click(screen.getByRole("button", { name: "Refresh detail" }));
+
+    await rerender({ provider: "gh", platformHost: undefined });
+
+    expect(screen.getByLabelText("Refreshing detail")).toBeTruthy();
+    failRefresh("current issue failed");
+    expect(getFlashes()).toEqual([expect.objectContaining({ message: "current issue failed" })]);
+  });
+
+  it("preserves a real issue-store refresh across an equivalent route alias", async () => {
+    const cached = issueDetail();
+    cached.issue.Title = "Cached issue detail";
+    const fresh = issueDetail();
+    fresh.issue.Title = "Fresh issue detail";
+    const syncResponse = Promise.withResolvers<{ data: IssueDetail; error: undefined }>();
+    const get = vi.fn(async () => ({ data: cached, error: undefined }));
+    const post = vi.fn(() => syncResponse.promise);
+    issueRuntime = makeTestAppRuntime({ GET: get, POST: post } as unknown as GeneratedClient);
+    const issuesStore = createIssuesStore({ runtime: issueRuntime });
+    let detailProps: ComponentProps<typeof IssueDetailComponent> = {
+      owner: "acme",
+      name: "widget",
+      number: 7,
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widget",
+      autoSync: false,
+    };
+    const rendered = render(IssueDetailTestHarness, {
+      props: { runtime: issueRuntime, detailProps },
+      context: new Map<symbol, unknown>([
+        [
+          STORES_KEY,
+          {
+            issues: issuesStore,
+            activity: { loadActivity: vi.fn() },
+            detailActivityView: createDetailActivityViewStore(),
+            settings: { getLaunchTargets: () => launchTargets },
+          },
+        ],
+        [ACTIONS_KEY, { issue: [] }],
+        [UI_CONFIG_KEY, { hideStar: true }],
+        [NAVIGATE_KEY, vi.fn()],
+      ]),
+    });
+    await waitFor(() => expect(get).toHaveBeenCalledOnce());
+    await waitFor(() => expect(issuesStore.isIssueDetailLoading()).toBe(false));
+
+    await fireEvent.click(screen.getByRole("button", { name: "Refresh detail" }));
+    await waitFor(() => expect(issuesStore.isIssueDetailSyncing()).toBe(true));
+    detailProps = { ...detailProps, provider: "gh", platformHost: undefined };
+    await rendered.rerender({ runtime: issueRuntime, detailProps });
+    syncResponse.resolve({ data: fresh, error: undefined });
+
+    await waitFor(() => expect(screen.queryByLabelText("Refreshing detail")).toBeNull());
+    expect(get).toHaveBeenCalledOnce();
+    expect(issuesStore.getIssueDetail()?.issue.Title).toBe("Fresh issue detail");
   });
 
   it("explains that creating a workspace enables agent sessions", () => {

--- a/frontend/src/lib/components/detail/PullDetail.svelte
+++ b/frontend/src/lib/components/detail/PullDetail.svelte
@@ -37,6 +37,7 @@
   import EventTimeline from "./EventTimeline.svelte";
   import CollapsibleDescription from "./CollapsibleDescription.svelte";
   import DetailActivityViewMenu from "./DetailActivityViewMenu.svelte";
+  import DetailRefreshButton from "./DetailRefreshButton.svelte";
   import CommentBox from "./CommentBox.svelte";
   import ApproveButton from "./ApproveButton.svelte";
   import ApproveWorkflowsButton from "./ApproveWorkflowsButton.svelte";
@@ -128,6 +129,47 @@
   const actions = getActions();
   const uiConfig = getUIConfig();
   const navigate = getNavigate();
+  let manualRefreshPending = $state(false);
+  let manualRefreshGeneration = 0;
+
+  function isCurrentManualRefresh(
+    requestGeneration: number,
+    requestIdentity: WorkspaceItemIdentity,
+  ): boolean {
+    return !componentDestroyed
+      && requestGeneration === manualRefreshGeneration
+      && identityEquals(requestIdentity, $state.snapshot(itemIdentity));
+  }
+
+  function refreshDetail(): void {
+    if (
+      manualRefreshPending
+      || detailStore.isDetailLoading()
+      || detailStore.isDetailSyncing()
+      || stalePR
+    ) return;
+    const requestIdentity = $state.snapshot(itemIdentity);
+    const requestGeneration = ++manualRefreshGeneration;
+    manualRefreshPending = true;
+    detailStore.syncDetailNow(
+      owner,
+      name,
+      number,
+      { provider, platformHost, repoPath },
+      {
+        onFailure: (message) => {
+          if (isCurrentManualRefresh(requestGeneration, requestIdentity)) {
+            showFlash(message, { tone: "danger" });
+          }
+        },
+        onSettled: () => {
+          if (isCurrentManualRefresh(requestGeneration, requestIdentity)) {
+            manualRefreshPending = false;
+          }
+        },
+      },
+    );
+  }
 
   const defaultProviderCapabilities: ProviderCapabilities = {
     read_repositories: true,
@@ -543,6 +585,10 @@
     return execution.interrupt;
   });
 
+  let lastDetailLoadIdentity: WorkspaceItemIdentity | null = null;
+  let lastDetailLoadAutoSync: DetailSyncMode | undefined;
+  let lastDetailLoadWorkflowApprovalSync: boolean | undefined;
+
   $effect(() => {
     const requestOwner = owner;
     const requestName = name;
@@ -552,19 +598,32 @@
     const requestRepoPath = repoPath;
     const requestAutoSync = autoSync;
     const requestWorkflowApprovalSync = workflowApprovalSync;
+    const requestIdentity = $state.snapshot(itemIdentity);
+    const shouldLoad =
+      lastDetailLoadIdentity === null
+      || !identityEquals(lastDetailLoadIdentity, requestIdentity)
+      || lastDetailLoadAutoSync !== requestAutoSync
+      || lastDetailLoadWorkflowApprovalSync !== requestWorkflowApprovalSync;
+    if (shouldLoad) {
+      lastDetailLoadIdentity = requestIdentity;
+      lastDetailLoadAutoSync = requestAutoSync;
+      lastDetailLoadWorkflowApprovalSync = requestWorkflowApprovalSync;
+    }
     untrack(() => {
-      detailStore.loadDetail(
-        requestOwner,
-        requestName,
-        requestNumber,
-        {
-          sync: requestAutoSync,
-          workflowApprovalSync: requestWorkflowApprovalSync,
-          provider: requestProvider,
-          platformHost: requestPlatformHost,
-          repoPath: requestRepoPath,
-        },
-      );
+      if (shouldLoad) {
+        detailStore.loadDetail(
+          requestOwner,
+          requestName,
+          requestNumber,
+          {
+            sync: requestAutoSync,
+            workflowApprovalSync: requestWorkflowApprovalSync,
+            provider: requestProvider,
+            platformHost: requestPlatformHost,
+            repoPath: requestRepoPath,
+          },
+        );
+      }
       detailStore.startDetailPolling(
         requestOwner,
         requestName,
@@ -621,6 +680,8 @@
     const current = $state.snapshot(itemIdentity);
     if (lastResetIdentity !== null && identityEquals(lastResetIdentity, current)) return;
     lastResetIdentity = current;
+    manualRefreshGeneration += 1;
+    manualRefreshPending = false;
     mutationRouteGeneration = untrack(() => mutationRouteGeneration) + 1;
     wsRequestGen += 1;
     // The generation bump above stops an in-flight create's finally from
@@ -2097,7 +2158,7 @@
             >{pr.BaseBranch}</button>
           </span>
         {/if}
-        {#if detailStore.isDetailSyncing()}
+        {#if detailStore.isDetailSyncing() && !manualRefreshPending}
           <span class="meta-sep meta-sep--sync">·</span>
           <span class="sync-indicator" title="Syncing from GitHub">
             <Spinner size={12} label="Syncing" />
@@ -2980,14 +3041,21 @@
       <div class="section">
         <div class="section-title-row">
           <h3 class="section-title">Activity</h3>
-          <DetailActivityViewMenu
-            viewMode={detailActivityView.getMode()}
-            onViewChange={(mode) => detailActivityView.setMode(mode)}
-            timelineOrder={detailActivityView.getOrder()}
-            onOrderChange={(order) => detailActivityView.setOrder(order)}
-            filter={timelineFilter}
-            onFilterChange={updateTimelineFilter}
-          />
+          <div class="section-title-actions">
+            <DetailRefreshButton
+              disabled={detailStore.isDetailLoading() || detailStore.isDetailSyncing() || stalePR}
+              refreshing={manualRefreshPending}
+              onRefresh={refreshDetail}
+            />
+            <DetailActivityViewMenu
+              viewMode={detailActivityView.getMode()}
+              onViewChange={(mode) => detailActivityView.setMode(mode)}
+              timelineOrder={detailActivityView.getOrder()}
+              onOrderChange={(order) => detailActivityView.setOrder(order)}
+              filter={timelineFilter}
+              onFilterChange={updateTimelineFilter}
+            />
+          </div>
         </div>
         {#if detailStore.getDetailLoaded()}
           <EventTimeline
@@ -3639,6 +3707,12 @@
     align-items: center;
     justify-content: space-between;
     gap: 12px;
+  }
+
+  .section-title-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
   }
 
   .section-title {

--- a/frontend/src/lib/components/detail/PullDetail.test.ts
+++ b/frontend/src/lib/components/detail/PullDetail.test.ts
@@ -19,7 +19,7 @@ import {
 import type { GeneratedClient } from "../../api/generated-api.js";
 import type { ProblemBody } from "../../api/problems.js";
 import type { ProviderRouteRef } from "../../api/provider-routes.js";
-import type { MergePullCallbacks, ProviderActionCallbacks } from "../../stores/detail.svelte.js";
+import type { DetailSyncCallbacks, MergePullCallbacks, ProviderActionCallbacks } from "../../stores/detail.svelte.js";
 import type { InlineWorkspaceController, WorkspaceItemIdentity } from "../../workspace-inline.js";
 import { openLabelPickerFor } from "./labelPickerCommand.js";
 import { createTestController } from "../workspace/inlineWorkspaceTestController.svelte.js";
@@ -227,7 +227,10 @@ function renderPullDetail(
     hideWorkspaceAction?: boolean;
     hideTabs?: boolean;
     actions?: { pull: unknown[] };
+    detailLoading?: boolean;
     detailSyncing?: boolean;
+    deferRefresh?: boolean;
+    refreshFailure?: string;
     diff?: ReturnType<typeof makeReviewSuggestionDiffStore>;
     diffReviewDraft?: { setRouteContext: ReturnType<typeof vi.fn>; isSubmitting: () => boolean };
     inlineWorkspace?: InlineWorkspaceController | null;
@@ -237,6 +240,7 @@ function renderPullDetail(
 ) {
   const actions = options.actions ?? { pull: [] };
   let envelopeTick = 0;
+  let pendingRefreshCallbacks: DetailSyncCallbacks | null = null;
   const runProviderAction = (path: string, body: unknown, callbacks: ProviderActionCallbacks): void => {
     void apiClient.POST(path, { body }).then((result) => {
       const error = "error" in result ? (result.error as ProblemBody | undefined) : undefined;
@@ -281,7 +285,7 @@ function renderPullDetail(
     stopDetailPolling: vi.fn(),
     getDetail: () => detail,
     getDetailEnvelopeTick: () => envelopeTick,
-    isDetailLoading: () => false,
+    isDetailLoading: () => options.detailLoading ?? false,
     getDetailError: () => null,
     isDetailSyncing: () => options.detailSyncing ?? false,
     getDetailLoaded: () => true,
@@ -296,14 +300,15 @@ function renderPullDetail(
     updatePRContent: vi.fn(),
     refreshPendingCI: vi.fn(async () => undefined),
     syncDetailNow: vi.fn(
-      (
-        _owner: string,
-        _name: string,
-        _number: number,
-        _identity: unknown,
-        callbacks: { onSuccess?: (value: boolean) => void },
-      ) => {
-        callbacks.onSuccess?.(true);
+      (_owner: string, _name: string, _number: number, _identity: unknown, callbacks: DetailSyncCallbacks) => {
+        if (options.deferRefresh) {
+          options.detailSyncing = true;
+          pendingRefreshCallbacks = callbacks;
+          return;
+        }
+        if (options.refreshFailure) callbacks.onFailure?.(options.refreshFailure);
+        else callbacks.onSuccess?.(true);
+        callbacks.onSettled?.();
       },
     ),
     refreshDetailOnly: vi.fn(
@@ -394,6 +399,18 @@ function renderPullDetail(
     },
     detailStore,
     navigate,
+    settleRefresh: () => {
+      options.detailSyncing = false;
+      pendingRefreshCallbacks?.onSuccess?.(true);
+      pendingRefreshCallbacks?.onSettled?.();
+      pendingRefreshCallbacks = null;
+    },
+    failRefresh: (message: string) => {
+      options.detailSyncing = false;
+      pendingRefreshCallbacks?.onFailure?.(message);
+      pendingRefreshCallbacks?.onSettled?.();
+      pendingRefreshCallbacks = null;
+    },
     setEnvelopeTick: (tick: number) => {
       envelopeTick = tick;
     },
@@ -518,6 +535,177 @@ function getActionMenuLabelsButton(): HTMLButtonElement {
   }
   return button;
 }
+
+describe("PullDetail activity refresh", () => {
+  afterEach(() => {
+    cleanup();
+    for (const item of getFlashes()) dismissFlash(item.id);
+  });
+
+  it("refreshes the whole selected pull request from the Activity header", async () => {
+    const { detailStore } = renderPullDetail(pullDetail());
+
+    await fireEvent.click(screen.getByRole("button", { name: "Refresh detail" }));
+
+    expect(detailStore.syncDetailNow).toHaveBeenCalledWith(
+      "acme",
+      "widget",
+      1,
+      {
+        provider: "github",
+        platformHost: "github.com",
+        repoPath: "acme/widget",
+      },
+      expect.objectContaining({ onFailure: expect.any(Function) }),
+    );
+  });
+
+  it("tracks manual refresh progress separately and reports pull-request sync failures", async () => {
+    renderPullDetail(pullDetail(), undefined, undefined, {
+      refreshFailure: "provider unavailable",
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Refresh detail" }));
+    expect(getFlashes()).toEqual([expect.objectContaining({ message: "provider unavailable", tone: "danger" })]);
+
+    cleanup();
+    const { settleRefresh } = renderPullDetail(pullDetail(), undefined, undefined, { deferRefresh: true });
+    await fireEvent.click(screen.getByRole("button", { name: "Refresh detail" }));
+    expect((screen.getByRole("button", { name: "Refresh detail" }) as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByLabelText("Refreshing detail")).toBeTruthy();
+    expect(document.querySelector(".sync-indicator")).toBeNull();
+
+    settleRefresh();
+    await waitFor(() => {
+      expect((screen.getByRole("button", { name: "Refresh detail" }) as HTMLButtonElement).disabled).toBe(false);
+    });
+  });
+
+  it("does not present a background pull-request sync as a manual refresh", () => {
+    renderPullDetail(pullDetail(), undefined, undefined, { detailSyncing: true });
+
+    expect((screen.getByRole("button", { name: "Refresh detail" }) as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.queryByLabelText("Refreshing detail")).toBeNull();
+    expect(document.querySelector(".sync-indicator")?.textContent).toContain("Syncing");
+  });
+
+  it("blocks manual refresh while pull-request detail navigation is loading or stale", async () => {
+    const loading = renderPullDetail(pullDetail(), undefined, undefined, { detailLoading: true });
+    const loadingButton = screen.getByRole("button", { name: "Refresh detail" });
+
+    expect((loadingButton as HTMLButtonElement).disabled).toBe(true);
+    await fireEvent.click(loadingButton);
+    expect(loading.detailStore.syncDetailNow).not.toHaveBeenCalled();
+
+    cleanup();
+    const navigating = renderPullDetail(pullDetail());
+    await navigating.rerender({ number: 2 });
+    const staleButton = screen.getByRole("button", { name: "Refresh detail" });
+
+    expect((staleButton as HTMLButtonElement).disabled).toBe(true);
+    await fireEvent.click(staleButton);
+    expect(navigating.detailStore.syncDetailNow).not.toHaveBeenCalled();
+  });
+
+  it("drops pending manual refresh UI and late failures after a pull-request reroute", async () => {
+    const { failRefresh, rerender } = renderPullDetail(pullDetail(), undefined, undefined, { deferRefresh: true });
+    await fireEvent.click(screen.getByRole("button", { name: "Refresh detail" }));
+    expect(screen.getByLabelText("Refreshing detail")).toBeTruthy();
+
+    await rerender({ number: 2 });
+
+    await waitFor(() => expect(screen.queryByLabelText("Refreshing detail")).toBeNull());
+
+    failRefresh("old pull request failed");
+    expect(getFlashes()).toHaveLength(0);
+  });
+
+  it("drops a manual refresh failure after the pull-request detail unmounts", async () => {
+    const { failRefresh, unmount } = renderPullDetail(pullDetail(), undefined, undefined, { deferRefresh: true });
+    await fireEvent.click(screen.getByRole("button", { name: "Refresh detail" }));
+
+    unmount();
+    failRefresh("unmounted pull request failed");
+
+    expect(getFlashes()).toHaveLength(0);
+  });
+
+  it("keeps a pending pull-request refresh across an equivalent route alias", async () => {
+    const { failRefresh, rerender } = renderPullDetail(pullDetail(), undefined, undefined, { deferRefresh: true });
+    await fireEvent.click(screen.getByRole("button", { name: "Refresh detail" }));
+
+    await rerender({ provider: "gh", platformHost: undefined });
+
+    expect(screen.getByLabelText("Refreshing detail")).toBeTruthy();
+    failRefresh("current pull request failed");
+    expect(getFlashes()).toEqual([expect.objectContaining({ message: "current pull request failed" })]);
+  });
+
+  it("preserves a real pull-request store refresh across an equivalent route alias", async () => {
+    const cached = pullDetail();
+    cached.merge_request.Title = "Cached pull request detail";
+    const fresh = pullDetail();
+    fresh.merge_request.Title = "Fresh pull request detail";
+    const syncResponse = Promise.withResolvers<{ data: PullDetail; error: undefined }>();
+    const get = vi.fn(async (path: string) =>
+      path.startsWith("/pulls/")
+        ? { data: cached, error: undefined }
+        : {
+            data: {
+              AllowSquashMerge: false,
+              AllowMergeCommit: false,
+              AllowRebaseMerge: false,
+              ViewerCanMerge: true,
+            },
+            error: undefined,
+          },
+    );
+    const post = vi.fn(() => syncResponse.promise);
+    detailRuntime = makeTestAppRuntime({ GET: get, POST: post } as unknown as GeneratedClient);
+    const detailStore = createDetailStore({ runtime: detailRuntime });
+    let detailProps: ComponentProps<typeof PullDetailComponent> = {
+      owner: "acme",
+      name: "widget",
+      number: cached.merge_request.Number,
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widget",
+      hideWorkspaceAction: true,
+      autoSync: false,
+    };
+    const rendered = render(PullDetailTestHarness, {
+      props: { runtime: detailRuntime, detailProps },
+      context: new Map<symbol, unknown>([
+        [
+          STORES_KEY,
+          {
+            detail: detailStore,
+            pulls: { loadPulls: vi.fn() },
+            activity: { loadActivity: vi.fn() },
+            detailActivityView: createDetailActivityViewStore(),
+            settings: { getLaunchTargets: () => launchTargets },
+          },
+        ],
+        [ACTIONS_KEY, { pull: [] }],
+        [UI_CONFIG_KEY, { hideStar: true }],
+        [NAVIGATE_KEY, vi.fn()],
+      ]),
+    });
+    const detailGets = () => get.mock.calls.filter(([path]) => path.startsWith("/pulls/"));
+    await waitFor(() => expect(detailGets()).toHaveLength(1));
+    await waitFor(() => expect(detailStore.isDetailLoading()).toBe(false));
+
+    await fireEvent.click(screen.getByRole("button", { name: "Refresh detail" }));
+    await waitFor(() => expect(detailStore.isDetailSyncing()).toBe(true));
+    detailProps = { ...detailProps, provider: "gh", platformHost: undefined };
+    await rendered.rerender({ runtime: detailRuntime, detailProps });
+    syncResponse.resolve({ data: fresh, error: undefined });
+
+    await waitFor(() => expect(screen.queryByLabelText("Refreshing detail")).toBeNull());
+    expect(detailGets()).toHaveLength(1);
+    expect(detailStore.getDetail()?.merge_request.Title).toBe("Fresh pull request detail");
+  });
+});
 
 describe("PullDetail approvals", () => {
   beforeEach(() => {

--- a/frontend/src/lib/stores/detail.svelte.test.ts
+++ b/frontend/src/lib/stores/detail.svelte.test.ts
@@ -772,6 +772,101 @@ describe("createDetailStore", () => {
     expect(store.getDetail()).toBeNull();
   });
 
+  it("skips a scheduled poll while an explicit detail sync is pending", async () => {
+    vi.useFakeTimers();
+    const syncResponse = Promise.withResolvers<{ data: PullDetail; error: undefined }>();
+    const post = vi.fn((path: string) =>
+      path.endsWith("/sync") ? syncResponse.promise : Promise.resolve({ data: undefined, error: undefined }),
+    );
+    const store = createDetailStore({ client: mockClient({ POST: post }) });
+    store.startDetailPolling("acme", "widget", 7, {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widget",
+    });
+
+    const syncing = syncDetail(store, "acme", "widget", 7, {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widget",
+    });
+    await vi.waitFor(() => expect(post).toHaveBeenCalledOnce());
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(post).toHaveBeenCalledTimes(1);
+    syncResponse.resolve({ data: pullDetail("fresh-head"), error: undefined });
+    await expect(syncing).resolves.toBe(true);
+    expect(store.getDetail()?.platform_head_sha).toBe("fresh-head");
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(post).toHaveBeenCalledTimes(2);
+    store.stopDetailPolling();
+  });
+
+  it("skips sync-completion refreshes while an explicit detail sync is pending", async () => {
+    const syncResponse = Promise.withResolvers<{ data: PullDetail; error: undefined }>();
+    const get = vi.fn().mockResolvedValue({ data: pullDetail("cached-head"), error: undefined });
+    const post = vi.fn(() => syncResponse.promise);
+    let notifySyncComplete: (() => void) | undefined;
+    const store = createDetailStore({
+      client: mockClient({ GET: get, POST: post }),
+      sync: {
+        subscribeSyncComplete: (callback) => {
+          notifySyncComplete = callback;
+          return vi.fn();
+        },
+      },
+    });
+    store.startDetailPolling("acme", "widget", 7, {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widget",
+    });
+
+    const syncing = syncDetail(store, "acme", "widget", 7, {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widget",
+    });
+    await vi.waitFor(() => expect(store.isDetailSyncing()).toBe(true));
+    notifySyncComplete?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(get).not.toHaveBeenCalled();
+    syncResponse.resolve({ data: pullDetail("fresh-head"), error: undefined });
+    await expect(syncing).resolves.toBe(true);
+    expect(store.getDetail()?.platform_head_sha).toBe("fresh-head");
+    store.stopDetailPolling();
+  });
+
+  it("skips pending CI refreshes while an explicit detail sync is pending", async () => {
+    const syncResponse = Promise.withResolvers<{ data: PullDetail; error: undefined }>();
+    const get = vi.fn().mockResolvedValue({ data: pullDetail("cached-head"), error: undefined });
+    const post = vi.fn((path: string) =>
+      path.endsWith("/sync")
+        ? syncResponse.promise
+        : Promise.resolve({ data: pullDetail("cached-head"), error: undefined }),
+    );
+    const store = createDetailStore({ client: mockClient({ GET: get, POST: post }) });
+    const routeIdentity = {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widget",
+    };
+    await loadDetail(store, "acme", "widget", 7, { ...routeIdentity, sync: false });
+
+    const syncing = syncDetail(store, "acme", "widget", 7, routeIdentity);
+    await vi.waitFor(() => expect(store.isDetailSyncing()).toBe(true));
+    const ciSettled = vi.fn();
+    store.refreshPendingCI("acme", "widget", 7, routeIdentity, { onSettled: ciSettled });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(post).toHaveBeenCalledOnce();
+    expect(ciSettled).toHaveBeenCalledOnce();
+    syncResponse.resolve({ data: pullDetail("fresh-head"), error: undefined });
+    await expect(syncing).resolves.toBe(true);
+    expect(store.getDetail()?.platform_head_sha).toBe("fresh-head");
+  });
+
   it("reconciles visible lists when selection closes during an explicit detail sync", async () => {
     const syncPost = Promise.withResolvers<{ data: PullDetail; error: undefined }>();
     const post = vi.fn(() => syncPost.promise);

--- a/frontend/src/lib/stores/detail.svelte.ts
+++ b/frontend/src/lib/stores/detail.svelte.ts
@@ -1282,7 +1282,7 @@ export function createDetailStore(opts: DetailStoreOptions) {
     callbacks: DetailRefreshCallbacks = {},
   ): void {
     const ref = detailRequestRef(owner, name, number, identity);
-    if (!isDetailShowingRef(ref)) {
+    if (syncing || !isDetailShowingRef(ref)) {
       callbacks.onSettled?.();
       return;
     }
@@ -1944,7 +1944,9 @@ export function createDetailStore(opts: DetailStoreOptions) {
       unsubSyncComplete = null;
     }
     const pollOnce = Effect.suspend(() =>
-      enqueueBackgroundDetailSyncEffect(owner, name, number, syncGeneration, observedFetchedAtBaseline(), ref),
+      syncing
+        ? Effect.void
+        : enqueueBackgroundDetailSyncEffect(owner, name, number, syncGeneration, observedFetchedAtBaseline(), ref),
     ).pipe(Effect.catch(() => Effect.void));
     const program = Effect.gen(function* () {
       const workflow = yield* DetailWorkflow;
@@ -1967,6 +1969,7 @@ export function createDetailStore(opts: DetailStoreOptions) {
     });
     if (syncDep) {
       unsubSyncComplete = syncDep.subscribeSyncComplete(() => {
+        if (syncing) return;
         refreshDetailOnly(owner, name, number, ref);
       });
     }

--- a/frontend/src/lib/stores/issues.svelte.test.ts
+++ b/frontend/src/lib/stores/issues.svelte.test.ts
@@ -381,6 +381,143 @@ describe("createIssuesStore", () => {
     expect(store.getIssueDetail()).toBeNull();
   });
 
+  it("synchronizes the selected issue on demand while preserving local body edits", async () => {
+    const cached = issueDetail();
+    cached.issue.Title = "Cached issue detail";
+    const fresh = issueDetail();
+    fresh.issue.Title = "Fresh issue detail";
+    fresh.issue.Body = "provider body";
+    const syncResponse = Promise.withResolvers<{ data: IssueDetail; error: undefined }>();
+    const get = vi.fn(async (path: string) =>
+      path === "/issues" ? { data: [], error: undefined } : { data: cached, error: undefined },
+    );
+    const onDetailSynchronized = vi.fn();
+    let page = "";
+    const store = createIssuesStore({
+      client: mockClient({ GET: get, POST: vi.fn(() => syncResponse.promise) }),
+      getPage: () => page,
+      onDetailSynchronized,
+    });
+    await loadIssueDetail(store, "acme", "widget", 7, {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widget",
+      sync: false,
+    });
+    onDetailSynchronized.mockClear();
+    page = "issues";
+    store.setLocalIssueBody("github", "github.com", "acme", "widget", 7, "local body");
+    const onSuccess = vi.fn();
+    const onSettled = vi.fn();
+
+    const result = store.syncIssueDetailNow(
+      "acme",
+      "widget",
+      7,
+      { provider: "github", platformHost: "github.com", repoPath: "acme/widget" },
+      { onSuccess, onSettled },
+    );
+
+    expect(result).toBeUndefined();
+    await vi.waitFor(() => expect(store.isIssueDetailSyncing()).toBe(true));
+    syncResponse.resolve({ data: fresh, error: undefined });
+    await vi.waitFor(() => expect(store.isIssueDetailSyncing()).toBe(false));
+    expect(store.getIssueDetail()?.issue).toMatchObject({
+      Title: "Fresh issue detail",
+      Body: "local body",
+    });
+    expect(get.mock.calls.filter(([path]) => path === "/issues")).toHaveLength(1);
+    expect(onDetailSynchronized).toHaveBeenCalledOnce();
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("skips a scheduled poll while an on-demand issue sync is pending", async () => {
+    vi.useFakeTimers();
+    const cached = issueDetail();
+    cached.issue.Title = "Cached issue detail";
+    const fresh = issueDetail();
+    fresh.issue.Title = "Fresh issue detail";
+    const syncResponse = Promise.withResolvers<{ data: IssueDetail; error: undefined }>();
+    const get = vi
+      .fn()
+      .mockResolvedValueOnce({ data: cached, error: undefined })
+      .mockResolvedValue({ data: fresh, error: undefined });
+    const store = createIssuesStore({
+      client: mockClient({ GET: get, POST: vi.fn(() => syncResponse.promise) }),
+    });
+    await loadIssueDetail(store, "acme", "widget", 7, {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widget",
+      sync: false,
+    });
+    store.startIssueDetailPolling("acme", "widget", 7, {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widget",
+    });
+    const settled = Promise.withResolvers<void>();
+
+    store.syncIssueDetailNow(
+      "acme",
+      "widget",
+      7,
+      { provider: "github", platformHost: "github.com", repoPath: "acme/widget" },
+      { onSettled: settled.resolve },
+    );
+    await vi.waitFor(() => expect(store.isIssueDetailSyncing()).toBe(true));
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(get).toHaveBeenCalledTimes(1);
+    syncResponse.resolve({ data: fresh, error: undefined });
+    await settled.promise;
+    expect(store.getIssueDetail()?.issue.Title).toBe("Fresh issue detail");
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(get).toHaveBeenCalledTimes(2);
+    store.stopIssueDetailPolling();
+  });
+
+  it("keeps cached issue detail and reports an on-demand synchronization failure", async () => {
+    const cached = issueDetail();
+    cached.issue.Title = "Cached issue detail";
+    const store = createIssuesStore({
+      client: mockClient({
+        GET: vi.fn(async () => ({ data: cached, error: undefined })),
+        POST: vi.fn(async () => ({
+          error: {
+            type: "about:blank",
+            title: "Provider unavailable",
+            status: 503,
+            detail: "provider unavailable",
+          },
+          response: new Response(null, { status: 503 }),
+        })),
+      }),
+    });
+    await loadIssueDetail(store, "acme", "widget", 7, {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widget",
+      sync: false,
+    });
+    const onFailure = vi.fn();
+    const onSettled = vi.fn();
+
+    store.syncIssueDetailNow(
+      "acme",
+      "widget",
+      7,
+      { provider: "github", platformHost: "github.com", repoPath: "acme/widget" },
+      { onFailure, onSettled },
+    );
+
+    await vi.waitFor(() => expect(onSettled).toHaveBeenCalledOnce());
+    expect(store.isIssueDetailSyncing()).toBe(false);
+    expect(store.getIssueDetail()?.issue.Title).toBe("Cached issue detail");
+    expect(onFailure).toHaveBeenCalledWith("provider unavailable");
+  });
+
   it("applies a local body edit addressed through a provider alias and omitted host", async () => {
     const get = vi.fn().mockResolvedValueOnce({ data: issueDetail() });
     const store = createIssuesStore({ client: mockClient({ GET: get }) });

--- a/frontend/src/lib/stores/issues.svelte.ts
+++ b/frontend/src/lib/stores/issues.svelte.ts
@@ -777,7 +777,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
     );
   }
 
-  function syncIssueDetailEffect(ref: IssueDetailRequestRef, expectedGeneration: number) {
+  function synchronizeIssueDetailEffect(ref: IssueDetailRequestRef, expectedGeneration: number) {
     const envelopeTick = nextWorkspaceLifecycleTick();
     const sync = executeGeneratedApiRequest("POST issue detail sync", (client, signal) =>
       client.POST(providerItemPath("issues", ref, "/sync"), {
@@ -797,7 +797,6 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
           }
         }),
       ),
-      Effect.catch(() => Effect.succeed(false)),
     );
     return Effect.sync(() => {
       if (expectedGeneration === issueSyncGeneration) detailSyncing = true;
@@ -812,6 +811,36 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
         }),
       ),
     );
+  }
+
+  function syncIssueDetailEffect(ref: IssueDetailRequestRef, expectedGeneration: number) {
+    return synchronizeIssueDetailEffect(ref, expectedGeneration).pipe(Effect.catch(() => Effect.succeed(false)));
+  }
+
+  function syncIssueDetailNow(
+    owner: string,
+    name: string,
+    number: number,
+    identity: IssueDetailRequestOptions,
+    callbacks: MutationCallbacks = {},
+  ): void {
+    const ref = issueDetailRequestRef(owner, name, number, identity);
+    const generation = ++issueSyncGeneration;
+    const program = synchronizeIssueDetailEffect(ref, generation).pipe(
+      Effect.tap(() => invokeMutationCallback(callbacks.onSuccess)),
+      Effect.ensuring(invokeMutationCallback(callbacks.onSettled)),
+    );
+    runtime.runCommand(program, {
+      operation: "synchronize issue detail",
+      safeContext: {
+        provider: ref.provider,
+        platformHost: concretePlatformHost(ref),
+        owner,
+        name,
+        number,
+      },
+      onFailure: (failure) => invokeMutationFailure(callbacks.onFailure, readErrorMessage(failure)),
+    });
   }
 
   function enqueueBackgroundIssueSyncEffect(
@@ -905,10 +934,9 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
   ): void {
     const ref = issueDetailRequestRef(owner, name, number, options);
     const pollingGeneration = ++issuePollingGeneration;
-    const pollOnce = Effect.suspend(() => refreshIssueDetailProgram(ref, issueSyncGeneration)).pipe(
-      Effect.catch(() => Effect.succeed(false)),
-      Effect.asVoid,
-    );
+    const pollOnce = Effect.suspend(() =>
+      detailSyncing ? Effect.void : refreshIssueDetailProgram(ref, issueSyncGeneration).pipe(Effect.asVoid),
+    ).pipe(Effect.catch(() => Effect.void));
     const program = Effect.gen(function* () {
       const workflow = yield* IssuesWorkflow;
       yield* workflow.poll(pollingGeneration, pollOnce, "60 seconds");
@@ -1843,6 +1871,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
     getIssueDetailLoaded,
     isIssueStaleRefreshing,
     loadIssueDetail,
+    syncIssueDetailNow,
     startIssueDetailPolling,
     stopIssueDetailPolling,
     clearIssueDetail,


### PR DESCRIPTION
Issue and pull request detail views now provide an explicit way to fetch current provider state without reloading the application.

- Add a compact refresh control beside the Activity view selector on both detail surfaces.
- Refresh the whole authoritative detail while keeping the existing conversation and local edits visible.
- Show progress in the control and retain the current detail if the provider refresh fails.

Automatic background synchronization remains unchanged; this adds an on-demand path only.
