### PR TITLE
feat(terminal): paste images into agent sessions

### DIFF
--- a/context/fleet-architecture.md
+++ b/context/fleet-architecture.md
@@ -33,6 +33,9 @@ peer transports, or remote workspace and session operations.
   non-hop-by-hop response headers instead of translating remote domain failures
   at the hub
   (`internal/server/fleetapi/fleet_proxy.go::Handler.serveRemoteFleetRESTProxy`).
+- Raw adapter handlers do not enforce Huma `MaxBodyBytes`; body-bounded fleet
+  routes must enforce the cap at the hub before either HTTP or SSH relay
+  (`internal/server/fleetapi/fleet_proxy.go::bufferFleetProxyBody`).
 
 ## Transport Trust Boundary
 

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -289,10 +289,10 @@ External identifiers are only normalized to one line, which preserves Markdown
 structure and is not a trust boundary; new free-prose fields must go through the
 fence.
 
-Before writing agent context or workspace-lifetime pasted images, kenn-forge
-makes the generated location invisible through the repository's private
-exclude, never tracked `.gitignore`; the write fails if the rule is ineffective
-(`internal/workspace/gitignore.go::EnsureWorkspaceGeneratedPathsIgnored`).
+Before writing agent context or workspace-lifetime pasted images, pin the path
+in the private exclude even when tracked rules already ignore it, then verify
+the result. Serialize pasted-image quota checks per workspace and stop at 100 entries
+(`internal/workspace/gitignore.go::EnsureWorkspaceGeneratedPathsIgnored`, `internal/workspace/pasted_images.go::Manager.StorePastedImage`).
 
 The recomputed head-repo trust classification must be persisted back to the
 workspace row, not just held on the in-memory struct: a sync that turns a

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -289,9 +289,10 @@ External identifiers are only normalized to one line, which preserves Markdown
 structure and is not a trust boundary; new free-prose fields must go through the
 fence.
 
-Before writing, kenn-forge ignores the generated path through the worktree's
-private exclude file, not tracked `.gitignore`. If the path would remain
-visible to Git, the write fails.
+Before writing agent context or workspace-lifetime pasted images, kenn-forge
+makes the generated location invisible through the repository's private
+exclude, never tracked `.gitignore`; the write fails if the rule is ineffective
+(`internal/workspace/gitignore.go::EnsureWorkspaceGeneratedPathsIgnored`).
 
 The recomputed head-repo trust classification must be persisted back to the
 workspace row, not just held on the in-memory struct: a sync that turns a

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -197,7 +197,8 @@ stale tabs.
   or alternate renderer path (`frontend/src/lib/components/terminal/TerminalPane.svelte`).
 - Own browser text and image paste at the terminal container boundary. Send
   sanitized text once; image paste requires an explicit workspace/fleet target,
-  inserts ordered bare paths once, and drops results after a connection generation change
+  uploads files within each batch concurrently, delivers separate batches in
+  paste-event order, inserts ordered bare paths once, and drops results after a connection generation change
   (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::handleTerminalPaste`).
 - Treat terminal processes as native-terminal-equivalent, but accept bounded, write-only OSC 52 writes only after one
   recent one-shot trusted DOM gesture; terminal data callbacks are not input provenance, and browser denial falls back

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -195,10 +195,10 @@ stale tabs.
   (`frontend/src/lib/components/terminal/workspace-runtime-workflow.ts::storeAndPresentMutation`).
 - Workspace terminals use xterm.js exclusively; there is no renderer setting
   or alternate renderer path (`frontend/src/lib/components/terminal/TerminalPane.svelte`).
-- Own every non-empty browser text paste at the terminal container boundary,
-  sanitize and send it once, and do not delegate single-line paste to xterm;
-  this event path must remain usable on insecure HTTP origins without the async
-  Clipboard API (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::handleTerminalPaste`).
+- Own browser text and image paste at the terminal container boundary. Send
+  sanitized text once; image paste requires an explicit workspace/fleet target,
+  inserts ordered bare paths once, and drops results after a connection generation change
+  (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::handleTerminalPaste`).
 - Treat terminal processes as native-terminal-equivalent, but accept bounded, write-only OSC 52 writes only after one
   recent one-shot trusted DOM gesture; terminal data callbacks are not input provenance, and browser denial falls back
   through CSRF-protected loopback (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::handleTerminalKeyDown`).

--- a/frontend/src/lib/api/workspace-pasted-image.test.ts
+++ b/frontend/src/lib/api/workspace-pasted-image.test.ts
@@ -1,0 +1,87 @@
+import { Effect } from "effect";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { makeWorkspacePastedImageUploader } from "./workspace-pasted-image.js";
+
+describe("workspace pasted image upload", () => {
+  it("posts base64 JSON to the encoded fleet workspace target", async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(
+          JSON.stringify({
+            path: ".kenn-forge/pasted-images/paste-abcdef0123456789abcdef0123456789.png",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+    );
+    const upload = makeWorkspacePastedImageUploader(fetchMock);
+
+    const path = await Effect.runPromise(
+      upload(
+        { workspaceId: "ws/a", hostKey: "host one" },
+        new File([new Uint8Array([0, 255, 1])], "shot.png", { type: "text/plain" }),
+      ),
+    );
+
+    expect(path).toBe(".kenn-forge/pasted-images/paste-abcdef0123456789abcdef0123456789.png");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const request = fetchMock.mock.calls[0]![0] as Request;
+    expect(request.url).toBe(`${window.location.origin}/api/v1/fleet/hosts/host%20one/workspaces/ws%2Fa/pasted-images`);
+    expect(request.method).toBe("POST");
+    expect(request.headers.get("Content-Type")).toBe("application/json");
+    expect(request.headers.get("X-Kenn-Forge-Csrf")).toBe("1");
+    await expect(request.json()).resolves.toEqual({ data: "AP8B" });
+  });
+
+  it("uses the local workspace route when no fleet host is present", async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(
+          JSON.stringify({
+            path: ".kenn-forge/pasted-images/paste-0123456789abcdef0123456789abcdef.png",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+    );
+    const upload = makeWorkspacePastedImageUploader(fetchMock);
+
+    await Effect.runPromise(upload({ workspaceId: "ws local" }, new File(["x"], "shot.png")));
+
+    const request = fetchMock.mock.calls[0]![0] as Request;
+    expect(request.url).toBe(`${window.location.origin}/api/v1/workspaces/ws%20local/pasted-images`);
+  });
+
+  it("returns typed failures for problem responses and invalid success payloads", async () => {
+    const problemFetch = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(JSON.stringify({ code: "validationError", detail: "unsupported image" }), {
+          status: 400,
+          headers: { "Content-Type": "application/problem+json" },
+        }),
+    );
+    const invalidFetch = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(JSON.stringify({ path: "$(touch /tmp/not-a-pasted-image)" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    await expect(
+      Effect.runPromise(
+        makeWorkspacePastedImageUploader(problemFetch)({ workspaceId: "ws-1" }, new File(["x"], "shot.png")),
+      ),
+    ).rejects.toMatchObject({ _tag: "WorkspacePastedImageUploadError", message: "unsupported image" });
+    await expect(
+      Effect.runPromise(
+        makeWorkspacePastedImageUploader(invalidFetch)({ workspaceId: "ws-1" }, new File(["x"], "shot.png")),
+      ),
+    ).rejects.toMatchObject({ _tag: "WorkspacePastedImageUploadError" });
+  });
+});

--- a/frontend/src/lib/api/workspace-pasted-image.ts
+++ b/frontend/src/lib/api/workspace-pasted-image.ts
@@ -1,0 +1,100 @@
+import { Data, Effect, Schema } from "effect";
+
+import { csrfFetch, type FetchFn } from "./csrf.js";
+import { isProblem } from "./problems.js";
+import { configuredAPIBaseURL } from "./runtime-base.js";
+import { tracedFetch } from "./runtime.js";
+
+export const MAX_PASTED_IMAGE_BYTES = 10 * 1024 * 1024;
+export const MAX_PASTED_IMAGES_PER_PASTE = 4;
+
+export interface WorkspaceImageUploadTarget {
+  readonly workspaceId: string;
+  readonly hostKey?: string | undefined;
+}
+
+export class WorkspacePastedImageUploadError extends Data.TaggedError("WorkspacePastedImageUploadError")<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+const PastedImagePath = Schema.String.pipe(
+  Schema.check(Schema.isPattern(/^\.kenn-forge\/pasted-images\/paste-[0-9a-f]{32}\.(png|jpg|gif|webp)$/)),
+);
+const PastedImageOutput = Schema.Struct({ path: PastedImagePath });
+
+function pastedImageUploadPath(target: WorkspaceImageUploadTarget): string {
+  const hostPrefix = target.hostKey ? `/fleet/hosts/${encodeURIComponent(target.hostKey)}` : "";
+  return `${configuredAPIBaseURL()}${hostPrefix}/workspaces/${encodeURIComponent(target.workspaceId)}/pasted-images`;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  const chunkSize = 0x8000;
+  let binary = "";
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+  }
+  return btoa(binary);
+}
+
+export function makeWorkspacePastedImageUploader(inner: FetchFn = fetch) {
+  const request = csrfFetch(tracedFetch(inner));
+  return Effect.fn("WorkspacePastedImage.upload")(function* (target: WorkspaceImageUploadTarget, file: File) {
+    const buffer = yield* Effect.tryPromise({
+      try: () => file.arrayBuffer(),
+      catch: (cause) =>
+        new WorkspacePastedImageUploadError({
+          message: "Could not read the pasted image.",
+          cause,
+        }),
+    });
+    const response = yield* Effect.tryPromise({
+      try: (signal) =>
+        request(pastedImageUploadPath(target), {
+          method: "POST",
+          body: JSON.stringify({ data: bytesToBase64(new Uint8Array(buffer)) }),
+          signal,
+        }),
+      catch: (cause) =>
+        new WorkspacePastedImageUploadError({
+          message: "Could not upload the pasted image.",
+          cause,
+        }),
+    });
+    const payload = yield* Effect.tryPromise({
+      try: () => response.json() as Promise<unknown>,
+      catch: (cause) =>
+        new WorkspacePastedImageUploadError({
+          message: `The pasted image upload returned invalid JSON (${response.status}).`,
+          cause,
+        }),
+    });
+    if (!response.ok) {
+      return yield* Effect.fail(
+        new WorkspacePastedImageUploadError({
+          message:
+            isProblem(payload) && payload.detail
+              ? payload.detail
+              : `Could not upload the pasted image (${response.status}).`,
+        }),
+      );
+    }
+    return yield* Schema.decodeUnknownEffect(PastedImageOutput)(payload).pipe(
+      Effect.mapError(
+        (cause) =>
+          new WorkspacePastedImageUploadError({
+            message: "The pasted image upload returned an invalid path.",
+            cause,
+          }),
+      ),
+      Effect.map((decoded) => decoded.path),
+    );
+  });
+}
+
+export function uploadWorkspacePastedImage(
+  target: WorkspaceImageUploadTarget,
+  file: File,
+): Effect.Effect<string, WorkspacePastedImageUploadError> {
+  return makeWorkspacePastedImageUploader()(target, file);
+}

--- a/frontend/src/lib/components/mobile/MobileWorkspaceTerminal.svelte
+++ b/frontend/src/lib/components/mobile/MobileWorkspaceTerminal.svelte
@@ -194,6 +194,7 @@
         hostKey: pooledKey,
         websocketPath: session.websocketPath,
         status: session.status,
+        uploadTarget: target(),
         cursorWheelInput: session.cursorWheelInput,
       });
     }

--- a/frontend/src/lib/components/terminal/PooledSessionTerminal.svelte
+++ b/frontend/src/lib/components/terminal/PooledSessionTerminal.svelte
@@ -215,6 +215,7 @@
   <TerminalPane
     bind:this={terminalPane}
     websocketPath={session.websocketPath}
+    uploadTarget={session.uploadTarget}
     reconnectOnExit={false}
     disabled={session.disabled ?? false}
     active={active && attached}

--- a/frontend/src/lib/components/terminal/TerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/TerminalPane.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+  import type { WorkspaceImageUploadTarget } from "../../api/workspace-pasted-image.js";
   import XtermTerminalPane from "./XtermTerminalPane.svelte";
 
   interface TerminalPaneProps {
     workspaceId?: string | undefined;
+    uploadTarget?: WorkspaceImageUploadTarget | undefined;
     websocketPath?: string | undefined;
     reconnectOnExit?: boolean | undefined;
     active?: boolean | undefined;
@@ -20,6 +22,7 @@
 
   let {
     workspaceId = undefined,
+    uploadTarget = undefined,
     websocketPath = undefined,
     reconnectOnExit = undefined,
     active = undefined,
@@ -50,6 +53,7 @@
 <XtermTerminalPane
   bind:this={xtermPane}
   {workspaceId}
+  {uploadTarget}
   {websocketPath}
   {reconnectOnExit}
   {active}

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/svelte";
+import { Effect } from "effect";
 import { tick } from "svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { beginTerminalGeometryIntent, extendTerminalGeometryIntent } from "./terminalGeometryIntent.js";
@@ -13,6 +14,7 @@ const {
   clipboardWriterWrite,
   ligaturesAddonCtor,
   mockShowFlash,
+  uploadWorkspacePastedImageMock,
   mockWebglCtor,
   mouseDragEndPointerGesture,
   mouseDragObserveTerminalData,
@@ -36,6 +38,7 @@ const {
   clipboardWriterWrite: vi.fn(),
   ligaturesAddonCtor: vi.fn(),
   mockShowFlash: vi.fn(),
+  uploadWorkspacePastedImageMock: vi.fn(),
   mockWebglCtor: vi.fn(),
   mouseDragEndPointerGesture: vi.fn(),
   mouseDragObserveTerminalData: vi.fn(),
@@ -155,6 +158,14 @@ vi.mock("../../stores/flash.svelte.js", () => ({
   showFlash: mockShowFlash,
 }));
 
+vi.mock("../../api/workspace-pasted-image.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/workspace-pasted-image.js")>();
+  return {
+    ...actual,
+    uploadWorkspacePastedImage: uploadWorkspacePastedImageMock,
+  };
+});
+
 vi.mock("./terminalClipboardWriter.js", async () => {
   const { Effect } = await import("effect");
   return {
@@ -195,8 +206,8 @@ vi.mock("@xterm/xterm", () => ({
     // The real xterm Terminal is a class instance, which Svelte leaves opaque.
     // Keep the double equally opaque so fit updates the same object the pane reads.
     class MockTerminal {}
-    const bufferType: "normal" = "normal";
-    const mouseTrackingMode: "none" = "none";
+    const bufferType = "normal" as const;
+    const mouseTrackingMode = "none" as const;
     const terminal = Object.assign(new MockTerminal(), {
       buffer: { active: { baseY: 0, type: bufferType } },
       cols: initialTerminalDimensions.cols,
@@ -283,6 +294,7 @@ vi.mock("@xterm/addon-webgl", () => ({
 vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
 
 import TerminalPane from "./TerminalPaneTestHarness.svelte";
+import { MAX_PASTED_IMAGE_BYTES } from "../../api/workspace-pasted-image.js";
 
 function resizeFramesOf(socket: MockWebSocket): string[] {
   return socket.sent.map(String).filter((frame) => frame.includes('"type":"resize"'));
@@ -317,6 +329,9 @@ describe("TerminalPane", () => {
     clipboardWriterDispose.mockReset();
     clipboardWriterWrite.mockReset().mockResolvedValue("unauthorized");
     mockShowFlash.mockReset();
+    uploadWorkspacePastedImageMock
+      .mockReset()
+      .mockImplementation((_target, file: File) => Effect.succeed(`.kenn-forge/pasted-images/${file.name}`));
     mockWebglCtor.mockReset();
     mouseDragEndPointerGesture.mockReset();
     mouseDragObserveTerminalData.mockReset();
@@ -1617,7 +1632,160 @@ describe("TerminalPane", () => {
       "single[201~ line",
     ]);
   });
+
+  it("uploads pasted images concurrently and inserts their paths once in clipboard order", async () => {
+    const first = deferred<string>();
+    const second = deferred<string>();
+    uploadWorkspacePastedImageMock.mockImplementation((_target, file: File) =>
+      Effect.promise(() => (file.name === "first.png" ? first.promise : second.promise)),
+    );
+    const { container } = render(TerminalPane, {
+      props: {
+        websocketPath: "/api/v1/fleet/hosts/host-a/workspaces/ws-123/runtime/sessions/agent/terminal",
+        uploadTarget: { workspaceId: "ws-123", hostKey: "host-a" },
+      },
+    });
+    await waitFor(() => expect(mockSockets).toHaveLength(1));
+    await waitForSocketConnected(mockSockets[0]!);
+    mockSockets[0]!.sent = [];
+
+    const event = imagePasteEvent([
+      new File(["first"], "first.png", { type: "image/png" }),
+      new File(["second"], "second.png", { type: "image/png" }),
+    ]);
+    const defaultAllowed = container.querySelector(".terminal-container")!.dispatchEvent(event);
+
+    expect(defaultAllowed).toBe(false);
+    await waitFor(() => expect(uploadWorkspacePastedImageMock).toHaveBeenCalledTimes(2));
+    expect(uploadWorkspacePastedImageMock.mock.calls.map(([target]) => target)).toEqual([
+      { workspaceId: "ws-123", hostKey: "host-a" },
+      { workspaceId: "ws-123", hostKey: "host-a" },
+    ]);
+    second.resolve(".kenn-forge/pasted-images/second.png");
+    await tick();
+    expect(mockSockets[0]!.sent.map((_, index) => sentText(mockSockets[0]!, index))).not.toContain(
+      ".kenn-forge/pasted-images/second.png",
+    );
+    first.resolve(".kenn-forge/pasted-images/first.png");
+    await waitFor(() =>
+      expect(mockSockets[0]!.sent.map((_, index) => sentText(mockSockets[0]!, index))).toContain(
+        ".kenn-forge/pasted-images/first.png .kenn-forge/pasted-images/second.png",
+      ),
+    );
+  });
+
+  it("reports missing upload ownership instead of silently dropping pasted images", async () => {
+    const { container } = render(TerminalPane, { props: { workspaceId: "ws-123" } });
+    await waitFor(() => expect(mockSockets).toHaveLength(1));
+    await waitForSocketConnected(mockSockets[0]!);
+
+    container
+      .querySelector(".terminal-container")!
+      .dispatchEvent(imagePasteEvent([new File(["image"], "image.png", { type: "image/png" })]));
+
+    expect(uploadWorkspacePastedImageMock).not.toHaveBeenCalled();
+    expect(mockShowFlash).toHaveBeenCalledWith("This terminal cannot receive pasted images.", {
+      tone: "danger",
+    });
+  });
+
+  it("caps each paste at four uploads and inserts only successful paths", async () => {
+    uploadWorkspacePastedImageMock.mockImplementation((_target, file: File) =>
+      file.name === "2.png"
+        ? Effect.fail(new Error("upload failed"))
+        : Effect.succeed(`.kenn-forge/pasted-images/${file.name}`),
+    );
+    const { container } = render(TerminalPane, {
+      props: {
+        workspaceId: "ws-123",
+        uploadTarget: { workspaceId: "ws-123" },
+      },
+    });
+    await waitFor(() => expect(mockSockets).toHaveLength(1));
+    await waitForSocketConnected(mockSockets[0]!);
+    mockSockets[0]!.sent = [];
+    const files = [1, 2, 3, 4, 5].map((number) => new File([String(number)], `${number}.png`, { type: "image/png" }));
+
+    container.querySelector(".terminal-container")!.dispatchEvent(imagePasteEvent(files));
+
+    await waitFor(() => expect(uploadWorkspacePastedImageMock).toHaveBeenCalledTimes(4));
+    await waitFor(() =>
+      expect(mockSockets[0]!.sent.map((_, index) => sentText(mockSockets[0]!, index))).toContain(
+        ".kenn-forge/pasted-images/1.png .kenn-forge/pasted-images/3.png .kenn-forge/pasted-images/4.png",
+      ),
+    );
+    expect(mockShowFlash).toHaveBeenCalledWith("2 of 5 pasted images could not be uploaded.", {
+      tone: "danger",
+    });
+  });
+
+  it("rejects a known oversized image before uploading it", async () => {
+    const oversized = {
+      name: "oversized.png",
+      type: "image/png",
+      size: MAX_PASTED_IMAGE_BYTES + 1,
+    } as File;
+    const { container } = render(TerminalPane, {
+      props: {
+        workspaceId: "ws-123",
+        uploadTarget: { workspaceId: "ws-123" },
+      },
+    });
+    await waitFor(() => expect(mockSockets).toHaveLength(1));
+    await waitForSocketConnected(mockSockets[0]!);
+
+    container.querySelector(".terminal-container")!.dispatchEvent(imagePasteEvent([oversized]));
+
+    await waitFor(() =>
+      expect(mockShowFlash).toHaveBeenCalledWith("1 of 1 pasted image could not be uploaded.", {
+        tone: "danger",
+      }),
+    );
+    expect(uploadWorkspacePastedImageMock).not.toHaveBeenCalled();
+  });
+
+  it("does not insert a completed upload after its terminal connection is replaced", async () => {
+    const upload = deferred<string>();
+    uploadWorkspacePastedImageMock.mockReturnValue(Effect.promise(() => upload.promise));
+    const { container } = render(TerminalPane, {
+      props: {
+        workspaceId: "ws-123",
+        uploadTarget: { workspaceId: "ws-123" },
+      },
+    });
+    await waitFor(() => expect(mockSockets).toHaveLength(1));
+    await waitForSocketConnected(mockSockets[0]!);
+    container
+      .querySelector(".terminal-container")!
+      .dispatchEvent(imagePasteEvent([new File(["image"], "image.png", { type: "image/png" })]));
+    await waitFor(() => expect(uploadWorkspacePastedImageMock).toHaveBeenCalledOnce());
+
+    mockSockets[0]!.onclose();
+    await waitFor(() => expect(mockSockets).toHaveLength(2), { timeout: 2_000 });
+    mockSockets[1]!.sent = [];
+    upload.resolve(".kenn-forge/pasted-images/image.png");
+    await tick();
+
+    expect(mockSockets[1]!.sent).toHaveLength(0);
+    expect(mockShowFlash).not.toHaveBeenCalled();
+  });
 });
+
+function imagePasteEvent(files: readonly File[]): ClipboardEvent {
+  const event = new Event("paste", { bubbles: true, cancelable: true }) as ClipboardEvent;
+  Object.defineProperty(event, "clipboardData", {
+    value: {
+      getData: vi.fn(() => ""),
+      items: files.map((file) => ({
+        kind: "file",
+        type: file.type,
+        getAsFile: () => file,
+      })),
+      files,
+    },
+  });
+  return event;
+}
 
 function socketFramesOfType(socket: MockWebSocket, type: string): string[] {
   return socket.sent

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -1674,6 +1674,45 @@ describe("TerminalPane", () => {
     );
   });
 
+  it("inserts separate image paste batches in event order when the second upload finishes first", async () => {
+    const first = deferred<string>();
+    const second = deferred<string>();
+    uploadWorkspacePastedImageMock.mockImplementation((_target, file: File) =>
+      Effect.promise(() => (file.name === "first.png" ? first.promise : second.promise)),
+    );
+    const { container } = render(TerminalPane, {
+      props: {
+        workspaceId: "ws-123",
+        uploadTarget: { workspaceId: "ws-123" },
+      },
+    });
+    await waitFor(() => expect(mockSockets).toHaveLength(1));
+    await waitForSocketConnected(mockSockets[0]!);
+    mockSockets[0]!.sent = [];
+    const terminal = container.querySelector(".terminal-container")!;
+
+    terminal.dispatchEvent(imagePasteEvent([new File(["first"], "first.png", { type: "image/png" })]));
+    terminal.dispatchEvent(imagePasteEvent([new File(["second"], "second.png", { type: "image/png" })]));
+
+    await waitFor(() => expect(uploadWorkspacePastedImageMock).toHaveBeenCalledTimes(2));
+    second.resolve(".kenn-forge/pasted-images/second.png");
+    await tick();
+    expect(
+      mockSockets[0]!.sent
+        .map((_, index) => sentText(mockSockets[0]!, index))
+        .filter((frame) => frame.includes(".kenn-forge/pasted-images/")),
+    ).toEqual([]);
+
+    first.resolve(".kenn-forge/pasted-images/first.png");
+    await waitFor(() =>
+      expect(
+        mockSockets[0]!.sent
+          .map((_, index) => sentText(mockSockets[0]!, index))
+          .filter((frame) => frame.includes(".kenn-forge/pasted-images/")),
+      ).toEqual([".kenn-forge/pasted-images/first.png", ".kenn-forge/pasted-images/second.png"]),
+    );
+  });
+
   it("reports missing upload ownership instead of silently dropping pasted images", async () => {
     const { container } = render(TerminalPane, { props: { workspaceId: "ws-123" } });
     await waitFor(() => expect(mockSockets).toHaveLength(1));

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -1709,6 +1709,10 @@
           workspaceHostKey,
         ),
         status: session.status,
+        uploadTarget: {
+          workspaceId,
+          ...(workspaceHostKey === undefined ? {} : { hostKey: workspaceHostKey }),
+        },
         cursorWheelInput: session.kind === "agent",
         disabled: actionsBlocked,
       });

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -1818,6 +1818,7 @@ describe("WorkspaceTerminalView", () => {
     await waitFor(() => expect(sockets[0]!.send).toHaveBeenCalled());
     const firstPrefix = sessionHostPrefix("ws-1", undefined);
     expect(mountedSessions()[0]?.hostKey.startsWith(firstPrefix)).toBe(true);
+    expect(mountedSessions()[0]?.uploadTarget).toEqual({ workspaceId: "ws-1" });
     const firstHostKey = mountedSessions()[0]!.hostKey;
     const firstWrapper = document.querySelector(`[data-session-host="${firstHostKey}"]`);
     const firstSocket = sockets[0];

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Deferred, Effect, Queue } from "effect";
+  import { Deferred, Effect, Exit, Queue } from "effect";
   import { getAppRuntime } from "../../app/runtime-context.js";
   import { makeAnimationFrameScheduler, nextAnimationFrame } from "../../browser/animation-frame.js";
   import { observeResize } from "../../browser/observers.js";
@@ -131,6 +131,7 @@
   let pointerOrigin: { clientX: number; clientY: number } | null = null;
   let explicitFocusRequested = false;
   const activeImagePasteInterrupts = new Set<() => void>();
+  let imagePasteDeliveryTail: Promise<void> = Promise.resolve();
   const encoder = new TextEncoder();
   let clipboardWriter: TerminalClipboardWriter | undefined;
   let mouseDragAutoscroll: TmuxMouseDragAutoscroll | undefined;
@@ -793,27 +794,7 @@
         );
       },
       { concurrency: "unbounded" },
-    ).pipe(
-      Effect.map((results) => formatPastedImagePaths([...results, ...skippedResults])),
-      Effect.tap(({ text, failed }) =>
-        Effect.sync(() => {
-          if (
-            disposed ||
-            generation !== connectionGeneration ||
-            !terminalSession?.isConnected()
-          ) {
-            return;
-          }
-          if (text !== "") sendPastedInput(text);
-          if (failed > 0) {
-            const noun = files.length === 1 ? "image" : "images";
-            showFlash(`${failed} of ${files.length} pasted ${noun} could not be uploaded.`, {
-              tone: "danger",
-            });
-          }
-        }),
-      ),
-    );
+    ).pipe(Effect.map((results) => formatPastedImagePaths([...results, ...skippedResults])));
     const execution = runtime.runCommand(program, {
       operation: "upload pasted terminal images",
       safeContext: {
@@ -834,6 +815,25 @@
     const interrupt = (): void => execution.interrupt();
     activeImagePasteInterrupts.add(interrupt);
     void execution.exit.finally(() => activeImagePasteInterrupts.delete(interrupt));
+    imagePasteDeliveryTail = imagePasteDeliveryTail.then(async () => {
+      const exit = await execution.exit;
+      if (!Exit.isSuccess(exit)) return;
+      if (
+        disposed ||
+        generation !== connectionGeneration ||
+        !terminalSession?.isConnected()
+      ) {
+        return;
+      }
+      const { text, failed } = exit.value;
+      if (text !== "") sendPastedInput(text);
+      if (failed > 0) {
+        const noun = files.length === 1 ? "image" : "images";
+        showFlash(`${failed} of ${files.length} pasted ${noun} could not be uploaded.`, {
+          tone: "danger",
+        });
+      }
+    });
   }
 
   function interruptImagePastes(): void {

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -13,9 +13,20 @@
   import { WebglAddon } from "@xterm/addon-webgl";
   import "@xterm/xterm/css/xterm.css";
   import { workspaceTmuxWebSocketPath } from "../../api/workspace-runtime.js";
+  import {
+    MAX_PASTED_IMAGE_BYTES,
+    MAX_PASTED_IMAGES_PER_PASTE,
+    uploadWorkspacePastedImage,
+    type WorkspaceImageUploadTarget,
+  } from "../../api/workspace-pasted-image.js";
   import { createWorkspaceSwitchPaneTimer } from "../../instrumentation/workspaceSwitchTiming.js";
   import { traceHeadersForRequest } from "../../instrumentation/traceContext.js";
   import { createTerminalPastePayload } from "./bracketedPaste.js";
+  import {
+    clipboardImageFiles,
+    formatPastedImagePaths,
+    type PastedImageUploadResult,
+  } from "./terminalImagePaste.js";
   import { embeddedWebSocketUrl } from "./embeddedWebSocket.js";
   import { parseOsc52ClipboardWrite } from "./osc52Clipboard.js";
   import {
@@ -48,6 +59,7 @@
 
   interface TerminalPaneProps {
     workspaceId?: string | undefined;
+    uploadTarget?: WorkspaceImageUploadTarget | undefined;
     websocketPath?: string | undefined;
     reconnectOnExit?: boolean | undefined;
     active?: boolean | undefined;
@@ -65,6 +77,7 @@
 
   let {
     workspaceId,
+    uploadTarget,
     websocketPath,
     reconnectOnExit = true,
     active = true,
@@ -117,6 +130,7 @@
   let activePointerId: number | null = null;
   let pointerOrigin: { clientX: number; clientY: number } | null = null;
   let explicitFocusRequested = false;
+  const activeImagePasteInterrupts = new Set<() => void>();
   const encoder = new TextEncoder();
   let clipboardWriter: TerminalClipboardWriter | undefined;
   let mouseDragAutoscroll: TmuxMouseDragAutoscroll | undefined;
@@ -723,6 +737,25 @@
       event.stopImmediatePropagation();
       return;
     }
+
+    const imageFiles = clipboardImageFiles(event.clipboardData);
+    if (imageFiles.length > 0) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      if (!terminalSession?.isConnected()) {
+        showFlash("Could not paste images while the terminal is disconnected.", {
+          tone: "danger",
+        });
+        return;
+      }
+      if (uploadTarget === undefined) {
+        showFlash("This terminal cannot receive pasted images.", { tone: "danger" });
+        return;
+      }
+      uploadPastedImages(imageFiles, uploadTarget, connectionGeneration);
+      return;
+    }
+
     if (!terminalSession?.isConnected()) return;
 
     const pastedText =
@@ -734,6 +767,78 @@
     if (!sendPastedInput(pastedText)) return;
     event.preventDefault();
     event.stopImmediatePropagation();
+  }
+
+  function uploadPastedImages(
+    files: readonly File[],
+    target: WorkspaceImageUploadTarget,
+    generation: number,
+  ): void {
+    const selectedFiles = files.slice(0, MAX_PASTED_IMAGES_PER_PASTE);
+    const skippedResults: PastedImageUploadResult[] = Array.from(
+      { length: files.length - selectedFiles.length },
+      () => ({ _tag: "Failure" }),
+    );
+    const program = Effect.forEach(
+      selectedFiles,
+      (file): Effect.Effect<PastedImageUploadResult> => {
+        if (file.size > MAX_PASTED_IMAGE_BYTES) {
+          return Effect.succeed({ _tag: "Failure" });
+        }
+        return uploadWorkspacePastedImage(target, file).pipe(
+          Effect.match({
+            onFailure: (): PastedImageUploadResult => ({ _tag: "Failure" }),
+            onSuccess: (path): PastedImageUploadResult => ({ _tag: "Success", path }),
+          }),
+        );
+      },
+      { concurrency: "unbounded" },
+    ).pipe(
+      Effect.map((results) => formatPastedImagePaths([...results, ...skippedResults])),
+      Effect.tap(({ text, failed }) =>
+        Effect.sync(() => {
+          if (
+            disposed ||
+            generation !== connectionGeneration ||
+            !terminalSession?.isConnected()
+          ) {
+            return;
+          }
+          if (text !== "") sendPastedInput(text);
+          if (failed > 0) {
+            const noun = files.length === 1 ? "image" : "images";
+            showFlash(`${failed} of ${files.length} pasted ${noun} could not be uploaded.`, {
+              tone: "danger",
+            });
+          }
+        }),
+      ),
+    );
+    const execution = runtime.runCommand(program, {
+      operation: "upload pasted terminal images",
+      safeContext: {
+        workspaceId: target.workspaceId,
+        remote: target.hostKey !== undefined,
+        count: files.length,
+      },
+      onFailure: () => {
+        if (
+          !disposed &&
+          generation === connectionGeneration &&
+          terminalSession?.isConnected()
+        ) {
+          showFlash("Could not upload the pasted images.", { tone: "danger" });
+        }
+      },
+    });
+    const interrupt = (): void => execution.interrupt();
+    activeImagePasteInterrupts.add(interrupt);
+    void execution.exit.finally(() => activeImagePasteInterrupts.delete(interrupt));
+  }
+
+  function interruptImagePastes(): void {
+    for (const interrupt of activeImagePasteInterrupts) interrupt();
+    activeImagePasteInterrupts.clear();
   }
 
   function handleTerminalMessage(data: string | Uint8Array): TerminalMessageDecision {
@@ -804,6 +909,7 @@
       onMessage: handleTerminalMessage,
       onDisconnected: () => {
         onConnectionChange?.(false);
+        interruptImagePastes();
         cancelPendingTerminalSequence();
         clipboardWriter?.cancelAuthorization();
         mouseDragAutoscroll?.reset();
@@ -813,6 +919,7 @@
 
   function cleanup(): void {
     disposed = true;
+    interruptImagePastes();
     pointerOrigin = null;
     clipboardWriter?.dispose();
     clipboardWriter = undefined;
@@ -886,9 +993,9 @@
     if (active) scheduleTerminalRefresh();
   });
 
-  const FONT_LOADED: "loaded" = "loaded";
-  const FONT_FAILED: "failed" = "failed";
-  const FONT_TIMED_OUT: "timed-out" = "timed-out";
+  const FONT_LOADED = "loaded" as const;
+  const FONT_FAILED = "failed" as const;
+  const FONT_TIMED_OUT = "timed-out" as const;
 
   function openTerminalPane(node: HTMLElement) {
     return Effect.gen(function* () {

--- a/frontend/src/lib/components/terminal/terminalImagePaste.test.ts
+++ b/frontend/src/lib/components/terminal/terminalImagePaste.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { clipboardImageFiles, formatPastedImagePaths } from "./terminalImagePaste.js";
+
+function clipboardData(items: readonly File[]): DataTransfer {
+  return {
+    items: items.map((file) => ({
+      kind: "file",
+      type: file.type,
+      getAsFile: () => file,
+    })),
+    files: items,
+  } as unknown as DataTransfer;
+}
+
+describe("terminal image paste helpers", () => {
+  it("extracts every image file in clipboard order", () => {
+    const png = new File(["png"], "first.png", { type: "image/png" });
+    const text = new File(["text"], "note.txt", { type: "text/plain" });
+    const jpeg = new File(["jpeg"], "second.jpg", { type: "image/jpeg" });
+    const gif = new File(["gif"], "third.gif", { type: "image/gif" });
+    const webp = new File(["webp"], "fourth.webp", { type: "image/webp" });
+    const fifth = new File(["png"], "fifth.png", { type: "image/png" });
+
+    expect(clipboardImageFiles(clipboardData([png, text, jpeg, gif, webp, fifth]))).toEqual([
+      png,
+      jpeg,
+      gif,
+      webp,
+      fifth,
+    ]);
+  });
+
+  it("falls back to clipboard files when items expose no image", () => {
+    const png = new File(["png"], "first.png", { type: "image/png" });
+    const data = {
+      items: [{ kind: "string", type: "text/plain", getAsFile: () => null }],
+      files: [png],
+    } as unknown as DataTransfer;
+
+    expect(clipboardImageFiles(data)).toEqual([png]);
+  });
+
+  it("treats text-only clipboard payloads without file collections as image-free", () => {
+    expect(clipboardImageFiles({} as DataTransfer)).toEqual([]);
+  });
+
+  it("joins successful paths in source order and counts failures", () => {
+    expect(
+      formatPastedImagePaths([
+        { _tag: "Success", path: "first.png" },
+        { _tag: "Failure" },
+        { _tag: "Success", path: "third.png" },
+      ]),
+    ).toEqual({ text: "first.png third.png", failed: 1 });
+  });
+});

--- a/frontend/src/lib/components/terminal/terminalImagePaste.ts
+++ b/frontend/src/lib/components/terminal/terminalImagePaste.ts
@@ -1,0 +1,28 @@
+export type PastedImageUploadResult =
+  | { readonly _tag: "Success"; readonly path: string }
+  | { readonly _tag: "Failure" };
+
+function imageFile(file: File | null): file is File {
+  return file !== null && file.type.startsWith("image/");
+}
+
+export function clipboardImageFiles(data: DataTransfer | null): readonly File[] {
+  if (data === null) return [];
+  const itemImages = Array.from(data.items ?? [])
+    .filter((item) => item.kind === "file" && item.type.startsWith("image/"))
+    .map((item) => item.getAsFile())
+    .filter(imageFile);
+  if (itemImages.length > 0) return itemImages;
+  return Array.from(data.files ?? []).filter(imageFile);
+}
+
+export function formatPastedImagePaths(results: readonly PastedImageUploadResult[]): {
+  readonly text: string;
+  readonly failed: number;
+} {
+  const paths = results.flatMap((result) => (result._tag === "Success" ? [result.path] : []));
+  return {
+    text: paths.join(" "),
+    failed: results.length - paths.length,
+  };
+}

--- a/frontend/src/lib/stores/session-host.svelte.ts
+++ b/frontend/src/lib/stores/session-host.svelte.ts
@@ -1,4 +1,5 @@
 import type { Attachment } from "svelte/attachments";
+import type { WorkspaceImageUploadTarget } from "../api/workspace-pasted-image.js";
 
 /**
  * Registry of live per-session terminal subtrees.
@@ -47,8 +48,16 @@ export interface MountedSession {
   hostKey: SessionHostKey;
   websocketPath: string;
   status: string;
+  uploadTarget?: WorkspaceImageUploadTarget;
   cursorWheelInput?: boolean;
   disabled?: boolean;
+}
+
+function uploadTargetsEqual(
+  left: WorkspaceImageUploadTarget | undefined,
+  right: WorkspaceImageUploadTarget | undefined,
+): boolean {
+  return left?.workspaceId === right?.workspaceId && left?.hostKey === right?.hostKey;
 }
 
 let parkingEl: HTMLElement | null = null;
@@ -181,6 +190,7 @@ export function noteSessionMounted(session: MountedSession): void {
     if (
       existing.websocketPath === session.websocketPath &&
       existing.status === session.status &&
+      uploadTargetsEqual(existing.uploadTarget, session.uploadTarget) &&
       (existing.cursorWheelInput ?? false) === (session.cursorWheelInput ?? false) &&
       (existing.disabled ?? false) === (session.disabled ?? false)
     ) {

--- a/frontend/src/lib/stores/session-host.test.ts
+++ b/frontend/src/lib/stores/session-host.test.ts
@@ -52,6 +52,30 @@ describe("session host registry", () => {
     expect(agentOnA).toBe(sessionHostKey("ws-1", undefined, "agent", "2026-01-01T00:00:00Z"));
   });
 
+  it("replaces mounted metadata when the image upload target changes", () => {
+    const session = mountedSession("ws-1", "agent");
+    noteSessionMounted({
+      ...session,
+      uploadTarget: { workspaceId: "ws-1", hostKey: "host-a" },
+    });
+    const first = mountedSessions()[0];
+
+    noteSessionMounted({
+      ...session,
+      uploadTarget: { workspaceId: "ws-1", hostKey: "host-a" },
+    });
+    expect(mountedSessions()[0]).toBe(first);
+
+    noteSessionMounted({
+      ...session,
+      uploadTarget: { workspaceId: "ws-1", hostKey: "host-b" },
+    });
+    expect(mountedSessions()[0]?.uploadTarget).toEqual({
+      workspaceId: "ws-1",
+      hostKey: "host-b",
+    });
+  });
+
   it("routes composed input to the current pooled terminal", () => {
     const first = {
       send: vi.fn(() => true),

--- a/internal/server/api_auth_test.go
+++ b/internal/server/api_auth_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -138,6 +139,40 @@ func TestAPIAuthGatesAPIRoutes(t *testing.T) {
 		r.Header.Set("Authorization", "Bearer wrong")
 	})
 	assert.Equal(http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestAPIAuthGatesPastedImageUpload(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ts := newAuthTestServer(t, "secret-token")
+	post := func(token string) *http.Response {
+		t.Helper()
+		req, err := http.NewRequestWithContext(
+			t.Context(), http.MethodPost,
+			ts.URL+"/api/v1/workspaces/ws-1/pasted-images",
+			strings.NewReader(`{"data":"aW1hZ2U="}`),
+		)
+		require.NoError(err)
+		req.Header.Set("Content-Type", "application/json")
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		resp, err := ts.Client().Do(req)
+		require.NoError(err)
+		t.Cleanup(func() { resp.Body.Close() })
+		return resp
+	}
+
+	unauthorized := post("")
+	require.Equal(http.StatusUnauthorized, unauthorized.StatusCode)
+	var problem struct {
+		Code string `json:"code"`
+	}
+	require.NoError(json.NewDecoder(unauthorized.Body).Decode(&problem))
+	assert.Equal("unauthorized", problem.Code)
+
+	authorized := post("secret-token")
+	assert.NotEqual(http.StatusUnauthorized, authorized.StatusCode)
 }
 
 // TestAPIAuthGatesTerminalWebSocketRoutes pins that the /ws/ terminal

--- a/internal/server/basepath_test.go
+++ b/internal/server/basepath_test.go
@@ -129,6 +129,22 @@ func TestCSRFRejectsCrossSite(t *testing.T) {
 	require.Equal(t, http.StatusForbidden, rr.Code)
 }
 
+func TestPastedImageUploadRejectsCrossSite(t *testing.T) {
+	srv := setupWithBasePath(t, "/", nil)
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/workspaces/ws-1/pasted-images",
+		strings.NewReader(`{"data":"aW1hZ2U="}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	recorder := httptest.NewRecorder()
+
+	srv.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusForbidden, recorder.Code, recorder.Body.String())
+}
+
 func TestCSRFRejectsWrongContentType(t *testing.T) {
 	srv := setupWithBasePath(t, "/", nil)
 

--- a/internal/server/fleetapi/fleet_proxy.go
+++ b/internal/server/fleetapi/fleet_proxy.go
@@ -1,6 +1,7 @@
 package fleetapi
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -30,14 +31,16 @@ import (
 )
 
 type fleetRESTProxyRoute struct {
-	operationID string
-	method      string
-	path        string
-	summary     string
-	pathParams  []string
-	queryParams []*huma.Param
-	body        bool
-	targetPath  func(*http.Request) string
+	operationID  string
+	method       string
+	path         string
+	summary      string
+	pathParams   []string
+	queryParams  []*huma.Param
+	body         bool
+	hidden       bool
+	maxBodyBytes int64
+	targetPath   func(*http.Request) string
 }
 
 type fleetHostTarget struct {
@@ -107,6 +110,19 @@ func (s *Handler) registerFleetOperationRoutes(api huma.API) {
 			pathParams:  []string{"host_key", "id"},
 			targetPath: func(r *http.Request) string {
 				return "/api/v1/workspaces/" + escapePath(r.PathValue("id"))
+			},
+		},
+		{
+			operationID:  "write-fleet-workspace-pasted-image",
+			method:       http.MethodPost,
+			path:         "/fleet/hosts/{host_key}/workspaces/{id}/pasted-images",
+			summary:      "Write a pasted image on fleet host",
+			pathParams:   []string{"host_key", "id"},
+			body:         true,
+			hidden:       true,
+			maxBodyBytes: workspaceapi.MaxPastedImageRequestBytes,
+			targetPath: func(r *http.Request) string {
+				return "/api/v1/workspaces/" + escapePath(r.PathValue("id")) + "/pasted-images"
 			},
 		},
 		{
@@ -539,6 +555,10 @@ func (s *Handler) registerFleetOperationRoutes(api huma.API) {
 	}
 
 	for _, route := range routes {
+		maxBodyBytes := int64(-1)
+		if route.maxBodyBytes > 0 {
+			maxBodyBytes = route.maxBodyBytes
+		}
 		op := &huma.Operation{
 			OperationID:  route.operationID,
 			Method:       route.method,
@@ -547,17 +567,51 @@ func (s *Handler) registerFleetOperationRoutes(api huma.API) {
 			Tags:         []string{"Fleet"},
 			Parameters:   fleetProxyParams(route.pathParams, route.queryParams...),
 			Responses:    fleetProxyResponses(),
-			MaxBodyBytes: -1,
+			Hidden:       route.hidden,
+			MaxBodyBytes: maxBodyBytes,
 		}
 		if route.body {
 			op.RequestBody = fleetProxyRequestBody()
 		}
-		api.OpenAPI().AddOperation(op)
+		if !route.hidden {
+			api.OpenAPI().AddOperation(op)
+		}
 		api.Adapter().Handle(op, func(ctx huma.Context) {
 			r, w := humago.Unwrap(ctx)
+			if route.maxBodyBytes > 0 && !bufferFleetProxyBody(w, r, route.maxBodyBytes) {
+				return
+			}
 			s.serveFleetRESTProxy(w, r, route.targetPath(r))
 		})
 	}
+}
+
+func bufferFleetProxyBody(w http.ResponseWriter, r *http.Request, maxBytes int64) bool {
+	limited := http.MaxBytesReader(w, r.Body, maxBytes)
+	body, err := io.ReadAll(limited)
+	_ = limited.Close()
+	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeProblemResponse(w, httpapi.NewProblem(
+				http.StatusRequestEntityTooLarge,
+				httpapi.CodePayloadTooLarge,
+				"fleet request body exceeds the size limit",
+				map[string]any{"maxBytes": maxBytes},
+			))
+			return false
+		}
+		writeProblemResponse(w, httpapi.NewProblem(
+			http.StatusBadRequest,
+			httpapi.CodeBadRequest,
+			"read fleet request body: "+err.Error(),
+			nil,
+		))
+		return false
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	r.ContentLength = int64(len(body))
+	return true
 }
 
 // RegisterTerminal registers hidden Fleet websocket proxy routes.

--- a/internal/server/fleetapi/fleet_proxy_test.go
+++ b/internal/server/fleetapi/fleet_proxy_test.go
@@ -2,9 +2,13 @@ package fleetapi
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -13,7 +17,84 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/forge/internal/config"
+	"go.kenn.io/forge/internal/server/workspaceapi"
 )
+
+func TestHTTPFleetProxyRelaysPastedImageJSON(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	require := require.New(t)
+	png := []byte("\x89PNG\r\n\x1a\nfleet http fixture")
+	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("/api/v1/workspaces/ws_1/pasted-images", r.URL.Path)
+		assert.Equal("application/json", r.Header.Get("Content-Type"))
+		var request struct {
+			Data string `json:"data"`
+		}
+		if !assert.NoError(json.NewDecoder(r.Body).Decode(&request)) {
+			return
+		}
+		decoded, err := base64.StdEncoding.DecodeString(request.Data)
+		if !assert.NoError(err) {
+			return
+		}
+		assert.Equal(png, decoded)
+		w.Header().Set("Content-Type", "application/json")
+		_, err = io.WriteString(w, `{"path":".kenn-forge/pasted-images/paste-http.png"}`)
+		assert.NoError(err)
+	}))
+	t.Cleanup(peer.Close)
+
+	srv, _ := setupTestServer(t)
+	setTestFleetConfig(srv, func(cfg *config.Config) {
+		cfg.Fleet.Enabled = true
+		cfg.Fleet.Peers = []config.FleetPeer{{Key: "member", BaseURL: peer.URL}}
+	})
+	hub := httptest.NewServer(srv.localHandler())
+	t.Cleanup(hub.Close)
+	body, err := json.Marshal(map[string]string{"data": base64.StdEncoding.EncodeToString(png)})
+	require.NoError(err)
+
+	response := httpDo(t, hub, http.MethodPost,
+		"/api/v1/fleet/hosts/member/workspaces/ws_1/pasted-images", body)
+	defer response.Body.Close()
+	require.Equal(http.StatusOK, response.StatusCode)
+	var output struct {
+		Path string `json:"path"`
+	}
+	require.NoError(json.NewDecoder(response.Body).Decode(&output))
+	assert.Equal(".kenn-forge/pasted-images/paste-http.png", output.Path)
+}
+
+func TestFleetPastedImageRejectsOversizedBodyBeforeRelay(t *testing.T) {
+	t.Parallel()
+	var relayed atomic.Bool
+	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		relayed.Store(true)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(peer.Close)
+
+	srv, _ := setupTestServer(t)
+	setTestFleetConfig(srv, func(cfg *config.Config) {
+		cfg.Fleet.Enabled = true
+		cfg.Fleet.Peers = []config.FleetPeer{{Key: "member", BaseURL: peer.URL}}
+	})
+	hub := httptest.NewServer(srv.localHandler())
+	t.Cleanup(hub.Close)
+	body := `{"data":"` + strings.Repeat("A", int(workspaceapi.MaxPastedImageRequestBytes)) + `"}`
+
+	response, err := http.Post(
+		hub.URL+"/api/v1/fleet/hosts/member/workspaces/ws_1/pasted-images",
+		"application/json",
+		strings.NewReader(body),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = response.Body.Close() })
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, response.StatusCode)
+	assert.False(t, relayed.Load())
+}
 
 func TestFleetWebSocketProxyNegotiatesContextTakeoverOnBothLegs(t *testing.T) {
 	require := require.New(t)

--- a/internal/server/fleetapi/fleet_ssh_test.go
+++ b/internal/server/fleetapi/fleet_ssh_test.go
@@ -2,6 +2,7 @@ package fleetapi
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -419,6 +420,47 @@ func TestSSHFleetProxyRelaysWrites(t *testing.T) {
 	}
 	assert.Contains(string(relayedBody), "create_on_disk",
 		"request body must ride the relay verbatim")
+}
+
+func TestSSHFleetProxyRelaysPastedImageJSON(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	png := []byte("\x89PNG\r\n\x1a\nfleet ssh fixture")
+	fake := &fakeSSHExec{routes: map[string]string{
+		"POST /api/v1/workspaces/ws_1/pasted-images": framedJSON(
+			http.StatusOK,
+			`{"path":".kenn-forge/pasted-images/paste-ssh.png"}`,
+		),
+	}}
+	srv, _ := setupTestServer(t)
+	setTestFleetConfig(srv, func(cfg *config.Config) { cfg.Fleet.Enabled = true })
+	srv.sshFleet = newSSHTestTransport(t, fake, config.FleetSSHPeer{
+		Key: "host-a", Destination: "maintainer@host-a.example",
+	})
+	hub := httptest.NewServer(srv.localHandler())
+	t.Cleanup(hub.Close)
+	body, err := json.Marshal(map[string]string{"data": base64.StdEncoding.EncodeToString(png)})
+	require.NoError(err)
+
+	response := httpDo(t, hub, http.MethodPost,
+		"/api/v1/fleet/hosts/host-a/workspaces/ws_1/pasted-images", body)
+	defer response.Body.Close()
+	require.Equal(http.StatusOK, response.StatusCode)
+	var output struct {
+		Path string `json:"path"`
+	}
+	require.NoError(json.NewDecoder(response.Body).Decode(&output))
+	assert.Equal(".kenn-forge/pasted-images/paste-ssh.png", output.Path)
+
+	index := slices.Index(fake.calls, "POST /api/v1/workspaces/ws_1/pasted-images")
+	require.NotEqual(-1, index)
+	var relayed struct {
+		Data string `json:"data"`
+	}
+	require.NoError(json.Unmarshal(fake.bodies[index], &relayed))
+	decoded, err := base64.StdEncoding.DecodeString(relayed.Data)
+	require.NoError(err)
+	assert.Equal(png, decoded)
 }
 
 func TestSSHFleetProxyRelaysWorkspaceDiffReads(t *testing.T) {

--- a/internal/server/workspaceapi/handler.go
+++ b/internal/server/workspaceapi/handler.go
@@ -242,6 +242,7 @@ func (h *Handler) enqueueDetailSyncWithCompletion(
 // Register registers workspace and local-project REST operations.
 func (s *Handler) Register(api huma.API) {
 	s.registerTerminalClipboard(api)
+	s.registerPastedImages(api)
 	huma.Register(api, huma.Operation{
 		OperationID: "receive-agent-hook",
 		Method:      http.MethodPost,

--- a/internal/server/workspaceapi/pasted_images.go
+++ b/internal/server/workspaceapi/pasted_images.go
@@ -1,0 +1,80 @@
+package workspaceapi
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"go.kenn.io/forge/internal/server/httpapi"
+	"go.kenn.io/forge/internal/workspace"
+)
+
+const MaxPastedImageRequestBytes = int64(
+	((workspace.MaxPastedImageBytes+2)/3)*4 + 1024,
+)
+
+type pastedImageInput struct {
+	ID   string `path:"id"`
+	Body struct {
+		Data string `json:"data"`
+	}
+}
+
+type pastedImageOutput struct {
+	Body struct {
+		Path string `json:"path"`
+	}
+}
+
+func (h *Handler) registerPastedImages(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID:  "write-workspace-pasted-image",
+		Method:       http.MethodPost,
+		Path:         "/workspaces/{id}/pasted-images",
+		Hidden:       true,
+		MaxBodyBytes: MaxPastedImageRequestBytes,
+	}, h.writeWorkspacePastedImage)
+}
+
+func (h *Handler) writeWorkspacePastedImage(
+	ctx context.Context,
+	input *pastedImageInput,
+) (*pastedImageOutput, error) {
+	decoded, err := base64.StdEncoding.DecodeString(input.Body.Data)
+	if err != nil {
+		return nil, httpapi.Validation("body.data", "data must be valid base64")
+	}
+	if len(decoded) > workspace.MaxPastedImageBytes {
+		return nil, httpapi.PayloadTooLarge(
+			"pasted image exceeds the size limit", workspace.MaxPastedImageBytes,
+		)
+	}
+	path, err := h.workspaces.StorePastedImage(ctx, input.ID, decoded)
+	if err != nil {
+		switch {
+		case errors.Is(err, workspace.ErrPastedImageTooLarge):
+			return nil, httpapi.PayloadTooLarge(
+				"pasted image exceeds the size limit", workspace.MaxPastedImageBytes,
+			)
+		case errors.Is(err, workspace.ErrUnsupportedPastedImage):
+			return nil, httpapi.Validation(
+				"body.data", "data must contain a supported PNG, JPEG, GIF, or WebP image",
+			)
+		case errors.Is(err, workspace.ErrWorkspaceNotFound):
+			return nil, httpapi.NotFound(
+				httpapi.CodeWorkspaceNotFound, "workspace not found", nil,
+			)
+		case errors.Is(err, workspace.ErrWorkspaceInvalidState),
+			errors.Is(err, workspace.ErrPastedImagePathConflict):
+			return nil, httpapi.Conflict(httpapi.CodeConflict, err.Error(), nil)
+		default:
+			return nil, err
+		}
+	}
+	output := &pastedImageOutput{}
+	output.Body.Path = path
+	return output, nil
+}

--- a/internal/server/workspaceapi/pasted_images.go
+++ b/internal/server/workspaceapi/pasted_images.go
@@ -68,6 +68,7 @@ func (h *Handler) writeWorkspacePastedImage(
 				httpapi.CodeWorkspaceNotFound, "workspace not found", nil,
 			)
 		case errors.Is(err, workspace.ErrWorkspaceInvalidState),
+			errors.Is(err, workspace.ErrPastedImageQuotaExceeded),
 			errors.Is(err, workspace.ErrPastedImagePathConflict):
 			return nil, httpapi.Conflict(httpapi.CodeConflict, err.Error(), nil)
 		default:

--- a/internal/server/workspaceapi/pasted_images_test.go
+++ b/internal/server/workspaceapi/pasted_images_test.go
@@ -1,0 +1,151 @@
+package workspaceapi
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humago"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+	"go.kenn.io/forge/internal/workspace"
+)
+
+func TestPostPastedImageWritesDecodedBytes(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	require := require.New(t)
+	mux, api, worktree := setupPastedImageAPI(t, "ready")
+	png := []byte("\x89PNG\r\n\x1a\napi fixture")
+
+	recorder := postPastedImage(t, mux, "ws-pasted-image-api", map[string]string{
+		"data": base64.StdEncoding.EncodeToString(png),
+	})
+
+	require.Equal(http.StatusOK, recorder.Code, recorder.Body.String())
+	var response struct {
+		Path string `json:"path"`
+	}
+	require.NoError(json.Unmarshal(recorder.Body.Bytes(), &response))
+	stored, err := os.ReadFile(filepath.Join(worktree, filepath.FromSlash(response.Path)))
+	require.NoError(err)
+	assert.Equal(png, stored)
+	_, documented := api.OpenAPI().Paths["/workspaces/{id}/pasted-images"]
+	assert.False(documented)
+}
+
+func TestPostPastedImageValidatesJSONAndDecodedContent(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		status     string
+		workspace  string
+		data       string
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name: "invalid base64", status: "ready", workspace: "ws-pasted-image-api",
+			data: "%%%", wantStatus: http.StatusBadRequest, wantCode: "validationError",
+		},
+		{
+			name: "unsupported bytes", status: "ready", workspace: "ws-pasted-image-api",
+			data:       base64.StdEncoding.EncodeToString([]byte("not an image")),
+			wantStatus: http.StatusBadRequest, wantCode: "validationError",
+		},
+		{
+			name: "missing workspace", status: "ready", workspace: "missing",
+			data:       base64.StdEncoding.EncodeToString([]byte("\x89PNG\r\n\x1a\nfixture")),
+			wantStatus: http.StatusNotFound, wantCode: "workspaceNotFound",
+		},
+		{
+			name: "workspace not ready", status: "starting", workspace: "ws-pasted-image-api",
+			data:       base64.StdEncoding.EncodeToString([]byte("\x89PNG\r\n\x1a\nfixture")),
+			wantStatus: http.StatusConflict, wantCode: "conflict",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mux, _, _ := setupPastedImageAPI(t, tt.status)
+			recorder := postPastedImage(t, mux, tt.workspace, map[string]string{"data": tt.data})
+			assert.Equal(t, tt.wantStatus, recorder.Code, recorder.Body.String())
+			var problem struct {
+				Code string `json:"code"`
+			}
+			require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &problem))
+			assert.Equal(t, tt.wantCode, problem.Code)
+		})
+	}
+}
+
+func TestPostPastedImageEnforcesEncodedAndDecodedLimits(t *testing.T) {
+	mux, _, _ := setupPastedImageAPI(t, "ready")
+	decoded := append([]byte("\x89PNG\r\n\x1a\n"), make([]byte, workspace.MaxPastedImageBytes-7)...)
+	recorder := postPastedImage(t, mux, "ws-pasted-image-api", map[string]string{
+		"data": base64.StdEncoding.EncodeToString(decoded),
+	})
+	require.Equal(t, http.StatusRequestEntityTooLarge, recorder.Code, recorder.Body.String())
+
+	body := `{"data":"` + strings.Repeat("A", int(MaxPastedImageRequestBytes)) + `"}`
+	request := httptest.NewRequest(
+		http.MethodPost, "/api/v1/workspaces/ws-pasted-image-api/pasted-images",
+		strings.NewReader(body),
+	)
+	request.Header.Set("Content-Type", "application/json")
+	recorder = httptest.NewRecorder()
+	mux.ServeHTTP(recorder, request)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, recorder.Code, recorder.Body.String())
+}
+
+func setupPastedImageAPI(t *testing.T, status string) (*http.ServeMux, huma.API, string) {
+	t.Helper()
+	database := dbtest.Open(t)
+	worktree := t.TempDir()
+	runTokenRuntimeTestGit(t, worktree, "init", "--initial-branch=main")
+	runTokenRuntimeTestGit(t, worktree, "config", "user.email", "test@example.test")
+	runTokenRuntimeTestGit(t, worktree, "config", "user.name", "Test User")
+	require.NoError(t, os.WriteFile(filepath.Join(worktree, "README.md"), []byte("# Test\n"), 0o644))
+	runTokenRuntimeTestGit(t, worktree, "add", "README.md")
+	runTokenRuntimeTestGit(t, worktree, "commit", "-m", "initial")
+	require.NoError(t, database.InsertWorkspace(t.Context(), &db.Workspace{
+		ID: "ws-pasted-image-api", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget", ItemType: db.WorkspaceItemTypePullRequest,
+		ItemNumber: 1, WorktreePath: worktree, Status: status,
+	}))
+	manager := workspace.NewManager(database, t.TempDir())
+	handler := New(Deps{DB: database, Workspaces: manager})
+	mux := http.NewServeMux()
+	api := humago.NewWithPrefix(mux, "/api/v1", huma.DefaultConfig("workspace test", "1"))
+	handler.Register(api)
+	return mux, api, worktree
+}
+
+func postPastedImage(
+	t *testing.T,
+	mux *http.ServeMux,
+	workspaceID string,
+	body any,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	encoded, err := json.Marshal(body)
+	require.NoError(t, err)
+	request := httptest.NewRequest(
+		http.MethodPost, "/api/v1/workspaces/"+workspaceID+"/pasted-images",
+		bytes.NewReader(encoded),
+	)
+	request.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, request)
+	return recorder
+}

--- a/internal/server/workspaceapi/pasted_images_test.go
+++ b/internal/server/workspaceapi/pasted_images_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -106,6 +107,33 @@ func TestPostPastedImageEnforcesEncodedAndDecodedLimits(t *testing.T) {
 	recorder = httptest.NewRecorder()
 	mux.ServeHTTP(recorder, request)
 	assert.Equal(t, http.StatusRequestEntityTooLarge, recorder.Code, recorder.Body.String())
+}
+
+func TestPostPastedImageReturnsConflictAtWorkspaceQuota(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	require := require.New(t)
+	mux, _, worktree := setupPastedImageAPI(t, "ready")
+	imageDir := filepath.Join(worktree, workspace.PastedImageDirectory)
+	require.NoError(os.MkdirAll(imageDir, 0o755))
+	for index := range workspace.MaxPastedImagesPerWorkspace {
+		require.NoError(os.WriteFile(
+			filepath.Join(imageDir, fmt.Sprintf("existing-%03d.png", index)),
+			[]byte("fixture"),
+			0o600,
+		))
+	}
+
+	recorder := postPastedImage(t, mux, "ws-pasted-image-api", map[string]string{
+		"data": base64.StdEncoding.EncodeToString([]byte("\x89PNG\r\n\x1a\nfixture")),
+	})
+
+	assert.Equal(http.StatusConflict, recorder.Code, recorder.Body.String())
+	var problem struct {
+		Code string `json:"code"`
+	}
+	require.NoError(json.Unmarshal(recorder.Body.Bytes(), &problem))
+	assert.Equal("conflict", problem.Code)
 }
 
 func setupPastedImageAPI(t *testing.T, status string) (*http.ServeMux, huma.API, string) {

--- a/internal/workspace/gitignore.go
+++ b/internal/workspace/gitignore.go
@@ -11,6 +11,8 @@ import (
 )
 
 const (
+	PastedImageDirectory = ".kenn-forge/pasted-images"
+
 	// generatedContextTempPattern ignores the atomic writer's staging files.
 	generatedContextTempPattern = "/.tmp-agent-context-*"
 	// generatedContextTempProbePath is a representative path used to check
@@ -18,11 +20,15 @@ const (
 	generatedContextTempProbePath = ".tmp-agent-context-probe"
 )
 
-// EnsureGeneratedContextFilesIgnored guarantees the requested generated
-// context paths are ignored by git before they are written, adding local
-// exclude rules (never touching tracked .gitignore) only for the paths that
-// will actually be generated.
-func EnsureGeneratedContextFilesIgnored(
+type generatedIgnoreCheck struct {
+	probe   string
+	pattern string
+}
+
+// EnsureWorkspaceGeneratedPathsIgnored guarantees that known Forge-generated
+// paths are ignored by git before they are written. It updates only the
+// repository-local exclude file, never a tracked .gitignore.
+func EnsureWorkspaceGeneratedPathsIgnored(
 	ctx context.Context,
 	worktreePath string,
 	generatedRelPaths []string,
@@ -30,24 +36,16 @@ func EnsureGeneratedContextFilesIgnored(
 	missingPaths := make([]string, 0, len(generatedRelPaths)+1)
 	missingPatterns := make([]string, 0, len(generatedRelPaths)+1)
 	seenPatterns := make(map[string]bool, len(generatedRelPaths)+1)
-	checks := make([][2]string, 0, len(generatedRelPaths)+1)
+	checks := make([]generatedIgnoreCheck, 0, len(generatedRelPaths)+1)
 	for _, rel := range generatedRelPaths {
-		clean, pattern, err := generatedContextIgnorePattern(rel)
+		pathChecks, err := generatedIgnoreChecks(rel)
 		if err != nil {
 			return err
 		}
-		checks = append(checks, [2]string{clean, pattern})
-	}
-	if len(checks) > 0 {
-		// The atomic writer stages content as .tmp-agent-context-* next to
-		// the target; a crash between create and rename must not leave an
-		// untracked file dirtying the workspace.
-		checks = append(checks, [2]string{
-			generatedContextTempProbePath, generatedContextTempPattern,
-		})
+		checks = append(checks, pathChecks...)
 	}
 	for _, check := range checks {
-		clean, pattern := check[0], check[1]
+		clean, pattern := check.probe, check.pattern
 		ignored, err := gitPathIgnored(ctx, worktreePath, clean)
 		if err != nil {
 			return err
@@ -93,7 +91,7 @@ func EnsureGeneratedContextFilesIgnored(
 		if len(text) > 0 && !strings.HasSuffix(text, "\n") {
 			block.WriteString("\n")
 		}
-		block.WriteString("# kenn-forge generated agent context\n")
+		block.WriteString("# kenn-forge generated files\n")
 		for _, pattern := range add {
 			block.WriteString(pattern)
 			block.WriteString("\n")
@@ -115,12 +113,22 @@ func EnsureGeneratedContextFilesIgnored(
 		}
 		if !ignored {
 			return fmt.Errorf(
-				"generated context path %s is still not ignored after updating %s (a later rule may negate it)",
+				"generated path %s is still not ignored after updating %s (a later rule may negate it)",
 				clean, excludePath,
 			)
 		}
 	}
 	return nil
+}
+
+// EnsureGeneratedContextFilesIgnored retains the context-writer entry point
+// while sharing the generic known-generated-path implementation.
+func EnsureGeneratedContextFilesIgnored(
+	ctx context.Context,
+	worktreePath string,
+	generatedRelPaths []string,
+) error {
+	return EnsureWorkspaceGeneratedPathsIgnored(ctx, worktreePath, generatedRelPaths)
 }
 
 // gitPathIgnored reports whether git ignores rel inside worktreePath,
@@ -138,23 +146,33 @@ func gitPathIgnored(ctx context.Context, worktreePath, rel string) (bool, error)
 	return false, fmt.Errorf("git check-ignore %s: %w", rel, err)
 }
 
-// generatedContextIgnorePattern maps a generated context path to the exact
-// local ignore rule that covers it. Only known kenn-forge-generated paths are
-// allowed; anything else is rejected rather than silently ignored.
-func generatedContextIgnorePattern(rel string) (cleanPath, pattern string, err error) {
+// generatedIgnoreChecks maps a known generated path to the local ignore rules
+// and representative paths needed to verify them.
+func generatedIgnoreChecks(rel string) ([]generatedIgnoreCheck, error) {
 	rel = strings.TrimSpace(rel)
 	if rel == "AGENTS.md" || rel == "CLAUDE.md" {
-		return "", "", fmt.Errorf("refusing to add root instruction file to generated ignore list: %s", rel)
+		return nil, fmt.Errorf("refusing to add root instruction file to generated ignore list: %s", rel)
 	}
 	if rel == "" || filepath.IsAbs(rel) || strings.HasPrefix(rel, "../") || strings.Contains(rel, "/../") {
-		return "", "", fmt.Errorf("invalid generated context path: %s", rel)
+		return nil, fmt.Errorf("invalid generated path: %s", rel)
 	}
 	clean := filepath.ToSlash(filepath.Clean(rel))
 	switch clean {
 	case "AGENTS.override.md", "CLAUDE.local.md":
-		return clean, "/" + clean, nil
+		return []generatedIgnoreCheck{
+			{probe: clean, pattern: "/" + clean},
+			{
+				probe:   generatedContextTempProbePath,
+				pattern: generatedContextTempPattern,
+			},
+		}, nil
+	case PastedImageDirectory:
+		return []generatedIgnoreCheck{{
+			probe:   PastedImageDirectory + "/.ignore-probe",
+			pattern: "/" + PastedImageDirectory + "/",
+		}}, nil
 	default:
-		return "", "", fmt.Errorf("unknown generated context path: %s", clean)
+		return nil, fmt.Errorf("unknown generated path: %s", clean)
 	}
 }
 

--- a/internal/workspace/gitignore.go
+++ b/internal/workspace/gitignore.go
@@ -33,8 +33,8 @@ func EnsureWorkspaceGeneratedPathsIgnored(
 	worktreePath string,
 	generatedRelPaths []string,
 ) error {
-	missingPaths := make([]string, 0, len(generatedRelPaths)+1)
-	missingPatterns := make([]string, 0, len(generatedRelPaths)+1)
+	probePaths := make([]string, 0, len(generatedRelPaths)+1)
+	patterns := make([]string, 0, len(generatedRelPaths)+1)
 	seenPatterns := make(map[string]bool, len(generatedRelPaths)+1)
 	checks := make([]generatedIgnoreCheck, 0, len(generatedRelPaths)+1)
 	for _, rel := range generatedRelPaths {
@@ -46,21 +46,11 @@ func EnsureWorkspaceGeneratedPathsIgnored(
 	}
 	for _, check := range checks {
 		clean, pattern := check.probe, check.pattern
-		ignored, err := gitPathIgnored(ctx, worktreePath, clean)
-		if err != nil {
-			return err
-		}
-		if ignored {
-			continue
-		}
-		missingPaths = append(missingPaths, clean)
+		probePaths = append(probePaths, clean)
 		if !seenPatterns[pattern] {
 			seenPatterns[pattern] = true
-			missingPatterns = append(missingPatterns, pattern)
+			patterns = append(patterns, pattern)
 		}
-	}
-	if len(missingPaths) == 0 {
-		return nil
 	}
 
 	excludePathOut, err := gitCombinedOutput(ctx, worktreePath, "rev-parse", "--git-path", "info/exclude")
@@ -80,8 +70,8 @@ func EnsureWorkspaceGeneratedPathsIgnored(
 		return fmt.Errorf("read git exclude: %w", err)
 	}
 	text := string(content)
-	add := make([]string, 0, len(missingPatterns))
-	for _, pattern := range missingPatterns {
+	add := make([]string, 0, len(patterns))
+	for _, pattern := range patterns {
 		if !gitExcludeContainsLine(text, pattern) {
 			add = append(add, pattern)
 		}
@@ -106,7 +96,7 @@ func EnsureWorkspaceGeneratedPathsIgnored(
 		}
 	}
 
-	for _, clean := range missingPaths {
+	for _, clean := range probePaths {
 		ignored, err := gitPathIgnored(ctx, worktreePath, clean)
 		if err != nil {
 			return err

--- a/internal/workspace/gitignore_test.go
+++ b/internal/workspace/gitignore_test.go
@@ -23,7 +23,7 @@ func TestEnsureGeneratedContextFilesIgnoredAppendsMissingEntriesToGitExclude(t *
 	}))
 
 	excludeText := readGitExclude(t, worktree)
-	assert.Contains(excludeText, "# kenn-forge generated agent context")
+	assert.Contains(excludeText, "# kenn-forge generated files")
 	assert.Contains(excludeText, "/AGENTS.override.md")
 	assert.Contains(excludeText, "/CLAUDE.local.md")
 	assert.Contains(excludeText, "/.tmp-agent-context-*")
@@ -113,7 +113,7 @@ func TestEnsureGeneratedContextFilesIgnoredRejectsUnknownPaths(t *testing.T) {
 
 	err := EnsureGeneratedContextFilesIgnored(context.Background(), worktree, []string{"notes/scratch.md"})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unknown generated context path")
+	assert.Contains(t, err.Error(), "unknown generated path")
 }
 
 func TestEnsureGeneratedContextFilesIgnoredRejectsRootInstructionFiles(t *testing.T) {
@@ -123,6 +123,31 @@ func TestEnsureGeneratedContextFilesIgnoredRejectsRootInstructionFiles(t *testin
 	err := EnsureGeneratedContextFilesIgnored(context.Background(), worktree, []string{"CLAUDE.md"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "refusing to add root instruction file")
+}
+
+func TestEnsureWorkspaceGeneratedPathsIgnoredAddsPastedImageDirectory(t *testing.T) {
+	t.Parallel()
+	worktree := initWorkspaceGitRepo(t)
+
+	require.NoError(t, EnsureWorkspaceGeneratedPathsIgnored(
+		context.Background(), worktree, []string{PastedImageDirectory},
+	))
+
+	excludeText := readGitExclude(t, worktree)
+	assert.Contains(t, excludeText, "/.kenn-forge/pasted-images/")
+	assert.NotContains(t, excludeText, generatedContextTempPattern)
+	assertGitIgnored(t, worktree, ".kenn-forge/pasted-images/paste-1.png")
+}
+
+func TestEnsureWorkspaceGeneratedPathsIgnoredRejectsUnknownDirectory(t *testing.T) {
+	t.Parallel()
+	worktree := initWorkspaceGitRepo(t)
+
+	err := EnsureWorkspaceGeneratedPathsIgnored(
+		context.Background(), worktree, []string{".kenn-forge/other"},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown generated path")
 }
 
 func initWorkspaceGitRepo(t *testing.T) string {

--- a/internal/workspace/gitignore_test.go
+++ b/internal/workspace/gitignore_test.go
@@ -103,7 +103,7 @@ func TestEnsureGeneratedContextFilesIgnoredFailsOnFatalGitError(t *testing.T) {
 
 	err := EnsureGeneratedContextFilesIgnored(context.Background(), notARepo, []string{"AGENTS.override.md"})
 	require.Error(err)
-	assert.Contains(t, err.Error(), "check-ignore")
+	assert.Contains(t, err.Error(), "resolve git exclude path")
 	assert.NoFileExists(t, filepath.Join(notARepo, ".git", "info", "exclude"))
 }
 
@@ -136,6 +136,28 @@ func TestEnsureWorkspaceGeneratedPathsIgnoredAddsPastedImageDirectory(t *testing
 	excludeText := readGitExclude(t, worktree)
 	assert.Contains(t, excludeText, "/.kenn-forge/pasted-images/")
 	assert.NotContains(t, excludeText, generatedContextTempPattern)
+	assertGitIgnored(t, worktree, ".kenn-forge/pasted-images/paste-1.png")
+}
+
+func TestEnsureWorkspaceGeneratedPathsIgnoredPinsTrackedRulesInPrivateExclude(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	require := require.New(t)
+	worktree := initWorkspaceGitRepo(t)
+	require.NoError(os.WriteFile(
+		filepath.Join(worktree, ".gitignore"),
+		[]byte("/.kenn-forge/pasted-images/\n"),
+		0o644,
+	))
+	runWorkspaceTestGit(t, worktree, "add", ".gitignore")
+	runWorkspaceTestGit(t, worktree, "commit", "-m", "ignore generated images")
+
+	require.NoError(EnsureWorkspaceGeneratedPathsIgnored(
+		context.Background(), worktree, []string{PastedImageDirectory},
+	))
+
+	assert.Contains(readGitExclude(t, worktree), "/.kenn-forge/pasted-images/")
+	require.NoError(os.WriteFile(filepath.Join(worktree, ".gitignore"), nil, 0o644))
 	assertGitIgnored(t, worktree, ".kenn-forge/pasted-images/paste-1.png")
 }
 

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -48,6 +48,7 @@ type Manager struct {
 	retryMu                   sync.Mutex
 	retryQueued               map[string]bool
 	runtimeTmuxMu             sync.Mutex
+	pastedImageLocks          pastedImageLockSet
 	issueBranchSlugEnabled    bool
 	summaryCacheMu            sync.RWMutex
 	summaryCache              []WorkspaceSummary

--- a/internal/workspace/pasted_images.go
+++ b/internal/workspace/pasted_images.go
@@ -11,15 +11,39 @@ import (
 	"os"
 	"path"
 	"strings"
+	"sync"
 )
 
-const MaxPastedImageBytes = 10 * 1024 * 1024
+const (
+	MaxPastedImageBytes         = 10 * 1024 * 1024
+	MaxPastedImagesPerWorkspace = 100
+)
 
 var (
-	ErrPastedImageTooLarge     = errors.New("pasted image exceeds the size limit")
-	ErrUnsupportedPastedImage  = errors.New("unsupported pasted image")
-	ErrPastedImagePathConflict = errors.New("pasted image storage path conflicts with an existing file")
+	ErrPastedImageTooLarge      = errors.New("pasted image exceeds the size limit")
+	ErrPastedImageQuotaExceeded = errors.New("pasted image workspace quota exceeded")
+	ErrUnsupportedPastedImage   = errors.New("unsupported pasted image")
+	ErrPastedImagePathConflict  = errors.New("pasted image storage path conflicts with an existing file")
 )
+
+type pastedImageLockSet struct {
+	mu    sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+func (s *pastedImageLockSet) workspace(workspaceID string) *sync.Mutex {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.locks == nil {
+		s.locks = make(map[string]*sync.Mutex)
+	}
+	if lock := s.locks[workspaceID]; lock != nil {
+		return lock
+	}
+	lock := &sync.Mutex{}
+	s.locks[workspaceID] = lock
+	return lock
+}
 
 // StorePastedImage validates decoded clipboard bytes and materializes them
 // inside a ready workspace. It returns only a slash-separated workspace path.
@@ -46,6 +70,9 @@ func (m *Manager) StorePastedImage(
 	if ws.Status != "ready" || strings.TrimSpace(ws.WorktreePath) == "" {
 		return "", ErrWorkspaceInvalidState
 	}
+	lock := m.pastedImageLocks.workspace(ws.ID)
+	lock.Lock()
+	defer lock.Unlock()
 	if err := preparePastedImageDirectory(ws.WorktreePath); err != nil {
 		return "", err
 	}
@@ -91,6 +118,9 @@ func writePastedImageAtomic(worktreePath string, data []byte, extension string) 
 	if err := ensurePastedImageDirectory(root); err != nil {
 		return "", err
 	}
+	if err := enforcePastedImageQuota(root); err != nil {
+		return "", err
+	}
 	id, err := pastedImageID()
 	if err != nil {
 		return "", err
@@ -116,6 +146,25 @@ func writePastedImageAtomic(worktreePath string, data []byte, extension string) 
 	}
 	installed = true
 	return finalPath, nil
+}
+
+func enforcePastedImageQuota(root *os.Root) error {
+	directory, err := root.Open(PastedImageDirectory)
+	if err != nil {
+		return fmt.Errorf("inspect pasted image quota: %w", err)
+	}
+	entries, readErr := directory.ReadDir(MaxPastedImagesPerWorkspace)
+	closeErr := directory.Close()
+	if readErr != nil && !errors.Is(readErr, io.EOF) {
+		return fmt.Errorf("inspect pasted image quota: %w", readErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close pasted image directory: %w", closeErr)
+	}
+	if len(entries) >= MaxPastedImagesPerWorkspace {
+		return ErrPastedImageQuotaExceeded
+	}
+	return nil
 }
 
 func ensurePastedImageDirectory(root *os.Root) error {

--- a/internal/workspace/pasted_images.go
+++ b/internal/workspace/pasted_images.go
@@ -1,0 +1,165 @@
+package workspace
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+)
+
+const MaxPastedImageBytes = 10 * 1024 * 1024
+
+var (
+	ErrPastedImageTooLarge     = errors.New("pasted image exceeds the size limit")
+	ErrUnsupportedPastedImage  = errors.New("unsupported pasted image")
+	ErrPastedImagePathConflict = errors.New("pasted image storage path conflicts with an existing file")
+)
+
+// StorePastedImage validates decoded clipboard bytes and materializes them
+// inside a ready workspace. It returns only a slash-separated workspace path.
+func (m *Manager) StorePastedImage(
+	ctx context.Context,
+	workspaceID string,
+	data []byte,
+) (string, error) {
+	if len(data) > MaxPastedImageBytes {
+		return "", ErrPastedImageTooLarge
+	}
+	extension, ok := pastedImageExtension(http.DetectContentType(data))
+	if !ok {
+		return "", ErrUnsupportedPastedImage
+	}
+
+	ws, err := m.Get(ctx, workspaceID)
+	if err != nil {
+		return "", err
+	}
+	if ws == nil {
+		return "", ErrWorkspaceNotFound
+	}
+	if ws.Status != "ready" || strings.TrimSpace(ws.WorktreePath) == "" {
+		return "", ErrWorkspaceInvalidState
+	}
+	if err := preparePastedImageDirectory(ws.WorktreePath); err != nil {
+		return "", err
+	}
+	if err := EnsureWorkspaceGeneratedPathsIgnored(
+		ctx, ws.WorktreePath, []string{PastedImageDirectory},
+	); err != nil {
+		return "", fmt.Errorf("ignore pasted image directory: %w", err)
+	}
+	return writePastedImageAtomic(ws.WorktreePath, data, extension)
+}
+
+func preparePastedImageDirectory(worktreePath string) error {
+	root, err := os.OpenRoot(worktreePath)
+	if err != nil {
+		return fmt.Errorf("open workspace root: %w", err)
+	}
+	defer root.Close()
+	return ensurePastedImageDirectory(root)
+}
+
+func pastedImageExtension(contentType string) (string, bool) {
+	switch contentType {
+	case "image/png":
+		return "png", true
+	case "image/jpeg":
+		return "jpg", true
+	case "image/gif":
+		return "gif", true
+	case "image/webp":
+		return "webp", true
+	default:
+		return "", false
+	}
+}
+
+func writePastedImageAtomic(worktreePath string, data []byte, extension string) (string, error) {
+	root, err := os.OpenRoot(worktreePath)
+	if err != nil {
+		return "", fmt.Errorf("open workspace root: %w", err)
+	}
+	defer root.Close()
+
+	if err := ensurePastedImageDirectory(root); err != nil {
+		return "", err
+	}
+	id, err := pastedImageID()
+	if err != nil {
+		return "", err
+	}
+	tempPath := path.Join(PastedImageDirectory, ".tmp-paste-"+id)
+	finalPath := path.Join(PastedImageDirectory, "paste-"+id+"."+extension)
+	installed := false
+	defer func() {
+		if !installed {
+			_ = root.Remove(tempPath)
+		}
+	}()
+
+	file, err := root.OpenFile(tempPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return "", fmt.Errorf("create pasted image temporary file: %w", err)
+	}
+	if err := writeAndSyncPastedImage(file, data); err != nil {
+		return "", err
+	}
+	if err := root.Rename(tempPath, finalPath); err != nil {
+		return "", fmt.Errorf("install pasted image: %w", err)
+	}
+	installed = true
+	return finalPath, nil
+}
+
+func ensurePastedImageDirectory(root *os.Root) error {
+	for _, directory := range []string{".kenn-forge", PastedImageDirectory} {
+		info, err := root.Lstat(directory)
+		if errors.Is(err, os.ErrNotExist) {
+			if err := root.Mkdir(directory, 0o755); err != nil && !errors.Is(err, os.ErrExist) {
+				return fmt.Errorf("create pasted image directory %s: %w", directory, err)
+			}
+			info, err = root.Lstat(directory)
+		}
+		if err != nil {
+			return fmt.Errorf("inspect pasted image directory %s: %w", directory, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return fmt.Errorf("%w: %s", ErrPastedImagePathConflict, directory)
+		}
+	}
+	return nil
+}
+
+func writeAndSyncPastedImage(file *os.File, data []byte) error {
+	written, writeErr := file.Write(data)
+	if writeErr == nil && written != len(data) {
+		writeErr = io.ErrShortWrite
+	}
+	if writeErr != nil {
+		_ = file.Close()
+		return fmt.Errorf("write pasted image: %w", writeErr)
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("sync pasted image: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close pasted image: %w", err)
+	}
+	return nil
+}
+
+func pastedImageID() (string, error) {
+	random := make([]byte, 16)
+	if _, err := rand.Read(random); err != nil {
+		return "", fmt.Errorf("generate pasted image name: %w", err)
+	}
+	return hex.EncodeToString(random), nil
+}

--- a/internal/workspace/pasted_images.go
+++ b/internal/workspace/pasted_images.go
@@ -130,6 +130,9 @@ func ensurePastedImageDirectory(root *os.Root) error {
 		if err != nil {
 			return fmt.Errorf("inspect pasted image directory %s: %w", directory, err)
 		}
+		if info == nil {
+			return fmt.Errorf("inspect pasted image directory %s: missing file information", directory)
+		}
 		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
 			return fmt.Errorf("%w: %s", ErrPastedImagePathConflict, directory)
 		}

--- a/internal/workspace/pasted_images_test.go
+++ b/internal/workspace/pasted_images_test.go
@@ -1,0 +1,194 @@
+package workspace
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+)
+
+func TestStorePastedImageDetectsSupportedFormats(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		data []byte
+		ext  string
+	}{
+		{name: "png", data: []byte("\x89PNG\r\n\x1a\nfixture"), ext: "png"},
+		{name: "jpeg", data: []byte("\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01fixture"), ext: "jpg"},
+		{name: "gif", data: []byte("GIF89a\x01\x00\x01\x00fixture"), ext: "gif"},
+		{name: "webp", data: []byte("RIFF\x10\x00\x00\x00WEBPVP8 fixture"), ext: "webp"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert := assert.New(t)
+			require := require.New(t)
+			manager, workspaceRow := setupPastedImageWorkspace(t, "ready")
+
+			relPath, err := manager.StorePastedImage(t.Context(), workspaceRow.ID, tt.data)
+			require.NoError(err)
+			assert.Regexp(`^\.kenn-forge/pasted-images/paste-[0-9a-f]{32}\.`+tt.ext+`$`, relPath)
+
+			absolutePath := filepath.Join(workspaceRow.WorktreePath, filepath.FromSlash(relPath))
+			stored, err := os.ReadFile(absolutePath)
+			require.NoError(err)
+			assert.Equal(tt.data, stored)
+			info, err := os.Stat(absolutePath)
+			require.NoError(err)
+			assert.Equal(fs.FileMode(0o600), info.Mode().Perm())
+		})
+	}
+}
+
+func TestStorePastedImageRejectsInvalidInputAndWorkspaceState(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	readyManager, readyWorkspace := setupPastedImageWorkspace(t, "ready")
+	startingManager, startingWorkspace := setupPastedImageWorkspace(t, "starting")
+
+	_, err := readyManager.StorePastedImage(
+		t.Context(), readyWorkspace.ID, make([]byte, MaxPastedImageBytes+1),
+	)
+	require.ErrorIs(err, ErrPastedImageTooLarge)
+
+	_, err = readyManager.StorePastedImage(t.Context(), readyWorkspace.ID, []byte("not an image"))
+	require.ErrorIs(err, ErrUnsupportedPastedImage)
+
+	_, err = readyManager.StorePastedImage(t.Context(), "missing", pastedImagePNGFixture())
+	require.ErrorIs(err, ErrWorkspaceNotFound)
+
+	_, err = startingManager.StorePastedImage(t.Context(), startingWorkspace.ID, pastedImagePNGFixture())
+	require.ErrorIs(err, ErrWorkspaceInvalidState)
+}
+
+func TestStorePastedImageRejectsConflictingStoragePaths(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		setup func(*testing.T, string, string)
+	}{
+		{
+			name: "root symlink",
+			setup: func(t *testing.T, worktree, outside string) {
+				require := require.New(t)
+				require.NoError(os.Symlink(outside, filepath.Join(worktree, ".kenn-forge")))
+			},
+		},
+		{
+			name: "root regular file",
+			setup: func(t *testing.T, worktree, _ string) {
+				require := require.New(t)
+				require.NoError(os.WriteFile(filepath.Join(worktree, ".kenn-forge"), []byte("conflict"), 0o600))
+			},
+		},
+		{
+			name: "image directory symlink",
+			setup: func(t *testing.T, worktree, outside string) {
+				require := require.New(t)
+				require.NoError(os.Mkdir(filepath.Join(worktree, ".kenn-forge"), 0o755))
+				require.NoError(os.Symlink(outside, filepath.Join(worktree, PastedImageDirectory)))
+			},
+		},
+		{
+			name: "image directory regular file",
+			setup: func(t *testing.T, worktree, _ string) {
+				require := require.New(t)
+				require.NoError(os.Mkdir(filepath.Join(worktree, ".kenn-forge"), 0o755))
+				require.NoError(os.WriteFile(filepath.Join(worktree, PastedImageDirectory), []byte("conflict"), 0o600))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			manager, workspaceRow := setupPastedImageWorkspace(t, "ready")
+			outside := t.TempDir()
+			tt.setup(t, workspaceRow.WorktreePath, outside)
+
+			_, err := manager.StorePastedImage(t.Context(), workspaceRow.ID, pastedImagePNGFixture())
+			require.ErrorIs(t, err, ErrPastedImagePathConflict)
+			entries, readErr := os.ReadDir(outside)
+			require.NoError(t, readErr)
+			assert.Empty(t, entries)
+		})
+	}
+}
+
+func TestStorePastedImageDoesNotDirtyGitStatus(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	require := require.New(t)
+	manager, workspaceRow := setupPastedImageWorkspace(t, "ready")
+
+	_, err := manager.StorePastedImage(t.Context(), workspaceRow.ID, pastedImagePNGFixture())
+	require.NoError(err)
+
+	status := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, workspaceRow.WorktreePath, "status", "--porcelain",
+	)))
+	assert.Empty(status)
+	entries, err := os.ReadDir(filepath.Join(workspaceRow.WorktreePath, PastedImageDirectory))
+	require.NoError(err)
+	for _, entry := range entries {
+		assert.False(strings.HasPrefix(entry.Name(), ".tmp-paste-"), entry.Name())
+	}
+}
+
+func TestStorePastedImageConcurrentFirstWrites(t *testing.T) {
+	t.Parallel()
+	manager, workspaceRow := setupPastedImageWorkspace(t, "ready")
+	const writes = 8
+	start := make(chan struct{})
+	errs := make(chan error, writes)
+	var wait sync.WaitGroup
+	for range writes {
+		wait.Go(func() {
+			<-start
+			_, err := manager.StorePastedImage(
+				t.Context(), workspaceRow.ID, pastedImagePNGFixture(),
+			)
+			errs <- err
+		})
+	}
+	close(start)
+	wait.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	entries, err := os.ReadDir(filepath.Join(workspaceRow.WorktreePath, PastedImageDirectory))
+	require.NoError(t, err)
+	assert.Len(t, entries, writes)
+}
+
+func setupPastedImageWorkspace(t *testing.T, status string) (*Manager, *db.Workspace) {
+	t.Helper()
+	database := dbtest.Open(t)
+	worktree := initWorkspaceGitRepo(t)
+	workspaceRow := &db.Workspace{
+		ID:           "ws-pasted-image-" + strings.ReplaceAll(t.Name(), "/", "-"),
+		Platform:     "github",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   1,
+		WorktreePath: worktree,
+		Status:       status,
+	}
+	require.NoError(t, database.InsertWorkspace(t.Context(), workspaceRow))
+	return NewManager(database, t.TempDir()), workspaceRow
+}
+
+func pastedImagePNGFixture() []byte {
+	return []byte("\x89PNG\r\n\x1a\nfixture")
+}

--- a/internal/workspace/pasted_images_test.go
+++ b/internal/workspace/pasted_images_test.go
@@ -1,6 +1,8 @@
 package workspace
 
 import (
+	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -168,6 +170,55 @@ func TestStorePastedImageConcurrentFirstWrites(t *testing.T) {
 	entries, err := os.ReadDir(filepath.Join(workspaceRow.WorktreePath, PastedImageDirectory))
 	require.NoError(t, err)
 	assert.Len(t, entries, writes)
+}
+
+func TestStorePastedImageEnforcesConcurrentWorkspaceQuota(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	require := require.New(t)
+	manager, workspaceRow := setupPastedImageWorkspace(t, "ready")
+	imageDir := filepath.Join(workspaceRow.WorktreePath, PastedImageDirectory)
+	require.NoError(os.MkdirAll(imageDir, 0o755))
+	for index := range MaxPastedImagesPerWorkspace - 1 {
+		require.NoError(os.WriteFile(
+			filepath.Join(imageDir, fmt.Sprintf("existing-%03d.png", index)),
+			pastedImagePNGFixture(),
+			0o600,
+		))
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var wait sync.WaitGroup
+	for range 2 {
+		wait.Go(func() {
+			<-start
+			_, err := manager.StorePastedImage(
+				t.Context(), workspaceRow.ID, pastedImagePNGFixture(),
+			)
+			errs <- err
+		})
+	}
+	close(start)
+	wait.Wait()
+	close(errs)
+
+	successes := 0
+	quotaFailures := 0
+	for err := range errs {
+		if err == nil {
+			successes++
+			continue
+		}
+		if errors.Is(err, ErrPastedImageQuotaExceeded) {
+			quotaFailures++
+		}
+	}
+	assert.Equal(1, successes)
+	assert.Equal(1, quotaFailures)
+	entries, err := os.ReadDir(imageDir)
+	require.NoError(err)
+	assert.Len(entries, MaxPastedImagesPerWorkspace)
 }
 
 func setupPastedImageWorkspace(t *testing.T, status string) (*Manager, *db.Workspace) {


### PR DESCRIPTION
Forge terminals accepted only text from the clipboard, so screenshots had to be saved and referenced outside Forge.

- Pasting one or more clipboard images now uploads them to the active local or Fleet workspace and inserts their paths into the terminal in clipboard order.
- Each paste accepts up to four PNG, JPEG, GIF, or WebP images, with a 10 MiB decoded limit per image and server-side content detection.
- Images live under `.kenn-forge/pasted-images`, stay out of Git, and remain for the workspace lifetime. This does not add a separate media cleanup lifecycle.
